### PR TITLE
[Relax] Fix bucketize output dtype during legalization

### DIFF
--- a/python/tvm/relax/backend/dispatch_sort_scan.py
+++ b/python/tvm/relax/backend/dispatch_sort_scan.py
@@ -85,8 +85,9 @@ class SortScanDispatcher(BackendDispatcher):
             with tgt:
                 if self.is_gpu_target(tgt):
                     te_func = topi.gpu.searchsorted
+            out_dtype = "int32" if call.attrs.out_int32 else "int64"
             return self.builder_.call_te(
-                te_func, boundaries, input_tensor, right, input_tensor.ty.dtype.dtype
+                te_func, boundaries, input_tensor, right, out_dtype
             )
         if call.op.name == "relax.sort":
             tgt = self._get_target(call.ty)

--- a/python/tvm/relax/transform/legalize_ops/search.py
+++ b/python/tvm/relax/transform/legalize_ops/search.py
@@ -48,4 +48,5 @@ def _bucketize(bb, call):
     input_tensor = call.args[0]
     boundaries = call.args[1]
     right = call.attrs.right
-    return bb.call_te(topi.searchsorted, boundaries, input_tensor, right, input_tensor.ty.dtype)
+    out_dtype = "int32" if call.attrs.out_int32 else "int64"
+    return bb.call_te(topi.searchsorted, boundaries, input_tensor, right, out_dtype)

--- a/tests/python/relax/test_frontend_from_exported_program.py
+++ b/tests/python/relax/test_frontend_from_exported_program.py
@@ -7829,6 +7829,19 @@ def test_bucketize():
     verify_model(Bucketize(), (input_tensor, boundaries), {}, Expected)
 
 
+@pytest.mark.parametrize("right", [False, True])
+@pytest.mark.parametrize("out_int32", [False, True])
+def test_bucketize_numerically(right, out_int32):
+    class Bucketize(Module):
+        def forward(self, input_tensor, boundaries):
+            return torch.bucketize(input_tensor, boundaries, right=right, out_int32=out_int32)
+
+    input_tensor = torch.tensor([-0.5, 0.0, 0.5, 1.0, 2.0, 2.5], dtype=torch.float32)
+    boundaries = torch.tensor([0.0, 1.0, 2.0], dtype=torch.float32)
+
+    verify_model_numerically(Bucketize(), (input_tensor, boundaries))
+
+
 def test_argsort():
     class Argsort(Module):
         def forward(self, x):


### PR DESCRIPTION
This PR fixes Relax bucketize lowering to pass the correct integer output dtype to TOPI searchsorted.

  Previously, both LegalizeOps and DispatchSortScan passed the input tensor dtype as the output dtype. For float input tensors, this caused TOPI searchsorted to receive a float output dtype, which later failed during binary-search lowering because bucket indices must be integer values.

  This patch derives the output dtype from bucketize's out_int32 attribute:
  - int32 when out_int32=True
  - int64 otherwise

  A numerical ExportedProgram frontend test is added to cover:
  - right=False
  - right=True
  - out_int32=False
  - out_int32=True
  - float input values on bucket boundaries

  Test:
  python -m pytest tests/python/relax/test_frontend_from_exported_program.py -k "bucketize" -q