### PR TITLE
[IR][TIRx] Make expression types structurally authoritative

### DIFF
--- a/include/tvm/ir/base_expr.h
+++ b/include/tvm/ir/base_expr.h
@@ -299,12 +299,11 @@ class ExprNode : public ffi::Object {
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
-    // span and ty do not participate in structural equal and hash.
+    // span does not participate in structural equal and hash.
     refl::ObjectDef<ExprNode>()
         .def_ro("span", &ExprNode::span, refl::DefaultValue(Span()),
                 refl::AttachFieldFlag::SEqHashIgnore())
-        .def_ro("ty", &ExprNode::ty, refl::DefaultValue(Type::Missing()),
-                refl::AttachFieldFlag::SEqHashIgnore());
+        .def_ro("ty", &ExprNode::ty, refl::DefaultValue(Type::Missing()));
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;

--- a/include/tvm/ir/expr.h
+++ b/include/tvm/ir/expr.h
@@ -276,6 +276,11 @@ class GlobalVarNode : public ExprNode {
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<GlobalVarNode>().def_ro("name_hint", &GlobalVarNode::name_hint);
+    // A GlobalVar identifies a module-level symbol.  Its type is derived from the
+    // corresponding function definition and is not part of the symbol identity.
+    refl::TypeAttrDef<GlobalVarNode>()
+        .def("__s_equal__", &GlobalVarNode::SEqual)
+        .def("__s_hash__", &GlobalVarNode::SHash);
   }
 
   bool SEqual(const GlobalVarNode* other,

--- a/include/tvm/relax/expr.h
+++ b/include/tvm/relax/expr.h
@@ -501,6 +501,25 @@ class SeqExprNode : public ExprNode {
     refl::ObjectDef<SeqExprNode>()
         .def_ro("blocks", &SeqExprNode::blocks)
         .def_ro("body", &SeqExprNode::body);
+    refl::TypeAttrDef<SeqExprNode>()
+        .def("__s_equal__", &SeqExprNode::SEqual)
+        .def("__s_hash__", &SeqExprNode::SHash);
+  }
+
+  bool SEqual(const SeqExprNode* other,
+              ffi::TypedFunction<bool(AnyView, AnyView, bool, AnyView)> equal) const {
+    // Establish mappings for symbolic variables defined by bindings before
+    // comparing their uses in the SeqExpr result type and body.
+    return equal(blocks, other->blocks, false, "blocks") && equal(ty, other->ty, false, "ty") &&
+           equal(body, other->body, false, "body");
+  }
+
+  int64_t SHash(int64_t init_hash, ffi::TypedFunction<int64_t(AnyView, int64_t, bool)> hash) const {
+    int64_t hash_value = init_hash;
+    hash_value = hash(blocks, hash_value, false);
+    hash_value = hash(ty, hash_value, false);
+    hash_value = hash(body, hash_value, false);
+    return hash_value;
   }
   TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.expr.SeqExpr", SeqExprNode, ExprNode);
 };

--- a/include/tvm/tirx/expr_functor.h
+++ b/include/tvm/tirx/expr_functor.h
@@ -261,7 +261,9 @@ class TVM_DLL ExprMutator : protected ExprFunctor<PrimExpr(const PrimExpr&)> {
   /*! \brief Mutate an expression with an arbitrary semantic type. */
   Expr VisitExpr(const Expr& expr);
   /*! \brief Mutate a variable while preserving its exact semantic type. */
-  Expr VisitExpr(const Var& var) { return VisitExpr(static_cast<const Expr&>(var)); }
+  virtual Expr VisitExpr(const Var& var) { return var; }
+  /*! \brief Mutate a size variable while preserving its exact semantic type. */
+  virtual Expr VisitExpr(const SizeVar& var) { return VisitExpr(static_cast<const Var&>(var)); }
   // list of functions to override.
   PrimExpr VisitExpr_(const VarNode* op) override;
   PrimExpr VisitExpr_(const SizeVarNode* op) override;

--- a/include/tvm/tirx/expr_functor.h
+++ b/include/tvm/tirx/expr_functor.h
@@ -211,6 +211,8 @@ class TVM_DLL ExprVisitor : public ExprFunctor<void(const PrimExpr&)> {
 
  protected:
   using ExprFunctor::VisitExpr;
+  /*! \brief Visit an expression with an arbitrary semantic type. */
+  void VisitExpr(const Expr& expr);
   // list of functions to override.
   void VisitExpr_(const VarNode* op) override;
   void VisitExpr_(const SizeVarNode* op) override;
@@ -256,6 +258,12 @@ class TVM_DLL ExprMutator : protected ExprFunctor<PrimExpr(const PrimExpr&)> {
 
  protected:
   using ExprFunctor::VisitExpr;
+  /*! \brief Mutate an expression with an arbitrary semantic type. */
+  Expr VisitExpr(const Expr& expr);
+  /*! \brief Mutate a variable through its checked primitive typed view. */
+  PrimExpr VisitExpr(const Var& var) {
+    return ExprFunctor::VisitExpr(var.as_or_throw<PrimExpr>());
+  }
   // list of functions to override.
   PrimExpr VisitExpr_(const VarNode* op) override;
   PrimExpr VisitExpr_(const SizeVarNode* op) override;

--- a/include/tvm/tirx/expr_functor.h
+++ b/include/tvm/tirx/expr_functor.h
@@ -260,10 +260,8 @@ class TVM_DLL ExprMutator : protected ExprFunctor<PrimExpr(const PrimExpr&)> {
   using ExprFunctor::VisitExpr;
   /*! \brief Mutate an expression with an arbitrary semantic type. */
   Expr VisitExpr(const Expr& expr);
-  /*! \brief Mutate a variable through its checked primitive typed view. */
-  PrimExpr VisitExpr(const Var& var) {
-    return ExprFunctor::VisitExpr(var.as_or_throw<PrimExpr>());
-  }
+  /*! \brief Mutate a variable while preserving its exact semantic type. */
+  Expr VisitExpr(const Var& var) { return VisitExpr(static_cast<const Expr&>(var)); }
   // list of functions to override.
   PrimExpr VisitExpr_(const VarNode* op) override;
   PrimExpr VisitExpr_(const SizeVarNode* op) override;

--- a/include/tvm/tirx/op.h
+++ b/include/tvm/tirx/op.h
@@ -69,6 +69,9 @@ namespace tvm {
  */
 TVM_DLL Type GetType(const PrimExpr& expr);
 
+/*! \brief Get the exact semantic type of a TIR variable. */
+TVM_DLL Type GetType(const tirx::Var& var);
+
 /*!
  * \brief Get the type corresponding to a runtime DLPack dtype.
  * \param dtype The runtime dtype.

--- a/include/tvm/tirx/op.h
+++ b/include/tvm/tirx/op.h
@@ -943,6 +943,11 @@ TVM_DLL bool is_const_power_of_two_integer(const PrimExpr& x, int* shift);
 // Implementation details after this
 inline bool is_const_int(const PrimExpr& x) { return as_const_int(x); }
 
+inline bool is_const_int(const Expr& x) {
+  auto prim = x.as<PrimExpr>();
+  return prim && is_const_int(prim.value());
+}
+
 inline bool is_const_number(const PrimExpr& x) {
   if (x.as<tirx::IntImmNode>()) {
     return true;
@@ -973,7 +978,8 @@ inline bool is_const_int(const PrimExpr& x, int64_t value) {
 inline bool is_no_op(const tirx::Stmt& stmt) {
   if (!stmt.defined()) return true;
   if (const auto* op = stmt.as<tirx::EvaluateNode>()) {
-    return is_const_int(op->value);
+    auto value = op->value.as<PrimExpr>();
+    return value && is_const_int(value.value());
   }
   if (const auto* op = stmt.as<tirx::SeqStmtNode>()) {
     return op->seq.size() == 0;

--- a/include/tvm/tirx/script/builder/ir.h
+++ b/include/tvm/tirx/script/builder/ir.h
@@ -337,7 +337,7 @@ AssertFrame Assert(PrimExpr condition, ffi::String error_kind,
  * \param var The variable to be bound. If not specified, a new variable will be created.
  * \return The bound Var.
  */
-Var Bind(PrimExpr value, ffi::Optional<Type> type_annotation = std::nullopt,
+Var Bind(ffi::Any value, ffi::Optional<Type> type_annotation = std::nullopt,
          ffi::Optional<Var> var = std::nullopt);
 
 /*!
@@ -482,7 +482,7 @@ void BufferStore(Buffer buffer, PrimExpr value, ffi::Array<PrimExpr> indices,
  * \brief Evaluate the input expression.
  * \param value The input expression to evaluate.
  */
-void Evaluate(PrimExpr value);
+void Evaluate(ffi::Any value);
 
 /*!
  * \brief Create a TIR var that represents a pointer

--- a/include/tvm/tirx/stmt.h
+++ b/include/tvm/tirx/stmt.h
@@ -337,7 +337,7 @@ class SeqStmtNode : public StmtNode {
 class EvaluateNode : public StmtNode {
  public:
   /*! \brief The expression to be evaluated. */
-  PrimExpr value;
+  Expr value;
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
@@ -352,7 +352,7 @@ class EvaluateNode : public StmtNode {
  */
 class Evaluate : public Stmt {
  public:
-  TVM_DLL explicit Evaluate(PrimExpr value, Span span = Span());
+  TVM_DLL explicit Evaluate(Expr value, Span span = Span());
 
   explicit Evaluate(int value, Span span = Span()) : Evaluate(PrimExpr(value), span) {}
 

--- a/include/tvm/tirx/stmt.h
+++ b/include/tvm/tirx/stmt.h
@@ -78,7 +78,7 @@ class BindNode : public StmtNode {
   /*! \brief The variable being bound. */
   Var var;
   /*! \brief The value to bind to the variable. */
-  PrimExpr value;
+  Expr value;
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
@@ -96,7 +96,7 @@ class BindNode : public StmtNode {
  */
 class Bind : public Stmt {
  public:
-  TVM_DLL Bind(Var var, PrimExpr value, Span span = Span());
+  TVM_DLL Bind(Var var, Expr value, Span span = Span());
 
   TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Bind, Stmt, BindNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(BindNode);

--- a/include/tvm/tirx/stmt_functor.h
+++ b/include/tvm/tirx/stmt_functor.h
@@ -458,9 +458,9 @@ auto Substitute(Obj&& obj, const ffi::Map<Var, PrimExpr>& vmap) {
  * \param vmap Map defining the TIR variables to be replaced
  * \return The modified object.
  */
-template <typename Obj, typename Expr,
-          typename = std::enable_if_t<std::is_base_of_v<PrimExpr, Expr> ||
-                                      std::is_same_v<Var, Expr>>>
+template <
+    typename Obj, typename Expr,
+    typename = std::enable_if_t<std::is_base_of_v<PrimExpr, Expr> || std::is_same_v<Var, Expr>>>
 auto Substitute(Obj&& obj, const ffi::Map<Var, Expr>& vmap) {
   auto func = [&vmap](const Var& var) -> ffi::Optional<PrimExpr> {
     if (auto opt = vmap.Get(var)) {
@@ -481,9 +481,9 @@ auto Substitute(Obj&& obj, const ffi::Map<Var, Expr>& vmap) {
  * \param vmap Map defining the TIR variables to be replaced
  * \return The modified object.
  */
-template <typename Obj, typename Expr,
-          typename = std::enable_if_t<std::is_base_of_v<PrimExpr, Expr> ||
-                                      std::is_same_v<Var, Expr>>>
+template <
+    typename Obj, typename Expr,
+    typename = std::enable_if_t<std::is_base_of_v<PrimExpr, Expr> || std::is_same_v<Var, Expr>>>
 auto Substitute(Obj&& obj, const std::unordered_map<const VarNode*, Expr>& vmap) {
   auto func = [&vmap](const Var& var) -> ffi::Optional<PrimExpr> {
     if (auto it = vmap.find(var.get()); it != vmap.end()) {
@@ -504,9 +504,9 @@ auto Substitute(Obj&& obj, const std::unordered_map<const VarNode*, Expr>& vmap)
  * \param vmap Map defining the TIR variables to be replaced
  * \return The modified object.
  */
-template <typename Obj, typename Expr, typename Hasher, typename EqualityChecker,
-          typename = std::enable_if_t<std::is_base_of_v<PrimExpr, Expr> ||
-                                      std::is_same_v<Var, Expr>>>
+template <
+    typename Obj, typename Expr, typename Hasher, typename EqualityChecker,
+    typename = std::enable_if_t<std::is_base_of_v<PrimExpr, Expr> || std::is_same_v<Var, Expr>>>
 auto Substitute(Obj&& obj, const std::unordered_map<Var, Expr, Hasher, EqualityChecker>& vmap) {
   auto func = [&vmap](const Var& var) -> ffi::Optional<PrimExpr> {
     if (auto it = vmap.find(var); it != vmap.end()) {
@@ -527,9 +527,9 @@ auto Substitute(Obj&& obj, const std::unordered_map<Var, Expr, Hasher, EqualityC
  * \param iter_vmap Map defining the TIR variables to be replaced
  * \return The modified object.
  */
-template <typename Obj, typename Expr,
-          typename = std::enable_if_t<std::is_base_of_v<PrimExpr, Expr> ||
-                                      std::is_same_v<Var, Expr>>>
+template <
+    typename Obj, typename Expr,
+    typename = std::enable_if_t<std::is_base_of_v<PrimExpr, Expr> || std::is_same_v<Var, Expr>>>
 auto Substitute(Obj&& obj, const std::unordered_map<IterVar, Expr>& iter_vmap) {
   std::unordered_map<const VarNode*, PrimExpr> vmap;
   for (const auto& [iter_var, expr] : iter_vmap) {

--- a/include/tvm/tirx/stmt_functor.h
+++ b/include/tvm/tirx/stmt_functor.h
@@ -153,6 +153,9 @@ class TVM_DLL StmtVisitor : protected StmtFunctor<void(const Stmt&)> {
    *       and redirect Visit to ExprMutator::VisitExpr(Expr)
    */
   virtual void VisitExpr(const PrimExpr& e) {}
+  virtual void VisitExpr(const Expr& e) {
+    if (auto prim = e.as<PrimExpr>()) VisitExpr(prim.value());
+  }
   /*!
    * \brief Visit buffer at definition site (AllocBuffer, DeclBuffer, SBlock alloc_buffers).
    *  Visits buffer shape, strides, elem_offset via VisitExpr.
@@ -269,6 +272,10 @@ class TVM_DLL StmtMutator : protected StmtFunctor<Stmt(const Stmt&)> {
    *       and redirect Mutate to ExprMutator::Mutate(Expr)
    */
   virtual PrimExpr VisitExpr(const PrimExpr& e) { return e; }
+  virtual Expr VisitExpr(const Expr& e) {
+    if (auto prim = e.as<PrimExpr>()) return VisitExpr(prim.value());
+    return e;
+  }
   /*!
    * \brief Visit buffer at definition site. Visits shape/strides/elem_offset via VisitExpr.
    *  If any field changes, creates a new buffer and records it in buffer_remap_.
@@ -336,6 +343,7 @@ class TVM_DLL StmtExprVisitor : public ExprVisitor, public StmtVisitor {
   using StmtVisitor::VisitStmt;
 
   void VisitExpr(const PrimExpr& e) override { return ExprVisitor::VisitExpr(e); }
+  void VisitExpr(const Expr& e) override { return ExprVisitor::VisitExpr(e); }
   void VisitExpr_(const BufferLoadNode* op) override;
 };
 
@@ -353,6 +361,7 @@ class TVM_DLL StmtExprMutator : public ExprMutator, public StmtMutator {
   using StmtMutator::VisitStmt;
 
   PrimExpr VisitExpr(const PrimExpr& e) override { return ExprMutator::VisitExpr(e); }
+  Expr VisitExpr(const Expr& e) override { return ExprMutator::VisitExpr(e); }
   PrimExpr VisitExpr_(const BufferLoadNode* op) override;
 };
 
@@ -450,11 +459,12 @@ auto Substitute(Obj&& obj, const ffi::Map<Var, PrimExpr>& vmap) {
  * \return The modified object.
  */
 template <typename Obj, typename Expr,
-          typename = std::enable_if_t<std::is_base_of_v<PrimExpr, Expr>>>
+          typename = std::enable_if_t<std::is_base_of_v<PrimExpr, Expr> ||
+                                      std::is_same_v<Var, Expr>>>
 auto Substitute(Obj&& obj, const ffi::Map<Var, Expr>& vmap) {
   auto func = [&vmap](const Var& var) -> ffi::Optional<PrimExpr> {
     if (auto opt = vmap.Get(var)) {
-      return opt.value();
+      return opt.value().template as_or_throw<PrimExpr>();
     } else {
       return std::nullopt;
     }
@@ -472,11 +482,12 @@ auto Substitute(Obj&& obj, const ffi::Map<Var, Expr>& vmap) {
  * \return The modified object.
  */
 template <typename Obj, typename Expr,
-          typename = std::enable_if_t<std::is_base_of_v<PrimExpr, Expr>>>
+          typename = std::enable_if_t<std::is_base_of_v<PrimExpr, Expr> ||
+                                      std::is_same_v<Var, Expr>>>
 auto Substitute(Obj&& obj, const std::unordered_map<const VarNode*, Expr>& vmap) {
   auto func = [&vmap](const Var& var) -> ffi::Optional<PrimExpr> {
     if (auto it = vmap.find(var.get()); it != vmap.end()) {
-      return it->second;
+      return it->second.template as_or_throw<PrimExpr>();
     } else {
       return std::nullopt;
     }
@@ -494,11 +505,12 @@ auto Substitute(Obj&& obj, const std::unordered_map<const VarNode*, Expr>& vmap)
  * \return The modified object.
  */
 template <typename Obj, typename Expr, typename Hasher, typename EqualityChecker,
-          typename = std::enable_if_t<std::is_base_of_v<PrimExpr, Expr>>>
+          typename = std::enable_if_t<std::is_base_of_v<PrimExpr, Expr> ||
+                                      std::is_same_v<Var, Expr>>>
 auto Substitute(Obj&& obj, const std::unordered_map<Var, Expr, Hasher, EqualityChecker>& vmap) {
   auto func = [&vmap](const Var& var) -> ffi::Optional<PrimExpr> {
     if (auto it = vmap.find(var); it != vmap.end()) {
-      return it->second;
+      return it->second.template as_or_throw<PrimExpr>();
     } else {
       return std::nullopt;
     }
@@ -516,11 +528,12 @@ auto Substitute(Obj&& obj, const std::unordered_map<Var, Expr, Hasher, EqualityC
  * \return The modified object.
  */
 template <typename Obj, typename Expr,
-          typename = std::enable_if_t<std::is_base_of_v<PrimExpr, Expr>>>
+          typename = std::enable_if_t<std::is_base_of_v<PrimExpr, Expr> ||
+                                      std::is_same_v<Var, Expr>>>
 auto Substitute(Obj&& obj, const std::unordered_map<IterVar, Expr>& iter_vmap) {
   std::unordered_map<const VarNode*, PrimExpr> vmap;
   for (const auto& [iter_var, expr] : iter_vmap) {
-    vmap[iter_var->var.get()] = expr;
+    vmap[iter_var->var.get()] = expr.template as_or_throw<PrimExpr>();
   }
 
   auto func = [&vmap](const Var& var) -> ffi::Optional<PrimExpr> {

--- a/include/tvm/tirx/var.h
+++ b/include/tvm/tirx/var.h
@@ -102,8 +102,18 @@ class Var : public Expr {
    */
   TVM_DLL Var copy_with_dtype(PrimType dtype) const;
 
-  /*! \return The exact semantic type of this variable. */
-  Type ty() const { return get()->ExprNode::ty; }
+  /*! \return The runtime primitive type of this variable. */
+  PrimType ty() const {
+    if (auto prim = get()->ExprNode::ty.as<PrimType>()) {
+      return prim.value();
+    }
+    if (get()->ExprNode::ty.as<PointerTypeNode>()) {
+      return PrimType::Handle();
+    }
+    TVM_FFI_THROW(TypeError) << "Variable has no runtime primitive type: "
+                             << get()->ExprNode::ty;
+    TVM_FFI_UNREACHABLE();
+  }
 
   /*! \brief Checked conversion for scalar variables. */
   operator PrimExpr() const { return this->as_or_throw<PrimExpr>(); }
@@ -332,6 +342,57 @@ inline const char* IterVarType2String(IterVarType t) {
   return "Unknown";
 }
 }  // namespace tirx
+
+// Keep mixed Var/PrimExpr comparisons in the arithmetic expression domain.  Without these
+// exact-match overloads, ObjectRef's pointer-comparison operators compete with Var's checked
+// conversion to PrimExpr.
+#define TVM_TIRX_DEFINE_VAR_COMPARISON_OP(Op)                                      \
+  inline PrimExpr operator Op(tirx::Var a, tirx::Var b) {                          \
+    return operator Op(a.as_or_throw<PrimExpr>(), b.as_or_throw<PrimExpr>());       \
+  }                                                                                \
+  inline PrimExpr operator Op(tirx::Var a, PrimExpr b) {                           \
+    return operator Op(a.as_or_throw<PrimExpr>(), std::move(b));                   \
+  }                                                                                \
+  inline PrimExpr operator Op(PrimExpr a, tirx::Var b) {                           \
+    return operator Op(std::move(a), b.as_or_throw<PrimExpr>());                   \
+  }
+
+TVM_TIRX_DEFINE_VAR_COMPARISON_OP(==)
+TVM_TIRX_DEFINE_VAR_COMPARISON_OP(!=)
+TVM_TIRX_DEFINE_VAR_COMPARISON_OP(<)
+TVM_TIRX_DEFINE_VAR_COMPARISON_OP(<=)
+TVM_TIRX_DEFINE_VAR_COMPARISON_OP(>)
+TVM_TIRX_DEFINE_VAR_COMPARISON_OP(>=)
+
+#undef TVM_TIRX_DEFINE_VAR_COMPARISON_OP
+
+#define TVM_TIRX_DEFINE_VAR_CONST_COMPARISON_OP(Op)                            \
+  inline PrimExpr operator Op(tirx::Var a, int b) {                            \
+    return operator Op(a.as_or_throw<PrimExpr>(), b);                          \
+  }                                                                            \
+  inline PrimExpr operator Op(int a, tirx::Var b) {                            \
+    return operator Op(a, b.as_or_throw<PrimExpr>());                          \
+  }                                                                            \
+  inline PrimExpr operator Op(tirx::Var a, float b) {                          \
+    return operator Op(a.as_or_throw<PrimExpr>(), b);                          \
+  }                                                                            \
+  inline PrimExpr operator Op(float a, tirx::Var b) {                          \
+    return operator Op(a, b.as_or_throw<PrimExpr>());                          \
+  }                                                                            \
+  inline PrimExpr operator Op(tirx::Var a, double b) {                         \
+    return operator Op(a.as_or_throw<PrimExpr>(),                              \
+                       FloatImm(PrimType::Float(64), b));                       \
+  }
+
+TVM_TIRX_DEFINE_VAR_CONST_COMPARISON_OP(==)
+TVM_TIRX_DEFINE_VAR_CONST_COMPARISON_OP(!=)
+TVM_TIRX_DEFINE_VAR_CONST_COMPARISON_OP(<)
+TVM_TIRX_DEFINE_VAR_CONST_COMPARISON_OP(<=)
+TVM_TIRX_DEFINE_VAR_CONST_COMPARISON_OP(>)
+TVM_TIRX_DEFINE_VAR_CONST_COMPARISON_OP(>=)
+
+#undef TVM_TIRX_DEFINE_VAR_CONST_COMPARISON_OP
+
 }  // namespace tvm
 
 /* \brief Allow tirx.Var as key in STL tables

--- a/include/tvm/tirx/var.h
+++ b/include/tvm/tirx/var.h
@@ -52,20 +52,10 @@ class VarNode : public ExprNode {
    * \note Each variable is uniquely identified by its address.
    */
   ffi::String name_hint;
-  /*!
-   * \brief type annotation of the variable.
-   *
-   * It is an optional field that provides a refined type of the variable than dtype.
-   *
-   * \sa tvm/ir/type.h for discussion of relations between DLPack dtype and Type.
-   */
-  Type type_annotation = Type::Missing();
-
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
-    refl::ObjectDef<VarNode>()
-        .def_ro("name", &VarNode::name_hint, refl::AttachFieldFlag::SEqHashIgnore())
-        .def_ro("type_annotation", &VarNode::type_annotation);
+    refl::ObjectDef<VarNode>().def_ro("name", &VarNode::name_hint,
+                                      refl::AttachFieldFlag::SEqHashIgnore());
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindFreeVar;
@@ -74,10 +64,10 @@ class VarNode : public ExprNode {
 };
 
 /*! \brief a named variable in TIR */
-class Var : public PrimExpr {
+class Var : public Expr {
  public:
-  explicit Var(ffi::UnsafeInit tag) : PrimExpr(tag) {}
-  explicit Var(ffi::ObjectPtr<VarNode> n) : PrimExpr(n) {}
+  explicit Var(ffi::UnsafeInit tag) : Expr(tag) {}
+  explicit Var(ffi::ObjectPtr<VarNode> n) : Expr(n) {}
   /*!
    * \brief Constructor
    * \param name_hint variable name
@@ -111,6 +101,12 @@ class Var : public PrimExpr {
    * \return The new variable
    */
   TVM_DLL Var copy_with_dtype(PrimType dtype) const;
+
+  /*! \return The exact semantic type of this variable. */
+  Type ty() const { return get()->ExprNode::ty; }
+
+  /*! \brief Checked conversion for scalar variables. */
+  operator PrimExpr() const { return this->as_or_throw<PrimExpr>(); }
 
   /*!
    * \brief Get pointer to the internal value.

--- a/include/tvm/tirx/var.h
+++ b/include/tvm/tirx/var.h
@@ -110,8 +110,7 @@ class Var : public Expr {
     if (get()->ExprNode::ty.as<PointerTypeNode>()) {
       return PrimType::Handle();
     }
-    TVM_FFI_THROW(TypeError) << "Variable has no runtime primitive type: "
-                             << get()->ExprNode::ty;
+    TVM_FFI_THROW(TypeError) << "Variable has no runtime primitive type: " << get()->ExprNode::ty;
     TVM_FFI_UNREACHABLE();
   }
 
@@ -346,15 +345,15 @@ inline const char* IterVarType2String(IterVarType t) {
 // Keep mixed Var/PrimExpr comparisons in the arithmetic expression domain.  Without these
 // exact-match overloads, ObjectRef's pointer-comparison operators compete with Var's checked
 // conversion to PrimExpr.
-#define TVM_TIRX_DEFINE_VAR_COMPARISON_OP(Op)                                      \
-  inline PrimExpr operator Op(tirx::Var a, tirx::Var b) {                          \
-    return operator Op(a.as_or_throw<PrimExpr>(), b.as_or_throw<PrimExpr>());       \
-  }                                                                                \
-  inline PrimExpr operator Op(tirx::Var a, PrimExpr b) {                           \
-    return operator Op(a.as_or_throw<PrimExpr>(), std::move(b));                   \
-  }                                                                                \
-  inline PrimExpr operator Op(PrimExpr a, tirx::Var b) {                           \
-    return operator Op(std::move(a), b.as_or_throw<PrimExpr>());                   \
+#define TVM_TIRX_DEFINE_VAR_COMPARISON_OP(Op)                                 \
+  inline PrimExpr operator Op(tirx::Var a, tirx::Var b) {                     \
+    return operator Op(a.as_or_throw<PrimExpr>(), b.as_or_throw<PrimExpr>()); \
+  }                                                                           \
+  inline PrimExpr operator Op(tirx::Var a, PrimExpr b) {                      \
+    return operator Op(a.as_or_throw<PrimExpr>(), std::move(b));              \
+  }                                                                           \
+  inline PrimExpr operator Op(PrimExpr a, tirx::Var b) {                      \
+    return operator Op(std::move(a), b.as_or_throw<PrimExpr>());              \
   }
 
 TVM_TIRX_DEFINE_VAR_COMPARISON_OP(==)
@@ -366,22 +365,21 @@ TVM_TIRX_DEFINE_VAR_COMPARISON_OP(>=)
 
 #undef TVM_TIRX_DEFINE_VAR_COMPARISON_OP
 
-#define TVM_TIRX_DEFINE_VAR_CONST_COMPARISON_OP(Op)                            \
-  inline PrimExpr operator Op(tirx::Var a, int b) {                            \
-    return operator Op(a.as_or_throw<PrimExpr>(), b);                          \
-  }                                                                            \
-  inline PrimExpr operator Op(int a, tirx::Var b) {                            \
-    return operator Op(a, b.as_or_throw<PrimExpr>());                          \
-  }                                                                            \
-  inline PrimExpr operator Op(tirx::Var a, float b) {                          \
-    return operator Op(a.as_or_throw<PrimExpr>(), b);                          \
-  }                                                                            \
-  inline PrimExpr operator Op(float a, tirx::Var b) {                          \
-    return operator Op(a, b.as_or_throw<PrimExpr>());                          \
-  }                                                                            \
-  inline PrimExpr operator Op(tirx::Var a, double b) {                         \
-    return operator Op(a.as_or_throw<PrimExpr>(),                              \
-                       FloatImm(PrimType::Float(64), b));                       \
+#define TVM_TIRX_DEFINE_VAR_CONST_COMPARISON_OP(Op)                                  \
+  inline PrimExpr operator Op(tirx::Var a, int b) {                                  \
+    return operator Op(a.as_or_throw<PrimExpr>(), b);                                \
+  }                                                                                  \
+  inline PrimExpr operator Op(int a, tirx::Var b) {                                  \
+    return operator Op(a, b.as_or_throw<PrimExpr>());                                \
+  }                                                                                  \
+  inline PrimExpr operator Op(tirx::Var a, float b) {                                \
+    return operator Op(a.as_or_throw<PrimExpr>(), b);                                \
+  }                                                                                  \
+  inline PrimExpr operator Op(float a, tirx::Var b) {                                \
+    return operator Op(a, b.as_or_throw<PrimExpr>());                                \
+  }                                                                                  \
+  inline PrimExpr operator Op(tirx::Var a, double b) {                               \
+    return operator Op(a.as_or_throw<PrimExpr>(), FloatImm(PrimType::Float(64), b)); \
   }
 
 TVM_TIRX_DEFINE_VAR_CONST_COMPARISON_OP(==)

--- a/include/tvm/topi/nn/pooling.h
+++ b/include/tvm/topi/nn/pooling.h
@@ -123,7 +123,8 @@ inline Tensor pool_grad_impl(const Tensor& out_grad, const Tensor& x,
     auto mp_argmax = tvm::te::compute(
         out_shape,
         [&](const ffi::Array<Var>& inds) {
-          ffi::Array<PrimExpr> window_inds{inds.begin(), inds.end()};
+          ffi::Array<PrimExpr> window_inds =
+              inds.Map([](const Var& var) { return var.as_or_throw<PrimExpr>(); });
           window_inds.Set(height_axis, inds[height_axis] * stride_height + dheight);
           window_inds.Set(width_axis, inds[width_axis] * stride_width + dwidth);
           auto idx = detail::RavelIndex(window_inds, ravel_shape);
@@ -136,12 +137,14 @@ inline Tensor pool_grad_impl(const Tensor& out_grad, const Tensor& x,
     return tvm::te::compute(
         data_shape,
         [&](const ffi::Array<Var>& inds) {
-          ffi::Array<PrimExpr> pad_inds{inds.begin(), inds.end()};
+          ffi::Array<PrimExpr> pad_inds =
+              inds.Map([](const Var& var) { return var.as_or_throw<PrimExpr>(); });
           pad_inds.Set(height_axis, pad_inds[height_axis] + pad_top);
           pad_inds.Set(width_axis, pad_inds[width_axis] + pad_left);
           auto idx = detail::RavelIndex(pad_inds, ravel_shape);
 
-          ffi::Array<PrimExpr> out_idx{inds.begin(), inds.end()};
+          ffi::Array<PrimExpr> out_idx =
+              inds.Map([](const Var& var) { return var.as_or_throw<PrimExpr>(); });
           out_idx.Set(height_axis, (inds[height_axis] + pad_top) / stride_height - windowh);
           out_idx.Set(width_axis, (inds[width_axis] + pad_left) / stride_width - windoww);
 
@@ -172,7 +175,8 @@ inline Tensor pool_grad_impl(const Tensor& out_grad, const Tensor& x,
           PrimExpr pad_w_idx = inds[width_axis] + pad_left;
 
           // output indices whose pooling windows cover current input element (can be out-of-bound)
-          ffi::Array<PrimExpr> out_idx{inds.begin(), inds.end()};
+          ffi::Array<PrimExpr> out_idx =
+              inds.Map([](const Var& var) { return var.as_or_throw<PrimExpr>(); });
           out_idx.Set(height_axis, (pad_h_idx / stride_height - windowh));
           out_idx.Set(width_axis, (pad_w_idx / stride_width - windoww));
 

--- a/include/tvm/topi/transform.h
+++ b/include/tvm/topi/transform.h
@@ -345,9 +345,9 @@ inline Tensor reshape(const Tensor& x, ffi::Array<PrimExpr> newshape,
     return compute(
         target_shape,
         [&](const ffi::Array<Var>& indices) {
-          return x(UnravelIndex(
-              RavelIndex(ffi::Array<PrimExpr>{indices.begin(), indices.end()}, target_shape),
-              x_shape));
+          ffi::Array<PrimExpr> prim_indices = indices.Map(
+              [](const Var& var) { return var.as_or_throw<PrimExpr>(); });
+          return x(UnravelIndex(RavelIndex(prim_indices, target_shape), x_shape));
         },
         name, tag);
   }
@@ -508,7 +508,7 @@ inline Tensor concatenate(const ffi::Array<Tensor>& inputs, int axis = 0,
       out_shape,
       [&](const ffi::Array<Var>& indices) {
         auto ret = inputs[0](indices);
-        auto ind = indices[axis];
+        PrimExpr ind = indices[axis].as_or_throw<PrimExpr>();
         for (size_t i = 0; i < inputs.size() - 1; ++i) {
           ind -= axis_sizes[i];
 
@@ -1667,15 +1667,20 @@ inline Tensor tensordot(const Tensor& A, const tvm::te::Tensor& B, int axes = 2,
     iter_vars.push_back(reduce_axis(Range(0, B->shape[i]), "k" + std::to_string(i)));
 
   auto func = [&A, &B, &iter_vars, axes](const ffi::Array<Var>& input_indices) {
-    ffi::Array<PrimExpr> A_indices(input_indices.begin(),
-                                   input_indices.begin() + (A->shape.size() - axes));
+    ffi::Array<PrimExpr> A_indices;
+    for (auto it = input_indices.begin(); it != input_indices.begin() + (A->shape.size() - axes);
+         ++it) {
+      A_indices.push_back((*it).as_or_throw<PrimExpr>());
+    }
     for (auto& v : iter_vars) A_indices.push_back(v);
 
     ffi::Array<PrimExpr> B_indices;
     for (auto& v : iter_vars) B_indices.push_back(v);
 
     auto it = input_indices.begin() + (A->shape.size() - axes);
-    for (; it != input_indices.end(); ++it) B_indices.push_back(*it);
+    for (; it != input_indices.end(); ++it) {
+      B_indices.push_back((*it).as_or_throw<PrimExpr>());
+    }
 
     // Some passes don't like reductions with empty axis, so avoid it here
     if (iter_vars.empty()) {
@@ -1851,7 +1856,8 @@ inline Tensor layout_transform(const Tensor& src, const std::string& src_layout,
   return compute(
       dst_shape,
       [&](const ffi::Array<Var>& dst_indices) {
-        ffi::Array<PrimExpr> dst_indices_expr(dst_indices.begin(), dst_indices.end());
+        ffi::Array<PrimExpr> dst_indices_expr = dst_indices.Map(
+            [](const Var& var) { return var.as_or_throw<PrimExpr>(); });
         ffi::Array<PrimExpr> src_indices = layout_converter.BackwardIndex(dst_indices_expr);
         PrimExpr in_range = PrimExpr(1) > PrimExpr(0);  // init with dtype=bool and value=true
         for (size_t i = 0; i < src.ndim(); ++i) {
@@ -1913,7 +1919,8 @@ inline Tensor auto_scheduler_layout_transform(
   return compute(
       dst_shape,
       [&](const ffi::Array<Var>& dst_indices) {
-        ffi::Array<PrimExpr> dst_indices_expr(dst_indices.begin(), dst_indices.end());
+        ffi::Array<PrimExpr> dst_indices_expr = dst_indices.Map(
+            [](const Var& var) { return var.as_or_throw<PrimExpr>(); });
         ffi::Array<PrimExpr> src_indices;
         for (const std::string& src_axis : src_axes) {
           PrimExpr src_index = 0;
@@ -1980,7 +1987,9 @@ inline Tensor meta_schedule_layout_transform(
       post_transform_shape,
       [src, inv = index_map.Inverse(iter_domain, analyzer),
        &analyzer](const ffi::Array<Var>& indices) -> PrimExpr {
-        return src(inv->MapIndices(ffi::Array<PrimExpr>{indices.begin(), indices.end()}, analyzer));
+        ffi::Array<PrimExpr> prim_indices = indices.Map(
+            [](const Var& var) { return var.as_or_throw<PrimExpr>(); });
+        return src(inv->MapIndices(prim_indices, analyzer));
       },
       name, tag);
 }

--- a/include/tvm/topi/transform.h
+++ b/include/tvm/topi/transform.h
@@ -345,8 +345,8 @@ inline Tensor reshape(const Tensor& x, ffi::Array<PrimExpr> newshape,
     return compute(
         target_shape,
         [&](const ffi::Array<Var>& indices) {
-          ffi::Array<PrimExpr> prim_indices = indices.Map(
-              [](const Var& var) { return var.as_or_throw<PrimExpr>(); });
+          ffi::Array<PrimExpr> prim_indices =
+              indices.Map([](const Var& var) { return var.as_or_throw<PrimExpr>(); });
           return x(UnravelIndex(RavelIndex(prim_indices, target_shape), x_shape));
         },
         name, tag);
@@ -1856,8 +1856,8 @@ inline Tensor layout_transform(const Tensor& src, const std::string& src_layout,
   return compute(
       dst_shape,
       [&](const ffi::Array<Var>& dst_indices) {
-        ffi::Array<PrimExpr> dst_indices_expr = dst_indices.Map(
-            [](const Var& var) { return var.as_or_throw<PrimExpr>(); });
+        ffi::Array<PrimExpr> dst_indices_expr =
+            dst_indices.Map([](const Var& var) { return var.as_or_throw<PrimExpr>(); });
         ffi::Array<PrimExpr> src_indices = layout_converter.BackwardIndex(dst_indices_expr);
         PrimExpr in_range = PrimExpr(1) > PrimExpr(0);  // init with dtype=bool and value=true
         for (size_t i = 0; i < src.ndim(); ++i) {
@@ -1919,8 +1919,8 @@ inline Tensor auto_scheduler_layout_transform(
   return compute(
       dst_shape,
       [&](const ffi::Array<Var>& dst_indices) {
-        ffi::Array<PrimExpr> dst_indices_expr = dst_indices.Map(
-            [](const Var& var) { return var.as_or_throw<PrimExpr>(); });
+        ffi::Array<PrimExpr> dst_indices_expr =
+            dst_indices.Map([](const Var& var) { return var.as_or_throw<PrimExpr>(); });
         ffi::Array<PrimExpr> src_indices;
         for (const std::string& src_axis : src_axes) {
           PrimExpr src_index = 0;
@@ -1987,8 +1987,8 @@ inline Tensor meta_schedule_layout_transform(
       post_transform_shape,
       [src, inv = index_map.Inverse(iter_domain, analyzer),
        &analyzer](const ffi::Array<Var>& indices) -> PrimExpr {
-        ffi::Array<PrimExpr> prim_indices = indices.Map(
-            [](const Var& var) { return var.as_or_throw<PrimExpr>(); });
+        ffi::Array<PrimExpr> prim_indices =
+            indices.Map([](const Var& var) { return var.as_or_throw<PrimExpr>(); });
         return src(inv->MapIndices(prim_indices, analyzer));
       },
       name, tag);

--- a/python/tvm/backend/cuda/operator/intrinsics/cp_async.py
+++ b/python/tvm/backend/cuda/operator/intrinsics/cp_async.py
@@ -239,13 +239,13 @@ def codegen_ptx_cp_async(*args):
         ca_or_cg = "cg" if cp_size_v == 16 else "ca"
 
         # Recover the per-side element dtype from each pointer's type
-        # annotation (Var has type_annotation = PointerType(PrimType(dtype))).
+        # type (Var has ty = PointerType(PrimType(dtype))).
         # InjectPTXAsyncCopy emits offsets in element-units of each side's
         # buffer dtype (dst gets dst_offset * src_elem_size only when dst is a
         # merged shared.dyn byte buffer, in which case dst_elem_dtype is uint8
         # and the resulting scale-by-1 is a no-op).
         def _elem_bytes(ptr):
-            ta = getattr(ptr, "type_annotation", None)
+            ta = getattr(ptr, "ty", None)
             if ta is None or getattr(ta, "element_type", None) is None:
                 return 1
             et = ta.element_type

--- a/python/tvm/backend/cuda/operator/tile_primitive/copy_async/tma.py
+++ b/python/tvm/backend/cuda/operator/tile_primitive/copy_async/tma.py
@@ -1179,9 +1179,7 @@ def copy_tma_impl(op_call: TilePrimitiveCall, sctx: DispatchContext) -> PrimFunc
         tensor_map = cached_tensormap
         tensormap_is_cached = True
     else:
-        tensor_map = T.Var(
-            g_buf.data.name + "_tensormap", dtype=T.handle("tensormap").ty
-        )
+        tensor_map = T.Var(g_buf.data.name + "_tensormap", dtype=T.handle("tensormap").ty)
         tensormap_is_cached = False
 
     # fmt: off

--- a/python/tvm/backend/cuda/operator/tile_primitive/copy_async/tma.py
+++ b/python/tvm/backend/cuda/operator/tile_primitive/copy_async/tma.py
@@ -1180,7 +1180,7 @@ def copy_tma_impl(op_call: TilePrimitiveCall, sctx: DispatchContext) -> PrimFunc
         tensormap_is_cached = True
     else:
         tensor_map = T.Var(
-            g_buf.data.name + "_tensormap", dtype=T.handle("tensormap").type_annotation
+            g_buf.data.name + "_tensormap", dtype=T.handle("tensormap").ty
         )
         tensormap_is_cached = False
 

--- a/python/tvm/ir/expr.py
+++ b/python/tvm/ir/expr.py
@@ -71,7 +71,16 @@ class GlobalVar(Expr):
         call: Expr
             A call taking the variable as a function.
         """
-        if args and all(isinstance(x, Number) or is_prim_expr(x) for x in args):
+        from .type import PointerType
+
+        def is_tir_arg(x):
+            return (
+                isinstance(x, Number)
+                or is_prim_expr(x)
+                or (isinstance(x, Expr) and isinstance(x.ty, PointerType))
+            )
+
+        if args and all(is_tir_arg(x) for x in args):
             return tvm.tirx.call_tir(self, *args)
 
         if all(isinstance(x, Expr) for x in args):

--- a/python/tvm/relax/op/memory/memory.py
+++ b/python/tvm/relax/op/memory/memory.py
@@ -98,6 +98,8 @@ def alloc_tensor(
     shape = convert_to_expr(shape)
     if isinstance(dtype, str):
         dtype = DataTypeImm(dtype)
+    if isinstance(runtime_device_ind, int):
+        runtime_device_ind = prim_value(runtime_device_ind)
     return _ffi_api.alloc_tensor(storage, offset, shape, dtype, runtime_device_ind)  # type: ignore
 
 

--- a/python/tvm/relax/op/vm/vm.py
+++ b/python/tvm/relax/op/vm/vm.py
@@ -98,6 +98,8 @@ def alloc_tensor(
     shape = convert_to_expr(shape)
     if isinstance(dtype, str):
         dtype = DataTypeImm(dtype)
+    if isinstance(runtime_device_ind, int):
+        runtime_device_ind = prim_value(runtime_device_ind)
     return _ffi_api.alloc_tensor(storage, offset, shape, dtype, runtime_device_ind)  # type: ignore
 
 

--- a/python/tvm/tirx/expr.py
+++ b/python/tvm/tirx/expr.py
@@ -424,6 +424,7 @@ class Var(ExprWithOp):
     """
 
     name_hint: str
+
     def __init__(self, name: str, dtype: str | ir.Type, span: Span | None = None) -> None:
         self.__init_handle_by_constructor__(_ffi_api.Var, name, dtype, span)  # type: ignore
 

--- a/python/tvm/tirx/expr.py
+++ b/python/tvm/tirx/expr.py
@@ -424,8 +424,6 @@ class Var(ExprWithOp):
     """
 
     name_hint: str
-    type_annotation: ir.Type
-
     def __init__(self, name: str, dtype: str | ir.Type, span: Span | None = None) -> None:
         self.__init_handle_by_constructor__(_ffi_api.Var, name, dtype, span)  # type: ignore
 

--- a/python/tvm/tirx/op.py
+++ b/python/tvm/tirx/op.py
@@ -652,12 +652,13 @@ def address_of(obj: Buffer | BufferLoad | Var, span: Span | None = None) -> Expr
     if isinstance(obj, Buffer):
         n_dim = len(obj.shape)
         buffer_load = BufferLoad(obj, [0] * n_dim)
-        return call_intrin("handle", "tirx.address_of", buffer_load, span=span)
+        return Call("tirx.address_of", [buffer_load], span=span, ret_ty=obj.data.ty)
     elif isinstance(obj, Var):
-        dtype = "uint64" if _is_tensormap_var(obj) else "handle"
-        return call_intrin(dtype, "tirx.address_of", obj, span=span)
+        if _is_tensormap_var(obj):
+            return call_intrin("uint64", "tirx.address_of", obj, span=span)
+        return Call("tirx.address_of", [obj], span=span, ret_ty=obj.ty)
     elif isinstance(obj, BufferLoad):
-        return call_intrin("handle", "tirx.address_of", obj, span=span)
+        return Call("tirx.address_of", [obj], span=span, ret_ty=obj.buffer.data.ty)
     else:
         raise ValueError(f"Invalid object type: {type(obj)}")
 

--- a/python/tvm/tirx/op.py
+++ b/python/tvm/tirx/op.py
@@ -630,10 +630,7 @@ def tvm_struct_set(arr, index, field, value):
 
 
 def _is_tensormap_var(obj: Var) -> bool:
-    type_annotation = obj.type_annotation
-    return isinstance(type_annotation, PointerType) and isinstance(
-        type_annotation.element_type, TensorMapType
-    )
+    return isinstance(obj.ty, PointerType) and isinstance(obj.ty.element_type, TensorMapType)
 
 
 def address_of(obj: Buffer | BufferLoad | Var, span: Span | None = None) -> Expr:

--- a/python/tvm/tirx/script/builder/ir.py
+++ b/python/tvm/tirx/script/builder/ir.py
@@ -150,9 +150,6 @@ def _normalize_prim_type(dtype) -> ir.PrimType:
         ty = getattr(value, "ty", None)
         if isinstance(ty, ir.PrimType):
             return ty
-        type_annotation = getattr(value, "type_annotation", None)
-        if isinstance(type_annotation, ir.PrimType):
-            return type_annotation
     return ir.PrimType(dtype)
 
 
@@ -1473,7 +1470,7 @@ def Bind(  # pylint: disable=invalid-name
         if callable(type_annotation):
             type_annotation = type_annotation()
         if isinstance(type_annotation, Var):
-            type_annotation = type_annotation.type_annotation
+            type_annotation = type_annotation.ty
     return _ffi_api.Bind(value, type_annotation, var)  # type: ignore[attr-defined] # pylint: disable=no-member
 
 

--- a/python/tvm/tirx/script/builder/triton.py
+++ b/python/tvm/tirx/script/builder/triton.py
@@ -114,7 +114,7 @@ class TritonKernel(BaseKernel):
                 continue
             if arg.dtype == "handle":
                 assert isinstance(arg, tirx.Var)
-                elem_type = arg.type_annotation.element_type.dtype
+                elem_type = arg.ty.element_type.dtype
                 pointer_type = "*" + type_canonicalisation_dict[elem_type]
                 signature[kernel_params[i].name] = pointer_type
             else:

--- a/python/tvm/tirx/script/parser/parser.py
+++ b/python/tvm/tirx/script/parser/parser.py
@@ -744,11 +744,10 @@ def visit_expr_stmt(self: Parser, node: doc.Expr) -> None:
         T.evaluate(res)
     elif isinstance(res, int | bool):
         T.evaluate(tvm.tirx.const(res))
-    elif isinstance(res, tvm.ir.Call) and not tvm.ir.is_prim_expr(res) and not res.args:
-        # Using GlobalVar.__call__ with no arguments is ambiguous, as
-        # each IR has a different function Call representation.  If
-        # this occurs, convert to the TIR representation.
-        T.evaluate(tvm.tirx.call_tir(res.op))
+    elif isinstance(res, tvm.ir.Call) and not tvm.ir.is_prim_expr(res):
+        # GlobalVar calls with a missing return type are ambiguous, as each IR has a
+        # different function Call representation. Convert to the TIR representation.
+        T.evaluate(tvm.tirx.call_tir(res.op, *res.args))
     elif isinstance(res, str):
         # Ignore docstrings
         pass

--- a/python/tvm/tirx/script/parser/parser.py
+++ b/python/tvm/tirx/script/parser/parser.py
@@ -23,7 +23,7 @@ from functools import partial
 from typing import Any
 
 import tvm
-from tvm.ir import GlobalVar, PrimType
+from tvm.ir import Expr, GlobalVar, PrimType
 from tvm.script.ir_builder import ir as I
 from tvm.script.ir_builder.base import IRBuilder
 from tvm.script.ir_builder.base import IRBuilderFrame as Frame
@@ -531,7 +531,7 @@ def visit_ann_assign(self: Parser, node: doc.AnnAssign) -> None:
         # T.let or T.let[type] -> immutable Bind var
         if rhs is None:
             self.report_error(node, "T.let annotation requires a value")
-        if not tvm.ir.is_prim_expr(rhs):
+        if not isinstance(rhs, Expr):
             if isinstance(rhs, str):
                 rhs = tvm.tirx.StringImm(rhs)
             else:

--- a/python/tvm/tirx/script/parser/parser.py
+++ b/python/tvm/tirx/script/parser/parser.py
@@ -548,7 +548,7 @@ def visit_ann_assign(self: Parser, node: doc.AnnAssign) -> None:
         ann_var = raw_ann() if callable(raw_ann) else raw_ann
         if not isinstance(ann_var, Var):
             self.report_error(node.annotation, "Annotation should resolve to Var")
-        if not isinstance(ann_var.type_annotation, PrimType):
+        if not isinstance(ann_var.ty, PrimType):
             self.report_error(
                 node.annotation,
                 "Use T.let[...] for non-PrimType annotations (e.g. PointerType, handle)",

--- a/src/arith/detect_linear_equation.cc
+++ b/src/arith/detect_linear_equation.cc
@@ -54,10 +54,10 @@ class LinearEqDetector : public ExprFunctor<LinearEqEntry(const PrimExpr&, const
     *ret = VisitExpr(e, e);
     if (fail_) return false;
     if (!ret->base.defined()) {
-      ret->base = IntImm(var_.ty(), 0);
+      ret->base = IntImm(var_.ty().as_or_throw<PrimType>(), 0);
     }
     if (!ret->coeff.defined()) {
-      ret->coeff = IntImm(var_.ty(), 0);
+      ret->coeff = IntImm(var_.ty().as_or_throw<PrimType>(), 0);
     }
     return true;
   }

--- a/src/arith/ir_mutator_with_analyzer.cc
+++ b/src/arith/ir_mutator_with_analyzer.cc
@@ -203,13 +203,11 @@ Stmt IRMutatorWithAnalyzer::VisitStmt_(const SBlockNode* op) {
 }
 
 Stmt IRMutatorWithAnalyzer::VisitStmt_(const BindNode* op) {
-  ffi::Optional<PrimExpr> prim_value = op->value.as<PrimExpr>();
-  if (!prim_value.defined()) {
-    return ffi::GetRef<Stmt>(op);
-  }
-  PrimExpr value = this->VisitExpr(prim_value.value());
-  if (SideEffect(value) <= CallEffectKind::kPure) {
-    analyzer_->Bind(op->var, value);
+  Expr value = this->VisitExpr(op->value);
+  if (auto prim_value = value.as<PrimExpr>()) {
+    if (SideEffect(prim_value.value()) <= CallEffectKind::kPure) {
+      analyzer_->Bind(op->var, prim_value.value());
+    }
   }
   if (value.same_as(op->value)) return ffi::GetRef<Stmt>(op);
   auto n = this->CopyOnWrite(op);

--- a/src/arith/ir_mutator_with_analyzer.cc
+++ b/src/arith/ir_mutator_with_analyzer.cc
@@ -203,7 +203,7 @@ Stmt IRMutatorWithAnalyzer::VisitStmt_(const SBlockNode* op) {
 }
 
 Stmt IRMutatorWithAnalyzer::VisitStmt_(const BindNode* op) {
-  Optional<PrimExpr> prim_value = op->value.as<PrimExpr>();
+  ffi::Optional<PrimExpr> prim_value = op->value.as<PrimExpr>();
   if (!prim_value.defined()) {
     return ffi::GetRef<Stmt>(op);
   }

--- a/src/arith/ir_mutator_with_analyzer.cc
+++ b/src/arith/ir_mutator_with_analyzer.cc
@@ -203,17 +203,18 @@ Stmt IRMutatorWithAnalyzer::VisitStmt_(const SBlockNode* op) {
 }
 
 Stmt IRMutatorWithAnalyzer::VisitStmt_(const BindNode* op) {
-  PrimExpr value = this->VisitExpr(op->value);
+  Optional<PrimExpr> prim_value = op->value.as<PrimExpr>();
+  if (!prim_value.defined()) {
+    return ffi::GetRef<Stmt>(op);
+  }
+  PrimExpr value = this->VisitExpr(prim_value.value());
   if (SideEffect(value) <= CallEffectKind::kPure) {
     analyzer_->Bind(op->var, value);
   }
-  if (value.same_as(op->value)) {
-    return ffi::GetRef<Stmt>(op);
-  } else {
-    auto n = this->CopyOnWrite(op);
-    n->value = std::move(value);
-    return Stmt(n);
-  }
+  if (value.same_as(op->value)) return ffi::GetRef<Stmt>(op);
+  auto n = this->CopyOnWrite(op);
+  n->value = std::move(value);
+  return Stmt(n);
 }
 
 Stmt IRMutatorWithAnalyzer::VisitStmt_(const IfThenElseNode* op) {

--- a/src/arith/ir_visitor_with_analyzer.cc
+++ b/src/arith/ir_visitor_with_analyzer.cc
@@ -50,8 +50,10 @@ void IRVisitorWithAnalyzer::VisitStmt_(const SBlockNode* op) {
 }
 
 void IRVisitorWithAnalyzer::VisitStmt_(const BindNode* op) {
-  this->VisitExpr(op->value);
-  analyzer_->Bind(op->var, op->value);
+  if (Optional<PrimExpr> value = op->value.as<PrimExpr>()) {
+    this->VisitExpr(value.value());
+    analyzer_->Bind(op->var, value.value());
+  }
 }
 
 void IRVisitorWithAnalyzer::VisitStmt_(const IfThenElseNode* op) {

--- a/src/arith/ir_visitor_with_analyzer.cc
+++ b/src/arith/ir_visitor_with_analyzer.cc
@@ -50,8 +50,8 @@ void IRVisitorWithAnalyzer::VisitStmt_(const SBlockNode* op) {
 }
 
 void IRVisitorWithAnalyzer::VisitStmt_(const BindNode* op) {
+  this->VisitExpr(op->value);
   if (ffi::Optional<PrimExpr> value = op->value.as<PrimExpr>()) {
-    this->VisitExpr(value.value());
     analyzer_->Bind(op->var, value.value());
   }
 }

--- a/src/arith/ir_visitor_with_analyzer.cc
+++ b/src/arith/ir_visitor_with_analyzer.cc
@@ -50,7 +50,7 @@ void IRVisitorWithAnalyzer::VisitStmt_(const SBlockNode* op) {
 }
 
 void IRVisitorWithAnalyzer::VisitStmt_(const BindNode* op) {
-  if (Optional<PrimExpr> value = op->value.as<PrimExpr>()) {
+  if (ffi::Optional<PrimExpr> value = op->value.as<PrimExpr>()) {
     this->VisitExpr(value.value());
     analyzer_->Bind(op->var, value.value());
   }

--- a/src/arith/pattern_match.h
+++ b/src/arith/pattern_match.h
@@ -211,11 +211,10 @@ class PVar : public Pattern<PVar<T>> {
     }
   }
 
-  template <typename NodeRefType,
-            typename = typename std::enable_if<
-                !std::is_same<NodeRefType, T>::value &&
-                std::is_base_of<ffi::ObjectRef, NodeRefType>::value &&
-                std::is_base_of<ffi::ObjectRef, T>::value>::type>
+  template <typename NodeRefType, typename = typename std::enable_if<
+                                      !std::is_same<NodeRefType, T>::value &&
+                                      std::is_base_of<ffi::ObjectRef, NodeRefType>::value &&
+                                      std::is_base_of<ffi::ObjectRef, T>::value>::type>
   bool Match_(const NodeRefType& value) const {
     if (auto typed_value = value.template as<T>()) {
       return Match_(*typed_value);

--- a/src/arith/pattern_match.h
+++ b/src/arith/pattern_match.h
@@ -212,7 +212,10 @@ class PVar : public Pattern<PVar<T>> {
   }
 
   template <typename NodeRefType,
-            typename = typename std::enable_if<std::is_base_of<NodeRefType, T>::value>::type>
+            typename = typename std::enable_if<
+                !std::is_same<NodeRefType, T>::value &&
+                std::is_base_of<ffi::ObjectRef, NodeRefType>::value &&
+                std::is_base_of<ffi::ObjectRef, T>::value>::type>
   bool Match_(const NodeRefType& value) const {
     if (auto typed_value = value.template as<T>()) {
       return Match_(*typed_value);

--- a/src/backend/hexagon/codegen/llvm/codegen_hexagon.cc
+++ b/src/backend/hexagon/codegen/llvm/codegen_hexagon.cc
@@ -84,7 +84,7 @@ class CodeGenHexagon final : public CodeGenCPU {
   llvm::Value* CreateIntrinsic(const CallNode* op) override;
 
   llvm::Value* CreateCallExtern(Type ret_type, ffi::String global_symbol,
-                                const ffi::Array<PrimExpr>& args, bool skip_first_arg) override;
+                                const ffi::Array<Expr>& args, bool skip_first_arg) override;
   llvm::Value* CreateCallExternQHL(Type ret_type, ffi::String global_symbol,
                                    const ffi::Array<PrimExpr>& args, bool skip_first_arg);
 
@@ -185,13 +185,13 @@ bool CodeGenHexagon::IsQHLFunction(const std::string& func) {
 }
 
 llvm::Value* CodeGenHexagon::CreateCallExtern(Type ret_type, ffi::String global_symbol,
-                                              const ffi::Array<PrimExpr>& args,
-                                              bool skip_first_arg) {
-  PrimType arg_ty = args[1].ty();
+                                              const ffi::Array<Expr>& args, bool skip_first_arg) {
+  PrimType arg_ty = args[1].as_or_throw<PrimExpr>().ty();
   int num_lanes = arg_ty.lanes();
   int vector_length = native_vector_bits_ / arg_ty.bits();
   if (IsQHLFunction(global_symbol) && (num_lanes > vector_length))
-    return CreateCallExternQHL(ret_type, global_symbol, args, skip_first_arg);
+    return CreateCallExternQHL(ret_type, global_symbol,
+                               args.as_or_throw<ffi::Array<PrimExpr>>(), skip_first_arg);
   return CodeGenCPU::CreateCallExtern(ret_type, global_symbol, args, skip_first_arg);
 }
 

--- a/src/backend/hexagon/codegen/llvm/codegen_hexagon.cc
+++ b/src/backend/hexagon/codegen/llvm/codegen_hexagon.cc
@@ -190,8 +190,8 @@ llvm::Value* CodeGenHexagon::CreateCallExtern(Type ret_type, ffi::String global_
   int num_lanes = arg_ty.lanes();
   int vector_length = native_vector_bits_ / arg_ty.bits();
   if (IsQHLFunction(global_symbol) && (num_lanes > vector_length))
-    return CreateCallExternQHL(ret_type, global_symbol,
-                               args.as_or_throw<ffi::Array<PrimExpr>>(), skip_first_arg);
+    return CreateCallExternQHL(ret_type, global_symbol, args.as_or_throw<ffi::Array<PrimExpr>>(),
+                               skip_first_arg);
   return CodeGenCPU::CreateCallExtern(ret_type, global_symbol, args, skip_first_arg);
 }
 

--- a/src/backend/metal/codegen/codegen_metal.cc
+++ b/src/backend/metal/codegen/codegen_metal.cc
@@ -108,7 +108,7 @@ void CodeGenMetal::AddFunction(const GlobalVar& gvar, const PrimFunc& func) {
     // Register handle data type
     // TODO(tvm-team): consider simply keep type info in the
     // type annotation(via a normalizing rewriting).
-    if (auto* ptr = v->type_annotation.as<PointerTypeNode>()) {
+    if (auto* ptr = v->ty.as<PointerTypeNode>()) {
       if (auto* prim = ptr->element_type.as<PrimTypeNode>()) {
         RegisterHandleType(v.get(), ffi::GetRef<PrimType>(prim));
       }

--- a/src/backend/opencl/codegen/codegen_opencl.cc
+++ b/src/backend/opencl/codegen/codegen_opencl.cc
@@ -79,7 +79,7 @@ void CodeGenOpenCL::InitFuncState(const PrimFunc& f) {
   CodeGenC::InitFuncState(f);
   this->SetTextureScope(InferTextureAccess().Infer(f->body));
   for (Var arg : f->params) {
-    auto ptr_type = arg->type_annotation.as<PointerTypeNode>();
+    auto ptr_type = arg->ty.as<PointerTypeNode>();
     if (ptr_type && runtime::IsTextureStorage(std::string(ptr_type->storage_scope))) {
       // Storage scope qualifiers for textures are inferred
       // and set prior to function codegen.
@@ -94,7 +94,7 @@ void CodeGenOpenCL::PrintFuncPrefix(std::ostream& os) { os << "__kernel "; }
 
 void CodeGenOpenCL::PreFunctionBody(const PrimFunc& f) {
   for (Var arg : f->params) {
-    auto ptr_type = arg->type_annotation.as<PointerTypeNode>();
+    auto ptr_type = arg->ty.as<PointerTypeNode>();
     if (ptr_type && runtime::IsTextureStorage(std::string(ptr_type->storage_scope))) {
       this->stream << "  const sampler_t image_sampler = "
                       "CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP | CLK_FILTER_NEAREST;\n";
@@ -373,7 +373,7 @@ void CodeGenOpenCL::PrintStorageScope(const std::string& scope, std::ostream& os
 
 void CodeGenOpenCL::PrintRestrict(const Var& v, std::ostream& os) {
   // Apply restrict qualifer for non-texture types only
-  if (auto* ptr = v->type_annotation.as<PointerTypeNode>()) {
+  if (auto* ptr = v->ty.as<PointerTypeNode>()) {
     if (!runtime::IsTextureStorage(std::string(ptr->storage_scope))) {
       os << ' ' << restrict_keyword_;
     }
@@ -433,7 +433,7 @@ void CodeGenOpenCL::VisitExpr_(const CallNode* op, std::ostream& os) {
     this->PrintExpr(load->indices[0], os);
     os << ')';
   } else if (op->op.same_as(builtin::texture2d_store())) {
-    auto* ptr_type = op->args[0].as<VarNode>()->type_annotation.as<PointerTypeNode>();
+    auto* ptr_type = op->args[0].as<VarNode>()->ty.as<PointerTypeNode>();
     TVM_FFI_ICHECK(ptr_type != nullptr) << "Texture Var's must be of PointerType";
     TVM_FFI_ICHECK(runtime::IsTextureStorage(std::string(ptr_type->storage_scope)))
         << "builtin::texture2d_store() only supports storing to texture buffers";

--- a/src/backend/vulkan/codegen/codegen_spirv.cc
+++ b/src/backend/vulkan/codegen/codegen_spirv.cc
@@ -76,7 +76,7 @@ runtime::SPIRVShader CodeGenSPIRV::BuildFunction(const PrimFunc& f, const std::s
   for (Var arg : f->params) {
     PrimType t = PrimType(arg.ty()->dtype);
     if (t.IsHandle()) {
-      auto* ptr = arg->type_annotation.as<PointerTypeNode>();
+      auto* ptr = arg->ty.as<PointerTypeNode>();
       TVM_FFI_ICHECK(ptr)
           << "All handles passed to the Vulkan codegen must have a type_annotation as a "
              "PointerType, "

--- a/src/backend/webgpu/codegen/codegen_webgpu.cc
+++ b/src/backend/webgpu/codegen/codegen_webgpu.cc
@@ -178,7 +178,7 @@ runtime::FunctionInfo CodeGenWebGPU::AddFunction(const PrimFunc& f, bool skip_re
     func_arg_types.push_back(t->dtype);
 
     if (t.IsHandle()) {
-      auto* ptr = arg->type_annotation.as<PointerTypeNode>();
+      auto* ptr = arg->ty.as<PointerTypeNode>();
       TVM_FFI_ICHECK(ptr)
           << "All handles passed to the CodeGenWebGPU must have a type_annotation as a "
              "PointerType, "

--- a/src/relax/analysis/type_analysis.cc
+++ b/src/relax/analysis/type_analysis.cc
@@ -1310,7 +1310,7 @@ class SymbolicVarCollector : public relax::ExprVisitor,
  public:
   static ffi::Array<tirx::Var> Free(const Expr& expr) {
     SymbolicVarCollector collector;
-    collector.VisitExpr(expr);
+    collector.relax::ExprVisitor::VisitExpr(expr);
     ffi::Array<tirx::Var> ret{collector.free_symbolic_var_.begin(),
                               collector.free_symbolic_var_.end()};
     return ret;
@@ -1318,7 +1318,7 @@ class SymbolicVarCollector : public relax::ExprVisitor,
 
   static ffi::Array<tirx::Var> Defined(const Expr& expr) {
     SymbolicVarCollector collector;
-    collector.VisitExpr(expr);
+    collector.relax::ExprVisitor::VisitExpr(expr);
     ffi::Array<tirx::Var> ret{collector.defined_symbolic_var_.begin(),
                               collector.defined_symbolic_var_.end()};
     return ret;

--- a/src/relax/distributed/transform/lower_global_view_to_local_view.cc
+++ b/src/relax/distributed/transform/lower_global_view_to_local_view.cc
@@ -166,10 +166,9 @@ class DistributedBufferCompactor : StmtExprMutator {
     }
     Stmt new_body = compactor(prim_func->body);
     new_body = DistBufferReplacer::BufferReplace(new_body, replace_buffer_map);
-    ffi::ObjectPtr<PrimFuncNode> new_func = ffi::make_object<PrimFuncNode>(*prim_func.get());
-    new_func->buffer_map = new_func_buffer_map;
-    new_func->body = new_body;
-    return std::make_tuple(PrimFunc(new_func), compactor.add_allreduce_kind_);
+    PrimFunc new_func(prim_func->params, new_body, prim_func->ret_type, new_func_buffer_map,
+                      prim_func->attrs, prim_func->span);
+    return std::make_tuple(new_func, compactor.add_allreduce_kind_);
   }
 
  private:

--- a/src/relax/ir/expr.cc
+++ b/src/relax/ir/expr.cc
@@ -432,7 +432,7 @@ Function::Function(ffi::Array<Var> params, Expr body, ffi::Optional<Type> ret_ty
       std::unordered_set<tirx::Var> lookup(tir_vars.begin(), tir_vars.end());
       return [lookup = std::move(lookup)](const tirx::Var& var) -> ffi::Optional<PrimExpr> {
         if (lookup.count(var)) {
-          return var;
+          return var.as_or_throw<PrimExpr>();
         } else {
           return std::nullopt;
         }

--- a/src/relax/transform/dataflow_inplace.cc
+++ b/src/relax/transform/dataflow_inplace.cc
@@ -977,7 +977,7 @@ class ModuleInplaceTransformer : public ExprMutator {
     new_body =
         tirx::Substitute(new_body, [&var_subst_map](const tirx::Var& v) -> ffi::Optional<PrimExpr> {
           if (var_subst_map.count(v)) {
-            return var_subst_map.at(v);
+            return var_subst_map.at(v).as_or_throw<PrimExpr>();
           }
           return ffi::Optional<PrimExpr>();
         });

--- a/src/relax/transform/lazy_transform_params.cc
+++ b/src/relax/transform/lazy_transform_params.cc
@@ -76,7 +76,7 @@ class LazyInputMutator : public ExprMutator {
     Type new_ret_ty =
         EraseToWellDefined(func->ret_ty, [&](const tirx::Var& var) -> ffi::Optional<PrimExpr> {
           if (externally_visible_vars.count(var)) {
-            return var;
+            return var.as_or_throw<PrimExpr>();
           } else {
             return std::nullopt;
           }

--- a/src/relax/transform/specialize_primfunc_based_on_callsite.cc
+++ b/src/relax/transform/specialize_primfunc_based_on_callsite.cc
@@ -141,7 +141,7 @@ class SpecializeTIRCallArgs : ExprMutator {
 
     auto new_pfunc = Specialize(pfunc, param_map);
     for (const auto& [var, buffer] : new_pfunc->buffer_map) {
-      auto* ptr = buffer->data->type_annotation.as<PointerTypeNode>();
+      auto* ptr = buffer->data->ty.as<PointerTypeNode>();
       TVM_FFI_ICHECK(ptr) << "Buffer Var's type annotation must be of PointerType";
     }
     auto new_prim_func = WithAttr(new_pfunc, "scoped", static_cast<int64_t>(1));

--- a/src/s_tir/analysis/calculate_allocated_memory.cc
+++ b/src/s_tir/analysis/calculate_allocated_memory.cc
@@ -40,7 +40,7 @@ namespace s_tir {
 using namespace tvm::tirx;
 
 std::string GetStorageScope(const Var& var) {
-  auto* ptr = var->type_annotation.as<PointerTypeNode>();
+  auto* ptr = var->ty.as<PointerTypeNode>();
   TVM_FFI_ICHECK(ptr) << "Buffer Var's type annotation must be of PointerType";
   return ptr->storage_scope;
 }

--- a/src/s_tir/analysis/estimate_flops.cc
+++ b/src/s_tir/analysis/estimate_flops.cc
@@ -181,8 +181,8 @@ class FlopEstimator : private ExprFunctor<TResult(const PrimExpr& n)>,
   }
 
   TResult VisitStmt_(const BindNode* let) override {
-    TResult value = VisitExpr(let->value);
-    return value;
+    if (auto value = let->value.as<PrimExpr>()) return VisitExpr(value.value());
+    return TResult();
   }
 
   TResult VisitExpr_(const SelectNode* op) override {

--- a/src/s_tir/analysis/sblock_access_region_detector.cc
+++ b/src/s_tir/analysis/sblock_access_region_detector.cc
@@ -191,7 +191,9 @@ void BlockReadWriteDetector::VisitStmt_(const IfThenElseNode* op) {
 }
 
 void BlockReadWriteDetector::VisitStmt_(const BindNode* op) {
-  let_bindings_[op->var.get()] = op->value;
+  if (auto value = op->value.as<PrimExpr>()) {
+    let_bindings_[op->var.get()] = value.value();
+  }
   StmtVisitor::VisitStmt_(op);
 }
 

--- a/src/s_tir/backend/adreno/inject_texture_alloc.cc
+++ b/src/s_tir/backend/adreno/inject_texture_alloc.cc
@@ -92,7 +92,7 @@ class TextureAllocInjector : public arith::IRMutatorWithAnalyzer {
 
  protected:
   std::string GetStorageScope(const Var& buffer_var) {
-    auto* ptr = buffer_var->type_annotation.as<PointerTypeNode>();
+    auto* ptr = buffer_var->ty.as<PointerTypeNode>();
     TVM_FFI_ICHECK(ptr) << "Buffer Var's type annotation must be of PointerType";
     return ptr->storage_scope;
   }

--- a/src/s_tir/backend/adreno/texture_flatten.cc
+++ b/src/s_tir/backend/adreno/texture_flatten.cc
@@ -72,7 +72,7 @@ class TextureLoweringBase : public StmtExprMutator {
 
  protected:
   std::string GetStorageScope(const Buffer& buffer) {
-    auto* ptr = buffer->data->type_annotation.as<PointerTypeNode>();
+    auto* ptr = buffer->data->ty.as<PointerTypeNode>();
     TVM_FFI_ICHECK(ptr) << "Buffer Var's type annotation must be of PointerType";
     return ptr->storage_scope;
   }

--- a/src/s_tir/schedule/analysis/layout.cc
+++ b/src/s_tir/schedule/analysis/layout.cc
@@ -188,7 +188,8 @@ ffi::Optional<IndexMap> SuggestIndexMap(const Buffer& buffer, const ffi::Array<P
       analyzer->Bind(indices[i], Range::FromMinExtent(0, shape[i]));
     }
     // Step 5.1: Fuse all indices into a flattened one
-    PrimExpr index = f_flatten_index({indices.begin(), indices.end()});
+    PrimExpr index = f_flatten_index(
+        indices.Map([](const Var& var) { return var.as_or_throw<PrimExpr>(); }));
     int ndim = split_exprs.size();
     // Step 5.2. Split the flattened index according to `split_exprs`
     std::vector<PrimExpr> split;

--- a/src/s_tir/schedule/analysis/layout.cc
+++ b/src/s_tir/schedule/analysis/layout.cc
@@ -188,8 +188,8 @@ ffi::Optional<IndexMap> SuggestIndexMap(const Buffer& buffer, const ffi::Array<P
       analyzer->Bind(indices[i], Range::FromMinExtent(0, shape[i]));
     }
     // Step 5.1: Fuse all indices into a flattened one
-    PrimExpr index = f_flatten_index(
-        indices.Map([](const Var& var) { return var.as_or_throw<PrimExpr>(); }));
+    PrimExpr index =
+        f_flatten_index(indices.Map([](const Var& var) { return var.as_or_throw<PrimExpr>(); }));
     int ndim = split_exprs.size();
     // Step 5.2. Split the flattened index according to `split_exprs`
     std::vector<PrimExpr> split;

--- a/src/s_tir/schedule/analysis/reducer.cc
+++ b/src/s_tir/schedule/analysis/reducer.cc
@@ -376,7 +376,7 @@ void ExtractReductionUpdates(const ffi::Optional<ScheduleState>& self, SBlock bl
     if (bind == nullptr) {
       ErrorRFactorCrossThreadReductionNotApplicable(self, std::move(block), /*violated_cond=*/3);
     }
-    let_values.push_back(bind->value);
+    let_values.push_back(bind->value.as_or_throw<PrimExpr>());
     auto insert_result = var2index.insert(std::make_pair(bind->var.get(), i));
     if (!insert_result.second) {
       ErrorRFactorCrossThreadReductionNotApplicable(self, std::move(block), /*violated_cond=*/4);

--- a/src/s_tir/schedule/instruction.cc
+++ b/src/s_tir/schedule/instruction.cc
@@ -83,7 +83,7 @@ ffi::String InstructionAsPythonRepr(const InstructionNode* self) {
       PrimExpr new_expr = Substitute(expr.value(), [](const Var& var) -> ffi::Optional<PrimExpr> {
         ffi::ObjectPtr<VarNode> new_var = ffi::make_object<VarNode>(*var.get());
         new_var->name_hint = "_";
-        return Var(new_var);
+        return Var(new_var).as_or_throw<PrimExpr>();
       });
       std::ostringstream os;
       os << new_expr;

--- a/src/s_tir/schedule/primitive/cache_read_write.cc
+++ b/src/s_tir/schedule/primitive/cache_read_write.cc
@@ -2035,9 +2035,9 @@ void CollectReindexCacheStageInfoAndCreateBuffer(
   // Create new buffer
   ffi::ObjectPtr<BufferNode> new_buffer = ffi::make_object<BufferNode>(*old_buffer.get());
   ffi::ObjectPtr<VarNode> new_var = ffi::make_object<VarNode>(*old_buffer->data.get());
-  const auto* ptr_type = TVM_TYPE_AS(old_buffer->data->type_annotation, PointerTypeNode);
-  new_var->type_annotation = PointerType(ptr_type->element_type, storage_scope);
-  new_buffer->data = Var(new_var->name_hint + "_" + storage_scope, new_var->type_annotation);
+  const auto* ptr_type = TVM_TYPE_AS(old_buffer->data->ty, PointerTypeNode);
+  new_var->ty = PointerType(ptr_type->element_type, storage_scope);
+  new_buffer->data = Var(new_var->name_hint + "_" + storage_scope, new_var->ty);
   new_buffer->name = old_buffer->name + "_" + storage_scope;
   new_buffer->shape = new_shape;
 

--- a/src/s_tir/schedule/primitive/compute_inline.cc
+++ b/src/s_tir/schedule/primitive/compute_inline.cc
@@ -515,8 +515,10 @@ class ComputeInliner : public BaseInliner {
     for (size_t i = 0; i < idx_vars_.size(); ++i) {
       idx_vars_[i] = Var("ph_" + std::to_string(i), inlined_store_->indices[i].ty());
     }
-    auto inverse_iter_map = arith::InverseAffineIterMap(
-        res->indices, ffi::Array<PrimExpr>(idx_vars_.begin(), idx_vars_.end()));
+    ffi::Array<PrimExpr> prim_idx_vars;
+    prim_idx_vars.reserve(idx_vars_.size());
+    for (const Var& var : idx_vars_) prim_idx_vars.push_back(var.as_or_throw<PrimExpr>());
+    auto inverse_iter_map = arith::InverseAffineIterMap(res->indices, prim_idx_vars);
     for (const auto& iter : producer_block->iter_vars) {
       if (is_const_int(iter->dom->min) && analyzer_->CanProveEqual(iter->dom->extent, 1)) {
         // fallback mapping for constant iters

--- a/src/s_tir/schedule/primitive/layout_transformation.cc
+++ b/src/s_tir/schedule/primitive/layout_transformation.cc
@@ -635,10 +635,13 @@ class TransformLayoutPlanner : private StmtExprVisitor {
   // binding must remain visible to subsequent sibling statements.
   struct BindVariableDefinition {
     BindVariableDefinition() {}
-    BindVariableDefinition(TransformLayoutPlanner* self, Var var, PrimExpr value) {
-      if (auto loop_depth = self->LoopDependencyRange(value); loop_depth.has_value()) {
+    BindVariableDefinition(TransformLayoutPlanner* self, Var var, Expr value) {
+      auto prim_value = value.as<PrimExpr>();
+      if (!prim_value) return;
+      if (auto loop_depth = self->LoopDependencyRange(prim_value.value()); loop_depth.has_value()) {
         self->loop_depth_lookup_[var.get()] = loop_depth.value();
-        self->active_var_bindings_[var.get()] = Substitute(value, self->active_var_bindings_);
+        self->active_var_bindings_[var.get()] =
+            Substitute(prim_value.value(), self->active_var_bindings_);
       }
     }
     ~BindVariableDefinition() {}

--- a/src/s_tir/schedule/primitive/pad_einsum.cc
+++ b/src/s_tir/schedule/primitive/pad_einsum.cc
@@ -203,8 +203,10 @@ struct BufferPadding {
     SBlock new_block(iter_vars, {read_region}, {write_region}, padded_buffer->name,
                      std::move(body));
     blocks->push_back(new_block);
-    body = SBlockRealize(ffi::Array<PrimExpr>{loop_vars.begin(), loop_vars.end()},
-                         IntImm::Bool(true), new_block);
+    ffi::Array<PrimExpr> prim_loop_vars;
+    prim_loop_vars.reserve(loop_vars.size());
+    for (const Var& var : loop_vars) prim_loop_vars.push_back(var.as_or_throw<PrimExpr>());
+    body = SBlockRealize(prim_loop_vars, IntImm::Bool(true), new_block);
     for (int i = ndim - 1; i >= 0; --i) {
       body = For(loop_vars[i], loop_doms[i]->min, loop_doms[i]->extent, ForKind::kSerial,
                  std::move(body));

--- a/src/s_tir/schedule/primitive/read_write_at.cc
+++ b/src/s_tir/schedule/primitive/read_write_at.cc
@@ -294,7 +294,7 @@ struct ReadWriteAtImpl {
         bindings.Set(var, Var(v));
         iter_values.push_back(var);
         iter_vars.push_back(IterVar(range, Var(v), IterVarType::kDataPar));
-        return Var(v);
+        return Var(v).as_or_throw<PrimExpr>();
       };
       ffi::ObjectPtr<RangeNode> dom = ffi::make_object<RangeNode>(*domain[i].get());
       dom->min = Substitute(std::move(dom->min), f_substitute);

--- a/src/s_tir/schedule/trace.cc
+++ b/src/s_tir/schedule/trace.cc
@@ -72,7 +72,7 @@ ffi::Array<Any> TranslateInputRVs(
     const ffi::Object* dst = it->second;
     TVM_FFI_CHECK(dst->IsInstance<VarNode>(), TypeError)
         << "Expect 'tirx.Var', but gets: " << dst->GetTypeKey();
-    return ffi::GetRef<Var>(static_cast<const VarNode*>(dst));
+    return ffi::GetRef<Var>(static_cast<const VarNode*>(dst)).as_or_throw<PrimExpr>();
   };
 
   for (const Any& input : inputs) {
@@ -201,7 +201,7 @@ ffi::Array<Any> TranslateInputRVs(
         index_map = Substitute(index_map, [&named_rvs](const Var& var) -> ffi::Optional<PrimExpr> {
           auto it = named_rvs.find(var->name_hint);
           if (it != named_rvs.end()) {
-            return it->second.as_or_throw<Var>();
+            return it->second.as_or_throw<Var>().as_or_throw<PrimExpr>();
           }
           return std::nullopt;
         });

--- a/src/s_tir/schedule/transform.cc
+++ b/src/s_tir/schedule/transform.cc
@@ -42,9 +42,9 @@ SBlock WithAnnotation(const SBlockNode* block, const ffi::String& attr_key,
 Buffer WithScope(const Buffer& buffer, const ffi::String& scope) {
   ffi::ObjectPtr<BufferNode> new_buffer = ffi::make_object<BufferNode>(*buffer.get());
   ffi::ObjectPtr<VarNode> new_var = ffi::make_object<VarNode>(*buffer->data.get());
-  const auto* ptr_type = TVM_TYPE_AS(buffer->data->type_annotation, PointerTypeNode);
-  new_var->type_annotation = PointerType(ptr_type->element_type, scope);
-  new_buffer->data = Var(new_var->name_hint + "_" + scope, new_var->type_annotation);
+  const auto* ptr_type = TVM_TYPE_AS(buffer->data->ty, PointerTypeNode);
+  new_var->ty = PointerType(ptr_type->element_type, scope);
+  new_buffer->data = Var(new_var->name_hint + "_" + scope, new_var->ty);
   new_buffer->name = buffer->name + "_" + scope;
   return Buffer(new_buffer);
 }
@@ -52,7 +52,7 @@ Buffer WithScope(const Buffer& buffer, const ffi::String& scope) {
 Buffer WithDType(const Buffer& buffer, PrimType dtype) {
   ffi::ObjectPtr<BufferNode> new_buffer = ffi::make_object<BufferNode>(*buffer.get());
   new_buffer->dtype = dtype;
-  const auto* ptr_type = TVM_TYPE_AS(buffer->data->type_annotation, PointerTypeNode);
+  const auto* ptr_type = TVM_TYPE_AS(buffer->data->ty, PointerTypeNode);
   new_buffer->data = Var(buffer->data->name_hint, PointerType(dtype, ptr_type->storage_scope));
   new_buffer->name = buffer->name;
   return Buffer(new_buffer);

--- a/src/s_tir/transform/compact_buffer_region.cc
+++ b/src/s_tir/transform/compact_buffer_region.cc
@@ -181,9 +181,9 @@ class BufferAccessRegionCollector : public StmtExprVisitor {
 
   void VisitStmt_(const BindNode* op) final {
     StmtExprVisitor::VisitExpr(op->value);
-    if (arith::IsIndexTypedExpr(op->value)) {
-      dom_analyzer_->Bind(op->var, op->value);
-      dom_map_.emplace(op->var.get(), arith::IntSet::SinglePoint(op->value));
+    if (auto value = op->value.as<PrimExpr>(); value && arith::IsIndexTypedExpr(value.value())) {
+      dom_analyzer_->Bind(op->var, value.value());
+      dom_map_.emplace(op->var.get(), arith::IntSet::SinglePoint(value.value()));
     }
   }
 

--- a/src/s_tir/transform/hoist_expression.cc
+++ b/src/s_tir/transform/hoist_expression.cc
@@ -324,7 +324,9 @@ class HoistInfoCollector : public StmtExprVisitor {
   }
 
   void VisitStmt_(const BindNode* op) final {
-    VisitBinding(op->var, op->value, HoistedLetBindings::kBind);
+    if (auto value = op->value.as<PrimExpr>()) {
+      VisitBinding(op->var, value.value(), HoistedLetBindings::kBind);
+    }
     Parent::VisitStmt_(op);
   }
 

--- a/src/s_tir/transform/inject_ptx_async_copy.cc
+++ b/src/s_tir/transform/inject_ptx_async_copy.cc
@@ -62,8 +62,8 @@ class PTXAsyncCopyInjector : public StmtMutator {
       const int bytes = indices_lanes * static_cast<int>(load->buffer->dtype.StorageBytes());
 
       if (bytes == 4 || bytes == 8 || bytes == 16) {
-        auto dst_elem_type = GetPointerType(store->buffer->data->type_annotation);
-        auto src_elem_type = GetPointerType(load->buffer->data->type_annotation);
+        auto dst_elem_type = GetPointerType(store->buffer->data->ty);
+        auto src_elem_type = GetPointerType(load->buffer->data->ty);
         TVM_FFI_ICHECK(dst_elem_type.has_value() && src_elem_type.has_value())
             << "Both store and load buffer should have a pointer type annotation.";
 

--- a/src/s_tir/transform/inject_virtual_thread.cc
+++ b/src/s_tir/transform/inject_virtual_thread.cc
@@ -49,6 +49,10 @@ class ExprTouched final : public StmtExprVisitor {
     if (expr_touched_ && !check_write_) return;
     StmtExprVisitor::VisitExpr(n);
   }
+  void VisitExpr(const Expr& n) final {
+    if (expr_touched_ && !check_write_) return;
+    StmtExprVisitor::VisitExpr(n);
+  }
   void VisitStmt(const Stmt& n) final {
     // early stopping
     if (expr_touched_ && !check_write_) return;
@@ -102,7 +106,7 @@ class VarTouchedAnalysis : public StmtVisitor {
  public:
   void VisitStmt_(const BindNode* op) final {
     ExprTouched tc(touched_var_, false);
-    tc(op->value);
+    tc.VisitExpr(op->value);
     Record(op->var.get(), tc);
   }
 
@@ -304,7 +308,7 @@ class VTInjector : public arith::IRMutatorWithAnalyzer {
   }
   // Bind
   Stmt VisitStmt_(const BindNode* op) final {
-    PrimExpr value = this->VisitExpr(op->value);
+    Expr value = this->VisitExpr(op->value);
     if (visit_touched_var_ && !vt_loop_injected_) {
       return InjectVTLoop(ffi::GetRef<Stmt>(op), true);
     }

--- a/src/s_tir/transform/inject_virtual_thread.cc
+++ b/src/s_tir/transform/inject_virtual_thread.cc
@@ -233,8 +233,7 @@ class VTInjector : public arith::IRMutatorWithAnalyzer {
       offset = RewriteIndex(offset, stride);
 
       return Call(op->ExprNode::ty.as_or_throw<PrimType>(), op->op,
-                  {op->args[0].as_or_throw<PrimExpr>(), op->args[1].as_or_throw<PrimExpr>(), offset,
-                   extent, op->args[4].as_or_throw<PrimExpr>()})
+                  {op->args[0], op->args[1], offset, extent, op->args[4]})
           .as_or_throw<PrimExpr>();
     } else if (op->op.same_as(builtin::tvm_context_id())) {
       return allow_share_ ? ffi::GetRef<Call>(op).as_or_throw<PrimExpr>() : var_;

--- a/src/s_tir/transform/inject_virtual_thread.cc
+++ b/src/s_tir/transform/inject_virtual_thread.cc
@@ -128,7 +128,7 @@ class VarTouchedAnalysis : public StmtVisitor {
   // external function call
   void VisitStmt_(const EvaluateNode* op) final {
     ExprTouched tc(touched_var_, true);
-    tc(op->value);
+    tc.VisitExpr(op->value);
     for (const VarNode* var : tc.write_vars_) {
       Record(var, tc);
     }

--- a/src/s_tir/transform/lower_thread_allreduce.cc
+++ b/src/s_tir/transform/lower_thread_allreduce.cc
@@ -665,8 +665,9 @@ class ThreadAllreduceBuilder final : public StmtExprMutator {
 
         std::vector<Stmt> in_let_statement;
         in_let_statement.emplace_back(SyncThread("warp"));
-        in_let_statement.emplace_back(
-            fstore({in_warp_local_vars.begin(), in_warp_local_vars.end()}));
+        ffi::Array<PrimExpr> prim_in_warp_local_vars = in_warp_local_vars.Map(
+            [](const Var& var) { return var.as_or_throw<PrimExpr>(); });
+        in_let_statement.emplace_back(fstore(prim_in_warp_local_vars));
         in_let_statement.emplace_back(SyncThread("warp"));
 
         ffi::Array<Stmt> bind_stmts;

--- a/src/s_tir/transform/lower_thread_allreduce.cc
+++ b/src/s_tir/transform/lower_thread_allreduce.cc
@@ -665,8 +665,8 @@ class ThreadAllreduceBuilder final : public StmtExprMutator {
 
         std::vector<Stmt> in_let_statement;
         in_let_statement.emplace_back(SyncThread("warp"));
-        ffi::Array<PrimExpr> prim_in_warp_local_vars = in_warp_local_vars.Map(
-            [](const Var& var) { return var.as_or_throw<PrimExpr>(); });
+        ffi::Array<PrimExpr> prim_in_warp_local_vars =
+            in_warp_local_vars.Map([](const Var& var) { return var.as_or_throw<PrimExpr>(); });
         in_let_statement.emplace_back(fstore(prim_in_warp_local_vars));
         in_let_statement.emplace_back(SyncThread("warp"));
 

--- a/src/s_tir/transform/lower_vtcm_alloc.cc
+++ b/src/s_tir/transform/lower_vtcm_alloc.cc
@@ -54,7 +54,7 @@ class VtcmAllocator : public StmtExprMutator {
 
  protected:
   std::string GetStorageScope(const Var& var) {
-    auto* ptr = var->type_annotation.as<PointerTypeNode>();
+    auto* ptr = var->ty.as<PointerTypeNode>();
     TVM_FFI_ICHECK(ptr) << "Buffer Var's type annotation must be of PointerType";
     return ptr->storage_scope;
   }

--- a/src/s_tir/transform/memhammer_coalesce.cc
+++ b/src/s_tir/transform/memhammer_coalesce.cc
@@ -48,7 +48,10 @@ Stmt FuseNestLoops(Stmt body) {
     tot = floordiv(tot, loops[i]->extent);
   }
   auto f_substitute = [&](const Var& v) -> ffi::Optional<PrimExpr> {
-    return subst_map.Get(v).value_or(v);
+    if (auto replacement = subst_map.Get(v)) {
+      return replacement.value();
+    }
+    return v.as_or_throw<PrimExpr>();
   };
   PrimExpr fused_extent = 1;
   for (int i = 0; i < n; i++) {

--- a/src/s_tir/transform/memhammer_lower_auto_copy.cc
+++ b/src/s_tir/transform/memhammer_lower_auto_copy.cc
@@ -467,14 +467,14 @@ class AutoPadder {
         if (v.same_as(var)) {
           return IntImm::Int32(0);
         } else {
-          return v;
+          return v.as_or_throw<PrimExpr>();
         }
       });
       PrimExpr e2 = Substitute(e, [var](const Var& v) -> ffi::Optional<PrimExpr> {
         if (v.same_as(var)) {
           return IntImm::Int32(1);
         } else {
-          return v;
+          return v.as_or_throw<PrimExpr>();
         }
       });
       arith::Analyzer analyzer;

--- a/src/s_tir/transform/merge_shared_memory_allocations.cc
+++ b/src/s_tir/transform/merge_shared_memory_allocations.cc
@@ -507,7 +507,7 @@ class SharedMemoryRewriter : public StmtExprMutator {
     } else if (op->op.same_as(ptx_cp_async_op)) {
       TVM_FFI_ICHECK((op->args.size() == 5U) || (op->args.size() == 6U));
       Var buffer = op->args[0].as_or_throw<Var>();
-      const auto* ptr_type = buffer->type_annotation.as<PointerTypeNode>();
+      const auto* ptr_type = buffer->ty.as<PointerTypeNode>();
       TVM_FFI_ICHECK(ptr_type) << "The buffer should be a pointer type.";
       const auto* prim_type = ptr_type->element_type.as<PrimTypeNode>();
       TVM_FFI_ICHECK(prim_type) << "The buffer should be a pointer to a primitive type.";

--- a/src/s_tir/transform/remove_store_undef.cc
+++ b/src/s_tir/transform/remove_store_undef.cc
@@ -57,7 +57,8 @@ class StoreUndefLocator : public StmtExprVisitor {
     StmtExprVisitor::VisitExpr(op->value);
     std::swap(has_undef_, stash_undef);
     if (stash_undef) {
-      TVM_FFI_ICHECK(SideEffect(op->value) <= CallEffectKind::kReadState)
+      auto value = op->value.as<PrimExpr>();
+      TVM_FFI_ICHECK(value && SideEffect(value.value()) <= CallEffectKind::kReadState)
           << "Error: T.undef() used in BufferStore expressions "
           << "must not have other side effects";
       undef_stores_.insert(op);
@@ -93,7 +94,8 @@ class StoreUndefLocator : public StmtExprVisitor {
     StmtExprVisitor::VisitExpr(op->value);
     std::swap(has_undef_, stash_undef);
     if (stash_undef) {
-      TVM_FFI_ICHECK(SideEffect(op->value) <= CallEffectKind::kReadState)
+      auto value = op->value.as<PrimExpr>();
+      TVM_FFI_ICHECK(value && SideEffect(value.value()) <= CallEffectKind::kReadState)
           << "Error: T.undef() used in Let expressions "
           << "must not have other side effects";
       var_bindings_with_undef_.insert(op->var.get());

--- a/src/s_tir/transform/storage_access.cc
+++ b/src/s_tir/transform/storage_access.cc
@@ -290,7 +290,7 @@ void StorageAccessVisitor::VisitExpr_(const CallNode* op) {
 }
 
 StorageScope StorageAccessVisitor::GetScope(Var buffer_var) const {
-  if (buffer_var->type_annotation.as<PointerTypeNode>()) {
+  if (buffer_var->ty.as<PointerTypeNode>()) {
     return StorageScope::Create(GetPtrStorageScope(buffer_var));
   }
   return StorageScope();  // global by default

--- a/src/target/build_common.h
+++ b/src/target/build_common.h
@@ -52,7 +52,7 @@ inline ffi::Map<ffi::String, runtime::FunctionInfo> ExtractFuncInfo(const IRModu
     for (size_t i = 0; i < f->params.size(); ++i) {
       arg_types.push_back(f->params[i].ty()->dtype);
       auto is_tensormap = [](const tirx::Var& var) -> bool {
-        const auto* type = var->type_annotation.as<PointerTypeNode>();
+        const auto* type = var->ty.as<PointerTypeNode>();
         if (type == nullptr) {
           return false;
         }

--- a/src/target/llvm/codegen_cpu.cc
+++ b/src/target/llvm/codegen_cpu.cc
@@ -210,8 +210,8 @@ llvm::DISubprogram* CodeGenCPU::CreateDebugFunction(llvm::StringRef name,
 
 llvm::DISubprogram* CodeGenCPU::CreateDebugFunction(const GlobalVar& gvar, const PrimFunc& func) {
   std::string name = func->GetAttr<ffi::String>(tvm::attr::kGlobalSymbol).value_or(gvar->name_hint);
-  return CreateDebugFunction(
-      name, func->params.Map([](const Var& var) { return GetType(var); }), func->ret_type);
+  return CreateDebugFunction(name, func->params.Map([](const Var& var) { return GetType(var); }),
+                             func->ret_type);
 }
 
 void CodeGenCPU::AddFunction(const GlobalVar& gvar, const PrimFunc& func) {
@@ -578,10 +578,9 @@ void CodeGenCPU::CreateComputeScope(const AttrStmtNode* op) {
   }
 
   function_ = fcompute;
-  di_subprogram_ =
-      CreateDebugFunction(MakeStringRef(value->value),
-                          vargs.Map([](const Var& var) { return GetType(var); }),
-                          PrimType::Int(32));
+  di_subprogram_ = CreateDebugFunction(MakeStringRef(value->value),
+                                       vargs.Map([](const Var& var) { return GetType(var); }),
+                                       PrimType::Int(32));
   auto* compute_entry = llvm::BasicBlock::Create(*ctx, "entry", function_);
   builder_->SetInsertPoint(compute_entry);
   this->VisitStmt(op->body);
@@ -1052,8 +1051,8 @@ llvm::Value* CodeGenCPU::CreateIntrinsic(const CallNode* op) {
     TVM_FFI_ICHECK_EQ(args.size(), 4U);
     int kind = args[2].as<IntImm>().value()->value;
     llvm::Value* value = MakeValue(args[3]);
-    TypedPointer ref = CreateStructRefPtr(args[3].as_or_throw<PrimExpr>().ty(),
-                                          MakeValue(args[0]), MakeValue(args[1]), kind);
+    TypedPointer ref = CreateStructRefPtr(args[3].as_or_throw<PrimExpr>().ty(), MakeValue(args[0]),
+                                          MakeValue(args[1]), kind);
     TVM_FFI_ICHECK(kind != builtin::kDLTensorAddr);
     if (value->getType()->isPointerTy()) {
       value = builder_->CreatePointerCast(value, ref.type);

--- a/src/target/llvm/codegen_cpu.cc
+++ b/src/target/llvm/codegen_cpu.cc
@@ -395,7 +395,7 @@ CodeGenLLVM::TypedPointer CodeGenCPU::CreateStructRefPtr(PrimType t, llvm::Value
 }
 
 llvm::Value* CodeGenCPU::CreateCallExtern(Type ret_type, ffi::String global_symbol,
-                                          const ffi::Array<PrimExpr>& args, bool skip_first_arg) {
+                                          const ffi::Array<Expr>& args, bool skip_first_arg) {
   std::vector<llvm::Value*> arg_values;
   for (size_t i = static_cast<size_t>(skip_first_arg); i < args.size(); ++i) {
     arg_values.push_back(MakeValue(args[i]));
@@ -1016,7 +1016,7 @@ void CodeGenCPU::AddStartupFunction() {
 }
 
 llvm::Value* CodeGenCPU::CreateIntrinsic(const CallNode* op) {
-  ffi::Array<PrimExpr> args = op->args.as_or_throw<ffi::Array<PrimExpr>>();
+  const ffi::Array<Expr>& args = op->args;
   if (op->op.same_as(builtin::tvm_call_packed_lowered())) {
     return CreateCallPacked(op);
   } else if (op->op.same_as(builtin::tvm_call_trace_packed_lowered())) {
@@ -1052,8 +1052,8 @@ llvm::Value* CodeGenCPU::CreateIntrinsic(const CallNode* op) {
     TVM_FFI_ICHECK_EQ(args.size(), 4U);
     int kind = args[2].as<IntImm>().value()->value;
     llvm::Value* value = MakeValue(args[3]);
-    TypedPointer ref =
-        CreateStructRefPtr(args[3].ty(), MakeValue(args[0]), MakeValue(args[1]), kind);
+    TypedPointer ref = CreateStructRefPtr(args[3].as_or_throw<PrimExpr>().ty(),
+                                          MakeValue(args[0]), MakeValue(args[1]), kind);
     TVM_FFI_ICHECK(kind != builtin::kDLTensorAddr);
     if (value->getType()->isPointerTy()) {
       value = builder_->CreatePointerCast(value, ref.type);
@@ -1074,7 +1074,7 @@ llvm::Value* CodeGenCPU::CreateIntrinsic(const CallNode* op) {
     TVM_FFI_ICHECK_EQ(args.size(), 2U);
     std::string type = args[0].as<StringImm>().value()->value;
     return WithFunctionEntry([&]() -> llvm::AllocaInst* {
-      const int64_t* pval = as_const_int(args[1]);
+      const int64_t* pval = as_const_int(args[1].as_or_throw<PrimExpr>());
       TVM_FFI_ICHECK(pval) << "require stack alloca to contain constant value";
       llvm::Value* num = ConstInt32(pval[0]);
       if (type == "shape") {

--- a/src/target/llvm/codegen_cpu.cc
+++ b/src/target/llvm/codegen_cpu.cc
@@ -210,7 +210,8 @@ llvm::DISubprogram* CodeGenCPU::CreateDebugFunction(llvm::StringRef name,
 
 llvm::DISubprogram* CodeGenCPU::CreateDebugFunction(const GlobalVar& gvar, const PrimFunc& func) {
   std::string name = func->GetAttr<ffi::String>(tvm::attr::kGlobalSymbol).value_or(gvar->name_hint);
-  return CreateDebugFunction(name, func->params.Map(GetType), func->ret_type);
+  return CreateDebugFunction(
+      name, func->params.Map([](const Var& var) { return GetType(var); }), func->ret_type);
 }
 
 void CodeGenCPU::AddFunction(const GlobalVar& gvar, const PrimFunc& func) {
@@ -223,7 +224,7 @@ void CodeGenCPU::AddFunction(const GlobalVar& gvar, const PrimFunc& func) {
           std::make_pair(global_symbol.value().operator std::string(), function_));
     }
   }
-  AddDebugInformation(function_, func->params.Map(GetType));
+  AddDebugInformation(function_, func->params.Map([](const Var& var) { return GetType(var); }));
 }
 
 void CodeGenCPU::AddMainFunction(const std::string& entry_func_name) {
@@ -578,14 +579,16 @@ void CodeGenCPU::CreateComputeScope(const AttrStmtNode* op) {
 
   function_ = fcompute;
   di_subprogram_ =
-      CreateDebugFunction(MakeStringRef(value->value), vargs.Map(GetType), PrimType::Int(32));
+      CreateDebugFunction(MakeStringRef(value->value),
+                          vargs.Map([](const Var& var) { return GetType(var); }),
+                          PrimType::Int(32));
   auto* compute_entry = llvm::BasicBlock::Create(*ctx, "entry", function_);
   builder_->SetInsertPoint(compute_entry);
   this->VisitStmt(op->body);
   builder_->CreateRet(ConstInt32(0));
   builder_->SetInsertPoint(compute_call_end);
 
-  AddDebugInformation(fcompute, vargs.Map(GetType));
+  AddDebugInformation(fcompute, vargs.Map([](const Var& var) { return GetType(var); }));
 }
 
 CodeGenLLVM::TypedPointer CodeGenCPU::PackClosureData(const ffi::Array<Var>& vfields,

--- a/src/target/llvm/codegen_cpu.h
+++ b/src/target/llvm/codegen_cpu.h
@@ -75,7 +75,7 @@ class CodeGenCPU : public CodeGenLLVM {
   void VisitStmt_(const ForNode* op) override;
   llvm::Value* CreateIntrinsic(const CallNode* op) override;
   llvm::Value* CreateCallExtern(Type ret_type, ffi::String global_symbol,
-                                const ffi::Array<PrimExpr>& args, bool skip_first_arg) override;
+                                const ffi::Array<Expr>& args, bool skip_first_arg) override;
 
  protected:
   void AddStartupFunction() final;

--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -274,7 +274,7 @@ llvm::Function* CodeGenLLVM::DeclareFunctionInternal(const GlobalVar& gvar, cons
   std::vector<llvm::Type*> param_types;
   is_restricted_ = func->HasNonzeroAttr(tirx::attr::kNoAlias);
   for (Var param : func->params) {
-    param_types.push_back(GetLLVMType(param));
+    param_types.push_back(GetLLVMType(param->ty));
     if (!is_restricted_ && PrimType(param.ty()->dtype).IsHandle()) {
       alias_var_set_.insert(param.get());
     }
@@ -1079,7 +1079,7 @@ llvm::Value* CodeGenLLVM::CreateLookupReturnAddress(unsigned int level) {
 }
 
 llvm::Value* CodeGenLLVM::CreateCallExtern(Type ret_type, ffi::String global_symbol,
-                                           const ffi::Array<PrimExpr>& args, bool skip_first_arg) {
+                                           const ffi::Array<Expr>& args, bool skip_first_arg) {
   std::vector<llvm::Value*> arg_value;
   std::vector<llvm::Type*> arg_type;
   for (size_t i = static_cast<size_t>(skip_first_arg); i < args.size(); ++i) {
@@ -1356,8 +1356,8 @@ void CodeGenLLVM::EmitFloat16ConversionBuiltins(bool use_float16_abi) {
 }
 
 llvm::Value* CodeGenLLVM::CreateIntrinsic(const CallNode* op) {
-  ffi::Array<PrimExpr> args = op->args.as_or_throw<ffi::Array<PrimExpr>>();
-  PrimType ret_ty = op->ty.as_or_throw<PrimType>();
+  const ffi::Array<Expr>& args = op->args;
+  PrimType ret_ty(GetRuntimeDLDataType(op->ty));
   if (op->op.same_as(builtin_call_llvm_intrin_) || op->op.same_as(builtin_call_llvm_pure_intrin_)) {
     TVM_FFI_ICHECK_GE(args.size(), 1U);
     llvm::Intrinsic::ID id = static_cast<llvm::Intrinsic::ID>(args[0].as_or_throw<IntImm>()->value);
@@ -1395,7 +1395,7 @@ llvm::Value* CodeGenLLVM::CreateIntrinsic(const CallNode* op) {
   } else if (op->op.same_as(builtin::shift_left())) {
     return builder_->CreateShl(MakeValue(args[0]), MakeValue(args[1]));
   } else if (op->op.same_as(builtin::shift_right())) {
-    if (args[0].ty().MatchesCode(DLDataTypeCode::kDLInt)) {
+    if (args[0].as_or_throw<PrimExpr>().ty().MatchesCode(DLDataTypeCode::kDLInt)) {
       return builder_->CreateAShr(MakeValue(args[0]), MakeValue(args[1]));
     } else {
       return builder_->CreateLShr(MakeValue(args[0]), MakeValue(args[1]));
@@ -1420,7 +1420,8 @@ llvm::Value* CodeGenLLVM::CreateIntrinsic(const CallNode* op) {
         CreateBufferPtr(MakeValue(load->buffer->data), load->buffer->dtype, indices_val,
                         PrimType(load->ty.as_or_throw<PrimType>()->dtype));
     return buffer_ptr.addr;
-  } else if (op->op.same_as(builtin::reinterpret()) && is_zero(args[0])) {
+  } else if (op->op.same_as(builtin::reinterpret()) &&
+             is_zero(args[0].as_or_throw<PrimExpr>())) {
     return llvm::Constant::getNullValue(t_void_p_);
   } else if (op->op.same_as(builtin::isnullptr())) {
     return builder_->CreateIsNull(MakeValue(args[0]));
@@ -1435,7 +1436,8 @@ llvm::Value* CodeGenLLVM::CreateIntrinsic(const CallNode* op) {
     uint64_t val = (high << 32U) | low;
     return llvm::ConstantInt::get(DTypeToLLVMType(ret_ty), val);
   } else if (op->op.same_as(builtin::if_then_else())) {
-    TVM_FFI_ICHECK_EQ(args[0].ty().lanes(), 1) << "if_then_else can only take scalar condition";
+    TVM_FFI_ICHECK_EQ(args[0].as_or_throw<PrimExpr>().ty().lanes(), 1)
+        << "if_then_else can only take scalar condition";
     llvm::LLVMContext* ctx = llvm_target_->GetContext();
     auto* then_block = llvm::BasicBlock::Create(*ctx, "if_then", function_);
     auto* else_block = llvm::BasicBlock::Create(*ctx, "if_else", function_);
@@ -1881,7 +1883,7 @@ llvm::Value* CodeGenLLVM::VisitExpr_(const BufferLoadNode* op) {
 }
 
 llvm::Value* CodeGenLLVM::VisitExpr_(const CallNode* op) {
-  ffi::Array<PrimExpr> args = op->args.as_or_throw<ffi::Array<PrimExpr>>();
+  const ffi::Array<Expr>& args = op->args;
   if (auto opt_call_op = op->op.as<Op>()) {
     auto call_op = opt_call_op.value();
     if (op->op.same_as(builtin_call_extern_) || op->op.same_as(builtin_call_pure_extern_)) {
@@ -1904,7 +1906,7 @@ llvm::Value* CodeGenLLVM::VisitExpr_(const CallNode* op) {
     TVM_FFI_ICHECK(it != functions_.end()) << "Call to undefined GlobalVar \"" << gvar << "\"";
     llvm::Function* callee = it->second;
     std::vector<llvm::Value*> arg_value;
-    for (const PrimExpr& arg : args) {
+    for (const Expr& arg : args) {
       arg_value.push_back(MakeValue(arg));
     }
     return builder_->CreateCall(callee, arg_value);

--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -2176,11 +2176,11 @@ void CodeGenLLVM::VisitStmt_(const BindNode* op) {
   // Therefore, to have the correct LLVM type for pointers, we may
   // need to introduce a pointer-cast, even though pointer-to-pointer
   // casts are not expressible with the `tirx::CastNode`.
-  if (var_ty.IsHandle() && !v->type_annotation.IsMissing()) {
+  if (var_ty.IsHandle() && !v->ty.IsMissing()) {
     TVM_FFI_ICHECK(op->value.ty().IsHandle())
         << "Variable " << op->var << " is a pointer with type " << op->value
         << ", but is being bound to expression with type " << op->value.ty();
-    auto* llvm_type = GetLLVMType(v->type_annotation);
+    auto* llvm_type = GetLLVMType(v->ty);
     if (llvm_type != value->getType()) {
       value->setName((v->name_hint + "_void_ptr").c_str());
       value = builder_->CreatePointerCast(value, llvm_type);

--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -1420,8 +1420,8 @@ llvm::Value* CodeGenLLVM::CreateIntrinsic(const CallNode* op) {
         CreateBufferPtr(MakeValue(load->buffer->data), load->buffer->dtype, indices_val,
                         PrimType(load->ty.as_or_throw<PrimType>()->dtype));
     return buffer_ptr.addr;
-  } else if (op->op.same_as(builtin::reinterpret()) &&
-             is_zero(args[0].as_or_throw<PrimExpr>())) {
+  } else if (op->op.same_as(builtin::reinterpret()) && args[0].as<PrimExpr>() &&
+             is_zero(args[0].as<PrimExpr>().value())) {
     return llvm::Constant::getNullValue(t_void_p_);
   } else if (op->op.same_as(builtin::isnullptr())) {
     return builder_->CreateIsNull(MakeValue(args[0]));

--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -2164,8 +2164,11 @@ void CodeGenLLVM::VisitStmt_(const BindNode* op) {
   EmitDebugLocation(op);
   const VarNode* v = op->var.get();
   TVM_FFI_ICHECK(!var_map_.count(v));
-  PrimType var_ty = v->ty.as_or_throw<PrimType>();
-  if (var_ty.IsHandle()) {
+  Type var_ty = v->ty;
+  auto prim_var_ty = var_ty.as<PrimType>();
+  bool is_pointer = var_ty.as<PointerTypeNode>() ||
+                    (prim_var_ty && prim_var_ty.value().IsHandle());
+  if (is_pointer) {
     if (!is_restricted_) {
       alias_var_set_.insert(v);
     }
@@ -2176,10 +2179,12 @@ void CodeGenLLVM::VisitStmt_(const BindNode* op) {
   // Therefore, to have the correct LLVM type for pointers, we may
   // need to introduce a pointer-cast, even though pointer-to-pointer
   // casts are not expressible with the `tirx::CastNode`.
-  if (var_ty.IsHandle() && !v->ty.IsMissing()) {
-    TVM_FFI_ICHECK(op->value.ty().IsHandle())
+  if (is_pointer && !v->ty.IsMissing()) {
+    TVM_FFI_ICHECK(op->value->ty.as<PointerTypeNode>() ||
+                   (op->value->ty.as<PrimTypeNode>() &&
+                    op->value->ty.as_or_throw<PrimType>().IsHandle()))
         << "Variable " << op->var << " is a pointer with type " << op->value
-        << ", but is being bound to expression with type " << op->value.ty();
+        << ", but is being bound to expression with type " << op->value->ty;
     auto* llvm_type = GetLLVMType(v->ty);
     if (llvm_type != value->getType()) {
       value->setName((v->name_hint + "_void_ptr").c_str());
@@ -2189,7 +2194,9 @@ void CodeGenLLVM::VisitStmt_(const BindNode* op) {
 
   AddDebugInformation(value, op->var);
   var_map_[v] = value;
-  analyzer_->Bind(op->var, op->value);
+  if (auto prim_value = op->value.as<PrimExpr>()) {
+    analyzer_->Bind(op->var, prim_value.value());
+  }
   if (alloc_storage_info_.count(v) && alloc_storage_info_[v].alignment > 1) {
     builder_->CreateAlignmentAssumption(*data_layout_, GetVarValue(v),
                                         alloc_storage_info_[v].alignment);

--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -2168,8 +2168,7 @@ void CodeGenLLVM::VisitStmt_(const BindNode* op) {
   TVM_FFI_ICHECK(!var_map_.count(v));
   Type var_ty = v->ty;
   auto prim_var_ty = var_ty.as<PrimType>();
-  bool is_pointer = var_ty.as<PointerTypeNode>() ||
-                    (prim_var_ty && prim_var_ty.value().IsHandle());
+  bool is_pointer = var_ty.as<PointerTypeNode>() || (prim_var_ty && prim_var_ty.value().IsHandle());
   if (is_pointer) {
     if (!is_restricted_) {
       alias_var_set_.insert(v);
@@ -2182,9 +2181,9 @@ void CodeGenLLVM::VisitStmt_(const BindNode* op) {
   // need to introduce a pointer-cast, even though pointer-to-pointer
   // casts are not expressible with the `tirx::CastNode`.
   if (is_pointer && !v->ty.IsMissing()) {
-    TVM_FFI_ICHECK(op->value->ty.as<PointerTypeNode>() ||
-                   (op->value->ty.as<PrimTypeNode>() &&
-                    op->value->ty.as_or_throw<PrimType>().IsHandle()))
+    TVM_FFI_ICHECK(
+        op->value->ty.as<PointerTypeNode>() ||
+        (op->value->ty.as<PrimTypeNode>() && op->value->ty.as_or_throw<PrimType>().IsHandle()))
         << "Variable " << op->var << " is a pointer with type " << op->value
         << ", but is being bound to expression with type " << op->value->ty;
     auto* llvm_type = GetLLVMType(v->ty);

--- a/src/target/llvm/codegen_llvm.h
+++ b/src/target/llvm/codegen_llvm.h
@@ -292,7 +292,7 @@ class CodeGenLLVM : public ExprFunctor<llvm::Value*(const PrimExpr&)>,
   // create extern function call
   // skip first arg mode used for call extern intrinsic.
   virtual llvm::Value* CreateCallExtern(Type ret_type, ffi::String global_symbol,
-                                        const ffi::Array<PrimExpr>& args, bool skip_first_arg);
+                                        const ffi::Array<Expr>& args, bool skip_first_arg);
 
   /*! \brief Insert a printf() call to the generated LLVM
    *

--- a/src/target/llvm/codegen_llvm.h
+++ b/src/target/llvm/codegen_llvm.h
@@ -182,6 +182,13 @@ class CodeGenLLVM : public ExprFunctor<llvm::Value*(const PrimExpr&)>,
    * \return created value.
    */
   llvm::Value* MakeValue(const PrimExpr& e) { return VisitExpr(e); }
+  llvm::Value* MakeValue(const Expr& e) {
+    if (auto prim = e.as<PrimExpr>()) return MakeValue(prim.value());
+    if (const auto* var = e.as<VarNode>()) return GetVarValue(var);
+    if (const auto* call = e.as<CallNode>()) return VisitExpr_(call);
+    TVM_FFI_THROW(TypeError) << "Cannot lower non-primitive expression " << e->GetTypeKey();
+    TVM_FFI_UNREACHABLE();
+  }
   // Short hande code to get a constant int 32
   llvm::Constant* ConstInt32(int64_t value) const {
     return llvm::ConstantInt::getSigned(t_int32_, value);

--- a/src/target/source/codegen_c.cc
+++ b/src/target/source/codegen_c.cc
@@ -109,7 +109,8 @@ void CodeGenC::PrintFunctionSignature(const ffi::String& function_name, const Pr
     }
 
     bool no_alias = func->HasNonzeroAttr(tirx::attr::kNoAlias);
-    bool is_handle = v.ty().IsHandle();
+    bool is_handle = v->ty.as<PointerTypeNode>() ||
+                     (v->ty.as<PrimTypeNode>() && v.ty().IsHandle());
     auto* ptr = v->ty.as<PointerTypeNode>();
     if (ptr && ptr->element_type.as<TensorMapTypeNode>()) {
       is_handle = false;
@@ -208,6 +209,19 @@ void CodeGenC::PrintExpr(const PrimExpr& n, std::ostream& os) {  // NOLINT(*)
     os << SSAGetID(temp.str(), n.ty());
   } else {
     VisitExpr(n, os);
+  }
+}
+
+void CodeGenC::PrintExpr(const Expr& n, std::ostream& os) {  // NOLINT(*)
+  if (auto prim = n.as<PrimExpr>()) {
+    PrintExpr(prim.value(), os);
+  } else if (auto* var = n.as<VarNode>()) {
+    VisitExpr_(var, os);
+  } else if (auto* call = n.as<CallNode>()) {
+    VisitExpr_(call, os);
+  } else {
+    TVM_FFI_THROW(TypeError) << "CodeGenC cannot print non-primitive expression "
+                             << n.GetTypeKey();
   }
 }
 
@@ -399,11 +413,11 @@ void CodeGenC::RegisterHandleType(const VarNode* buf_var, const PrimType& t) {
   }
 }
 
-void CodeGenC::RegisterHandleTypeFromPointer(const tirx::Var& var, const PrimExpr* value) {
+void CodeGenC::RegisterHandleTypeFromPointer(const tirx::Var& var, const Expr* value) {
   if (value == nullptr) return;
   auto* call = value->as<CallNode>();
   if (call == nullptr || !call->op.same_as(builtin::ptr_byte_offset())) return;
-  std::optional<PrimType> value_dtype = tirx::GetPointerType(GetType(*value));
+  std::optional<PrimType> value_dtype = tirx::GetPointerType((*value)->ty);
   if (!value_dtype.has_value()) return;
   RegisterHandleType(var.get(), value_dtype.value());
   pointer_offset_vars_.insert(var.get());
@@ -996,13 +1010,13 @@ void CodeGenC::VisitExpr_(const LetNode* op, std::ostream& os) {  // NOLINT(*)
     var_idmap_[op->var.get()] = value;
   } else {
     PrintIndent();
-    if (op->var.ty().IsHandle() && handle_data_type_.count(op->var.get())) {
+    if (op->var->ty.as<PointerTypeNode>() && handle_data_type_.count(op->var.get())) {
       PrintType(handle_data_type_.at(op->var.get()), this->stream);
       this->stream << "* " << AllocVarID(op->var.get()) << " = (";
       PrintType(handle_data_type_.at(op->var.get()), this->stream);
       this->stream << "*)" << value << ";\n";
     } else {
-      PrintType(op->var.ty(), this->stream);
+      PrintType(GetType(op->var), this->stream);
       this->stream << ' ' << AllocVarID(op->var.get()) << " = " << value << ";\n";
     }
   }
@@ -1121,13 +1135,13 @@ void CodeGenC::VisitStmt_(const BindNode* op) {
     var_idmap_[op->var.get()] = value;
   } else {
     PrintIndent();
-    if (op->var.ty().IsHandle() && handle_data_type_.count(op->var.get())) {
+    if (op->var->ty.as<PointerTypeNode>() && handle_data_type_.count(op->var.get())) {
       PrintType(handle_data_type_.at(op->var.get()), stream);
       stream << "* " << AllocVarID(op->var.get()) << " = (";
       PrintType(handle_data_type_.at(op->var.get()), stream);
       stream << "*)" << value << ";\n";
     } else {
-      PrintType(op->var.ty(), this->stream);
+      PrintType(GetType(op->var), this->stream);
       this->stream << ' ' << AllocVarID(op->var.get()) << " = " << value << ";\n";
     }
   }

--- a/src/target/source/codegen_c.cc
+++ b/src/target/source/codegen_c.cc
@@ -97,7 +97,7 @@ void CodeGenC::PrintFunctionSignature(const ffi::String& function_name, const Pr
     }
 
     auto is_tensormap_ptr = [&]() -> bool {
-      if (auto* ptr = v->type_annotation.as<PointerTypeNode>()) {
+      if (auto* ptr = v->ty.as<PointerTypeNode>()) {
         return ptr->element_type.as<TensorMapTypeNode>();
       }
       return false;
@@ -110,7 +110,7 @@ void CodeGenC::PrintFunctionSignature(const ffi::String& function_name, const Pr
 
     bool no_alias = func->HasNonzeroAttr(tirx::attr::kNoAlias);
     bool is_handle = v.ty().IsHandle();
-    auto* ptr = v->type_annotation.as<PointerTypeNode>();
+    auto* ptr = v->ty.as<PointerTypeNode>();
     if (ptr && ptr->element_type.as<TensorMapTypeNode>()) {
       is_handle = false;
     }
@@ -126,7 +126,7 @@ void CodeGenC::PrintFunctionSignature(const ffi::String& function_name, const Pr
   // TODO(tvm-team): consider simply keep type info in the
   // type annotation(via a normalizing rewriting).
   for (const auto& param : func->params) {
-    if (auto* ptr = param->type_annotation.as<PointerTypeNode>()) {
+    if (auto* ptr = param->ty.as<PointerTypeNode>()) {
       if (auto* prim = ptr->element_type.as<PrimTypeNode>()) {
         RegisterHandleType(param.get(), ffi::GetRef<PrimType>(prim));
       }
@@ -745,7 +745,7 @@ void CodeGenC::VisitExpr_(const CallNode* op, std::ostream& os) {  // NOLINT(*)
         TVM_FFI_ICHECK(var)
             << "Builtin address_of() expects the argument to be a BufferLoad or Var, but "
             << "received argument " << op->args[0];
-        if (auto* ptr = var->type_annotation.as<PointerTypeNode>()) {
+        if (auto* ptr = var->ty.as<PointerTypeNode>()) {
           if (ptr->element_type.as<TensorMapTypeNode>()) {
             os << "((unsigned long long)(&(";
             this->PrintExpr(op->args[0], os);

--- a/src/target/source/codegen_c.cc
+++ b/src/target/source/codegen_c.cc
@@ -109,8 +109,7 @@ void CodeGenC::PrintFunctionSignature(const ffi::String& function_name, const Pr
     }
 
     bool no_alias = func->HasNonzeroAttr(tirx::attr::kNoAlias);
-    bool is_handle = v->ty.as<PointerTypeNode>() ||
-                     (v->ty.as<PrimTypeNode>() && v.ty().IsHandle());
+    bool is_handle = v->ty.as<PointerTypeNode>() || (v->ty.as<PrimTypeNode>() && v.ty().IsHandle());
     auto* ptr = v->ty.as<PointerTypeNode>();
     if (ptr && ptr->element_type.as<TensorMapTypeNode>()) {
       is_handle = false;
@@ -220,8 +219,7 @@ void CodeGenC::PrintExpr(const Expr& n, std::ostream& os) {  // NOLINT(*)
   } else if (auto* call = n.as<CallNode>()) {
     VisitExpr_(call, os);
   } else {
-    TVM_FFI_THROW(TypeError) << "CodeGenC cannot print non-primitive expression "
-                             << n.GetTypeKey();
+    TVM_FFI_THROW(TypeError) << "CodeGenC cannot print non-primitive expression " << n.GetTypeKey();
   }
 }
 
@@ -417,7 +415,12 @@ void CodeGenC::RegisterHandleTypeFromPointer(const tirx::Var& var, const Expr* v
   if (value == nullptr) return;
   auto* call = value->as<CallNode>();
   if (call == nullptr || !call->op.same_as(builtin::ptr_byte_offset())) return;
-  std::optional<PrimType> value_dtype = tirx::GetPointerType((*value)->ty);
+  std::optional<PrimType> value_dtype = [&]() {
+    if (auto prim_value = value->as<PrimExpr>()) {
+      return tirx::GetPointerType(GetType(prim_value.value()));
+    }
+    return tirx::GetPointerType((*value)->ty);
+  }();
   if (!value_dtype.has_value()) return;
   RegisterHandleType(var.get(), value_dtype.value());
   pointer_offset_vars_.insert(var.get());
@@ -1010,7 +1013,9 @@ void CodeGenC::VisitExpr_(const LetNode* op, std::ostream& os) {  // NOLINT(*)
     var_idmap_[op->var.get()] = value;
   } else {
     PrintIndent();
-    if (op->var->ty.as<PointerTypeNode>() && handle_data_type_.count(op->var.get())) {
+    bool is_pointer = op->var->ty.as<PointerTypeNode>() ||
+                      (op->var->ty.as<PrimTypeNode>() && op->var.ty().IsHandle());
+    if (is_pointer && handle_data_type_.count(op->var.get())) {
       PrintType(handle_data_type_.at(op->var.get()), this->stream);
       this->stream << "* " << AllocVarID(op->var.get()) << " = (";
       PrintType(handle_data_type_.at(op->var.get()), this->stream);
@@ -1135,7 +1140,9 @@ void CodeGenC::VisitStmt_(const BindNode* op) {
     var_idmap_[op->var.get()] = value;
   } else {
     PrintIndent();
-    if (op->var->ty.as<PointerTypeNode>() && handle_data_type_.count(op->var.get())) {
+    bool is_pointer = op->var->ty.as<PointerTypeNode>() ||
+                      (op->var->ty.as<PrimTypeNode>() && op->var.ty().IsHandle());
+    if (is_pointer && handle_data_type_.count(op->var.get())) {
       PrintType(handle_data_type_.at(op->var.get()), stream);
       stream << "* " << AllocVarID(op->var.get()) << " = (";
       PrintType(handle_data_type_.at(op->var.get()), stream);

--- a/src/target/source/codegen_c.h
+++ b/src/target/source/codegen_c.h
@@ -108,7 +108,7 @@ class CodeGenC : public ExprFunctor<void(const PrimExpr&, std::ostream&)>,
    * \param os The output stream
    */
   void PrintExpr(const PrimExpr& n, std::ostream& os);
-  void PrintExpr(const Expr& n, std::ostream& os) { PrintExpr(n.as_or_throw<PrimExpr>(), os); }
+  void PrintExpr(const Expr& n, std::ostream& os);
   /*!
    * \brief Same as PrintExpr, but simply returns result string
    * \param n The expression to be printed.
@@ -118,7 +118,11 @@ class CodeGenC : public ExprFunctor<void(const PrimExpr&, std::ostream&)>,
     PrintExpr(n, os);
     return os.str();
   }
-  std::string PrintExpr(const Expr& n) { return PrintExpr(n.as_or_throw<PrimExpr>()); }
+  std::string PrintExpr(const Expr& n) {
+    std::ostringstream os;
+    PrintExpr(n, os);
+    return os.str();
+  }
 
   // The following parts are overloadable print operations.
 
@@ -316,7 +320,7 @@ class CodeGenC : public ExprFunctor<void(const PrimExpr&, std::ostream&)>,
    * code shape.  Only explicit pointer-offset values opt into typed pointer
    * arithmetic.
    */
-  void RegisterHandleTypeFromPointer(const tirx::Var& var, const PrimExpr* value);
+  void RegisterHandleTypeFromPointer(const tirx::Var& var, const Expr* value);
   // override
   void PrintSSAAssign(const std::string& target, const std::string& src,
                       const PrimType& t) override;

--- a/src/te/tensor.cc
+++ b/src/te/tensor.cc
@@ -73,7 +73,8 @@ inline PrimExpr Tensor::IndexTensor(ffi::Array<PrimExpr> indices,
 }
 
 PrimExpr Tensor::operator()(ffi::Array<Var> indices) const {
-  ffi::Array<PrimExpr> arr(indices.begin(), indices.end());
+  ffi::Array<PrimExpr> arr =
+      indices.Map([](const Var& var) { return var.as_or_throw<PrimExpr>(); });
   return operator()(arr);
 }
 
@@ -82,7 +83,8 @@ PrimExpr Tensor::operator()(ffi::Array<PrimExpr> indices) const {
 }
 
 PrimExpr Tensor::IndexWithNegativeIndices(ffi::Array<Var> indices) const {
-  ffi::Array<PrimExpr> arr(indices.begin(), indices.end());
+  ffi::Array<PrimExpr> arr =
+      indices.Map([](const Var& var) { return var.as_or_throw<PrimExpr>(); });
   return IndexWithNegativeIndices(arr);
 }
 

--- a/src/tirx/analysis/deep_equal.cc
+++ b/src/tirx/analysis/deep_equal.cc
@@ -87,8 +87,7 @@ class ExprDeepEqualChecker : private ExprFunctor<bool(const PrimExpr&, const Pri
     if (auto* lhs_call = lhs.as<CallNode>()) {
       auto* rhs_call = rhs.as<CallNode>();
       return ffi::StructuralEqual()(lhs_call->ty, rhs_call->ty) &&
-             lhs_call->op.same_as(rhs_call->op) &&
-             ArrayDeepEqual(lhs_call->args, rhs_call->args) &&
+             lhs_call->op.same_as(rhs_call->op) && ArrayDeepEqual(lhs_call->args, rhs_call->args) &&
              ffi::StructuralEqual()(lhs_call->attrs, rhs_call->attrs);
     }
     return false;

--- a/src/tirx/analysis/deep_equal.cc
+++ b/src/tirx/analysis/deep_equal.cc
@@ -65,7 +65,33 @@ class ExprDeepEqualChecker : private ExprFunctor<bool(const PrimExpr&, const Pri
     if (!lhs.defined() && rhs.defined()) return false;
     if (!rhs.defined() && lhs.defined()) return false;
     if (lhs->type_index() != rhs->type_index()) return false;
+    // Arithmetic analyzers use private PrimExpr subclasses that are not part
+    // of the TIR expression functor's dispatch table.
+    if (lhs->GetTypeKey().rfind("arith.", 0) == 0) {
+      return ffi::StructuralEqual()(lhs, rhs);
+    }
     return ExprFunctor::VisitExpr(lhs, rhs);
+  }
+
+  bool VisitExpr(const Expr& lhs, const Expr& rhs) {
+    if (lhs.same_as(rhs)) return true;
+    if (!lhs.defined() || !rhs.defined()) return false;
+    if (lhs->type_index() != rhs->type_index()) return false;
+    if (auto lhs_prim = lhs.as<PrimExpr>()) {
+      auto rhs_prim = rhs.as<PrimExpr>();
+      return rhs_prim && VisitExpr(lhs_prim.value(), rhs_prim.value());
+    }
+    if (lhs.as<VarNode>()) {
+      return false;
+    }
+    if (auto* lhs_call = lhs.as<CallNode>()) {
+      auto* rhs_call = rhs.as<CallNode>();
+      return ffi::StructuralEqual()(lhs_call->ty, rhs_call->ty) &&
+             lhs_call->op.same_as(rhs_call->op) &&
+             ArrayDeepEqual(lhs_call->args, rhs_call->args) &&
+             ffi::StructuralEqual()(lhs_call->attrs, rhs_call->attrs);
+    }
+    return false;
   }
 
  private:
@@ -80,7 +106,7 @@ class ExprDeepEqualChecker : private ExprFunctor<bool(const PrimExpr&, const Pri
   bool ArrayDeepEqual(const ffi::Array<Expr>& lhs, const ffi::Array<Expr>& rhs) {
     if (lhs.size() != rhs.size()) return false;
     for (size_t i = 0; i < lhs.size(); i++) {
-      if (!VisitExpr(lhs[i].as_or_throw<PrimExpr>(), rhs[i].as_or_throw<PrimExpr>())) return false;
+      if (!VisitExpr(lhs[i], rhs[i])) return false;
     }
     return true;
   }

--- a/src/tirx/analysis/verify_memory.cc
+++ b/src/tirx/analysis/verify_memory.cc
@@ -160,8 +160,8 @@ class MemoryAccessVerifier final : protected StmtExprVisitor {
   bool in_thread_env_{false};
   std::vector<ffi::String> errs_;
   //@}
-  tirx::PrimFunc func_{nullptr};                       ///< Function to be verified.
-  int dev_type_{kDLCPU};                               ///< Device type
+  tirx::PrimFunc func_{nullptr};                   ///< Function to be verified.
+  int dev_type_{kDLCPU};                           ///< Device type
   std::unordered_map<const VarNode*, Expr> defs_;  ///< Variable definitions
 };
 }  // namespace

--- a/src/tirx/analysis/verify_memory.cc
+++ b/src/tirx/analysis/verify_memory.cc
@@ -162,7 +162,7 @@ class MemoryAccessVerifier final : protected StmtExprVisitor {
   //@}
   tirx::PrimFunc func_{nullptr};                       ///< Function to be verified.
   int dev_type_{kDLCPU};                               ///< Device type
-  std::unordered_map<const VarNode*, PrimExpr> defs_;  ///< Variable definitions
+  std::unordered_map<const VarNode*, Expr> defs_;  ///< Variable definitions
 };
 }  // namespace
 

--- a/src/tirx/analysis/verify_ssa.cc
+++ b/src/tirx/analysis/verify_ssa.cc
@@ -58,7 +58,7 @@ class SSAVerifier final : public StmtExprVisitor {
     // (let x = 1 in x + 1) * (let x = 1 in x + 1)
     auto it = def_map_.find(op->var);
     if (it != def_map_.end()) {
-      if (!deep_equal_(it->second, op->value)) {
+      if (!deep_equal_(it->second.as_or_throw<PrimExpr>(), op->value)) {
         is_ssa_ = false;
         return;
       }
@@ -117,7 +117,7 @@ class SSAVerifier final : public StmtExprVisitor {
   }
 
  private:
-  void MarkDef(const Var& var, PrimExpr value, bool allow_dup = false) {
+  void MarkDef(const Var& var, Expr value, bool allow_dup = false) {
     if (def_map_.count(var) != 0) {
       if (!allow_dup) {
         is_ssa_ = false;
@@ -132,7 +132,7 @@ class SSAVerifier final : public StmtExprVisitor {
   // deep equal
   ExprDeepEqual deep_equal_;
   // def map, for let, maps to the bind value, for others maps to self.
-  std::unordered_map<Var, PrimExpr> def_map_;
+  std::unordered_map<Var, Expr> def_map_;
 };
 
 bool VerifySSA(const PrimFunc& func) {

--- a/src/tirx/ir/buffer.cc
+++ b/src/tirx/ir/buffer.cc
@@ -478,7 +478,7 @@ Stmt Buffer::vstore(ffi::Array<PrimExpr> begin, PrimExpr value,
 }
 
 ffi::String Buffer::scope() const {
-  const auto* ptr_type = (*this)->data->type_annotation.as<PointerTypeNode>();
+  const auto* ptr_type = (*this)->data->ty.as<PointerTypeNode>();
   TVM_FFI_ICHECK(ptr_type) << "Buffer variable is not of pointer type";
   if (ptr_type->storage_scope.empty()) {
     return "global";
@@ -597,11 +597,11 @@ Buffer::Buffer(Var data, PrimType dtype, ffi::Array<PrimExpr> shape, ffi::Array<
   // TODO(Lunderberg): Use an explicit pointer cast for the data
   // pointer.  Should be done alongside extensions to StmtExprMutator
   // to more easily handle buffer/buffer_var updates.
-  TVM_FFI_ICHECK(!data->type_annotation.IsMissing())
+  TVM_FFI_ICHECK(!data->ty.IsMissing())
       << "Variable " << data->name_hint << " is missing a type annotation.";
-  TVM_FFI_ICHECK(data->type_annotation.as<PointerTypeNode>())
+  TVM_FFI_ICHECK(data->ty.as<PointerTypeNode>())
       << "Variable " << data->name_hint << " is not a pointer.";
-  TVM_FFI_ICHECK(data->type_annotation.as<PointerTypeNode>()->element_type.as<PrimTypeNode>())
+  TVM_FFI_ICHECK(data->ty.as<PointerTypeNode>()->element_type.as<PrimTypeNode>())
       << "Variable " << data->name_hint << " does not point to a primitive.";
 
   ValidateAxisSeparators(axis_separators, shape.size());

--- a/src/tirx/ir/buffer.cc
+++ b/src/tirx/ir/buffer.cc
@@ -574,8 +574,7 @@ PrimExpr Buffer::access_ptr(int access_mask, PrimType ptr_type, int content_lane
   if (input_extent.defined()) {
     extent = input_extent.value();
   }
-  ffi::Array<PrimExpr> acc_args{e_dtype, self->data, elem_offset, extent,
-                                IntImm::Int32(access_mask)};
+  ffi::Array<Expr> acc_args{e_dtype, self->data, elem_offset, extent, IntImm::Int32(access_mask)};
   return Call(ptr_type, tirx::builtin::tvm_access_ptr(), acc_args).as_or_throw<PrimExpr>();
 }
 

--- a/src/tirx/ir/data_type_rewriter.cc
+++ b/src/tirx/ir/data_type_rewriter.cc
@@ -46,7 +46,7 @@ Stmt DataTypeLegalizer::VisitStmt_(const ForNode* op) {
   Stmt s = StmtExprMutator::VisitStmt_(op);
   op = s.as<ForNode>();
   TVM_FFI_ICHECK(op != nullptr) << "Expected type to be ForNode, but get " << s->GetTypeKey();
-  PrimExpr e = VisitExpr(op->loop_var);
+  PrimExpr e = VisitExpr(op->loop_var).as_or_throw<PrimExpr>();
   Var var = e.as_or_throw<Var>();
   auto n = CopyOnWrite(op);
   n->min = cast(var.ty(), op->min);
@@ -105,7 +105,7 @@ Stmt DataTypeLegalizer::VisitStmt_(const AttrStmtNode* op) {
     const IterVarNode* iv = op->node.as<IterVarNode>();
     TVM_FFI_ICHECK(iv != nullptr) << "Expected type to be IterVarNode"
                                   << ", but get " << op->node.GetTypeKey();
-    PrimExpr e = VisitExpr(iv->var);
+    PrimExpr e = VisitExpr(iv->var).as_or_throw<PrimExpr>();
     Var var = e.as_or_throw<Var>();
     if (ivmap_.find(iv) == ivmap_.end()) {
       Range dom = iv->dom;

--- a/src/tirx/ir/data_type_rewriter.cc
+++ b/src/tirx/ir/data_type_rewriter.cc
@@ -145,12 +145,14 @@ PrimExpr DataTypeLegalizer::VisitExpr_(const LetNode* op) {
 }
 
 Stmt DataTypeLegalizer::VisitStmt_(const BindNode* op) {
-  PrimExpr value = this->VisitExpr(op->value);
+  Expr value = this->VisitExpr(op->value);
   Var var = op->var;
 
-  if (value.ty() != op->var.ty()) {
-    var = op->var.copy_with_dtype(value.ty());
-    var_remap_[op->var.get()] = var;
+  if (auto prim_value = value.as<PrimExpr>()) {
+    if (prim_value.value().ty() != op->var.ty()) {
+      var = op->var.copy_with_dtype(prim_value.value().ty());
+      var_remap_[op->var.get()] = var;
+    }
   }
 
   if (value.same_as(op->value) && var.same_as(op->var)) {
@@ -551,7 +553,7 @@ Stmt IndexDataTypeRewriter::VisitStmt_(const BindNode* op) {
   }
   bool is_enabled = is_enabled_;
   is_enabled_ = true;
-  PrimExpr value = VisitExpr(op->value);
+  PrimExpr value = VisitExpr(op->value).as_or_throw<PrimExpr>();
   Var var = var_remap_[bind_stmt->var.get()];
   is_enabled_ = is_enabled;
   TVM_FFI_ICHECK(value.ty() == var.ty());

--- a/src/tirx/ir/expr.cc
+++ b/src/tirx/ir/expr.cc
@@ -160,7 +160,6 @@ TVM_FFI_STATIC_INIT_BLOCK() {
 Var::Var(ffi::String name_hint, PrimType dtype, Span span) {
   auto n = ffi::make_object<VarNode>();
   n->name_hint = std::move(name_hint);
-  n->type_annotation = dtype;
   n->ExprNode::ty = dtype;
   n->span = std::move(span);
   data_ = std::move(n);
@@ -169,12 +168,7 @@ Var::Var(ffi::String name_hint, PrimType dtype, Span span) {
 Var::Var(ffi::String name_hint, Type type_annotation, Span span) {
   auto n = ffi::make_object<VarNode>();
   n->name_hint = std::move(name_hint);
-  n->type_annotation = std::move(type_annotation);
-  if (n->type_annotation.as<PrimTypeNode>()) {
-    n->ExprNode::ty = n->type_annotation;
-  } else {
-    n->ExprNode::ty = PrimType(GetRuntimeDLDataType(n->type_annotation));
-  }
+  n->ExprNode::ty = std::move(type_annotation);
   n->span = std::move(span);
   data_ = std::move(n);
 }
@@ -203,7 +197,6 @@ Var Var::copy_with_dtype(PrimType dtype) const {
   } else {
     new_ptr = ffi::make_object<VarNode>(*node);
   }
-  new_ptr->type_annotation = dtype;
   new_ptr->ExprNode::ty = dtype;
   return Var(new_ptr);
 }
@@ -223,8 +216,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
 SizeVar::SizeVar(ffi::String name_hint, PrimType dtype, Span span) {
   auto n = ffi::make_object<SizeVarNode>();
   n->name_hint = std::move(name_hint);
-  n->type_annotation = dtype;
-  n->ExprNode::ty = n->type_annotation;
+  n->ExprNode::ty = dtype;
   n->span = std::move(span);
   data_ = std::move(n);
 }
@@ -232,8 +224,7 @@ SizeVar::SizeVar(ffi::String name_hint, PrimType dtype, Span span) {
 SizeVar::SizeVar(ffi::String name_hint, Type type_annotation, Span span) {
   auto n = ffi::make_object<SizeVarNode>();
   n->name_hint = std::move(name_hint);
-  n->type_annotation = std::move(type_annotation);
-  n->ExprNode::ty = PrimType(GetRuntimeDLDataType(n->type_annotation));
+  n->ExprNode::ty = std::move(type_annotation);
   n->span = std::move(span);
   data_ = std::move(n);
 }

--- a/src/tirx/ir/expr_functor.cc
+++ b/src/tirx/ir/expr_functor.cc
@@ -27,6 +27,31 @@
 namespace tvm {
 namespace tirx {
 
+void ExprVisitor::VisitExpr(const Expr& expr) {
+  if (auto prim = expr.as<PrimExpr>()) {
+    return ExprFunctor::VisitExpr(prim.value());
+  }
+  if (const auto* op = expr.as<SizeVarNode>()) return VisitExpr_(op);
+  if (const auto* op = expr.as<VarNode>()) return VisitExpr_(op);
+  if (const auto* op = expr.as<CallNode>()) return VisitExpr_(op);
+  if (const auto* op = expr.as<StringImmNode>()) return VisitExpr_(op);
+  TVM_FFI_THROW(TypeError) << "Unsupported non-primitive expression: " << expr->GetTypeKey();
+}
+
+Expr ExprMutator::VisitExpr(const Expr& expr) {
+  if (auto prim = expr.as<PrimExpr>()) {
+    return ExprFunctor::VisitExpr(prim.value());
+  }
+  if (expr.as<VarNode>() || expr.as<StringImmNode>()) return expr;
+  if (const auto* op = expr.as<CallNode>()) {
+    ffi::Array<Expr> args =
+        op->args.Map([this](const Expr& arg) -> Expr { return this->VisitExpr(arg); });
+    if (args.same_as(op->args)) return expr;
+    return Call(op->ty, op->op, args, op->attrs, op->ty_args, op->span);
+  }
+  TVM_FFI_THROW(TypeError) << "Unsupported non-primitive expression: " << expr->GetTypeKey();
+}
+
 void ExprVisitor::VisitExpr_(const VarNode* op) {}
 
 void ExprVisitor::VisitExpr_(const SizeVarNode* op) {
@@ -47,7 +72,7 @@ void ExprVisitor::VisitExpr_(const LetNode* op) {
 }
 
 void ExprVisitor::VisitExpr_(const CallNode* op) {
-  VisitArray(op->args, [this](const Expr& e) { this->VisitExpr(e.as_or_throw<PrimExpr>()); });
+  VisitArray(op->args, [this](const Expr& e) { this->VisitExpr(e); });
 }
 
 #define DEFINE_BINOP_VISIT_(OP)                \
@@ -150,7 +175,7 @@ PrimExpr ExprMutator::VisitExpr_(const LetNode* op) {
 
 PrimExpr ExprMutator::VisitExpr_(const CallNode* op) {
   ffi::Array<Expr> args = op->args.Map(
-      [this](const Expr& arg) -> Expr { return this->VisitExpr(arg.as_or_throw<PrimExpr>()); });
+      [this](const Expr& arg) -> Expr { return this->VisitExpr(arg); });
 
   if (args.same_as(op->args)) {
     return ffi::GetRef<Call>(op).as_or_throw<PrimExpr>();

--- a/src/tirx/ir/expr_functor.cc
+++ b/src/tirx/ir/expr_functor.cc
@@ -42,7 +42,9 @@ Expr ExprMutator::VisitExpr(const Expr& expr) {
   if (auto prim = expr.as<PrimExpr>()) {
     return this->VisitExpr(prim.value());
   }
-  if (expr.as<VarNode>() || expr.as<StringImmNode>()) return expr;
+  if (const auto* op = expr.as<SizeVarNode>()) return VisitExpr(ffi::GetRef<SizeVar>(op));
+  if (const auto* op = expr.as<VarNode>()) return VisitExpr(ffi::GetRef<Var>(op));
+  if (expr.as<StringImmNode>()) return expr;
   if (const auto* op = expr.as<CallNode>()) {
     ffi::Array<Expr> args =
         op->args.Map([this](const Expr& arg) -> Expr { return this->VisitExpr(arg); });
@@ -174,8 +176,8 @@ PrimExpr ExprMutator::VisitExpr_(const LetNode* op) {
 }
 
 PrimExpr ExprMutator::VisitExpr_(const CallNode* op) {
-  ffi::Array<Expr> args = op->args.Map(
-      [this](const Expr& arg) -> Expr { return this->VisitExpr(arg); });
+  ffi::Array<Expr> args =
+      op->args.Map([this](const Expr& arg) -> Expr { return this->VisitExpr(arg); });
 
   if (args.same_as(op->args)) {
     return ffi::GetRef<Call>(op).as_or_throw<PrimExpr>();

--- a/src/tirx/ir/expr_functor.cc
+++ b/src/tirx/ir/expr_functor.cc
@@ -29,7 +29,7 @@ namespace tirx {
 
 void ExprVisitor::VisitExpr(const Expr& expr) {
   if (auto prim = expr.as<PrimExpr>()) {
-    return ExprFunctor::VisitExpr(prim.value());
+    return this->VisitExpr(prim.value());
   }
   if (const auto* op = expr.as<SizeVarNode>()) return VisitExpr_(op);
   if (const auto* op = expr.as<VarNode>()) return VisitExpr_(op);
@@ -40,7 +40,7 @@ void ExprVisitor::VisitExpr(const Expr& expr) {
 
 Expr ExprMutator::VisitExpr(const Expr& expr) {
   if (auto prim = expr.as<PrimExpr>()) {
-    return ExprFunctor::VisitExpr(prim.value());
+    return this->VisitExpr(prim.value());
   }
   if (expr.as<VarNode>() || expr.as<StringImmNode>()) return expr;
   if (const auto* op = expr.as<CallNode>()) {

--- a/src/tirx/ir/function.cc
+++ b/src/tirx/ir/function.cc
@@ -49,7 +49,7 @@ tvm::Type InferType(const PrimFunc& prim_func) {
         return relax::TensorType(shape, buf->dtype);
       }
 
-      if (auto prim_type = param->type_annotation.as<PrimTypeNode>()) {
+      if (auto prim_type = param->ty.as<PrimTypeNode>()) {
         const DLDataType& dtype = prim_type->dtype;
         if (dtype.code == kDLOpaqueHandle && (dtype.bits != 0 || dtype.lanes != 0)) {
           return relax::AnyType();

--- a/src/tirx/ir/index_map.cc
+++ b/src/tirx/ir/index_map.cc
@@ -105,8 +105,10 @@ std::pair<IndexMap, PrimExpr> IndexMapInverseImpl(const IndexMap& self,
 
   // Determine expressions for the input variables, in terms of the
   // output variables.
-  ffi::Map<Var, PrimExpr> inverse_exprs_map = InverseAffineIterMap(
-      padded_iter_map->indices, ffi::Array<PrimExpr>(output_vars.begin(), output_vars.end()));
+  ffi::Array<PrimExpr> prim_output_vars =
+      output_vars.Map([](const Var& var) { return var.as_or_throw<PrimExpr>(); });
+  ffi::Map<Var, PrimExpr> inverse_exprs_map =
+      InverseAffineIterMap(padded_iter_map->indices, prim_output_vars);
 
   // Unpack the map to an array, maintaining the same parameter order.
   ffi::Array<PrimExpr> inverse_exprs;

--- a/src/tirx/ir/specialize.cc
+++ b/src/tirx/ir/specialize.cc
@@ -183,6 +183,7 @@ class PrimFuncSpecializer : public StmtExprMutator {
   Buffer VisitBufferUse(const Buffer& buffer) final { return GetNewBuffer(buffer); }
 
   using StmtExprMutator::VisitExpr;
+  Expr VisitExpr(const Var& var) { return VisitExpr(static_cast<const Expr&>(var)); }
   Expr VisitExpr(const Expr& expr) final {
     if (auto var = expr.as<Var>()) {
       auto it = var_map_.find(var.value());
@@ -421,7 +422,7 @@ void UpdateSpecializeVarMap(const PrimFunc& func, const Var& param, const Buffer
  * \param specific_expr The parameter value.
  * \param var_map The var mapping to be updated.
  */
-void UpdateSpecializeVarMap(const PrimFunc& func, const Var& param, const PrimExpr& specific_expr,
+void UpdateSpecializeVarMap(const PrimFunc& func, const Var& param, const Expr& specific_expr,
                             VarMap* var_map) {
   // check param is in PrimFunc's parameters
   TVM_FFI_CHECK(IsParam(func, param), ValueError)
@@ -455,7 +456,24 @@ PrimFunc Specialize(PrimFunc func, const ffi::Map<Var, ffi::Variant<Buffer, Prim
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
-  refl::GlobalDef().def("tirx.Specialize", Specialize);
+  refl::GlobalDef().def(
+      "tirx.Specialize", [](PrimFunc func, const ffi::Map<Var, ffi::Any>& param_map) {
+        VarMap var_map;
+        for (const auto& [param, instance] : param_map) {
+          if (auto buffer = instance.as<Buffer>()) {
+            UpdateSpecializeVarMap(func, param, buffer.value(), &var_map);
+          } else if (const ExprNode* expr = instance.as<ExprNode>()) {
+            UpdateSpecializeVarMap(func, param, ffi::GetRef<Expr>(expr), &var_map);
+          } else if (instance.type_index() < ffi::TypeIndex::kTVMFFISmallStr) {
+            UpdateSpecializeVarMap(func, param, instance.cast<PrimExpr>(), &var_map);
+          } else {
+            TVM_FFI_THROW(TypeError)
+                << "specialize expected instance to be Buffer or Expr, but got "
+                << instance.GetTypeKey();
+          }
+        }
+        return PrimFuncSpecializer::Specialize(func, std::move(var_map));
+      });
 }
 
 }  // namespace tirx

--- a/src/tirx/ir/specialize.cc
+++ b/src/tirx/ir/specialize.cc
@@ -183,7 +183,10 @@ class PrimFuncSpecializer : public StmtExprMutator {
   Buffer VisitBufferUse(const Buffer& buffer) final { return GetNewBuffer(buffer); }
 
   using StmtExprMutator::VisitExpr;
-  Expr VisitExpr(const Var& var) { return VisitExpr(static_cast<const Expr&>(var)); }
+  Expr VisitExpr(const Var& var) final {
+    auto it = var_map_.find(var);
+    return it == var_map_.end() ? Expr(var) : it->second;
+  }
   Expr VisitExpr(const Expr& expr) final {
     if (auto var = expr.as<Var>()) {
       auto it = var_map_.find(var.value());
@@ -456,24 +459,23 @@ PrimFunc Specialize(PrimFunc func, const ffi::Map<Var, ffi::Variant<Buffer, Prim
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
-  refl::GlobalDef().def(
-      "tirx.Specialize", [](PrimFunc func, const ffi::Map<Var, ffi::Any>& param_map) {
-        VarMap var_map;
-        for (const auto& [param, instance] : param_map) {
-          if (auto buffer = instance.as<Buffer>()) {
-            UpdateSpecializeVarMap(func, param, buffer.value(), &var_map);
-          } else if (const ExprNode* expr = instance.as<ExprNode>()) {
-            UpdateSpecializeVarMap(func, param, ffi::GetRef<Expr>(expr), &var_map);
-          } else if (instance.type_index() < ffi::TypeIndex::kTVMFFISmallStr) {
-            UpdateSpecializeVarMap(func, param, instance.cast<PrimExpr>(), &var_map);
-          } else {
-            TVM_FFI_THROW(TypeError)
-                << "specialize expected instance to be Buffer or Expr, but got "
-                << instance.GetTypeKey();
-          }
-        }
-        return PrimFuncSpecializer::Specialize(func, std::move(var_map));
-      });
+  refl::GlobalDef().def("tirx.Specialize", [](PrimFunc func,
+                                              const ffi::Map<Var, ffi::Any>& param_map) {
+    VarMap var_map;
+    for (const auto& [param, instance] : param_map) {
+      if (auto buffer = instance.as<Buffer>()) {
+        UpdateSpecializeVarMap(func, param, buffer.value(), &var_map);
+      } else if (const ExprNode* expr = instance.as<ExprNode>()) {
+        UpdateSpecializeVarMap(func, param, ffi::GetRef<Expr>(expr), &var_map);
+      } else if (instance.type_index() < ffi::TypeIndex::kTVMFFISmallStr) {
+        UpdateSpecializeVarMap(func, param, instance.cast<PrimExpr>(), &var_map);
+      } else {
+        TVM_FFI_THROW(TypeError) << "specialize expected instance to be Buffer or Expr, but got "
+                                 << instance.GetTypeKey();
+      }
+    }
+    return PrimFuncSpecializer::Specialize(func, std::move(var_map));
+  });
 }
 
 }  // namespace tirx

--- a/src/tirx/ir/specialize.cc
+++ b/src/tirx/ir/specialize.cc
@@ -38,7 +38,7 @@
 namespace tvm {
 namespace tirx {
 
-using VarMap = std::unordered_map<Var, PrimExpr>;
+using VarMap = std::unordered_map<Var, Expr>;
 
 /**************** Helper functions ****************/
 
@@ -182,12 +182,21 @@ class PrimFuncSpecializer : public StmtExprMutator {
   // Override VisitBufferUse to use our own buffer_map_ instead of base class field visiting.
   Buffer VisitBufferUse(const Buffer& buffer) final { return GetNewBuffer(buffer); }
 
+  using StmtExprMutator::VisitExpr;
+  Expr VisitExpr(const Expr& expr) final {
+    if (auto var = expr.as<Var>()) {
+      auto it = var_map_.find(var.value());
+      if (it != var_map_.end()) return it->second;
+    }
+    return StmtExprMutator::VisitExpr(expr);
+  }
+
   PrimExpr VisitExpr_(const VarNode* op) final {
     auto it = var_map_.find(ffi::GetRef<Var>(op));
     if (it == var_map_.end()) {
       return ffi::GetRef<Var>(op);
     } else {
-      return it->second;
+      return it->second.as_or_throw<PrimExpr>();
     }
   }
 
@@ -351,15 +360,22 @@ void UpdateSpecializeVarMap(const PrimFunc& func, const Var& param, const Buffer
   const Buffer& buf_to_specialize = (*it).second;
 
   // build var mapping using specific_buf's parameters
-  auto build_var_mapping = [&](const PrimExpr& new_expr, const PrimExpr& old_expr) {
-    if (!equal(new_expr, old_expr)) {
+  auto build_var_mapping = [&](const Expr& new_expr, const Expr& old_expr) {
+    auto expr_equal = [&](const Expr& lhs, const Expr& rhs) {
+      if (auto lhs_prim = lhs.as<PrimExpr>()) {
+        auto rhs_prim = rhs.as<PrimExpr>();
+        return rhs_prim && equal(lhs_prim.value(), rhs_prim.value());
+      }
+      return lhs.same_as(rhs);
+    };
+    if (!expr_equal(new_expr, old_expr)) {
       TVM_FFI_CHECK(old_expr->IsInstance<VarNode>(), TypeError)
           << "The signature of target buffer exprected an independent Var, but got " << old_expr
           << ".";
       const Var& var = old_expr.as_or_throw<Var>();
       auto it = var_map->find(var);
       if (it != var_map->end()) {
-        TVM_FFI_CHECK(equal(it->second, new_expr), ValueError)
+        TVM_FFI_CHECK(expr_equal(it->second, new_expr), ValueError)
             << "The assigned value of var " << var << " mismatched. " << it->second << " vs. "
             << new_expr << ".";
       } else {

--- a/src/tirx/ir/stmt.cc
+++ b/src/tirx/ir/stmt.cc
@@ -58,15 +58,9 @@ TVM_FFI_STATIC_INIT_BLOCK() {
 }
 
 // Bind
-Bind::Bind(Var var, PrimExpr value, Span span) {
+Bind::Bind(Var var, Expr value, Span span) {
   TVM_FFI_ICHECK(value.defined());
-  PrimType value_ty = value.ty();
-  // It is still valid to bind a pointer type var to a value that is of type handle.
-  if (var->type_annotation.as<PointerTypeNode>()) {
-    TVM_FFI_ICHECK(value_ty.IsHandle());
-  } else {
-    TVM_FFI_ICHECK(value.ty() == var.ty());
-  }
+  TVM_FFI_ICHECK(ffi::StructuralEqual()(value->ty, var->ty));
 
   ffi::ObjectPtr<BindNode> node = ffi::make_object<BindNode>();
   node->var = std::move(var);
@@ -78,7 +72,7 @@ Bind::Bind(Var var, PrimExpr value, Span span) {
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
   refl::GlobalDef().def("tirx.Bind",
-                        [](Var var, PrimExpr value, Span span) { return Bind(var, value, span); });
+                        [](Var var, Expr value, Span span) { return Bind(var, value, span); });
 }
 
 // AttrStmt

--- a/src/tirx/ir/stmt.cc
+++ b/src/tirx/ir/stmt.cc
@@ -34,6 +34,18 @@
 namespace tvm {
 namespace tirx {
 
+namespace {
+Expr AsExpr(const ffi::Any& value) {
+  if (value.type_index() < ffi::TypeIndex::kTVMFFISmallStr) {
+    return value.cast<PrimExpr>();
+  }
+  const ExprNode* node = value.as<ExprNode>();
+  TVM_FFI_CHECK(node != nullptr, TypeError) << "Expected an expression, but got "
+                                           << value.GetTypeKey();
+  return ffi::GetRef<Expr>(node);
+}
+}  // namespace
+
 TVM_FFI_STATIC_INIT_BLOCK() {
   StmtNode::RegisterReflection();
   BindNode::RegisterReflection();
@@ -72,7 +84,9 @@ Bind::Bind(Var var, Expr value, Span span) {
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
   refl::GlobalDef().def("tirx.Bind",
-                        [](Var var, Expr value, Span span) { return Bind(var, value, span); });
+                        [](Var var, ffi::Any value, Span span) {
+                          return Bind(var, AsExpr(value), span);
+                        });
 }
 
 // AttrStmt
@@ -379,7 +393,9 @@ Evaluate::Evaluate(Expr value, Span span) {
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
   refl::GlobalDef().def("tirx.Evaluate",
-                        [](Expr value, Span span) { return Evaluate(value, span); });
+                        [](ffi::Any value, Span span) {
+                          return Evaluate(AsExpr(value), span);
+                        });
 }
 
 // BufferStore

--- a/src/tirx/ir/stmt.cc
+++ b/src/tirx/ir/stmt.cc
@@ -40,8 +40,8 @@ Expr AsExpr(const ffi::Any& value) {
     return value.cast<PrimExpr>();
   }
   const ExprNode* node = value.as<ExprNode>();
-  TVM_FFI_CHECK(node != nullptr, TypeError) << "Expected an expression, but got "
-                                           << value.GetTypeKey();
+  TVM_FFI_CHECK(node != nullptr, TypeError)
+      << "Expected an expression, but got " << value.GetTypeKey();
   return ffi::GetRef<Expr>(node);
 }
 }  // namespace
@@ -83,10 +83,9 @@ Bind::Bind(Var var, Expr value, Span span) {
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
-  refl::GlobalDef().def("tirx.Bind",
-                        [](Var var, ffi::Any value, Span span) {
-                          return Bind(var, AsExpr(value), span);
-                        });
+  refl::GlobalDef().def("tirx.Bind", [](Var var, ffi::Any value, Span span) {
+    return Bind(var, AsExpr(value), span);
+  });
 }
 
 // AttrStmt
@@ -393,9 +392,7 @@ Evaluate::Evaluate(Expr value, Span span) {
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
   refl::GlobalDef().def("tirx.Evaluate",
-                        [](ffi::Any value, Span span) {
-                          return Evaluate(AsExpr(value), span);
-                        });
+                        [](ffi::Any value, Span span) { return Evaluate(AsExpr(value), span); });
 }
 
 // BufferStore

--- a/src/tirx/ir/stmt.cc
+++ b/src/tirx/ir/stmt.cc
@@ -367,7 +367,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
 }
 
 // Evaluate
-Evaluate::Evaluate(PrimExpr value, Span span) {
+Evaluate::Evaluate(Expr value, Span span) {
   TVM_FFI_ICHECK(value.defined());
 
   ffi::ObjectPtr<EvaluateNode> node = ffi::make_object<EvaluateNode>();
@@ -379,7 +379,7 @@ Evaluate::Evaluate(PrimExpr value, Span span) {
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
   refl::GlobalDef().def("tirx.Evaluate",
-                        [](PrimExpr value, Span span) { return Evaluate(value, span); });
+                        [](Expr value, Span span) { return Evaluate(value, span); });
 }
 
 // BufferStore

--- a/src/tirx/ir/stmt_functor.cc
+++ b/src/tirx/ir/stmt_functor.cc
@@ -679,6 +679,9 @@ class IRApplyVisit : public StmtExprVisitor {
   explicit IRApplyVisit(std::function<void(const ffi::ObjectRef&)> f) : f_(f) {}
 
   void VisitExpr(const Expr& node) final {
+    if (auto prim = node.as<PrimExpr>()) {
+      return VisitExpr(prim.value());
+    }
     if (visited_.count(node.get()) != 0) return;
     visited_.insert(node.get());
     ExprVisitor::VisitExpr(node);

--- a/src/tirx/ir/stmt_functor.cc
+++ b/src/tirx/ir/stmt_functor.cc
@@ -554,7 +554,7 @@ Stmt StmtMutator::VisitStmt_(const AssertStmtNode* op) {
 }
 
 Stmt StmtMutator::VisitStmt_(const EvaluateNode* op) {
-  PrimExpr value = this->VisitExpr(op->value);
+  Expr value = this->VisitExpr(op->value);
   if (value.same_as(op->value)) {
     return ffi::GetRef<Stmt>(op);
   } else {
@@ -790,7 +790,7 @@ class IRSubstitute : public StmtExprMutator {
   Buffer VisitBufferDef(const Buffer& buffer, bool alloc_data) final {
     Buffer new_buf = StmtExprMutator::VisitBufferDef(buffer, alloc_data);
     // Additionally handle data var substitution (base does not visit data).
-    PrimExpr new_data_expr = VisitExpr(new_buf->data);
+    Expr new_data_expr = VisitExpr(new_buf->data);
     TVM_FFI_ICHECK(new_data_expr->IsInstance<VarNode>())
         << "Buffer " << new_buf << " uses backing allocation " << new_buf->data
         << ", which was substituted into the expression " << new_data_expr

--- a/src/tirx/ir/stmt_functor.cc
+++ b/src/tirx/ir/stmt_functor.cc
@@ -678,6 +678,13 @@ class IRApplyVisit : public StmtExprVisitor {
  public:
   explicit IRApplyVisit(std::function<void(const ffi::ObjectRef&)> f) : f_(f) {}
 
+  void VisitExpr(const Expr& node) final {
+    if (visited_.count(node.get()) != 0) return;
+    visited_.insert(node.get());
+    ExprVisitor::VisitExpr(node);
+    f_(node);
+  }
+
   void VisitExpr(const PrimExpr& node) final {
     if (visited_.count(node.get()) != 0) return;
     visited_.insert(node.get());
@@ -706,7 +713,10 @@ void PostOrderVisit(const ffi::ObjectRef& node, std::function<void(const ffi::Ob
     visitor(node.as_or_throw<Stmt>());
   } else {
     IRApplyVisit visitor(fvisit);
-    visitor(node.as_or_throw<PrimExpr>());
+    const ExprNode* expr = node.as<ExprNode>();
+    TVM_FFI_CHECK(expr != nullptr, TypeError)
+        << "PostOrderVisit expected a Stmt or Expr, but got " << node->GetTypeKey();
+    visitor.VisitExpr(ffi::GetRef<Expr>(expr));
   }
 }
 

--- a/src/tirx/ir/stmt_functor.cc
+++ b/src/tirx/ir/stmt_functor.cc
@@ -287,7 +287,7 @@ class StmtMutator::Internal {
 
 Stmt StmtMutator::VisitStmt_(const BindNode* op) {
   // Bind has no body -- only mutate the value expression.
-  PrimExpr value = this->VisitExpr(op->value);
+  Expr value = this->VisitExpr(op->value);
   if (value.same_as(op->value)) {
     return ffi::GetRef<Stmt>(op);
   } else {

--- a/src/tirx/ir/tir_visitor_with_path.h
+++ b/src/tirx/ir/tir_visitor_with_path.h
@@ -55,10 +55,18 @@ class TIRVisitorWithPath
   virtual inline void Visit(const PrimExpr& obj, ffi::reflection::AccessPath path) {
     VisitExpr(obj, path);
   }
-  // Core Call stores arguments as Expr. TIR path traversal still expects the
-  // primitive typed view for these children.
+  // Core Call stores arguments as Expr, including pointer-typed Vars.
   virtual inline void Visit(const Expr& obj, ffi::reflection::AccessPath path) {
-    Visit(obj.as_or_throw<PrimExpr>(), path);
+    if (auto prim = obj.as<PrimExpr>()) {
+      Visit(prim.value(), path);
+    } else if (auto* var = obj.as<VarNode>()) {
+      VisitExpr_(var, path);
+    } else if (auto* call = obj.as<CallNode>()) {
+      VisitExpr_(call, path);
+    } else {
+      TVM_FFI_THROW(TypeError) << "Unsupported non-primitive TIR expression "
+                               << obj.GetTypeKey();
+    }
   }
   // Delegate to ExprFunctor::VisitStmt for Stmt, and any subclasses
   virtual inline void Visit(const Stmt& obj, ffi::reflection::AccessPath path) {
@@ -239,7 +247,7 @@ class TIRVisitorWithPath
   std::vector<DefContext<Var>> WithMatchBufferDefs(Buffer buf, ffi::reflection::AccessPath path) {
     std::vector<DefContext<Var>> context;
 
-    auto try_visit_implicit_var_def = [this, &context](const PrimExpr& expr,
+    auto try_visit_implicit_var_def = [this, &context](const Expr& expr,
                                                        ffi::reflection::AccessPath path) {
       if (auto opt = expr.as<Var>()) {
         auto var = opt.value();

--- a/src/tirx/ir/tir_visitor_with_path.h
+++ b/src/tirx/ir/tir_visitor_with_path.h
@@ -64,8 +64,7 @@ class TIRVisitorWithPath
     } else if (auto* call = obj.as<CallNode>()) {
       VisitExpr_(call, path);
     } else {
-      TVM_FFI_THROW(TypeError) << "Unsupported non-primitive TIR expression "
-                               << obj.GetTypeKey();
+      TVM_FFI_THROW(TypeError) << "Unsupported non-primitive TIR expression " << obj.GetTypeKey();
     }
   }
   // Delegate to ExprFunctor::VisitStmt for Stmt, and any subclasses

--- a/src/tirx/op/op.cc
+++ b/src/tirx/op/op.cc
@@ -166,6 +166,8 @@ Type GetType(const PrimExpr& expr) {
   return expr.ty();
 }
 
+Type GetType(const tirx::Var& var) { return var->ty; }
+
 Type GetTypeFromRuntimeDataType(DLDataType dtype) { return PrimType(dtype); }
 
 // LargeUIntImm

--- a/src/tirx/op/op.cc
+++ b/src/tirx/op/op.cc
@@ -113,8 +113,8 @@ Type GetType(const PrimExpr& expr) {
   if (auto* ptr = expr.as<tirx::VarNode>()) {
     // If Var has a more refined type annotation,
     // return the type anotation
-    if (!ptr->type_annotation.IsMissing()) {
-      return ptr->type_annotation;
+    if (!ptr->ty.IsMissing()) {
+      return ptr->ty;
     }
   }
 
@@ -150,7 +150,7 @@ Type GetType(const PrimExpr& expr) {
       }
 
       if (auto* var = address_of->args[0].as<VarNode>()) {
-        if (auto* ptr = var->type_annotation.as<PointerTypeNode>()) {
+        if (auto* ptr = var->ty.as<PointerTypeNode>()) {
           if (ptr->element_type.as<TensorMapTypeNode>()) {
             return PrimType::UInt(64);
           }

--- a/src/tirx/script/builder/ir.cc
+++ b/src/tirx/script/builder/ir.cc
@@ -616,6 +616,16 @@ Var Bind(ffi::Any value, ffi::Optional<Type> type_annotation, ffi::Optional<Var>
       return Var("v", value_expr->ty);
     }
   }();
+  if (!ffi::StructuralEqual()(value_expr->ty, bind_var->ty)) {
+    ffi::Optional<PrimType> value_prim_type = value_expr->ty.as<PrimType>();
+    if (bind_var->ty.as<PointerTypeNode>() && value_prim_type.defined() &&
+        value_prim_type.value().IsHandle()) {
+      if (auto call = value_expr.as<Call>()) {
+        value_expr = Call(bind_var->ty, call.value()->op, call.value()->args, call.value()->attrs,
+                          call.value()->ty_args, call.value()->span);
+      }
+    }
+  }
   AddToParent(tvm::tirx::Bind(bind_var, value_expr));
   return bind_var;
 }

--- a/src/tirx/script/builder/ir.cc
+++ b/src/tirx/script/builder/ir.cc
@@ -597,18 +597,26 @@ AssertFrame Assert(PrimExpr condition, ffi::String error_kind,
   return AssertFrame(n);
 }
 
-Var Bind(PrimExpr value, ffi::Optional<Type> type_annotation, ffi::Optional<Var> var) {
-  TVM_FFI_ICHECK(value.defined()) << "ValueError: Bind value must be defined";
+Var Bind(ffi::Any value, ffi::Optional<Type> type_annotation, ffi::Optional<Var> var) {
+  Expr value_expr = [&]() {
+    if (value.type_index() < ffi::TypeIndex::kTVMFFISmallStr) {
+      return Expr(value.cast<PrimExpr>());
+    }
+    const ExprNode* value_node = value.as<ExprNode>();
+    TVM_FFI_CHECK(value_node != nullptr, TypeError)
+        << "Bind value must be an expression, but got " << value.GetTypeKey();
+    return ffi::GetRef<Expr>(value_node);
+  }();
   Var bind_var = [&]() {
     if (var.defined()) {
       return var.value();
     } else if (type_annotation.defined()) {
       return Var("v", type_annotation.value());
     } else {
-      return Var("v", value.ty());
+      return Var("v", value_expr->ty);
     }
   }();
-  AddToParent(tvm::tirx::Bind(bind_var, value));
+  AddToParent(tvm::tirx::Bind(bind_var, value_expr));
   return bind_var;
 }
 
@@ -858,9 +866,18 @@ Buffer AllocBuffer(ffi::Array<PrimExpr> shape, PrimType dtype, ffi::String stora
   return buffer;
 }
 
-void Evaluate(PrimExpr value) { AddToParent(tvm::tirx::Evaluate(value)); }
+void Evaluate(ffi::Any value) {
+  if (value.type_index() < ffi::TypeIndex::kTVMFFISmallStr) {
+    AddToParent(tvm::tirx::Evaluate(value.cast<PrimExpr>()));
+    return;
+  }
+  const ExprNode* value_node = value.as<ExprNode>();
+  TVM_FFI_CHECK(value_node != nullptr, TypeError)
+      << "Evaluate value must be an expression, but got " << value.GetTypeKey();
+  AddToParent(tvm::tirx::Evaluate(ffi::GetRef<Expr>(value_node)));
+}
 
-PrimExpr Ptr(PrimType dtype, ffi::String storage_scope = "global", bool is_size_var = false) {
+Var Ptr(PrimType dtype, ffi::String storage_scope = "global", bool is_size_var = false) {
   PointerType type_annotation(dtype, storage_scope);
   return is_size_var ? tvm::tirx::SizeVar("", type_annotation)
                      : tvm::tirx::Var("", type_annotation);

--- a/src/tirx/script/printer/buffer.cc
+++ b/src/tirx/script/printer/buffer.cc
@@ -101,7 +101,7 @@ ffi::Map<ffi::String, ExprDoc> BufferAttrs(tirx::Buffer buffer, const AccessPath
   // Step 3. Handle `buffer.data`
   // For tmem scope, DeclBuffer does not accept `data` (it auto-creates the data var).
   bool is_tmem_scope = false;
-  if (auto* ptr_type = buffer->data->type_annotation.as<PointerTypeNode>()) {
+  if (auto* ptr_type = buffer->data->ty.as<PointerTypeNode>()) {
     is_tmem_scope = (ptr_type->storage_scope == "tmem");
   }
   bool is_inline_data = false;

--- a/src/tirx/script/printer/buffer.cc
+++ b/src/tirx/script/printer/buffer.cc
@@ -167,7 +167,7 @@ ffi::Map<ffi::String, ExprDoc> BufferAttrs(tirx::Buffer buffer, const AccessPath
       kwargs.Set(
           "scope",
           LiteralDoc::Str(scope,
-                          buffer_p->Attr("data")->Attr("type_annotation")->Attr("storage_scope")));
+                          buffer_p->Attr("data")->Attr("ty")->Attr("storage_scope")));
     }
   }
   // Step 7. Handle `buffer.data_alignment`

--- a/src/tirx/script/printer/buffer.cc
+++ b/src/tirx/script/printer/buffer.cc
@@ -52,9 +52,7 @@ ffi::Map<ffi::String, ExprDoc> BufferAttrs(tirx::Buffer buffer, const AccessPath
   for (const PrimExpr& e : buffer->shape) {
     update_use_count(e);
   }
-  auto is_new_var = [&](const Expr& e) {
-    return e->IsInstance<VarNode>() && !d->IsVarDefined(e);
-  };
+  auto is_new_var = [&](const Expr& e) { return e->IsInstance<VarNode>() && !d->IsVarDefined(e); };
   auto add_out_of_line_var_def = [&](const Var& var, const AccessPath& var_p) {
     TVM_FFI_ICHECK(!d->IsVarDefined(var));
     ExprDoc lhs = DefineVar(var, frame, d);
@@ -164,10 +162,8 @@ ffi::Map<ffi::String, ExprDoc> BufferAttrs(tirx::Buffer buffer, const AccessPath
   {
     ffi::String scope = buffer.scope();
     if (scope != "global") {
-      kwargs.Set(
-          "scope",
-          LiteralDoc::Str(scope,
-                          buffer_p->Attr("data")->Attr("ty")->Attr("storage_scope")));
+      kwargs.Set("scope",
+                 LiteralDoc::Str(scope, buffer_p->Attr("data")->Attr("ty")->Attr("storage_scope")));
     }
   }
   // Step 7. Handle `buffer.data_alignment`

--- a/src/tirx/script/printer/buffer.cc
+++ b/src/tirx/script/printer/buffer.cc
@@ -37,7 +37,7 @@ ffi::Map<ffi::String, ExprDoc> BufferAttrs(tirx::Buffer buffer, const AccessPath
 
   // Step 0. Set up statistics
   std::unordered_map<const ffi::Object*, int> use_count;
-  auto update_use_count = [&](const PrimExpr& e) {
+  auto update_use_count = [&](const Expr& e) {
     tirx::PostOrderVisit(e, [&](const ffi::ObjectRef& n) {
       if (const VarNode* var = n.as<VarNode>()) {
         ++use_count[var];
@@ -52,7 +52,7 @@ ffi::Map<ffi::String, ExprDoc> BufferAttrs(tirx::Buffer buffer, const AccessPath
   for (const PrimExpr& e : buffer->shape) {
     update_use_count(e);
   }
-  auto is_new_var = [&](const PrimExpr& e) {
+  auto is_new_var = [&](const Expr& e) {
     return e->IsInstance<VarNode>() && !d->IsVarDefined(e);
   };
   auto add_out_of_line_var_def = [&](const Var& var, const AccessPath& var_p) {
@@ -62,7 +62,7 @@ ffi::Map<ffi::String, ExprDoc> BufferAttrs(tirx::Buffer buffer, const AccessPath
     var_def_lhs.push_back(lhs);
     var_def_rhs.push_back(PrintVarCreation(var, var_p, d));
   };
-  auto try_inline_def = [&](const PrimExpr& e, const AccessPath& e_p,
+  auto try_inline_def = [&](const Expr& e, const AccessPath& e_p,
                             std::function<ExprDoc()> inline_f) {
     TVM_FFI_ICHECK(is_new_var(e));
     Var var = e.as_or_throw<Var>();

--- a/src/tirx/script/printer/expr.cc
+++ b/src/tirx/script/printer/expr.cc
@@ -278,9 +278,9 @@ Doc PrintTIRCall(Call call, AccessPath call_p, IRDocsifier d) {
     ExprDoc ret_ty_doc = call_prim_type.defined()
                              ? LiteralDoc::DataType(get_call_dtype(), call_p->Attr("ty"))
                              : d->AsDoc<ExprDoc>(call->ty, call_p->Attr("ty"));
-    return TIR(d, "Call")->Call({op_doc, ListDoc(call_args)}, {"attrs", "ret_ty"},
-                                {d->AsDoc<ExprDoc>(call->attrs, call_p->Attr("attrs")),
-                                 ret_ty_doc});
+    return TIR(d, "Call")->Call(
+        {op_doc, ListDoc(call_args)}, {"attrs", "ret_ty"},
+        {d->AsDoc<ExprDoc>(call->attrs, call_p->Attr("attrs")), ret_ty_doc});
   }
   static const OpAttrMap<tirx::TScriptPrinterName>& op_names =
       Op::GetAttrMap<tirx::TScriptPrinterName>("TScriptPrinterName");

--- a/src/tirx/script/printer/expr.cc
+++ b/src/tirx/script/printer/expr.cc
@@ -257,7 +257,14 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
     });
 
 Doc PrintTIRCall(Call call, AccessPath call_p, IRDocsifier d) {
-  DLDataType call_dtype = call->ty.as_or_throw<PrimType>()->dtype;
+  ffi::Optional<PrimType> call_prim_type = call->ty.as<PrimType>();
+  auto get_call_dtype = [&]() -> DLDataType {
+    if (call_prim_type.defined()) return call_prim_type.value()->dtype;
+    if (call->ty.as<PointerTypeNode>()) return PrimType::Handle()->dtype;
+    TVM_FFI_THROW(TypeError) << "Call dtype is only available for primitive or pointer return "
+                                "types, but got "
+                             << call->ty;
+  };
   if (call->attrs.defined()) {
     ffi::Array<ExprDoc> call_args;
     int n_args = call->args.size();
@@ -268,9 +275,12 @@ Doc PrintTIRCall(Call call, AccessPath call_p, IRDocsifier d) {
     ExprDoc op_doc = call->op.as<Op>()
                          ? LiteralDoc::Str(call->op.as<Op>().value()->name, call_p->Attr("op"))
                          : d->AsDoc<ExprDoc>(call->op, call_p->Attr("op"));
+    ExprDoc ret_ty_doc = call_prim_type.defined()
+                             ? LiteralDoc::DataType(get_call_dtype(), call_p->Attr("ty"))
+                             : d->AsDoc<ExprDoc>(call->ty, call_p->Attr("ty"));
     return TIR(d, "Call")->Call({op_doc, ListDoc(call_args)}, {"attrs", "ret_ty"},
                                 {d->AsDoc<ExprDoc>(call->attrs, call_p->Attr("attrs")),
-                                 LiteralDoc::DataType(call_dtype, call_p->Attr("ty"))});
+                                 ret_ty_doc});
   }
   static const OpAttrMap<tirx::TScriptPrinterName>& op_names =
       Op::GetAttrMap<tirx::TScriptPrinterName>("TScriptPrinterName");
@@ -297,7 +307,7 @@ Doc PrintTIRCall(Call call, AccessPath call_p, IRDocsifier d) {
       ffi::Array<ExprDoc> args;
       args.reserve(n_args + 1);
       if (dtype_print_location == tirx::ScriptDtypePrintLocation::kFirst) {
-        args.push_back(LiteralDoc::DataType(call_dtype, call_p->Attr("dtype")));
+        args.push_back(LiteralDoc::DataType(get_call_dtype(), call_p->Attr("dtype")));
       }
 
       for (int i = 0; i < n_args; ++i) {
@@ -309,7 +319,7 @@ Doc PrintTIRCall(Call call, AccessPath call_p, IRDocsifier d) {
         }
       }
       if (dtype_print_location == tirx::ScriptDtypePrintLocation::kLast) {
-        args.push_back(LiteralDoc::DataType(call_dtype, call_p->Attr("dtype")));
+        args.push_back(LiteralDoc::DataType(get_call_dtype(), call_p->Attr("dtype")));
       }
       return prefix.value()->Call(args);
     }
@@ -333,9 +343,9 @@ Doc PrintTIRCall(Call call, AccessPath call_p, IRDocsifier d) {
       kw_keys.push_back("source_code");
       kw_vals.push_back(src);
       // If non-void return type, print return_type keyword.
-      if (!call->ty.as_or_throw<PrimType>().IsVoid()) {
+      if (!call_prim_type.value().IsVoid()) {
         kw_keys.push_back("return_type");
-        kw_vals.push_back(LiteralDoc::DataType(call_dtype, call_p->Attr("dtype")));
+        kw_vals.push_back(LiteralDoc::DataType(get_call_dtype(), call_p->Attr("dtype")));
       }
       return prefix.value()->Call(args, kw_keys, kw_vals);
     }
@@ -348,14 +358,14 @@ Doc PrintTIRCall(Call call, AccessPath call_p, IRDocsifier d) {
   int n_args = call->args.size();
   args.reserve(n_args + 1);
   if (dtype_print_location == tirx::ScriptDtypePrintLocation::kFirst) {
-    args.push_back(LiteralDoc::DataType(call_dtype, call_p->Attr("dtype")));
+    args.push_back(LiteralDoc::DataType(get_call_dtype(), call_p->Attr("dtype")));
   }
 
   for (int i = 0; i < n_args; ++i) {
     args.push_back(d->AsDoc<ExprDoc>(call->args[i], call_p->Attr("args")->ArrayItem(i)));
   }
   if (dtype_print_location == tirx::ScriptDtypePrintLocation::kLast) {
-    args.push_back(LiteralDoc::DataType(call_dtype, call_p->Attr("dtype")));
+    args.push_back(LiteralDoc::DataType(get_call_dtype(), call_p->Attr("dtype")));
   }
   return prefix.value()->Call(args);
 }

--- a/src/tirx/script/printer/expr.cc
+++ b/src/tirx/script/printer/expr.cc
@@ -25,7 +25,7 @@ namespace script {
 namespace printer {
 
 ExprDoc PrintVarCreation(const tirx::Var& var, const AccessPath& var_p, const IRDocsifier& d) {
-  Type type = var->type_annotation;
+  Type type = var->ty;
   AccessPath type_p = var_p->Attr("type_annotation");
   ExprDoc rhs{ffi::UnsafeInit()};
   ffi::Array<ffi::String> kwargs_keys;

--- a/src/tirx/script/printer/expr.cc
+++ b/src/tirx/script/printer/expr.cc
@@ -26,7 +26,7 @@ namespace printer {
 
 ExprDoc PrintVarCreation(const tirx::Var& var, const AccessPath& var_p, const IRDocsifier& d) {
   Type type = var->ty;
-  AccessPath type_p = var_p->Attr("type_annotation");
+  AccessPath type_p = var_p->Attr("ty");
   ExprDoc rhs{ffi::UnsafeInit()};
   ffi::Array<ffi::String> kwargs_keys;
   ffi::Array<ExprDoc> kwargs_values;

--- a/src/tirx/script/printer/function.cc
+++ b/src/tirx/script/printer/function.cc
@@ -116,7 +116,7 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
             continue;
           }
         }
-        ExprDoc a = d->AsDoc<ExprDoc>(var->type_annotation, var_p->Attr("type_annotation"));
+        ExprDoc a = d->AsDoc<ExprDoc>(var->ty, var_p->Attr("type_annotation"));
         args.push_back(AssignDoc(DefineVar(var, *f, d), std::nullopt, a));
       }
       // Step 2. Handle `func->attrs`

--- a/src/tirx/script/printer/function.cc
+++ b/src/tirx/script/printer/function.cc
@@ -70,10 +70,10 @@ int CountVarOccurrence(const tirx::PrimFunc& f, const tirx::Var& v) {
   OccurrenceCounter counter(v.get());
   counter(f->body);
   for (const tirx::Var& v : f->params) {
-    counter(v);
+    counter.VisitVar(v);
   }
   for (const auto& pair : f->buffer_map) {
-    counter(pair.first);
+    counter.VisitVar(pair.first);
     counter.VisitBuffer(pair.second.get());
   }
   return counter.count;

--- a/src/tirx/script/printer/function.cc
+++ b/src/tirx/script/printer/function.cc
@@ -116,7 +116,7 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
             continue;
           }
         }
-        ExprDoc a = d->AsDoc<ExprDoc>(var->ty, var_p->Attr("type_annotation"));
+        ExprDoc a = d->AsDoc<ExprDoc>(var->ty, var_p->Attr("ty"));
         args.push_back(AssignDoc(DefineVar(var, *f, d), std::nullopt, a));
       }
       // Step 2. Handle `func->attrs`

--- a/src/tirx/script/printer/stmt.cc
+++ b/src/tirx/script/printer/stmt.cc
@@ -207,11 +207,11 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
 TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
     .set_dispatch<tirx::Bind>("", [](tirx::Bind stmt, AccessPath p, IRDocsifier d) -> Doc {
       // Step 1. Type annotation
-      TVM_FFI_ICHECK(!stmt->var->type_annotation.IsMissing())
+      TVM_FFI_ICHECK(!stmt->var->ty.IsMissing())
           << "Type annotation is required for variable: " << stmt->var->name_hint;
-      ffi::Optional<ExprDoc> type_doc = d->AsDoc<ExprDoc>(stmt->var->type_annotation,  //
+      ffi::Optional<ExprDoc> type_doc = d->AsDoc<ExprDoc>(stmt->var->ty,  //
                                                           p->Attr("var")->Attr("type_annotation"));
-      if (const auto* tuple_type = stmt->var->type_annotation.as<TupleTypeNode>()) {
+      if (const auto* tuple_type = stmt->var->ty.as<TupleTypeNode>()) {
         if (tuple_type->fields.empty()) {
           type_doc = std::nullopt;
         }

--- a/src/tirx/script/printer/stmt.cc
+++ b/src/tirx/script/printer/stmt.cc
@@ -210,7 +210,7 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
       TVM_FFI_ICHECK(!stmt->var->ty.IsMissing())
           << "Type annotation is required for variable: " << stmt->var->name_hint;
       ffi::Optional<ExprDoc> type_doc = d->AsDoc<ExprDoc>(stmt->var->ty,  //
-                                                          p->Attr("var")->Attr("type_annotation"));
+                                                          p->Attr("var")->Attr("ty"));
       if (const auto* tuple_type = stmt->var->ty.as<TupleTypeNode>()) {
         if (tuple_type->fields.empty()) {
           type_doc = std::nullopt;

--- a/src/tirx/script/printer/utils.h
+++ b/src/tirx/script/printer/utils.h
@@ -335,6 +335,8 @@ class OccurrenceCounter : public tirx::StmtExprVisitor {
   /*! \brief The Var to count occurrence */
   const tirx::VarNode* v = nullptr;
 
+  void VisitVar(const tirx::Var& var) { VisitExpr(static_cast<const Expr&>(var)); }
+
   void VisitExpr_(const tirx::VarNode* op) final {
     if (op == v) {
       ++count;

--- a/src/tirx/transform/ir_utils.cc
+++ b/src/tirx/transform/ir_utils.cc
@@ -372,7 +372,7 @@ class IRConvertSSA final : public StmtExprMutator {
     // body-carrying statement's scope exits.
     const Var& v = op->var;
     if (defined_.count(v.get())) {
-      PrimExpr value = this->VisitExpr(op->value);
+      Expr value = this->VisitExpr(op->value);
       Var new_var = MakeNewVar(v);
       PushVarRemap(v, new_var);
       return Bind(new_var, value);

--- a/src/tirx/transform/ir_utils.cc
+++ b/src/tirx/transform/ir_utils.cc
@@ -456,8 +456,8 @@ class IRConvertSSA final : public StmtExprMutator {
         var = it->second;
       } else if (defined_.count(var.get())) {
         Var new_var = [&]() {
-          if (!var->type_annotation.IsMissing()) {
-            return Var(var->name_hint, var->type_annotation);
+          if (!var->ty.IsMissing()) {
+            return Var(var->name_hint, var->ty);
           } else {
             return Var(var->name_hint, var.ty());
           }
@@ -534,11 +534,11 @@ class IRConvertSSA final : public StmtExprMutator {
   /*! \brief Create a new variable with the same name and type as the original. */
   static Var MakeNewVar(const Var& old_var) {
     bool is_size_var = old_var->IsInstance<SizeVarNode>();
-    if (!old_var->type_annotation.IsMissing()) {
+    if (!old_var->ty.IsMissing()) {
       if (is_size_var) {
-        return SizeVar(old_var->name_hint, old_var->type_annotation);
+        return SizeVar(old_var->name_hint, old_var->ty);
       } else {
-        return Var(old_var->name_hint, old_var->type_annotation);
+        return Var(old_var->name_hint, old_var->ty);
       }
     } else {
       if (is_size_var) {
@@ -667,7 +667,7 @@ class IRConvertSSA final : public StmtExprMutator {
 Stmt ConvertSSA(Stmt stmt) { return IRConvertSSA()(std::move(stmt)); }
 
 ffi::String GetPtrStorageScope(Var buffer_var) {
-  const auto* ptr_type = buffer_var->type_annotation.as<PointerTypeNode>();
+  const auto* ptr_type = buffer_var->ty.as<PointerTypeNode>();
   TVM_FFI_ICHECK(ptr_type) << "The provided variable is not of pointer type";
   return ptr_type->storage_scope;
 }

--- a/src/tirx/transform/lower_tirx_dedup_tensormap.cc
+++ b/src/tirx/transform/lower_tirx_dedup_tensormap.cc
@@ -255,7 +255,7 @@ class CuTensorMapDedupRewriter : public StmtExprMutator {
   }
 
   Stmt VisitStmt_(const BindNode* op) final {
-    PrimExpr value = VisitExpr(op->value);
+    Expr value = VisitExpr(op->value);
     if (IsTensorMapAlloca(op)) {
       // If this bind allocates a tensormap that is remapped to a canonical var, drop it.
       auto it = var_remap_.find(op->var);

--- a/src/tirx/transform/lower_tirx_dedup_tensormap.cc
+++ b/src/tirx/transform/lower_tirx_dedup_tensormap.cc
@@ -174,7 +174,8 @@ class CuTensorMapDedupRewriter : public StmtExprMutator {
       Stmt new_stmt = VisitStmt(stmt);
       // Dropped statements are represented as Evaluate(0).
       if (const auto* eval = new_stmt.as<EvaluateNode>()) {
-        if (is_zero(eval->value)) {
+        auto value = eval->value.as<PrimExpr>();
+        if (value && is_zero(value.value())) {
           changed = true;
           continue;
         }

--- a/src/tirx/transform/lower_tvm_builtin.cc
+++ b/src/tirx/transform/lower_tvm_builtin.cc
@@ -259,8 +259,7 @@ class BuiltinLower : public StmtExprMutator {
     int64_t nbytes = GetVectorBytes(op->buffer->dtype);
     if (const auto* dev_type = device_type_.as<IntImmNode>();
         dev_type && dev_type->value == kDLCPU) {
-      auto storage_scope =
-          op->buffer->data->ty.as_or_throw<PointerType>()->storage_scope;
+      auto storage_scope = op->buffer->data->ty.as_or_throw<PointerType>()->storage_scope;
       if (storage_scope == "global") {
         auto constant_size = stmt.as_or_throw<AllocBuffer>().ConstantAllocationSize();
         if (constant_size.has_value() && constant_size.value() > 0 &&
@@ -687,8 +686,7 @@ class BuiltinLower : public StmtExprMutator {
     Stmt throw_last_error = Evaluate(
         Call(PrimType::Int(32), builtin::tvm_throw_last_error(), {}).as_or_throw<PrimExpr>());
 
-    const auto* dtype_node =
-        let->var->ty.as<PointerTypeNode>()->element_type.as<PrimTypeNode>();
+    const auto* dtype_node = let->var->ty.as<PointerTypeNode>()->element_type.as<PrimTypeNode>();
     TVM_FFI_ICHECK(dtype_node);
     PrimType dtype = ffi::GetRef<PrimType>(dtype_node);
 

--- a/src/tirx/transform/lower_tvm_builtin.cc
+++ b/src/tirx/transform/lower_tvm_builtin.cc
@@ -295,11 +295,10 @@ class BuiltinLower : public StmtExprMutator {
 
     Stmt alloc_bind = Bind(
         op->buffer->data,
-        Call(op->buffer->data.ty(), alloc_workspace_op,
+        Call(op->buffer->data->ty, alloc_workspace_op,
              {cast(PrimType::Int(32), device_type_.value()),
               cast(PrimType::Int(32), device_id_.value()), total_bytes,
-              IntImm::Int32(op->buffer->dtype.code()), IntImm::Int32(op->buffer->dtype.bits())})
-            .as_or_throw<PrimExpr>());
+              IntImm::Int32(op->buffer->dtype.code()), IntImm::Int32(op->buffer->dtype.bits())}));
 
     return SeqStmt({alloc_bind, alloc_nullptr_check});
   }
@@ -646,8 +645,14 @@ class BuiltinLower : public StmtExprMutator {
     op = expr.as<CallNode>();
 
     for (size_t i = 0; i < num_args; ++i) {
-      this->SetPackedArg(op->args[args_begin + i].as_or_throw<PrimExpr>(), scope.stack_ffi_any,
-                         arg_stack_begin + i, &prep_seq);
+      const Expr& arg = op->args[args_begin + i];
+      PrimExpr runtime_arg = [&]() {
+        if (auto prim = arg.as<PrimExpr>()) return prim.value();
+        TVM_FFI_CHECK(arg->ty.as<PointerTypeNode>(), TypeError)
+            << "Packed call argument must have a primitive or pointer type, but got " << arg->ty;
+        return Call(PrimType::Handle(), builtin::reinterpret(), {arg}).as_or_throw<PrimExpr>();
+      }();
+      this->SetPackedArg(runtime_arg, scope.stack_ffi_any, arg_stack_begin + i, &prep_seq);
     }
     // explicitly set return value to None to avoid bad state interpretation
     prep_seq.emplace_back(TVMStructSet(scope.stack_ffi_any, num_args, builtin::kTVMFFIAnyTypeIndex,

--- a/src/tirx/transform/lower_tvm_builtin.cc
+++ b/src/tirx/transform/lower_tvm_builtin.cc
@@ -260,7 +260,7 @@ class BuiltinLower : public StmtExprMutator {
     if (const auto* dev_type = device_type_.as<IntImmNode>();
         dev_type && dev_type->value == kDLCPU) {
       auto storage_scope =
-          op->buffer->data->type_annotation.as_or_throw<PointerType>()->storage_scope;
+          op->buffer->data->ty.as_or_throw<PointerType>()->storage_scope;
       if (storage_scope == "global") {
         auto constant_size = stmt.as_or_throw<AllocBuffer>().ConstantAllocationSize();
         if (constant_size.has_value() && constant_size.value() > 0 &&
@@ -683,7 +683,7 @@ class BuiltinLower : public StmtExprMutator {
         Call(PrimType::Int(32), builtin::tvm_throw_last_error(), {}).as_or_throw<PrimExpr>());
 
     const auto* dtype_node =
-        let->var->type_annotation.as<PointerTypeNode>()->element_type.as<PrimTypeNode>();
+        let->var->ty.as<PointerTypeNode>()->element_type.as<PrimTypeNode>();
     TVM_FFI_ICHECK(dtype_node);
     PrimType dtype = ffi::GetRef<PrimType>(dtype_node);
 

--- a/src/tirx/transform/remove_no_op.cc
+++ b/src/tirx/transform/remove_no_op.cc
@@ -168,6 +168,14 @@ class NoOpRemover : public arith::IRMutatorWithAnalyzer {
     }
   }
 
+  bool HasSideEffect(const Expr& value) {
+    if (auto prim = value.as<PrimExpr>()) return HasSideEffect(prim.value());
+    // Variables and string literals are pure.  Preserve non-primitive calls
+    // conservatively because their effect metadata is independent of the
+    // call's semantic return type.
+    return value.as<CallNode>() != nullptr;
+  }
+
   Stmt VisitStmt_(const BufferStoreNode* op) final {
     BufferStore store = ffi::GetRef<BufferStore>(op);
 

--- a/src/tirx/transform/split_host_device.cc
+++ b/src/tirx/transform/split_host_device.cc
@@ -199,7 +199,7 @@ class HostDeviceSplitter : public StmtMutator {
     }
     GlobalVar kernel_symbol_global = var_supply_();
     (*device_mod_)->Add(kernel_symbol_global, device_func);
-    ffi::Array<PrimExpr> args = params.Map([](const Var& var) -> PrimExpr { return var; });
+    ffi::Array<Expr> args = params.Map([](const Var& var) -> Expr { return var; });
 
     if (can_propagate_errors) {
       Var kernel_error_code("kernel_error_code", success.ty());
@@ -572,9 +572,9 @@ class DeviceKernelMutator : public StmtExprMutator {
         // calling a custom TIRToRuntime target) do not require a kernel
         // launch, but need to be replaced with call_extern.
         extern_function_call_.insert(gvar);
-        ffi::Array<PrimExpr> args;
+        ffi::Array<Expr> args;
         args.push_back(StringImm(gvar->name_hint));
-        for (const PrimExpr& arg : node->args.as_or_throw<ffi::Array<PrimExpr>>()) {
+        for (const Expr& arg : node->args) {
           args.push_back(arg);
         }
         return Call(node->ty.as_or_throw<PrimType>(), builtin::call_extern(), args)
@@ -593,23 +593,25 @@ class DeviceKernelMutator : public StmtExprMutator {
     // caller's parameters.  The param_map allows substitution of
     // parameter values into the thread extents, to generate
     // expressions that are valid within the caller.
-    ffi::Array<PrimExpr> prim_args = node->args.as_or_throw<ffi::Array<PrimExpr>>();
+    const ffi::Array<Expr>& args = node->args;
     ffi::Map<Var, PrimExpr> param_map = [&]() {
       ffi::Map<Var, PrimExpr> param_map;
-      TVM_FFI_ICHECK_EQ(prim_args.size(), dev_info.params.size())
+      TVM_FFI_ICHECK_EQ(args.size(), dev_info.params.size())
           << "Function " << gvar->name_hint << " accepts " << dev_info.params.size()
-          << " arguments as input, but is called using " << prim_args.size() << " arguments";
-      for (size_t i = 0; i < prim_args.size(); i++) {
-        param_map.Set(dev_info.params[i], prim_args[i]);
+          << " arguments as input, but is called using " << args.size() << " arguments";
+      for (size_t i = 0; i < args.size(); i++) {
+        if (auto prim_arg = args[i].as<PrimExpr>()) {
+          param_map.Set(dev_info.params[i], prim_arg.value());
+        }
       }
       return param_map;
     }();
 
     device_kernel_launch_.insert(gvar);
 
-    ffi::Array<PrimExpr> call_args;
+    ffi::Array<Expr> call_args;
     call_args.push_back(StringImm(dev_info.global_symbol));
-    for (const PrimExpr& arg : prim_args) {
+    for (const Expr& arg : args) {
       call_args.push_back(arg);
     }
     for (const auto& launch_arg : dev_info.launch_args) {

--- a/src/tirx/transform/split_host_device.cc
+++ b/src/tirx/transform/split_host_device.cc
@@ -310,7 +310,13 @@ class DeviceInfoCollector : public StmtVisitor {
     // variables (e.g. CSE variables) can be inlined back to
     // expressions over function parameters.  Substitute earlier
     // bindings into the value to handle chains (cse_v2 = f(cse_v1)).
-    PrimExpr value = bind_map_.size() ? Substitute(op->value, bind_map_) : op->value;
+    auto prim_value = op->value.as<PrimExpr>();
+    if (!prim_value) {
+      StmtVisitor::VisitStmt_(op);
+      return;
+    }
+    PrimExpr value = bind_map_.size() ? Substitute(prim_value.value(), bind_map_)
+                                      : prim_value.value();
     bind_map_.Set(op->var, value);
     StmtVisitor::VisitStmt_(op);
   }

--- a/src/tirx/transform/split_host_device.cc
+++ b/src/tirx/transform/split_host_device.cc
@@ -141,7 +141,7 @@ class HostDeviceSplitter : public StmtMutator {
         std::sort(params.begin(), params.end(), [](const Var& a, const Var& b) {
           auto sort_key = [](const Var& var) {
             return std::tuple{
-                !var->ty.as_or_throw<PrimType>().IsHandle(),
+                !var.ty().IsHandle(),
                 var->name_hint,
             };
           };

--- a/src/tirx/transform/split_host_device.cc
+++ b/src/tirx/transform/split_host_device.cc
@@ -315,8 +315,8 @@ class DeviceInfoCollector : public StmtVisitor {
       StmtVisitor::VisitStmt_(op);
       return;
     }
-    PrimExpr value = bind_map_.size() ? Substitute(prim_value.value(), bind_map_)
-                                      : prim_value.value();
+    PrimExpr value =
+        bind_map_.size() ? Substitute(prim_value.value(), bind_map_) : prim_value.value();
     bind_map_.Set(op->var, value);
     StmtVisitor::VisitStmt_(op);
   }

--- a/src/tirx/transform/stmt_simplify.cc
+++ b/src/tirx/transform/stmt_simplify.cc
@@ -143,7 +143,11 @@ class StmtSimplifier : public IRMutatorWithAnalyzer {
   }
 
   Stmt VisitStmt_(const BindNode* op) override {
-    PrimExpr value = this->VisitExpr(op->value);
+    auto prim_value = op->value.as<PrimExpr>();
+    if (!prim_value) {
+      return Parent::VisitStmt_(op);
+    }
+    PrimExpr value = this->VisitExpr(prim_value.value());
     // Bind in analyzer for constraint proving and simplification of
     // subsequent expressions.  Don't remove the Bind statement --
     // with flat Bind there's no body to inspect for usage patterns,

--- a/src/tirx/transform/storage_rewrite.cc
+++ b/src/tirx/transform/storage_rewrite.cc
@@ -1236,7 +1236,7 @@ class VectorTypeAccessChecker : public StmtExprVisitor {
     // If a pointer parameter isn't in the buffer map, then we want to
     // track the parameter itself.
     for (Var buffer_var : params) {
-      auto pointer_type = GetPointerType(buffer_var->type_annotation);
+      auto pointer_type = GetPointerType(buffer_var->ty);
       if (pointer_type.has_value() && (buffer_map.count(buffer_var) == 0)) {
         PrimType dtype = pointer_type.value();
         PrimExpr extent = 0;
@@ -1296,7 +1296,7 @@ class VectorTypeAccessChecker : public StmtExprVisitor {
 
   void HandleLetNode(Var let_var) {
     if (let_var.ty().IsHandle()) {
-      auto pointer_type = GetPointerType(let_var->type_annotation);
+      auto pointer_type = GetPointerType(let_var->ty);
       if (pointer_type.has_value()) {
         OnArrayDeclaration(let_var, pointer_type.value(), 0, BufferVarInfo::kLetNode);
       } else if (allow_untyped_pointers_) {

--- a/src/tirx/transform/storage_rewrite.cc
+++ b/src/tirx/transform/storage_rewrite.cc
@@ -1604,7 +1604,7 @@ class VectorTypeRewriter : public StmtExprMutator {
 
   Stmt VisitStmt_(const BindNode* op) final {
     auto it = rewrite_map_.find(op->var.get());
-    PrimExpr value = this->VisitExpr(op->value);
+    Expr value = this->VisitExpr(op->value);
     Var var = (it == rewrite_map_.end()) ? op->var : it->second.new_buffer_var;
     if (var.same_as(op->var) && value.same_as(op->value)) {
       return ffi::GetRef<Stmt>(op);

--- a/src/tirx/transform/tvm_ffi_binder.cc
+++ b/src/tirx/transform/tvm_ffi_binder.cc
@@ -179,7 +179,7 @@ bool TVMFFIABIBuilder::BindScalar(const PrimExpr& arg, const PrimExpr& value,
       return true;
     } else {
       // Duplicate bind: create rich assertion with both paths
-      PrimExpr prev_value = it->second.value;
+      PrimExpr prev_value = it->second.value.as_or_throw<PrimExpr>();
       PrimExpr scond = analyzer_->Simplify(prev_value == value);
       if (is_zero(scond)) {
         TVM_FFI_THROW(InternalError) << "Bind have an unmet assertion: " << prev_value
@@ -218,6 +218,41 @@ bool TVMFFIABIBuilder::BindScalar(const PrimExpr& arg, const PrimExpr& value,
     if (!is_one(scond)) {
       pending_const_asserts_.push_back({scond, path, arg});
     }
+  }
+  return false;
+}
+
+bool TVMFFIABIBuilder::BindPointer(const Var& arg, const Expr& value,
+                                   const ffi::reflection::AccessPath& path, bool with_lets) {
+  TVM_FFI_ICHECK(ffi::StructuralEqual()(arg->ty, value->ty));
+  auto it = var_defs_.find(arg.get());
+  if (it == var_defs_.end()) {
+    var_defs_.emplace(arg.get(), VarDefInfo{value, path});
+    if (with_lets) {
+      init_nest_.emplace_back(Bind(arg, value));
+    }
+    return true;
+  }
+
+  auto pointer_as_uint = [](const Expr& expr) {
+    return Call(PrimType::UInt(64), builtin::reinterpret(), {expr}).as_or_throw<PrimExpr>();
+  };
+  PrimExpr prev_value = pointer_as_uint(it->second.value);
+  PrimExpr current_value = pointer_as_uint(value);
+  PrimExpr condition = analyzer_->Simplify(prev_value == current_value);
+  if (is_zero(condition)) {
+    TVM_FFI_THROW(InternalError) << "Bind has an unmet pointer assertion at "
+                                 << RenderAccessPath(path);
+  }
+  if (!is_one(condition)) {
+    ffi::String current_path = RenderAccessPath(path);
+    ffi::String first_path = RenderAccessPath(it->second.first_def_path);
+    ffi::Array<StringImm> parts{StringImm("Mismatched "), StringImm(current_path)};
+    if (!first_path.empty() && first_path != current_path) {
+      parts.push_back(StringImm("`,\n  expected to match "));
+      parts.push_back(StringImm(first_path));
+    }
+    asserts_.emplace_back(AssertStmt(condition, StringImm("ValueError"), parts));
   }
   return false;
 }
@@ -766,9 +801,10 @@ void TVMFFIABIBuilder::DecodeParamDLTensor(const Buffer& buffer, const PrimExpr&
   // ── Section: data pointer ────────────────────────────────────
   {
     ffi::reflection::AccessPath data_path = param_path->Attr(ffi::String("data"));
-    if (BindScalar(buffer->data,
-                   TVMStructGet(PrimType::Handle(), handle, 0, builtin::kDLTensorData), data_path,
-                   true)) {
+    PrimExpr raw_data =
+        TVMStructGet(PrimType::Handle(), handle, 0, builtin::kDLTensorData);
+    Expr typed_data = Call(buffer->data->ty, builtin::reinterpret(), {raw_data});
+    if (BindPointer(buffer->data, typed_data, data_path, true)) {
       Var vptr(buffer->data);
 
       auto alloc_size = [&]() -> PrimExpr {

--- a/src/tirx/transform/tvm_ffi_binder.cc
+++ b/src/tirx/transform/tvm_ffi_binder.cc
@@ -801,8 +801,7 @@ void TVMFFIABIBuilder::DecodeParamDLTensor(const Buffer& buffer, const PrimExpr&
   // ── Section: data pointer ────────────────────────────────────
   {
     ffi::reflection::AccessPath data_path = param_path->Attr(ffi::String("data"));
-    PrimExpr raw_data =
-        TVMStructGet(PrimType::Handle(), handle, 0, builtin::kDLTensorData);
+    PrimExpr raw_data = TVMStructGet(PrimType::Handle(), handle, 0, builtin::kDLTensorData);
     Expr typed_data = Call(buffer->data->ty, builtin::reinterpret(), {raw_data});
     if (BindPointer(buffer->data, typed_data, data_path, true)) {
       Var vptr(buffer->data);

--- a/src/tirx/transform/tvm_ffi_binder.h
+++ b/src/tirx/transform/tvm_ffi_binder.h
@@ -245,8 +245,8 @@ class TVMFFIABIBuilder {
                   const ffi::reflection::AccessPath& path, bool with_lets);
 
   /*! \brief Bind an exact pointer-typed variable to a pointer-valued expression. */
-  bool BindPointer(const Var& arg, const Expr& value,
-                   const ffi::reflection::AccessPath& path, bool with_lets);
+  bool BindPointer(const Var& arg, const Expr& value, const ffi::reflection::AccessPath& path,
+                   bool with_lets);
 
   /*!
    * \brief Array bind: binds element-wise with ffi::reflection::AccessPath[k] for each element.

--- a/src/tirx/transform/tvm_ffi_binder.h
+++ b/src/tirx/transform/tvm_ffi_binder.h
@@ -88,7 +88,7 @@ class TVMFFIABIBuilder {
   /*! \brief Variable definition info: bound value and the ffi::reflection::AccessPath where first
    * defined. */
   struct VarDefInfo {
-    PrimExpr value;
+    Expr value;
     ffi::reflection::AccessPath first_def_path;
   };
 
@@ -243,6 +243,10 @@ class TVMFFIABIBuilder {
    */
   bool BindScalar(const PrimExpr& arg, const PrimExpr& value,
                   const ffi::reflection::AccessPath& path, bool with_lets);
+
+  /*! \brief Bind an exact pointer-typed variable to a pointer-valued expression. */
+  bool BindPointer(const Var& arg, const Expr& value,
+                   const ffi::reflection::AccessPath& path, bool with_lets);
 
   /*!
    * \brief Array bind: binds element-wise with ffi::reflection::AccessPath[k] for each element.

--- a/src/tirx/transform/unsupported_dtype_legalize.cc
+++ b/src/tirx/transform/unsupported_dtype_legalize.cc
@@ -330,10 +330,14 @@ class ComputeLegalizer : public StmtExprMutator {
   DEFINE_BIOP_EXPR_LEGALIZE(NENode, operator!=);
 
   Stmt VisitStmt_(const BindNode* op) final {
-    PrimExpr value = PromoteToTarget(op->value);
+    auto prim_value = op->value.as<PrimExpr>();
+    if (!prim_value) {
+      return StmtExprMutator::VisitStmt_(op);
+    }
+    PrimExpr value = PromoteToTarget(prim_value.value());
     Var var = op->var;
-    if (value.ty() != op->value.ty()) {
-      var = op->var.copy_with_dtype(op->value.ty());
+    if (value.ty() != prim_value.value().ty()) {
+      var = op->var.copy_with_dtype(prim_value.value().ty());
       var_remap_[op->var] = var;
     }
 
@@ -621,7 +625,7 @@ class StorageLegalizer : public StmtExprMutator {
   }
 
   Stmt VisitStmt_(const BindNode* op) final {
-    PrimExpr value = VisitExpr(op->value);
+    Expr value = VisitExpr(op->value);
     Var var = RemapVarDef(op->var);
 
     if (value.same_as(op->value) && var.same_as(op->var)) {

--- a/src/tirx/transform/unsupported_dtype_legalize.cc
+++ b/src/tirx/transform/unsupported_dtype_legalize.cc
@@ -116,7 +116,7 @@ class ComputeLegalizePlanner : public StmtExprVisitor {
     if (MatchType(op->buffer->dtype)) {
       PrimType dtype = promote_dtype_.WithLanes(op->buffer->dtype.lanes());
       ffi::String storage_scope = "global";
-      if (auto* ptr_type = op->buffer->data->type_annotation.as<PointerTypeNode>()) {
+      if (auto* ptr_type = op->buffer->data->ty.as<PointerTypeNode>()) {
         storage_scope = ptr_type->storage_scope;
       }
       Var buffer_var = Var(op->buffer->data->name_hint, PointerType(dtype, storage_scope));
@@ -570,7 +570,7 @@ class StorageLegalizer : public StmtExprMutator {
     if (MatchType(buf->dtype)) {
       PrimType new_dtype = GetStorageUIntDType(buf->dtype);
       ffi::String storage_scope = "global";
-      if (auto* ptr_type = buf->data->type_annotation.as<PointerTypeNode>()) {
+      if (auto* ptr_type = buf->data->ty.as<PointerTypeNode>()) {
         storage_scope = ptr_type->storage_scope;
       }
       Var new_data = Var(buf->data->name_hint, PointerType(new_dtype, storage_scope));
@@ -720,7 +720,7 @@ class StorageLegalizer : public StmtExprMutator {
   Var RemapVarDef(Var var) {
     // remap the var
     if (var.ty().IsHandle()) {
-      if (auto* ptr_type = var->type_annotation.as<PointerTypeNode>()) {
+      if (auto* ptr_type = var->ty.as<PointerTypeNode>()) {
         if (auto* elem_type = ptr_type->element_type.as<PrimTypeNode>()) {
           PrimType elem_prim_type = ffi::GetRef<PrimType>(elem_type);
           if (MatchType(elem_prim_type)) {

--- a/src/tirx/transform/update_pointer_storage_scope.cc
+++ b/src/tirx/transform/update_pointer_storage_scope.cc
@@ -39,7 +39,7 @@ namespace tvm {
 namespace tirx {
 
 Var WithStorageScope(const VarNode* buffer_var, ffi::String storage_scope) {
-  auto* ptr_type = buffer_var->type_annotation.as<PointerTypeNode>();
+  auto* ptr_type = buffer_var->ty.as<PointerTypeNode>();
   TVM_FFI_ICHECK(ptr_type) << "The provided variable is not of pointer type";
   return Var(buffer_var->name_hint, PointerType(ptr_type->element_type, storage_scope),
              buffer_var->span);

--- a/src/tirx/transform/vectorize_loop.cc
+++ b/src/tirx/transform/vectorize_loop.cc
@@ -935,8 +935,7 @@ class Vectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimExp
     TVM_FFI_ICHECK(!let_binding_.count(op->var)) << "SSA violation, a single var is binded twice";
     let_binding_[op->var] = value;
 
-    if (GetLanesOrVScaleFactor(value.ty()) !=
-        GetLanesOrVScaleFactor(prim_value.value().ty())) {
+    if (GetLanesOrVScaleFactor(value.ty()) != GetLanesOrVScaleFactor(prim_value.value().ty())) {
       Var new_var(op->var->name_hint, value.ty());
       let_binding_[op->var] = new_var;
       return Bind(new_var, value);

--- a/src/tirx/transform/vectorize_loop.cc
+++ b/src/tirx/transform/vectorize_loop.cc
@@ -921,17 +921,22 @@ class Vectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimExp
   }
   // Bind
   Stmt VisitStmt_(const BindNode* op) final {
-    PrimExpr value = this->VisitExpr(op->value);
+    auto prim_value = op->value.as<PrimExpr>();
+    if (!prim_value) {
+      return StmtMutator::VisitStmt_(op);
+    }
+    PrimExpr value = this->VisitExpr(prim_value.value());
     // if visit of value triggers need scalarize
     // we need to scalarize the let
     if (need_scalarize_) {
       need_scalarize_ = false;
-      Scalarize(ffi::GetRef<Stmt>(op));
+      return Scalarize(ffi::GetRef<Stmt>(op));
     }
     TVM_FFI_ICHECK(!let_binding_.count(op->var)) << "SSA violation, a single var is binded twice";
     let_binding_[op->var] = value;
 
-    if (GetLanesOrVScaleFactor(value.ty()) != GetLanesOrVScaleFactor(op->value.ty())) {
+    if (GetLanesOrVScaleFactor(value.ty()) !=
+        GetLanesOrVScaleFactor(prim_value.value().ty())) {
       Var new_var(op->var->name_hint, value.ty());
       let_binding_[op->var] = new_var;
       return Bind(new_var, value);

--- a/src/tirx/transform/vectorize_loop.cc
+++ b/src/tirx/transform/vectorize_loop.cc
@@ -612,7 +612,7 @@ class Vectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimExp
       ffi::Array<PrimExpr> fcd = MutateArray({op->args.back().as_or_throw<PrimExpr>()}, &lane);
       DLDataType dtype = op->args[0]
                              .as<VarNode>()
-                             ->type_annotation.as<PointerTypeNode>()
+                             ->ty.as<PointerTypeNode>()
                              ->element_type.as<PrimTypeNode>()
                              ->dtype;
       TVM_FFI_ICHECK(lane * dtype.bits <= op->args[4].as<IntImmNode>()->value)
@@ -632,7 +632,7 @@ class Vectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimExp
       ffi::Array<PrimExpr> mutated_value = MutateArray(value, &lane);
       DLDataType dtype = op->args[0]
                              .as<VarNode>()
-                             ->type_annotation.as<PointerTypeNode>()
+                             ->ty.as<PointerTypeNode>()
                              ->element_type.as<PrimTypeNode>()
                              ->dtype;
       TVM_FFI_ICHECK(lane * dtype.bits == op->args[4].as<IntImmNode>()->value)

--- a/tests/cpp/expr_test.cc
+++ b/tests/cpp/expr_test.cc
@@ -43,7 +43,7 @@ TEST(Expr, VarTypeAnnotation) {
   Var y("y", PrimType::Float(32));
   tvm::ffi::StructuralEqual checker;
   TVM_FFI_ICHECK(checker(x.ty(), y.ty()));
-  TVM_FFI_ICHECK(checker(x->type_annotation, y->type_annotation));
+  TVM_FFI_ICHECK(checker(x->ty, y->ty));
 }
 
 TEST(Expr, PrimTypeBoolLanes) {

--- a/tests/python/codegen/test_target_codegen_c_host.py
+++ b/tests/python/codegen/test_target_codegen_c_host.py
@@ -227,5 +227,28 @@ def test_subroutine_call():
     )
 
 
+def test_pointer_offset_bindings_use_element_type():
+    buffer = tvm.tirx.decl_buffer([4], "float32", name="A")
+    bind_var = tvm.tirx.Var("bind_shifted", "handle")
+    let_var = tvm.tirx.Var("let_shifted", "handle")
+    pointer_value = tvm.tirx.ptr_byte_offset(buffer.data, 4, "float32")
+    body = tvm.tirx.SeqStmt(
+        [
+            tvm.tirx.Bind(bind_var, pointer_value),
+            tvm.tirx.Evaluate(tvm.tirx.Let(let_var, pointer_value, 0)),
+        ]
+    )
+    func = tvm.tirx.PrimFunc([buffer.data], body, buffer_map={buffer.data: buffer}).with_attr(
+        "global_symbol", "main"
+    )
+    built = tvm.get_global_func("target.build.c")(
+        tvm.IRModule({"main": func}), tvm.target.Target("c")
+    )
+
+    source = built.inspect_source()
+    assert "float* bind_shifted" in source
+    assert "float* let_shifted" in source
+
+
 if __name__ == "__main__":
     tvm.testing.main()

--- a/tests/python/relax/test_expr.py
+++ b/tests/python/relax/test_expr.py
@@ -36,6 +36,11 @@ def _check_equal(x, y, map_free_vars=False):
     assert xhash == yhash
 
 
+def _check_not_equal(x, y, map_free_vars=False):
+    assert not tvm_ffi.structural_equal(x, y, map_free_vars)
+    assert tvm_ffi.structural_hash(x, map_free_vars) != tvm_ffi.structural_hash(y, map_free_vars)
+
+
 def _check_json_roundtrip(x):
     xret = tvm.ir.load_json(tvm.ir.save_json(x))
     _check_equal(x, xret, map_free_vars=True)
@@ -331,6 +336,48 @@ def test_call():
     assert call.op.same_as(func)
     assert len(call.args) == 1
     assert call.args[0].same_as(arg)
+
+
+def test_expr_structural_identity_includes_type_but_not_span():
+    span_a = tvm.ir.Span(tvm.ir.SourceName("a.py"), 1, 1, 0, 1)
+    span_b = tvm.ir.Span(tvm.ir.SourceName("b.py"), 2, 2, 0, 1)
+
+    int32_a = tirx.IntImm("int32", 1, span_a)
+    int32_b = tirx.IntImm("int32", 1, span_b)
+    int64 = tirx.IntImm("int64", 1)
+    _check_equal(int32_a, int32_b)
+    _check_not_equal(int32_a, int64)
+
+    string_a = rx.StringImm("value", span_a)
+    string_b = rx.StringImm("value", span_b)
+    _check_equal(string_a, string_b)
+    _check_not_equal(string_a, rx.StringImm("other"))
+
+    op = rx.Var("op", rx.FuncType([], tvm.ir.PrimType("int32")))
+    missing = tvm.ir.Call(op, [], span=span_a)
+    known_a = tvm.ir.Call(op, [], ret_ty="int32", span=span_a)
+    known_b = tvm.ir.Call(op, [], ret_ty="int32", span=span_b)
+    different = tvm.ir.Call(op, [], ret_ty="int64")
+    _check_equal(known_a, known_b)
+    _check_not_equal(missing, known_a)
+    _check_not_equal(known_a, different)
+
+
+def test_variable_structural_identity_includes_exact_type():
+    span_a = tvm.ir.Span(tvm.ir.SourceName("a.py"), 1, 1, 0, 1)
+    span_b = tvm.ir.Span(tvm.ir.SourceName("b.py"), 2, 2, 0, 1)
+
+    tirx_int32_a = tirx.Var("v", "int32", span_a)
+    tirx_int32_b = tirx.Var("v", "int32", span_b)
+    tirx_int64 = tirx.Var("v", "int64")
+    _check_equal(tirx_int32_a, tirx_int32_b, map_free_vars=True)
+    _check_not_equal(tirx_int32_a, tirx_int64, map_free_vars=True)
+
+    relax_var = rx.Var("v", tvm.ir.PrimType("int32"), span_a)
+    relax_same = rx.Var(relax_var.vid, tvm.ir.PrimType("int32"), span_b)
+    relax_different = rx.Var(relax_var.vid, tvm.ir.PrimType("int64"))
+    _check_equal(relax_var, relax_same)
+    _check_not_equal(relax_var, relax_different)
 
 
 def test_call_accepts_core_expr_operator():

--- a/tests/python/relax/test_frontend_from_exported_program.py
+++ b/tests/python/relax/test_frontend_from_exported_program.py
@@ -6227,9 +6227,9 @@ def test_hamming_window():
             with R.dataflow():
                 lv: R.Tensor((20,), dtype="float32") = R.hamming_window(
                     R.prim_value(20),
-                    R.prim_value(1),
-                    R.prim_value(T.float32(0.54000000000000004)),
-                    R.prim_value(T.float32(0.46000000000000002)),
+                    R.prim_value(True),
+                    R.prim_value(T.float64(0.54000000000000004)),
+                    R.prim_value(T.float64(0.46000000000000002)),
                     dtype="float32",
                 )
                 gv: R.Tuple(R.Tensor((20,), dtype="float32")) = (lv,)

--- a/tests/python/relax/test_transform_specialize_primfunc_based_on_callsite.py
+++ b/tests/python/relax/test_transform_specialize_primfunc_based_on_callsite.py
@@ -45,8 +45,8 @@ class ValidateBufferScopes(PyExprVisitor):  # pylint: disable=abstract-method
             if not self.is_matched:
                 # All scopes should be global in before pass
                 for _, buf in pfunc.buffer_map.items():
-                    assert "global" == buf.data.type_annotation.storage_scope, (
-                        f"expected to be global scoped, but got {val.data.type_annotation.storage_scope}"
+                    assert "global" == buf.data.ty.storage_scope, (
+                        f"expected to be global scoped, but got {val.data.ty.storage_scope}"
                     )
             else:
                 for idx, arg in enumerate(call.args[1]):
@@ -55,16 +55,16 @@ class ValidateBufferScopes(PyExprVisitor):  # pylint: disable=abstract-method
                         f"Expected TensorType but git {type(arg_ty)}"
                     )
                     buf = pfunc.buffer_map[pfunc.params[idx]]
-                    assert arg_ty.vdevice.memory_scope == buf.data.type_annotation.storage_scope, (
-                        f"scope mismatched after specialization {arg_ty.vdevice.memory_scope} vs {buf.data.type_annotation.storage_scope}"
+                    assert arg_ty.vdevice.memory_scope == buf.data.ty.storage_scope, (
+                        f"scope mismatched after specialization {arg_ty.vdevice.memory_scope} vs {buf.data.ty.storage_scope}"
                     )
                 if isinstance(call.ty_args[0], relax.TensorType):
                     buf = pfunc.buffer_map[pfunc.params[-1]]
                     assert (
                         call.ty_args[0].vdevice.memory_scope
-                        == buf.data.type_annotation.storage_scope
+                        == buf.data.ty.storage_scope
                     ), (
-                        f"scope mismatched after specialization {call.ty_args[0].vdevice.memory_scope} vs {buf.data.type_annotation.storage_scope}"
+                        f"scope mismatched after specialization {call.ty_args[0].vdevice.memory_scope} vs {buf.data.ty.storage_scope}"
                     )
                 else:
                     assert isinstance(call.ty_args[0], relax.TupleType), (
@@ -72,8 +72,8 @@ class ValidateBufferScopes(PyExprVisitor):  # pylint: disable=abstract-method
                     )
                     for idx, ty in enumerate(call.ty_args[0].fields):
                         buf = pfunc.buffer_map[pfunc.params[len(call.args[1]) + idx]]
-                        assert ty.vdevice.memory_scope == buf.data.type_annotation.storage_scope, (
-                            f"scope mismatched after specialization {ty.vdevice.memory_scope} vs {buf.data.type_annotation.storage_scope}"
+                        assert ty.vdevice.memory_scope == buf.data.ty.storage_scope, (
+                            f"scope mismatched after specialization {ty.vdevice.memory_scope} vs {buf.data.ty.storage_scope}"
                         )
 
 

--- a/tests/python/relax/test_transform_specialize_primfunc_based_on_callsite.py
+++ b/tests/python/relax/test_transform_specialize_primfunc_based_on_callsite.py
@@ -60,10 +60,7 @@ class ValidateBufferScopes(PyExprVisitor):  # pylint: disable=abstract-method
                     )
                 if isinstance(call.ty_args[0], relax.TensorType):
                     buf = pfunc.buffer_map[pfunc.params[-1]]
-                    assert (
-                        call.ty_args[0].vdevice.memory_scope
-                        == buf.data.ty.storage_scope
-                    ), (
+                    assert call.ty_args[0].vdevice.memory_scope == buf.data.ty.storage_scope, (
                         f"scope mismatched after specialization {call.ty_args[0].vdevice.memory_scope} vs {buf.data.ty.storage_scope}"
                     )
                 else:

--- a/tests/python/relax/test_utils.py
+++ b/tests/python/relax/test_utils.py
@@ -143,7 +143,7 @@ def test_assert_structural_equal_in_seqexpr():
 
     with pytest.raises(
         ValueError,
-        match=re.escape("<root>.body.blocks[0].bindings[0].value.op"),
+        match=re.escape("<root>.ty.ret.shape.ty.values[0].value"),
     ):
         assert_structural_equal(func_1, func_2)
 

--- a/tests/python/s_tir/analysis/test_s_tir_analysis_oob.py
+++ b/tests/python/s_tir/analysis/test_s_tir_analysis_oob.py
@@ -48,6 +48,12 @@ def unknown_bounds(A: T.Buffer((2, 3), "float32"), B: T.Buffer((3, 2), "float32"
         B[0, N] = A[1, i]
 
 
+@T.prim_func(s_tir=True)
+def bad_load_in_pointer_bind(A: T.Buffer((2,), "float32")):
+    pointer: T.let[T.handle("float32")] = T.address_of(A[2])
+    T.evaluate(pointer)
+
+
 def test_oob_load():
     with pytest.raises(tvm.s_tir.ScheduleError) as err:
         tvm.s_tir.analysis.OOBChecker()(tvm.IRModule.from_expr(bad_load))
@@ -55,6 +61,10 @@ def test_oob_load():
 
     with pytest.raises(tvm.s_tir.ScheduleError) as err:
         tvm.s_tir.analysis.OOBChecker()(tvm.IRModule.from_expr(bad_load_loop))
+    assert "buffer A" in err.value.args[0]
+
+    with pytest.raises(tvm.s_tir.ScheduleError) as err:
+        tvm.s_tir.analysis.OOBChecker()(tvm.IRModule.from_expr(bad_load_in_pointer_bind))
     assert "buffer A" in err.value.args[0]
 
 

--- a/tests/python/s_tir/transform/test_s_tir_transform_inject_virtual_thread.py
+++ b/tests/python/s_tir/transform/test_s_tir_transform_inject_virtual_thread.py
@@ -205,7 +205,7 @@ def test_vthread_vectorized():
 
     def visitor(op):
         nonlocal allocate_node
-        if isinstance(op, tvm.tirx.AllocBuffer) and "shared" in str(op.buffer.data.type_annotation):
+        if isinstance(op, tvm.tirx.AllocBuffer) and "shared" in str(op.buffer.data.ty):
             allocate_node = op
 
     tvm.tirx.stmt_functor.post_order_visit(after_func.body, visitor)

--- a/tests/python/tirx-base/test_tir_constructor.py
+++ b/tests/python/tirx-base/test_tir_constructor.py
@@ -195,6 +195,24 @@ def test_expr_constructor():
     assert x.body == v
 
 
+def test_stmt_simplify_visits_pointer_bind_value():
+    pointer_type = tvm.ir.PointerType(tvm.ir.PrimType("float32"), "global")
+    scalar = tvm.tirx.Var("scalar", "int32")
+    pointer = tvm.tirx.Var("pointer", pointer_type)
+    pointer_value = tvm.ir.Call(
+        "tirx.call_extern",
+        [tvm.tirx.StringImm("get_pointer"), scalar + 0],
+        ret_ty=pointer_type,
+    )
+    body = tvm.tirx.SeqStmt([tvm.tirx.Bind(pointer, pointer_value), tvm.tirx.Evaluate(pointer)])
+    before = tvm.IRModule({"main": tvm.tirx.PrimFunc([scalar], body)})
+
+    after = tvm.tirx.transform.StmtSimplify()(before)["main"]
+    simplified_value = after.body[0].value
+
+    assert simplified_value.args[1].same_as(scalar)
+
+
 def test_stmt_constructor():
     v = tvm.tirx.Var("aa", "int32")
     nop = tvm.tirx.Evaluate(1)

--- a/tests/python/tirx-base/test_tir_nodes.py
+++ b/tests/python/tirx-base/test_tir_nodes.py
@@ -93,6 +93,15 @@ def test_let():
     y = tvm.tirx.Var("y", "int32")
     stmt = tvm.tirx.Bind(x, 10)
 
+    pointer_type = ir.PointerType(ir.PrimType("float32"), "global")
+    pointer_var = tvm.tirx.Var("pointer_var", pointer_type)
+    pointer_value = tvm.tirx.Var("pointer_value", pointer_type)
+    pointer_stmt = tvm.tirx.Bind(pointer_var, pointer_value)
+    assert pointer_stmt.value.same_as(pointer_value)
+
+    with pytest.raises(RuntimeError):
+        tvm.tirx.Bind(pointer_var, x)
+
 
 def test_cast():
     x = tvm.tirx.Var("x", "float32")
@@ -321,10 +330,13 @@ def test_prim_func():
 def test_vars():
     x = tvm.tirx.Var("xyz", "int8")
     assert x.ty.dtype == "int8"
+    assert isinstance(x + 1, tvm.tirx.Add)
     ptype = tvm.ir.PointerType(tvm.ir.PrimType("float"))
     x = tvm.tirx.Var("xyz", ptype)
-    assert x.ty.dtype == "handle"
-    assert x.type_annotation == ptype
+    assert x.ty == ptype
+    assert not hasattr(x, "type_annotation")
+    with pytest.raises(TypeError):
+        x + 1
     assert isinstance(ptype.element_type, tvm.ir.PrimType)
 
 
@@ -333,9 +345,8 @@ def test_scoped_storage_vars():
     storage_scope = "global.texture"
     ptype = tvm.ir.PointerType(tvm.ir.PrimType(dtype), storage_scope)
     x = tvm.tirx.Var("xyz", ptype)
-    assert x.ty.dtype == "handle"
-    assert x.type_annotation == ptype
-    assert x.type_annotation.storage_scope == storage_scope
+    assert x.ty == ptype
+    assert x.ty.storage_scope == storage_scope
     assert isinstance(ptype.element_type, tvm.ir.PrimType)
 
 

--- a/tests/python/tvmscript/test_tvmscript_parser_tir.py
+++ b/tests/python/tvmscript/test_tvmscript_parser_tir.py
@@ -44,19 +44,17 @@ def test_tir_ptr_proxy():
     ptr_0 = T.handle("int32", "global")
     assert (
         isinstance(ptr_0, tirx.Var)
-        and ptr_0.ty.dtype == "handle"
-        and isinstance(ptr_0.type_annotation, ir.PointerType)
-        and ptr_0.type_annotation.element_type == ir.PrimType("int32")
-        and ptr_0.type_annotation.storage_scope == "global"
+        and isinstance(ptr_0.ty, ir.PointerType)
+        and ptr_0.ty.element_type == ir.PrimType("int32")
+        and ptr_0.ty.storage_scope == "global"
     )
 
     ptr_1 = T.handle("float32", "shared")
     assert (
         isinstance(ptr_1, tirx.Var)
-        and ptr_1.ty.dtype == "handle"
-        and isinstance(ptr_1.type_annotation, ir.PointerType)
-        and ptr_1.type_annotation.element_type == ir.PrimType("float32")
-        and ptr_1.type_annotation.storage_scope == "shared"
+        and isinstance(ptr_1.ty, ir.PointerType)
+        and ptr_1.ty.element_type == ir.PrimType("float32")
+        and ptr_1.ty.storage_scope == "shared"
     )
 
 

--- a/tests/python/tvmscript/test_tvmscript_printer_structural_equal.py
+++ b/tests/python/tvmscript/test_tvmscript_printer_structural_equal.py
@@ -74,15 +74,21 @@ def test_prim_func_buffer_map():
         func1,
         func2,
         AccessPath.root()
-        .attr("buffer_map")
-        .map_item(func1.params[1])
+        .attr("ty")
+        .attr("params")
+        .array_item(1)
         .attr("shape")
+        .attr("ty")
+        .attr("values")
         .array_item(1)
         .attr("value"),
         AccessPath.root()
-        .attr("buffer_map")
-        .map_item(func2.params[1])
+        .attr("ty")
+        .attr("params")
+        .array_item(1)
         .attr("shape")
+        .attr("ty")
+        .attr("values")
         .array_item(1)
         .attr("value"),
     )


### PR DESCRIPTION
Make `ExprNode::ty` participate in structural equality and hashing, then remove the duplicate reflected `tirx::VarNode::type_annotation` field so inherited `VarNode::ty` is the exact semantic type source.

Scalar variables remain primitive expressions, while pointer variables retain `PointerType` and remain valid generic expressions. `Var::ty()` continues to provide the runtime primitive-type view at machine-facing boundaries. The change updates traversal, substitution, script parsing/printing, analysis, lowering, and code generation to narrow to primitive expressions only where required, while retaining the explicit `tirx.type_annotation` access-pointer intrinsic.

Validation includes the full compiler build, TIRx base tests, TVMScript round trips, focused arithmetic/Relax/S-TIR/structural-identity coverage, and representative LLVM texture compilation.