### PR TITLE
[FFI] Use thread-safe packed function initialization

### DIFF
--- a/include/tvm/runtime/c_backend_api.h
+++ b/include/tvm/runtime/c_backend_api.h
@@ -116,19 +116,6 @@ TVM_RUNTIME_DLL int TVMBackendParallelLaunch(FTVMParallelLambda flambda, void* c
  */
 TVM_RUNTIME_DLL int TVMBackendParallelBarrier(int task_id, TVMParallelGroupEnv* penv);
 
-/*!
- * \brief Simple static initialization function.
- *  Run f once and set handle to be not null.
- *  This function is mainly used for test purpose.
- *
- * \param handle A global address to indicate f
- * \param f The function to be run
- * \param cdata The closure data to pass to the function.
- * \param nbytes Number of bytes in the closure data.
- * \return 0 when no error is thrown, -1 when failure happens
- */
-TVM_RUNTIME_DLL int TVMBackendRunOnce(void** handle, int (*f)(void*), void* cdata, int nbytes);
-
 #ifdef __cplusplus
 }  // TVM_EXTERN_C
 #endif

--- a/include/tvm/runtime/c_backend_api.h
+++ b/include/tvm/runtime/c_backend_api.h
@@ -35,19 +35,6 @@ extern "C" {
 #endif
 
 /*!
- * \brief Backend function for modules to get function
- *  from its environment mod_node (its imports and global function).
- *  The user do should not call TVMFuncFree on func.
- *
- * \param mod_node The module handle.
- * \param func_name The name of the function.
- * \param out The result function.
- * \return 0 when no error is thrown, -1 when failure happens
- */
-TVM_RUNTIME_DLL int TVMBackendGetFuncFromEnv(void* mod_node, const char* func_name,
-                                             TVMFFIObjectHandle* out);
-
-/*!
  * \brief Backend function to allocate temporal workspace.
  *
  * \note The result allocated space is ensured to be aligned to kTempAllocaAlignment.

--- a/src/runtime/device_api.cc
+++ b/src/runtime/device_api.cc
@@ -266,11 +266,3 @@ int TVMBackendFreeWorkspace(int device_type, int device_id, void* ptr) {
   DeviceAPIManager::Get(dev)->FreeWorkspace(dev, ptr);
   return 0;
 }
-
-int TVMBackendRunOnce(void** handle, int (*f)(void*), void* cdata, int nbytes) {
-  if (*handle == nullptr) {
-    *handle = reinterpret_cast<void*>(1);
-    return (*f)(cdata);
-  }
-  return 0;
-}

--- a/src/runtime/device_api.cc
+++ b/src/runtime/device_api.cc
@@ -241,10 +241,6 @@ TVM_FFI_STATIC_INIT_BLOCK() {
 
 using namespace tvm::runtime;
 
-int TVMBackendGetFuncFromEnv(void* mod_node, const char* func_name, TVMFFIObjectHandle* func) {
-  return TVMFFIEnvModLookupFromImports(mod_node, func_name, func);
-}
-
 void* TVMBackendAllocWorkspace(int device_type, int device_id, uint64_t size, int dtype_code_hint,
                                int dtype_bits_hint) {
   DLDevice dev;

--- a/src/runtime/module.cc
+++ b/src/runtime/module.cc
@@ -80,8 +80,6 @@ TVM_FFI_STATIC_INIT_BLOCK() {
   TVM_INIT_CONTEXT_FUNC(TVMFFIErrorSetRaisedFromCStr);
   TVM_INIT_CONTEXT_FUNC(TVMFFIEnvModLookupFromImports);
   TVM_INIT_CONTEXT_FUNC(TVMFFIHandleInitOnce);
-  // Keep populating the legacy slot for libraries built by older TVM versions.
-  TVM_INIT_CONTEXT_FUNC(TVMBackendGetFuncFromEnv);
   TVM_INIT_CONTEXT_FUNC(TVMBackendAllocWorkspace);
   TVM_INIT_CONTEXT_FUNC(TVMBackendFreeWorkspace);
   TVM_INIT_CONTEXT_FUNC(TVMBackendParallelLaunch);

--- a/src/runtime/module.cc
+++ b/src/runtime/module.cc
@@ -80,9 +80,6 @@ TVM_FFI_STATIC_INIT_BLOCK() {
   TVM_INIT_CONTEXT_FUNC(TVMFFIErrorSetRaisedFromCStr);
   TVM_INIT_CONTEXT_FUNC(TVMFFIEnvModLookupFromImports);
   TVM_INIT_CONTEXT_FUNC(TVMFFIHandleInitOnce);
-  TVM_INIT_CONTEXT_FUNC(TVMFFIHandleDeinitOnce);
-  TVM_INIT_CONTEXT_FUNC(TVMFFIObjectIncRef);
-  TVM_INIT_CONTEXT_FUNC(TVMFFIObjectDecRef);
   // Keep populating the legacy slot for libraries built by older TVM versions.
   TVM_INIT_CONTEXT_FUNC(TVMBackendGetFuncFromEnv);
   TVM_INIT_CONTEXT_FUNC(TVMBackendAllocWorkspace);

--- a/src/runtime/module.cc
+++ b/src/runtime/module.cc
@@ -79,6 +79,10 @@ TVM_FFI_STATIC_INIT_BLOCK() {
   TVM_INIT_CONTEXT_FUNC(TVMFFIFunctionCall);
   TVM_INIT_CONTEXT_FUNC(TVMFFIErrorSetRaisedFromCStr);
   TVM_INIT_CONTEXT_FUNC(TVMFFIEnvModLookupFromImports);
+  TVM_INIT_CONTEXT_FUNC(TVMFFIHandleInitOnce);
+  TVM_INIT_CONTEXT_FUNC(TVMFFIHandleDeinitOnce);
+  TVM_INIT_CONTEXT_FUNC(TVMFFIObjectIncRef);
+  TVM_INIT_CONTEXT_FUNC(TVMFFIObjectDecRef);
   // Keep populating the legacy slot for libraries built by older TVM versions.
   TVM_INIT_CONTEXT_FUNC(TVMBackendGetFuncFromEnv);
   TVM_INIT_CONTEXT_FUNC(TVMBackendAllocWorkspace);

--- a/src/runtime/module.cc
+++ b/src/runtime/module.cc
@@ -78,6 +78,8 @@ TVM_FFI_STATIC_INIT_BLOCK() {
   // Initialize the functions
   TVM_INIT_CONTEXT_FUNC(TVMFFIFunctionCall);
   TVM_INIT_CONTEXT_FUNC(TVMFFIErrorSetRaisedFromCStr);
+  TVM_INIT_CONTEXT_FUNC(TVMFFIEnvModLookupFromImports);
+  // Keep populating the legacy slot for libraries built by older TVM versions.
   TVM_INIT_CONTEXT_FUNC(TVMBackendGetFuncFromEnv);
   TVM_INIT_CONTEXT_FUNC(TVMBackendAllocWorkspace);
   TVM_INIT_CONTEXT_FUNC(TVMBackendFreeWorkspace);

--- a/src/target/llvm/codegen_cpu.cc
+++ b/src/target/llvm/codegen_cpu.cc
@@ -143,15 +143,6 @@ void CodeGenCPU::Init(const std::string& module_name, LLVMTarget* llvm_target,
       t_int_,
       {llvmGetPointerTo(t_void_p_, 0), llvmGetPointerTo(ftype_tvm_ffi_handle_init_callback_, 0)},
       false);
-  // int TVMFFIHandleDeinitOnce(void** handle_addr, int (*deinit_func)(void* handle));
-  ftype_tvm_ffi_handle_deinit_callback_ = llvm::FunctionType::get(t_int_, {t_void_p_}, false);
-  ftype_tvm_ffi_handle_deinit_once_ = llvm::FunctionType::get(
-      t_int_,
-      {llvmGetPointerTo(t_void_p_, 0), llvmGetPointerTo(ftype_tvm_ffi_handle_deinit_callback_, 0)},
-      false);
-  // int TVMFFIObject{Inc,Dec}Ref(TVMFFIObjectHandle obj);
-  ftype_tvm_ffi_object_inc_ref_ = llvm::FunctionType::get(t_int_, {t_void_p_}, false);
-  ftype_tvm_ffi_object_dec_ref_ = llvm::FunctionType::get(t_int_, {t_void_p_}, false);
   // Defined in include/tvm/runtime/c_backend_api.h:
   // int TVMBackendParallelLaunch(FTVMParallelLambda flambda, void* cdata, int num_task);
   ftype_tvm_parallel_launch_ = llvm::FunctionType::get(
@@ -187,15 +178,6 @@ void CodeGenCPU::Init(const std::string& module_name, LLVMTarget* llvm_target,
     f_tvm_ffi_handle_init_once_ =
         llvm::Function::Create(ftype_tvm_ffi_handle_init_once_, llvm::Function::ExternalLinkage,
                                "TVMFFIHandleInitOnce", module_.get());
-    f_tvm_ffi_handle_deinit_once_ =
-        llvm::Function::Create(ftype_tvm_ffi_handle_deinit_once_, llvm::Function::ExternalLinkage,
-                               "TVMFFIHandleDeinitOnce", module_.get());
-    f_tvm_ffi_object_inc_ref_ =
-        llvm::Function::Create(ftype_tvm_ffi_object_inc_ref_, llvm::Function::ExternalLinkage,
-                               "TVMFFIObjectIncRef", module_.get());
-    f_tvm_ffi_object_dec_ref_ =
-        llvm::Function::Create(ftype_tvm_ffi_object_dec_ref_, llvm::Function::ExternalLinkage,
-                               "TVMFFIObjectDecRef", module_.get());
     f_tvm_parallel_launch_ =
         llvm::Function::Create(ftype_tvm_parallel_launch_, llvm::Function::ExternalLinkage,
                                "TVMBackendParallelLaunch", module_.get());
@@ -492,12 +474,6 @@ void CodeGenCPU::InitGlobalContext(bool dynamic_lookup) {
                          "__TVMFFIEnvModLookupFromImports");
       gv_tvm_ffi_handle_init_once_ = InitContextPtr(
           llvmGetPointerTo(ftype_tvm_ffi_handle_init_once_, 0), "__TVMFFIHandleInitOnce");
-      gv_tvm_ffi_handle_deinit_once_ = InitContextPtr(
-          llvmGetPointerTo(ftype_tvm_ffi_handle_deinit_once_, 0), "__TVMFFIHandleDeinitOnce");
-      gv_tvm_ffi_object_inc_ref_ = InitContextPtr(
-          llvmGetPointerTo(ftype_tvm_ffi_object_inc_ref_, 0), "__TVMFFIObjectIncRef");
-      gv_tvm_ffi_object_dec_ref_ = InitContextPtr(
-          llvmGetPointerTo(ftype_tvm_ffi_object_dec_ref_, 0), "__TVMFFIObjectDecRef");
       gv_tvm_ffi_set_last_error_c_str_ =
           InitContextPtr(llvmGetPointerTo(ftype_tvm_ffi_error_set_raised_by_c_str_, 0),
                          "__TVMFFIErrorSetRaisedFromCStr");
@@ -723,11 +699,40 @@ llvm::Value* CodeGenCPU::CreateStaticHandle() {
   return gv;
 }
 
+llvm::Function* CodeGenCPU::CreatePackedFuncInit(const std::string& fname) {
+  // Generate the equivalent of:
+  //
+  //   static int __tvm_func_handle_init.<fname>(void** result) {
+  //     return TVMFFIEnvModLookupFromImports(__tvm_ffi__library_ctx, "<fname>", result);
+  //   }
+  //
+  // The lookup result is owned by the module and remains valid for the generated module's lifetime.
+  llvm::IRBuilderBase::InsertPoint saved_ip = builder_->saveIP();
+  llvm::Function* saved_function = function_;
+  llvm::LLVMContext* ctx = llvm_target_->GetContext();
+  llvm::Function* init_func =
+      llvm::Function::Create(ftype_tvm_ffi_handle_init_callback_, llvm::Function::InternalLinkage,
+                             "__tvm_func_handle_init." + fname, module_.get());
+  init_func->setVisibility(llvm::GlobalValue::HiddenVisibility);
+  SetTargetAttributes(init_func);
+  function_ = init_func;
+  builder_->SetInsertPoint(llvm::BasicBlock::Create(*ctx, "entry", init_func));
+
+  llvm::Value* result = &*init_func->arg_begin();
+  llvm::Value* module_ctx = builder_->CreateAlignedLoad(gv_mod_ctx_->getValueType(), gv_mod_ctx_,
+                                                        llvm::Align(gv_mod_ctx_->getAlignment()));
+  auto lookup_callee = llvm::FunctionCallee(ftype_tvm_ffi_env_mod_lookup_from_imports_,
+                                            RuntimeTVMFFIEnvModLookupFromImports());
+  builder_->CreateRet(
+      builder_->CreateCall(lookup_callee, {module_ctx, GetConstString(fname), result}));
+
+  function_ = saved_function;
+  builder_->restoreIP(saved_ip);
+  return init_func;
+}
+
 llvm::Value* CodeGenCPU::GetPackedFuncHandle(const std::string& fname) {
-  // Store one owning reference to the packed function in global space.  The module lookup returns
-  // a weak reference, so the initialization callback retains it and the global destructor releases
-  // it.  The module loader excludes calls while destructors run, so initialization needs to be
-  // thread-safe but does not need to overlap deinitialization.
+  // Cache the module-owned packed-function handle in global space with thread-safe initialization.
 #if TVM_LLVM_VERSION >= 200
   llvm::DataLayout layout(module_.get()->getDataLayout());
 #else
@@ -745,67 +750,7 @@ llvm::Value* CodeGenCPU::GetPackedFuncHandle(const std::string& fname) {
     hptr->setAlignment(llvm::Align(align));
     hptr->setInitializer(llvm::Constant::getNullValue(t_tvm_func_handle_));
     func_handle_map_[fname] = hptr;
-
-    llvm::IRBuilderBase::InsertPoint saved_ip = builder_->saveIP();
-    llvm::Function* saved_function = function_;
-    llvm::LLVMContext* ctx = llvm_target_->GetContext();
-
-    init_func =
-        llvm::Function::Create(ftype_tvm_ffi_handle_init_callback_, llvm::Function::InternalLinkage,
-                               "__tvm_func_handle_init", module_.get());
-    SetTargetAttributes(init_func);
-    function_ = init_func;
-    builder_->SetInsertPoint(llvm::BasicBlock::Create(*ctx, "entry", init_func));
-    llvm::Value* result = &*init_func->arg_begin();
-    llvm::LoadInst* ctx_load = builder_->CreateAlignedLoad(
-        gv_mod_ctx_->getValueType(), gv_mod_ctx_, llvm::Align(gv_mod_ctx_->getAlignment()));
-    ctx_load->setMetadata(
-        "tbaa", md_builder_->createTBAAStructTagNode(md_tbaa_ctx_ptr_, md_tbaa_ctx_ptr_, 0));
-    auto lookup_callee = llvm::FunctionCallee(ftype_tvm_ffi_env_mod_lookup_from_imports_,
-                                              RuntimeTVMFFIEnvModLookupFromImports());
-    llvm::Value* lookup_ret =
-        builder_->CreateCall(lookup_callee, {ctx_load, GetConstString(fname), result});
-    auto* retain_block = llvm::BasicBlock::Create(*ctx, "retain", init_func);
-    auto* return_block = llvm::BasicBlock::Create(*ctx, "return", init_func);
-    llvm::Value* lookup_ok = builder_->CreateICmpEQ(lookup_ret, llvm::ConstantInt::get(t_int_, 0));
-    builder_->CreateCondBr(lookup_ok, retain_block, return_block, md_very_likely_branch_);
-    builder_->SetInsertPoint(retain_block);
-    llvm::Value* handle = builder_->CreateLoad(t_tvm_func_handle_, result);
-    auto retain_callee =
-        llvm::FunctionCallee(ftype_tvm_ffi_object_inc_ref_, RuntimeTVMFFIObjectIncRef());
-    llvm::Value* retain_ret = builder_->CreateCall(retain_callee, {handle});
-    builder_->CreateBr(return_block);
-    builder_->SetInsertPoint(return_block);
-    llvm::PHINode* init_ret = builder_->CreatePHI(t_int_, 2);
-    init_ret->addIncoming(lookup_ret, &init_func->getEntryBlock());
-    init_ret->addIncoming(retain_ret, retain_block);
-    builder_->CreateRet(init_ret);
-
-    llvm::Function* release_func = llvm::Function::Create(
-        ftype_tvm_ffi_handle_deinit_callback_, llvm::Function::InternalLinkage,
-        "__tvm_func_handle_release", module_.get());
-    SetTargetAttributes(release_func);
-    function_ = release_func;
-    builder_->SetInsertPoint(llvm::BasicBlock::Create(*ctx, "entry", release_func));
-    auto release_callee =
-        llvm::FunctionCallee(ftype_tvm_ffi_object_dec_ref_, RuntimeTVMFFIObjectDecRef());
-    builder_->CreateRet(builder_->CreateCall(release_callee, {&*release_func->arg_begin()}));
-
-    llvm::FunctionType* dtor_ftype = llvm::FunctionType::get(t_void_, {}, false);
-    llvm::Function* dtor_func = llvm::Function::Create(dtor_ftype, llvm::Function::ExternalLinkage,
-                                                       "__tvm_func_handle_deinit", module_.get());
-    dtor_func->setVisibility(llvm::GlobalValue::HiddenVisibility);
-    SetTargetAttributes(dtor_func);
-    function_ = dtor_func;
-    builder_->SetInsertPoint(llvm::BasicBlock::Create(*ctx, "entry", dtor_func));
-    auto deinit_callee =
-        llvm::FunctionCallee(ftype_tvm_ffi_handle_deinit_once_, RuntimeTVMFFIHandleDeinitOnce());
-    builder_->CreateCall(deinit_callee, {hptr, release_func});
-    builder_->CreateRetVoid();
-    llvm::appendToGlobalDtors(*module_, dtor_func, 65535);
-
-    function_ = saved_function;
-    builder_->restoreIP(saved_ip);
+    init_func = CreatePackedFuncInit(fname);
     func_handle_init_map_[fname] = init_func;
   } else {
     hptr = it->second;
@@ -941,21 +886,6 @@ llvm::Value* CodeGenCPU::RuntimeTVMFFIEnvModLookupFromImports() {
 llvm::Value* CodeGenCPU::RuntimeTVMFFIHandleInitOnce() {
   if (f_tvm_ffi_handle_init_once_ != nullptr) return f_tvm_ffi_handle_init_once_;
   return GetContextPtr(gv_tvm_ffi_handle_init_once_);
-}
-
-llvm::Value* CodeGenCPU::RuntimeTVMFFIHandleDeinitOnce() {
-  if (f_tvm_ffi_handle_deinit_once_ != nullptr) return f_tvm_ffi_handle_deinit_once_;
-  return GetContextPtr(gv_tvm_ffi_handle_deinit_once_);
-}
-
-llvm::Value* CodeGenCPU::RuntimeTVMFFIObjectIncRef() {
-  if (f_tvm_ffi_object_inc_ref_ != nullptr) return f_tvm_ffi_object_inc_ref_;
-  return GetContextPtr(gv_tvm_ffi_object_inc_ref_);
-}
-
-llvm::Value* CodeGenCPU::RuntimeTVMFFIObjectDecRef() {
-  if (f_tvm_ffi_object_dec_ref_ != nullptr) return f_tvm_ffi_object_dec_ref_;
-  return GetContextPtr(gv_tvm_ffi_object_dec_ref_);
 }
 
 llvm::Value* CodeGenCPU::RuntimeTVMFFIErrorSetRaisedFromCStr() {

--- a/src/target/llvm/codegen_cpu.cc
+++ b/src/target/llvm/codegen_cpu.cc
@@ -128,9 +128,10 @@ void CodeGenCPU::Init(const std::string& module_name, LLVMTarget* llvm_target,
       t_void_,
       {llvmGetPointerTo(t_char_, 0), llvmGetPointerTo(llvmGetPointerTo(t_char_, 0), 0), t_int_},
       false);
-  // Defined in include/tvm/runtime/c_backend_api.h:
-  // int TVMBackendGetFuncFromEnv(void* mod_node, const char* func_name, TVMFunctionHandle* out);
-  ftype_tvm_get_func_from_env_ = llvm::FunctionType::get(
+  // Defined in include/tvm/ffi/extra/c_env_api.h:
+  // int TVMFFIEnvModLookupFromImports(TVMFFIObjectHandle library_ctx, const char* func_name,
+  //                                   TVMFFIObjectHandle* out);
+  ftype_tvm_ffi_env_mod_lookup_from_imports_ = llvm::FunctionType::get(
       t_int_, {t_void_p_, llvmGetPointerTo(t_char_, 0), llvmGetPointerTo(t_tvm_func_handle_, 0)},
       false);
   // Defined in include/tvm/runtime/c_backend_api.h:
@@ -141,12 +142,6 @@ void CodeGenCPU::Init(const std::string& module_name, LLVMTarget* llvm_target,
   // int TVMBackendParallelBarrier(int task_id, TVMParallelGroupEnv* penv);
   ftype_tvm_parallel_barrier_ = llvm::FunctionType::get(
       t_int_, {t_int_, llvmGetPointerTo(t_tvm_parallel_group_env_, 0)}, false);
-  ftype_tvm_static_init_callback_ = llvm::FunctionType::get(t_int_, {t_void_p_}, false);
-  ftype_tvm_static_init_ = llvm::FunctionType::get(
-      t_int_,
-      {llvmGetPointerTo(t_void_p_, 0), llvmGetPointerTo(ftype_tvm_static_init_callback_, 0),
-       t_void_p_, t_int_},
-      false);
   // initialize TVM runtime API
   if (system_lib_prefix_.has_value() && !target_c_runtime) {
     // We will need this in environment for backward registration.
@@ -168,9 +163,9 @@ void CodeGenCPU::Init(const std::string& module_name, LLVMTarget* llvm_target,
     f_tvm_ffi_set_raised_from_c_str_parts_ = llvm::Function::Create(
         ftype_tvm_ffi_error_set_raised_from_c_str_parts_, llvm::Function::ExternalLinkage,
         "TVMFFIErrorSetRaisedFromCStrParts", module_.get());
-    f_tvm_get_func_from_env_ =
-        llvm::Function::Create(ftype_tvm_get_func_from_env_, llvm::Function::ExternalLinkage,
-                               "TVMBackendGetFuncFromEnv", module_.get());
+    f_tvm_ffi_env_mod_lookup_from_imports_ = llvm::Function::Create(
+        ftype_tvm_ffi_env_mod_lookup_from_imports_, llvm::Function::ExternalLinkage,
+        "TVMFFIEnvModLookupFromImports", module_.get());
     f_tvm_parallel_launch_ =
         llvm::Function::Create(ftype_tvm_parallel_launch_, llvm::Function::ExternalLinkage,
                                "TVMBackendParallelLaunch", module_.get());
@@ -462,8 +457,9 @@ void CodeGenCPU::InitGlobalContext(bool dynamic_lookup) {
     if (!dynamic_lookup) {
       gv_tvm_ffi_func_call_ =
           InitContextPtr(llvmGetPointerTo(ftype_tvm_ffi_func_call_, 0), "__TVMFFIFunctionCall");
-      gv_tvm_get_func_from_env_ = InitContextPtr(llvmGetPointerTo(ftype_tvm_get_func_from_env_, 0),
-                                                 "__TVMBackendGetFuncFromEnv");
+      gv_tvm_ffi_env_mod_lookup_from_imports_ =
+          InitContextPtr(llvmGetPointerTo(ftype_tvm_ffi_env_mod_lookup_from_imports_, 0),
+                         "__TVMFFIEnvModLookupFromImports");
       gv_tvm_ffi_set_last_error_c_str_ =
           InitContextPtr(llvmGetPointerTo(ftype_tvm_ffi_error_set_raised_by_c_str_, 0),
                          "__TVMFFIErrorSetRaisedFromCStr");
@@ -689,46 +685,6 @@ llvm::Value* CodeGenCPU::CreateStaticHandle() {
   return gv;
 }
 
-void CodeGenCPU::CreateStaticInit(const std::string& init_fname, const Stmt& body) {
-  // closure data
-  llvm::Function* f =
-      llvm::Function::Create(ftype_tvm_static_init_callback_, llvm::Function::PrivateLinkage,
-                             "__tvm_static_init_lambda", module_.get());
-  SetTargetAttributes(f);
-  llvm::Value* gv = CreateStaticHandle();
-  llvm::Function* finit = module_->getFunction(init_fname);
-  if (finit == nullptr) {
-    finit = llvm::Function::Create(ftype_tvm_static_init_, llvm::Function::ExternalLinkage,
-                                   init_fname, module_.get());
-  }
-  // allocate and setup the closure, call the closure.
-  uint64_t nbytes;
-  ffi::Array<Var> vfields = tirx::UndefinedVars(body, {});
-  TypedPointer cdata = PackClosureData(vfields, &nbytes);
-  llvm::BasicBlock* init_end = CheckCallSuccess(builder_->CreateCall(
-      finit, {gv, f, builder_->CreatePointerCast(cdata.addr, t_void_p_), ConstInt32(nbytes)}));
-  // Setup the closure function.
-  auto* lambda_entry = llvm::BasicBlock::Create(*llvm_target_->GetContext(), "entry", f);
-  builder_->SetInsertPoint(lambda_entry);
-  auto it = f->arg_begin();
-  cdata.addr = builder_->CreatePointerCast(&(*it++), cdata.addr->getType());
-  // setup new variable map, swap it with current var context.
-  std::unordered_map<const VarNode*, llvm::Value*> new_vmap;
-  UnpackClosureData(cdata, vfields, &new_vmap);
-  TVM_FFI_ICHECK(parallel_env_.penv == nullptr);
-  auto new_analyzer = arith::Analyzer();
-  std::swap(function_, f);
-  std::swap(analyzer_, new_analyzer);
-  std::swap(var_map_, new_vmap);
-  this->VisitStmt(body);
-  builder_->CreateRet(ConstInt32(0));
-  // swap the var map back, now we are back on track.
-  std::swap(var_map_, new_vmap);
-  std::swap(analyzer_, new_analyzer);
-  std::swap(function_, f);
-  builder_->SetInsertPoint(init_end);
-}
-
 llvm::Value* CodeGenCPU::GetPackedFuncHandle(const std::string& fname) {
   // We will store the packed function handle in global space.
   // Initialize it during the first call.
@@ -770,7 +726,8 @@ llvm::Value* CodeGenCPU::GetPackedFuncHandle(const std::string& fname) {
                                                          llvm::Align(gv_mod_ctx_->getAlignment()));
   ctx_load->setMetadata(
       "tbaa", md_builder_->createTBAAStructTagNode(md_tbaa_ctx_ptr_, md_tbaa_ctx_ptr_, 0));
-  auto env_callee = llvm::FunctionCallee(ftype_tvm_get_func_from_env_, RuntimeTVMGetFuncFromEnv());
+  auto env_callee = llvm::FunctionCallee(ftype_tvm_ffi_env_mod_lookup_from_imports_,
+                                         RuntimeTVMFFIEnvModLookupFromImports());
   llvm::Value* retcode = builder_->CreateCall(env_callee, {ctx_load, GetConstString(fname), out});
   init_block = CheckCallSuccess(retcode);
   llvm::Value* loaded_handle =
@@ -899,9 +856,11 @@ llvm::Value* CodeGenCPU::RuntimeTVMFFIFunctionCall() {
   return GetContextPtr(gv_tvm_ffi_func_call_);
 }
 
-llvm::Value* CodeGenCPU::RuntimeTVMGetFuncFromEnv() {
-  if (f_tvm_get_func_from_env_ != nullptr) return f_tvm_get_func_from_env_;
-  return GetContextPtr(gv_tvm_get_func_from_env_);
+llvm::Value* CodeGenCPU::RuntimeTVMFFIEnvModLookupFromImports() {
+  if (f_tvm_ffi_env_mod_lookup_from_imports_ != nullptr) {
+    return f_tvm_ffi_env_mod_lookup_from_imports_;
+  }
+  return GetContextPtr(gv_tvm_ffi_env_mod_lookup_from_imports_);
 }
 llvm::Value* CodeGenCPU::RuntimeTVMFFIErrorSetRaisedFromCStr() {
   if (f_tvm_ffi_set_raised_by_c_str_ != nullptr) return f_tvm_ffi_set_raised_by_c_str_;

--- a/src/target/llvm/codegen_cpu.cc
+++ b/src/target/llvm/codegen_cpu.cc
@@ -760,7 +760,7 @@ llvm::Value* CodeGenCPU::GetPackedFuncHandle(const std::string& fname) {
   auto init_once_callee =
       llvm::FunctionCallee(ftype_tvm_ffi_handle_init_once_, RuntimeTVMFFIHandleInitOnce());
   CheckCallSuccess(builder_->CreateCall(init_once_callee, {hptr, init_func}));
-  return builder_->CreateAlignedLoad(t_tvm_func_handle_, hptr, llvm::Align(align));
+  return builder_->CreateAlignedLoad(hptr->getValueType(), hptr, llvm::Align(align));
 }
 
 CodeGenCPU::PackedCall CodeGenCPU::MakeCallPackedLowered(const ffi::Array<PrimExpr>& args,

--- a/src/target/llvm/codegen_cpu.cc
+++ b/src/target/llvm/codegen_cpu.cc
@@ -76,6 +76,7 @@ void CodeGenCPU::Init(const std::string& module_name, LLVMTarget* llvm_target,
   system_lib_prefix_ = system_lib_prefix;
   dbg_info_ = CreateDebugInfo(module_.get());
   func_handle_map_.clear();
+  func_handle_init_map_.clear();
   export_system_symbols_.clear();
 
   // Runtime types.
@@ -134,6 +135,23 @@ void CodeGenCPU::Init(const std::string& module_name, LLVMTarget* llvm_target,
   ftype_tvm_ffi_env_mod_lookup_from_imports_ = llvm::FunctionType::get(
       t_int_, {t_void_p_, llvmGetPointerTo(t_char_, 0), llvmGetPointerTo(t_tvm_func_handle_, 0)},
       false);
+  // Defined in include/tvm/ffi/c_api.h:
+  // int TVMFFIHandleInitOnce(void** handle_addr, int (*init_func)(void** result));
+  ftype_tvm_ffi_handle_init_callback_ =
+      llvm::FunctionType::get(t_int_, {llvmGetPointerTo(t_void_p_, 0)}, false);
+  ftype_tvm_ffi_handle_init_once_ = llvm::FunctionType::get(
+      t_int_,
+      {llvmGetPointerTo(t_void_p_, 0), llvmGetPointerTo(ftype_tvm_ffi_handle_init_callback_, 0)},
+      false);
+  // int TVMFFIHandleDeinitOnce(void** handle_addr, int (*deinit_func)(void* handle));
+  ftype_tvm_ffi_handle_deinit_callback_ = llvm::FunctionType::get(t_int_, {t_void_p_}, false);
+  ftype_tvm_ffi_handle_deinit_once_ = llvm::FunctionType::get(
+      t_int_,
+      {llvmGetPointerTo(t_void_p_, 0), llvmGetPointerTo(ftype_tvm_ffi_handle_deinit_callback_, 0)},
+      false);
+  // int TVMFFIObject{Inc,Dec}Ref(TVMFFIObjectHandle obj);
+  ftype_tvm_ffi_object_inc_ref_ = llvm::FunctionType::get(t_int_, {t_void_p_}, false);
+  ftype_tvm_ffi_object_dec_ref_ = llvm::FunctionType::get(t_int_, {t_void_p_}, false);
   // Defined in include/tvm/runtime/c_backend_api.h:
   // int TVMBackendParallelLaunch(FTVMParallelLambda flambda, void* cdata, int num_task);
   ftype_tvm_parallel_launch_ = llvm::FunctionType::get(
@@ -166,6 +184,18 @@ void CodeGenCPU::Init(const std::string& module_name, LLVMTarget* llvm_target,
     f_tvm_ffi_env_mod_lookup_from_imports_ = llvm::Function::Create(
         ftype_tvm_ffi_env_mod_lookup_from_imports_, llvm::Function::ExternalLinkage,
         "TVMFFIEnvModLookupFromImports", module_.get());
+    f_tvm_ffi_handle_init_once_ =
+        llvm::Function::Create(ftype_tvm_ffi_handle_init_once_, llvm::Function::ExternalLinkage,
+                               "TVMFFIHandleInitOnce", module_.get());
+    f_tvm_ffi_handle_deinit_once_ =
+        llvm::Function::Create(ftype_tvm_ffi_handle_deinit_once_, llvm::Function::ExternalLinkage,
+                               "TVMFFIHandleDeinitOnce", module_.get());
+    f_tvm_ffi_object_inc_ref_ =
+        llvm::Function::Create(ftype_tvm_ffi_object_inc_ref_, llvm::Function::ExternalLinkage,
+                               "TVMFFIObjectIncRef", module_.get());
+    f_tvm_ffi_object_dec_ref_ =
+        llvm::Function::Create(ftype_tvm_ffi_object_dec_ref_, llvm::Function::ExternalLinkage,
+                               "TVMFFIObjectDecRef", module_.get());
     f_tvm_parallel_launch_ =
         llvm::Function::Create(ftype_tvm_parallel_launch_, llvm::Function::ExternalLinkage,
                                "TVMBackendParallelLaunch", module_.get());
@@ -460,6 +490,14 @@ void CodeGenCPU::InitGlobalContext(bool dynamic_lookup) {
       gv_tvm_ffi_env_mod_lookup_from_imports_ =
           InitContextPtr(llvmGetPointerTo(ftype_tvm_ffi_env_mod_lookup_from_imports_, 0),
                          "__TVMFFIEnvModLookupFromImports");
+      gv_tvm_ffi_handle_init_once_ = InitContextPtr(
+          llvmGetPointerTo(ftype_tvm_ffi_handle_init_once_, 0), "__TVMFFIHandleInitOnce");
+      gv_tvm_ffi_handle_deinit_once_ = InitContextPtr(
+          llvmGetPointerTo(ftype_tvm_ffi_handle_deinit_once_, 0), "__TVMFFIHandleDeinitOnce");
+      gv_tvm_ffi_object_inc_ref_ = InitContextPtr(
+          llvmGetPointerTo(ftype_tvm_ffi_object_inc_ref_, 0), "__TVMFFIObjectIncRef");
+      gv_tvm_ffi_object_dec_ref_ = InitContextPtr(
+          llvmGetPointerTo(ftype_tvm_ffi_object_dec_ref_, 0), "__TVMFFIObjectDecRef");
       gv_tvm_ffi_set_last_error_c_str_ =
           InitContextPtr(llvmGetPointerTo(ftype_tvm_ffi_error_set_raised_by_c_str_, 0),
                          "__TVMFFIErrorSetRaisedFromCStr");
@@ -686,8 +724,10 @@ llvm::Value* CodeGenCPU::CreateStaticHandle() {
 }
 
 llvm::Value* CodeGenCPU::GetPackedFuncHandle(const std::string& fname) {
-  // We will store the packed function handle in global space.
-  // Initialize it during the first call.
+  // Store one owning reference to the packed function in global space.  The module lookup returns
+  // a weak reference, so the initialization callback retains it and the global destructor releases
+  // it.  The module loader excludes calls while destructors run, so initialization needs to be
+  // thread-safe but does not need to overlap deinitialization.
 #if TVM_LLVM_VERSION >= 200
   llvm::DataLayout layout(module_.get()->getDataLayout());
 #else
@@ -697,50 +737,85 @@ llvm::Value* CodeGenCPU::GetPackedFuncHandle(const std::string& fname) {
   auto it = func_handle_map_.find(fname);
 
   llvm::GlobalVariable* hptr;
+  llvm::Function* init_func;
   if (it == func_handle_map_.end()) {
-    // create global location for the handle
-    // create the function handle
     hptr =
         new llvm::GlobalVariable(*module_, t_tvm_func_handle_, false,
                                  llvm::GlobalValue::InternalLinkage, nullptr, ".tvm_func." + fname);
     hptr->setAlignment(llvm::Align(align));
     hptr->setInitializer(llvm::Constant::getNullValue(t_tvm_func_handle_));
     func_handle_map_[fname] = hptr;
+
+    llvm::IRBuilderBase::InsertPoint saved_ip = builder_->saveIP();
+    llvm::Function* saved_function = function_;
+    llvm::LLVMContext* ctx = llvm_target_->GetContext();
+
+    init_func =
+        llvm::Function::Create(ftype_tvm_ffi_handle_init_callback_, llvm::Function::InternalLinkage,
+                               "__tvm_func_handle_init", module_.get());
+    SetTargetAttributes(init_func);
+    function_ = init_func;
+    builder_->SetInsertPoint(llvm::BasicBlock::Create(*ctx, "entry", init_func));
+    llvm::Value* result = &*init_func->arg_begin();
+    llvm::LoadInst* ctx_load = builder_->CreateAlignedLoad(
+        gv_mod_ctx_->getValueType(), gv_mod_ctx_, llvm::Align(gv_mod_ctx_->getAlignment()));
+    ctx_load->setMetadata(
+        "tbaa", md_builder_->createTBAAStructTagNode(md_tbaa_ctx_ptr_, md_tbaa_ctx_ptr_, 0));
+    auto lookup_callee = llvm::FunctionCallee(ftype_tvm_ffi_env_mod_lookup_from_imports_,
+                                              RuntimeTVMFFIEnvModLookupFromImports());
+    llvm::Value* lookup_ret =
+        builder_->CreateCall(lookup_callee, {ctx_load, GetConstString(fname), result});
+    auto* retain_block = llvm::BasicBlock::Create(*ctx, "retain", init_func);
+    auto* return_block = llvm::BasicBlock::Create(*ctx, "return", init_func);
+    llvm::Value* lookup_ok = builder_->CreateICmpEQ(lookup_ret, llvm::ConstantInt::get(t_int_, 0));
+    builder_->CreateCondBr(lookup_ok, retain_block, return_block, md_very_likely_branch_);
+    builder_->SetInsertPoint(retain_block);
+    llvm::Value* handle = builder_->CreateLoad(t_tvm_func_handle_, result);
+    auto retain_callee =
+        llvm::FunctionCallee(ftype_tvm_ffi_object_inc_ref_, RuntimeTVMFFIObjectIncRef());
+    llvm::Value* retain_ret = builder_->CreateCall(retain_callee, {handle});
+    builder_->CreateBr(return_block);
+    builder_->SetInsertPoint(return_block);
+    llvm::PHINode* init_ret = builder_->CreatePHI(t_int_, 2);
+    init_ret->addIncoming(lookup_ret, &init_func->getEntryBlock());
+    init_ret->addIncoming(retain_ret, retain_block);
+    builder_->CreateRet(init_ret);
+
+    llvm::Function* release_func = llvm::Function::Create(
+        ftype_tvm_ffi_handle_deinit_callback_, llvm::Function::InternalLinkage,
+        "__tvm_func_handle_release", module_.get());
+    SetTargetAttributes(release_func);
+    function_ = release_func;
+    builder_->SetInsertPoint(llvm::BasicBlock::Create(*ctx, "entry", release_func));
+    auto release_callee =
+        llvm::FunctionCallee(ftype_tvm_ffi_object_dec_ref_, RuntimeTVMFFIObjectDecRef());
+    builder_->CreateRet(builder_->CreateCall(release_callee, {&*release_func->arg_begin()}));
+
+    llvm::FunctionType* dtor_ftype = llvm::FunctionType::get(t_void_, {}, false);
+    llvm::Function* dtor_func = llvm::Function::Create(dtor_ftype, llvm::Function::ExternalLinkage,
+                                                       "__tvm_func_handle_deinit", module_.get());
+    dtor_func->setVisibility(llvm::GlobalValue::HiddenVisibility);
+    SetTargetAttributes(dtor_func);
+    function_ = dtor_func;
+    builder_->SetInsertPoint(llvm::BasicBlock::Create(*ctx, "entry", dtor_func));
+    auto deinit_callee =
+        llvm::FunctionCallee(ftype_tvm_ffi_handle_deinit_once_, RuntimeTVMFFIHandleDeinitOnce());
+    builder_->CreateCall(deinit_callee, {hptr, release_func});
+    builder_->CreateRetVoid();
+    llvm::appendToGlobalDtors(*module_, dtor_func, 65535);
+
+    function_ = saved_function;
+    builder_->restoreIP(saved_ip);
+    func_handle_init_map_[fname] = init_func;
   } else {
     hptr = it->second;
+    init_func = func_handle_init_map_.at(fname);
   }
-  // create emit codes that checks and load the function.
-  llvm::LLVMContext* ctx = llvm_target_->GetContext();
-  llvm::BasicBlock* pre_block = builder_->GetInsertBlock();
-  auto* init_block = llvm::BasicBlock::Create(*ctx, "handle_init", function_);
-  auto* end_block = llvm::BasicBlock::Create(*ctx, "handle_init_end", function_);
-  llvm::Value* handle = builder_->CreateAlignedLoad(hptr->getValueType(), hptr, llvm::Align(align));
-  llvm::Value* handle_not_null =
-      builder_->CreateICmpNE(handle, llvm::Constant::getNullValue(t_tvm_func_handle_));
-  builder_->CreateCondBr(handle_not_null, end_block, init_block, md_very_likely_branch_);
-  // Initialize the handle if needed.
-  builder_->SetInsertPoint(init_block);
-  llvm::Value* out =
-      WithFunctionEntry([&]() { return builder_->CreateAlloca(t_tvm_func_handle_); });
-  llvm::LoadInst* ctx_load = builder_->CreateAlignedLoad(gv_mod_ctx_->getValueType(), gv_mod_ctx_,
-                                                         llvm::Align(gv_mod_ctx_->getAlignment()));
-  ctx_load->setMetadata(
-      "tbaa", md_builder_->createTBAAStructTagNode(md_tbaa_ctx_ptr_, md_tbaa_ctx_ptr_, 0));
-  auto env_callee = llvm::FunctionCallee(ftype_tvm_ffi_env_mod_lookup_from_imports_,
-                                         RuntimeTVMFFIEnvModLookupFromImports());
-  llvm::Value* retcode = builder_->CreateCall(env_callee, {ctx_load, GetConstString(fname), out});
-  init_block = CheckCallSuccess(retcode);
-  llvm::Value* loaded_handle =
-      builder_->CreateAlignedLoad(t_tvm_func_handle_, out, llvm::Align(align));
-  // Store the handle
-  builder_->CreateStore(loaded_handle, hptr);
-  builder_->CreateBr(end_block);
-  // end block
-  builder_->SetInsertPoint(end_block);
-  llvm::PHINode* phi = builder_->CreatePHI(t_tvm_func_handle_, 2);
-  phi->addIncoming(handle, pre_block);
-  phi->addIncoming(loaded_handle, init_block);
-  return phi;
+
+  auto init_once_callee =
+      llvm::FunctionCallee(ftype_tvm_ffi_handle_init_once_, RuntimeTVMFFIHandleInitOnce());
+  CheckCallSuccess(builder_->CreateCall(init_once_callee, {hptr, init_func}));
+  return builder_->CreateAlignedLoad(t_tvm_func_handle_, hptr, llvm::Align(align));
 }
 
 CodeGenCPU::PackedCall CodeGenCPU::MakeCallPackedLowered(const ffi::Array<PrimExpr>& args,
@@ -862,6 +937,27 @@ llvm::Value* CodeGenCPU::RuntimeTVMFFIEnvModLookupFromImports() {
   }
   return GetContextPtr(gv_tvm_ffi_env_mod_lookup_from_imports_);
 }
+
+llvm::Value* CodeGenCPU::RuntimeTVMFFIHandleInitOnce() {
+  if (f_tvm_ffi_handle_init_once_ != nullptr) return f_tvm_ffi_handle_init_once_;
+  return GetContextPtr(gv_tvm_ffi_handle_init_once_);
+}
+
+llvm::Value* CodeGenCPU::RuntimeTVMFFIHandleDeinitOnce() {
+  if (f_tvm_ffi_handle_deinit_once_ != nullptr) return f_tvm_ffi_handle_deinit_once_;
+  return GetContextPtr(gv_tvm_ffi_handle_deinit_once_);
+}
+
+llvm::Value* CodeGenCPU::RuntimeTVMFFIObjectIncRef() {
+  if (f_tvm_ffi_object_inc_ref_ != nullptr) return f_tvm_ffi_object_inc_ref_;
+  return GetContextPtr(gv_tvm_ffi_object_inc_ref_);
+}
+
+llvm::Value* CodeGenCPU::RuntimeTVMFFIObjectDecRef() {
+  if (f_tvm_ffi_object_dec_ref_ != nullptr) return f_tvm_ffi_object_dec_ref_;
+  return GetContextPtr(gv_tvm_ffi_object_dec_ref_);
+}
+
 llvm::Value* CodeGenCPU::RuntimeTVMFFIErrorSetRaisedFromCStr() {
   if (f_tvm_ffi_set_raised_by_c_str_ != nullptr) return f_tvm_ffi_set_raised_by_c_str_;
   return GetContextPtr(gv_tvm_ffi_set_last_error_c_str_);

--- a/src/target/llvm/codegen_cpu.h
+++ b/src/target/llvm/codegen_cpu.h
@@ -94,11 +94,7 @@ class CodeGenCPU : public CodeGenLLVM {
   llvm::FunctionType* ftype_tvm_ffi_func_call_{nullptr};
   llvm::FunctionType* ftype_tvm_ffi_env_mod_lookup_from_imports_{nullptr};
   llvm::FunctionType* ftype_tvm_ffi_handle_init_callback_{nullptr};
-  llvm::FunctionType* ftype_tvm_ffi_handle_deinit_callback_{nullptr};
   llvm::FunctionType* ftype_tvm_ffi_handle_init_once_{nullptr};
-  llvm::FunctionType* ftype_tvm_ffi_handle_deinit_once_{nullptr};
-  llvm::FunctionType* ftype_tvm_ffi_object_inc_ref_{nullptr};
-  llvm::FunctionType* ftype_tvm_ffi_object_dec_ref_{nullptr};
   llvm::FunctionType* ftype_tvm_ffi_error_set_raised_by_c_str_{nullptr};
   llvm::FunctionType* ftype_tvm_ffi_error_set_raised_from_c_str_parts_{nullptr};
   llvm::FunctionType* ftype_tvm_parallel_launch_{nullptr};
@@ -122,9 +118,6 @@ class CodeGenCPU : public CodeGenLLVM {
   llvm::Value* RuntimeTVMFFIFunctionCall();
   llvm::Value* RuntimeTVMFFIEnvModLookupFromImports();
   llvm::Value* RuntimeTVMFFIHandleInitOnce();
-  llvm::Value* RuntimeTVMFFIHandleDeinitOnce();
-  llvm::Value* RuntimeTVMFFIObjectIncRef();
-  llvm::Value* RuntimeTVMFFIObjectDecRef();
   llvm::Value* RuntimeTVMFFIErrorSetRaisedFromCStr();
   llvm::Value* RuntimeTVMFFIErrorSetRaisedFromCStrParts();
   // Create a temp function to simplify error raising.
@@ -132,6 +125,7 @@ class CodeGenCPU : public CodeGenLLVM {
   llvm::Value* RuntimeTVMParallelLaunch();
   llvm::Value* RuntimeTVMParallelBarrier();
   llvm::Value* CreateStaticHandle();
+  llvm::Function* CreatePackedFuncInit(const std::string& fname);
   llvm::Value* GetPackedFuncHandle(const std::string& str);
   TypedPointer PackClosureData(const ffi::Array<Var>& fields, uint64_t* num_bytes,
                                std::string struct_name = "");
@@ -168,9 +162,6 @@ class CodeGenCPU : public CodeGenLLVM {
   llvm::GlobalVariable* gv_tvm_ffi_func_call_{nullptr};
   llvm::GlobalVariable* gv_tvm_ffi_env_mod_lookup_from_imports_{nullptr};
   llvm::GlobalVariable* gv_tvm_ffi_handle_init_once_{nullptr};
-  llvm::GlobalVariable* gv_tvm_ffi_handle_deinit_once_{nullptr};
-  llvm::GlobalVariable* gv_tvm_ffi_object_inc_ref_{nullptr};
-  llvm::GlobalVariable* gv_tvm_ffi_object_dec_ref_{nullptr};
   llvm::GlobalVariable* gv_tvm_ffi_set_last_error_c_str_{nullptr};
   llvm::GlobalVariable* gv_tvm_parallel_launch_{nullptr};
   llvm::GlobalVariable* gv_tvm_parallel_barrier_{nullptr};
@@ -179,9 +170,6 @@ class CodeGenCPU : public CodeGenLLVM {
   llvm::Function* f_tvm_ffi_func_call_{nullptr};
   llvm::Function* f_tvm_ffi_env_mod_lookup_from_imports_{nullptr};
   llvm::Function* f_tvm_ffi_handle_init_once_{nullptr};
-  llvm::Function* f_tvm_ffi_handle_deinit_once_{nullptr};
-  llvm::Function* f_tvm_ffi_object_inc_ref_{nullptr};
-  llvm::Function* f_tvm_ffi_object_dec_ref_{nullptr};
   llvm::Function* f_tvm_ffi_set_raised_by_c_str_{nullptr};
   llvm::Function* f_tvm_ffi_set_raised_from_c_str_parts_{nullptr};
   llvm::Function* f_tvm_parallel_launch_{nullptr};

--- a/src/target/llvm/codegen_cpu.h
+++ b/src/target/llvm/codegen_cpu.h
@@ -93,6 +93,12 @@ class CodeGenCPU : public CodeGenLLVM {
   llvm::FunctionType* ftype_tvm_parallel_lambda_{nullptr};
   llvm::FunctionType* ftype_tvm_ffi_func_call_{nullptr};
   llvm::FunctionType* ftype_tvm_ffi_env_mod_lookup_from_imports_{nullptr};
+  llvm::FunctionType* ftype_tvm_ffi_handle_init_callback_{nullptr};
+  llvm::FunctionType* ftype_tvm_ffi_handle_deinit_callback_{nullptr};
+  llvm::FunctionType* ftype_tvm_ffi_handle_init_once_{nullptr};
+  llvm::FunctionType* ftype_tvm_ffi_handle_deinit_once_{nullptr};
+  llvm::FunctionType* ftype_tvm_ffi_object_inc_ref_{nullptr};
+  llvm::FunctionType* ftype_tvm_ffi_object_dec_ref_{nullptr};
   llvm::FunctionType* ftype_tvm_ffi_error_set_raised_by_c_str_{nullptr};
   llvm::FunctionType* ftype_tvm_ffi_error_set_raised_from_c_str_parts_{nullptr};
   llvm::FunctionType* ftype_tvm_parallel_launch_{nullptr};
@@ -115,6 +121,10 @@ class CodeGenCPU : public CodeGenLLVM {
   llvm::Value* GetContextPtr(llvm::GlobalVariable* gv);
   llvm::Value* RuntimeTVMFFIFunctionCall();
   llvm::Value* RuntimeTVMFFIEnvModLookupFromImports();
+  llvm::Value* RuntimeTVMFFIHandleInitOnce();
+  llvm::Value* RuntimeTVMFFIHandleDeinitOnce();
+  llvm::Value* RuntimeTVMFFIObjectIncRef();
+  llvm::Value* RuntimeTVMFFIObjectDecRef();
   llvm::Value* RuntimeTVMFFIErrorSetRaisedFromCStr();
   llvm::Value* RuntimeTVMFFIErrorSetRaisedFromCStrParts();
   // Create a temp function to simplify error raising.
@@ -157,6 +167,10 @@ class CodeGenCPU : public CodeGenLLVM {
   llvm::GlobalVariable* gv_mod_ctx_{nullptr};
   llvm::GlobalVariable* gv_tvm_ffi_func_call_{nullptr};
   llvm::GlobalVariable* gv_tvm_ffi_env_mod_lookup_from_imports_{nullptr};
+  llvm::GlobalVariable* gv_tvm_ffi_handle_init_once_{nullptr};
+  llvm::GlobalVariable* gv_tvm_ffi_handle_deinit_once_{nullptr};
+  llvm::GlobalVariable* gv_tvm_ffi_object_inc_ref_{nullptr};
+  llvm::GlobalVariable* gv_tvm_ffi_object_dec_ref_{nullptr};
   llvm::GlobalVariable* gv_tvm_ffi_set_last_error_c_str_{nullptr};
   llvm::GlobalVariable* gv_tvm_parallel_launch_{nullptr};
   llvm::GlobalVariable* gv_tvm_parallel_barrier_{nullptr};
@@ -164,6 +178,10 @@ class CodeGenCPU : public CodeGenLLVM {
   // context for direct dynamic lookup
   llvm::Function* f_tvm_ffi_func_call_{nullptr};
   llvm::Function* f_tvm_ffi_env_mod_lookup_from_imports_{nullptr};
+  llvm::Function* f_tvm_ffi_handle_init_once_{nullptr};
+  llvm::Function* f_tvm_ffi_handle_deinit_once_{nullptr};
+  llvm::Function* f_tvm_ffi_object_inc_ref_{nullptr};
+  llvm::Function* f_tvm_ffi_object_dec_ref_{nullptr};
   llvm::Function* f_tvm_ffi_set_raised_by_c_str_{nullptr};
   llvm::Function* f_tvm_ffi_set_raised_from_c_str_parts_{nullptr};
   llvm::Function* f_tvm_parallel_launch_{nullptr};
@@ -175,6 +193,7 @@ class CodeGenCPU : public CodeGenLLVM {
   std::unordered_map<int, llvm::Function*> set_raised_helpers_;
   // global to packed function handle
   std::unordered_map<std::string, llvm::GlobalVariable*> func_handle_map_;
+  std::unordered_map<std::string, llvm::Function*> func_handle_init_map_;
   // List of symbols to be exported to TVM system lib.
   std::vector<std::pair<std::string, llvm::Constant*>> export_system_symbols_;
   // List of functions to be registered in the FuncRegistry, if generated.

--- a/src/target/llvm/codegen_cpu.h
+++ b/src/target/llvm/codegen_cpu.h
@@ -92,15 +92,12 @@ class CodeGenCPU : public CodeGenLLVM {
   llvm::FunctionType* ftype_tvm_ffi_c_func_{nullptr};
   llvm::FunctionType* ftype_tvm_parallel_lambda_{nullptr};
   llvm::FunctionType* ftype_tvm_ffi_func_call_{nullptr};
-  llvm::FunctionType* ftype_tvm_get_func_from_env_{nullptr};
+  llvm::FunctionType* ftype_tvm_ffi_env_mod_lookup_from_imports_{nullptr};
   llvm::FunctionType* ftype_tvm_ffi_error_set_raised_by_c_str_{nullptr};
   llvm::FunctionType* ftype_tvm_ffi_error_set_raised_from_c_str_parts_{nullptr};
   llvm::FunctionType* ftype_tvm_parallel_launch_{nullptr};
   llvm::FunctionType* ftype_tvm_parallel_barrier_{nullptr};
   llvm::FunctionType* ftype_tvm_register_system_symbol_{nullptr};
-  // Lazy entry for function call.
-  llvm::FunctionType* ftype_tvm_static_init_callback_{nullptr};
-  llvm::FunctionType* ftype_tvm_static_init_{nullptr};
 
  private:
   // the parallel group information
@@ -117,7 +114,7 @@ class CodeGenCPU : public CodeGenLLVM {
   llvm::GlobalVariable* InitContextPtr(llvm::Type* type, std::string name);
   llvm::Value* GetContextPtr(llvm::GlobalVariable* gv);
   llvm::Value* RuntimeTVMFFIFunctionCall();
-  llvm::Value* RuntimeTVMGetFuncFromEnv();
+  llvm::Value* RuntimeTVMFFIEnvModLookupFromImports();
   llvm::Value* RuntimeTVMFFIErrorSetRaisedFromCStr();
   llvm::Value* RuntimeTVMFFIErrorSetRaisedFromCStrParts();
   // Create a temp function to simplify error raising.
@@ -143,8 +140,6 @@ class CodeGenCPU : public CodeGenLLVM {
   llvm::Value* CreateCallPacked(const CallNode* op);
   // Create trace call into tvm packed function.
   llvm::Value* CreateCallTracePacked(const CallNode* op);
-  // Create static initialization
-  void CreateStaticInit(const std::string& init_fname, const Stmt& body);
   // Create parallel launch
   void CreateParallelLaunch(const Stmt& body, int num_task, std::string name = "");
   // Create a new compute scope.
@@ -161,14 +156,14 @@ class CodeGenCPU : public CodeGenLLVM {
   // Context for injection lookup
   llvm::GlobalVariable* gv_mod_ctx_{nullptr};
   llvm::GlobalVariable* gv_tvm_ffi_func_call_{nullptr};
-  llvm::GlobalVariable* gv_tvm_get_func_from_env_{nullptr};
+  llvm::GlobalVariable* gv_tvm_ffi_env_mod_lookup_from_imports_{nullptr};
   llvm::GlobalVariable* gv_tvm_ffi_set_last_error_c_str_{nullptr};
   llvm::GlobalVariable* gv_tvm_parallel_launch_{nullptr};
   llvm::GlobalVariable* gv_tvm_parallel_barrier_{nullptr};
   std::unordered_map<ffi::String, llvm::GlobalVariable*> gv_func_map_;
   // context for direct dynamic lookup
   llvm::Function* f_tvm_ffi_func_call_{nullptr};
-  llvm::Function* f_tvm_get_func_from_env_{nullptr};
+  llvm::Function* f_tvm_ffi_env_mod_lookup_from_imports_{nullptr};
   llvm::Function* f_tvm_ffi_set_raised_by_c_str_{nullptr};
   llvm::Function* f_tvm_ffi_set_raised_from_c_str_parts_{nullptr};
   llvm::Function* f_tvm_parallel_launch_{nullptr};

--- a/src/target/source/codegen_c_host.cc
+++ b/src/target/source/codegen_c_host.cc
@@ -46,6 +46,7 @@ void CodeGenCHost::Init(bool output_ssa, bool emit_asserts, bool emit_fwd_func_d
   declared_globals_.clear();
   decl_stream << "// tvm target: " << target_str << "\n";
   decl_stream << "#define TVM_EXPORTS\n";
+  decl_stream << "#include \"tvm/ffi/extra/c_env_api.h\"\n";
   decl_stream << "#include \"tvm/runtime/base.h\"\n";
   decl_stream << "#include \"tvm/runtime/c_backend_api.h\"\n";
   decl_stream << "#include \"tvm/ffi/c_api.h\"\n";
@@ -209,8 +210,8 @@ void CodeGenCHost::PrintGetFuncFromBackend(const std::string& func_name,
   this->stream << "if (" << packed_func_name << " == NULL) {\n";
   int packed_func_if_scope = this->BeginScope();
   this->PrintIndent();
-  this->stream << "if (TVMBackendGetFuncFromEnv(" << module_name_ << ", \"" << func_name << "\""
-               << ", &" << packed_func_name << ") != 0) {\n";
+  this->stream << "if (TVMFFIEnvModLookupFromImports(" << module_name_ << ", \"" << func_name
+               << "\", &" << packed_func_name << ") != 0) {\n";
   int get_func_env_scope = this->BeginScope();
   this->PrintIndent();
   this->stream << "return -1;\n";

--- a/tests/python/codegen/test_target_codegen_static_init.py
+++ b/tests/python/codegen/test_target_codegen_static_init.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import ctypes
+import gc
 
 import numpy as np
 
@@ -69,7 +70,39 @@ def test_generated_lookup_uses_tvm_ffi_symbol():
 
     llvm_source = tvm.compile(mod, target="llvm").mod.inspect_source("ll")
     assert "@__TVMFFIEnvModLookupFromImports" in llvm_source
+    assert "@__TVMFFIHandleInitOnce" in llvm_source
+    assert "@__TVMFFIHandleDeinitOnce" in llvm_source
+    assert "@__TVMFFIObjectIncRef" in llvm_source
+    assert "@__TVMFFIObjectDecRef" in llvm_source
+    assert "@llvm.global_dtors" in llvm_source
+    assert "define internal i32 @__tvm_func_handle_init" in llvm_source
+    assert "define internal i32 @__tvm_func_handle_release" in llvm_source
+    assert "define hidden void @__tvm_func_handle_deinit" in llvm_source
     assert "@__TVMBackendGetFuncFromEnv" not in llvm_source
+
+
+def test_generated_lookup_handle_lifecycle():
+    call_count = 0
+
+    @tvm.register_global_func("test_codegen_lookup", override=True)
+    def test_codegen_lookup(_):
+        nonlocal call_count
+        call_count += 1
+
+    built = tvm.compile(_lookup_module(), target="llvm")
+    function = built.mod["ramp"]
+    argument = tvm.runtime.tensor(np.zeros(1, dtype="int64"))
+    function(argument)
+    function(argument)
+    assert call_count == 2
+
+    # Dropping the generated module runs its global destructor.  The retained packed-function
+    # handle must be released exactly once without invalidating the registry-owned function.
+    del function
+    del built
+    gc.collect()
+    tvm.get_global_func("test_codegen_lookup")(argument)
+    assert call_count == 3
 
 
 def test_legacy_lookup_context_slot_is_still_populated():
@@ -88,6 +121,10 @@ def test_legacy_lookup_context_slot_is_still_populated():
 extern "C" {
 TVM_TEST_EXPORT void* __TVMBackendGetFuncFromEnv = nullptr;
 TVM_TEST_EXPORT void* __TVMFFIEnvModLookupFromImports = nullptr;
+TVM_TEST_EXPORT void* __TVMFFIHandleInitOnce = nullptr;
+TVM_TEST_EXPORT void* __TVMFFIHandleDeinitOnce = nullptr;
+TVM_TEST_EXPORT void* __TVMFFIObjectIncRef = nullptr;
+TVM_TEST_EXPORT void* __TVMFFIObjectDecRef = nullptr;
 TVM_TEST_EXPORT void* __tvm_ffi__library_ctx = nullptr;
 }
 """
@@ -99,6 +136,10 @@ TVM_TEST_EXPORT void* __tvm_ffi__library_ctx = nullptr;
     assert loaded_module is not None
     assert ctypes.c_void_p.in_dll(loaded_library, "__TVMBackendGetFuncFromEnv").value
     assert ctypes.c_void_p.in_dll(loaded_library, "__TVMFFIEnvModLookupFromImports").value
+    assert ctypes.c_void_p.in_dll(loaded_library, "__TVMFFIHandleInitOnce").value
+    assert ctypes.c_void_p.in_dll(loaded_library, "__TVMFFIHandleDeinitOnce").value
+    assert ctypes.c_void_p.in_dll(loaded_library, "__TVMFFIObjectIncRef").value
+    assert ctypes.c_void_p.in_dll(loaded_library, "__TVMFFIObjectDecRef").value
 
 
 if __name__ == "__main__":

--- a/tests/python/codegen/test_target_codegen_static_init.py
+++ b/tests/python/codegen/test_target_codegen_static_init.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 import ctypes
-import gc
 
 import numpy as np
 
@@ -71,38 +70,10 @@ def test_generated_lookup_uses_tvm_ffi_symbol():
     llvm_source = tvm.compile(mod, target="llvm").mod.inspect_source("ll")
     assert "@__TVMFFIEnvModLookupFromImports" in llvm_source
     assert "@__TVMFFIHandleInitOnce" in llvm_source
-    assert "@__TVMFFIHandleDeinitOnce" in llvm_source
-    assert "@__TVMFFIObjectIncRef" in llvm_source
-    assert "@__TVMFFIObjectDecRef" in llvm_source
-    assert "@llvm.global_dtors" in llvm_source
-    assert "define internal i32 @__tvm_func_handle_init" in llvm_source
-    assert "define internal i32 @__tvm_func_handle_release" in llvm_source
-    assert "define hidden void @__tvm_func_handle_deinit" in llvm_source
+    assert "define internal hidden i32 @__tvm_func_handle_init.test_codegen_lookup" in llvm_source
+    assert "@__TVMFFIHandleDeinitOnce" not in llvm_source
+    assert "@llvm.global_dtors" not in llvm_source
     assert "@__TVMBackendGetFuncFromEnv" not in llvm_source
-
-
-def test_generated_lookup_handle_lifecycle():
-    call_count = 0
-
-    @tvm.register_global_func("test_codegen_lookup", override=True)
-    def test_codegen_lookup(_):
-        nonlocal call_count
-        call_count += 1
-
-    built = tvm.compile(_lookup_module(), target="llvm")
-    function = built.mod["ramp"]
-    argument = tvm.runtime.tensor(np.zeros(1, dtype="int64"))
-    function(argument)
-    function(argument)
-    assert call_count == 2
-
-    # Dropping the generated module runs its global destructor.  The retained packed-function
-    # handle must be released exactly once without invalidating the registry-owned function.
-    del function
-    del built
-    gc.collect()
-    tvm.get_global_func("test_codegen_lookup")(argument)
-    assert call_count == 3
 
 
 def test_legacy_lookup_context_slot_is_still_populated():
@@ -122,9 +93,6 @@ extern "C" {
 TVM_TEST_EXPORT void* __TVMBackendGetFuncFromEnv = nullptr;
 TVM_TEST_EXPORT void* __TVMFFIEnvModLookupFromImports = nullptr;
 TVM_TEST_EXPORT void* __TVMFFIHandleInitOnce = nullptr;
-TVM_TEST_EXPORT void* __TVMFFIHandleDeinitOnce = nullptr;
-TVM_TEST_EXPORT void* __TVMFFIObjectIncRef = nullptr;
-TVM_TEST_EXPORT void* __TVMFFIObjectDecRef = nullptr;
 TVM_TEST_EXPORT void* __tvm_ffi__library_ctx = nullptr;
 }
 """
@@ -137,9 +105,6 @@ TVM_TEST_EXPORT void* __tvm_ffi__library_ctx = nullptr;
     assert ctypes.c_void_p.in_dll(loaded_library, "__TVMBackendGetFuncFromEnv").value
     assert ctypes.c_void_p.in_dll(loaded_library, "__TVMFFIEnvModLookupFromImports").value
     assert ctypes.c_void_p.in_dll(loaded_library, "__TVMFFIHandleInitOnce").value
-    assert ctypes.c_void_p.in_dll(loaded_library, "__TVMFFIHandleDeinitOnce").value
-    assert ctypes.c_void_p.in_dll(loaded_library, "__TVMFFIObjectIncRef").value
-    assert ctypes.c_void_p.in_dll(loaded_library, "__TVMFFIObjectDecRef").value
 
 
 if __name__ == "__main__":

--- a/tests/python/codegen/test_target_codegen_static_init.py
+++ b/tests/python/codegen/test_target_codegen_static_init.py
@@ -21,6 +21,18 @@ import numpy as np
 import tvm
 from tvm.script import ir as I
 from tvm.script import tirx as T
+from tvm.support import cc, utils
+
+
+def _lookup_module():
+    @I.ir_module
+    class Module:
+        @T.prim_func(s_tir=True)
+        def ramp(A: T.handle):
+            T.func_attr({"global_symbol": "ramp"})
+            T.call_packed("test_codegen_lookup", A)
+
+    return Module
 
 
 def test_static_init():
@@ -46,6 +58,47 @@ def test_static_init():
     f = tvm.driver.build(mod, target="llvm")
     a = tvm.runtime.tensor(np.zeros(10, dtype="int64"))
     f(a)
+
+
+def test_generated_lookup_uses_tvm_ffi_symbol():
+    mod = _lookup_module()
+
+    c_source = tvm.compile(mod, target="c").mod.inspect_source()
+    assert "TVMFFIEnvModLookupFromImports(" in c_source
+    assert "TVMBackendGetFuncFromEnv(" not in c_source
+
+    llvm_source = tvm.compile(mod, target="llvm").mod.inspect_source("ll")
+    assert "@__TVMFFIEnvModLookupFromImports" in llvm_source
+    assert "@__TVMBackendGetFuncFromEnv" not in llvm_source
+
+
+def test_legacy_lookup_context_slot_is_still_populated():
+    temp = utils.tempdir()
+    source_path = temp.relpath("legacy_lookup_context.cc")
+    library_path = temp.relpath("legacy_lookup_context.so")
+    with open(source_path, "w", encoding="utf-8") as source_file:
+        source_file.write(
+            r"""
+#if defined(_WIN32)
+#define TVM_TEST_EXPORT __declspec(dllexport)
+#else
+#define TVM_TEST_EXPORT __attribute__((visibility("default")))
+#endif
+
+extern "C" {
+TVM_TEST_EXPORT void* __TVMBackendGetFuncFromEnv = nullptr;
+TVM_TEST_EXPORT void* __TVMFFIEnvModLookupFromImports = nullptr;
+TVM_TEST_EXPORT void* __tvm_ffi__library_ctx = nullptr;
+}
+"""
+        )
+
+    cc.create_shared(library_path, [source_path])
+    loaded_module = tvm.runtime.load_module(library_path)
+    loaded_library = ctypes.CDLL(library_path)
+    assert loaded_module is not None
+    assert ctypes.c_void_p.in_dll(loaded_library, "__TVMBackendGetFuncFromEnv").value
+    assert ctypes.c_void_p.in_dll(loaded_library, "__TVMFFIEnvModLookupFromImports").value
 
 
 if __name__ == "__main__":

--- a/tests/python/codegen/test_target_codegen_static_init.py
+++ b/tests/python/codegen/test_target_codegen_static_init.py
@@ -21,18 +21,6 @@ import numpy as np
 import tvm
 from tvm.script import ir as I
 from tvm.script import tirx as T
-from tvm.support import cc, utils
-
-
-def _lookup_module():
-    @I.ir_module
-    class Module:
-        @T.prim_func(s_tir=True)
-        def ramp(A: T.handle):
-            T.func_attr({"global_symbol": "ramp"})
-            T.call_packed("test_codegen_lookup", A)
-
-    return Module
 
 
 def test_static_init():
@@ -58,53 +46,6 @@ def test_static_init():
     f = tvm.driver.build(mod, target="llvm")
     a = tvm.runtime.tensor(np.zeros(10, dtype="int64"))
     f(a)
-
-
-def test_generated_lookup_uses_tvm_ffi_symbol():
-    mod = _lookup_module()
-
-    c_source = tvm.compile(mod, target="c").mod.inspect_source()
-    assert "TVMFFIEnvModLookupFromImports(" in c_source
-    assert "TVMBackendGetFuncFromEnv(" not in c_source
-
-    llvm_source = tvm.compile(mod, target="llvm").mod.inspect_source("ll")
-    assert "@__TVMFFIEnvModLookupFromImports" in llvm_source
-    assert "@__TVMFFIHandleInitOnce" in llvm_source
-    assert "define internal hidden i32 @__tvm_func_handle_init.test_codegen_lookup" in llvm_source
-    assert "@__TVMFFIHandleDeinitOnce" not in llvm_source
-    assert "@llvm.global_dtors" not in llvm_source
-    assert "@__TVMBackendGetFuncFromEnv" not in llvm_source
-
-
-def test_legacy_lookup_context_slot_is_still_populated():
-    temp = utils.tempdir()
-    source_path = temp.relpath("legacy_lookup_context.cc")
-    library_path = temp.relpath("legacy_lookup_context.so")
-    with open(source_path, "w", encoding="utf-8") as source_file:
-        source_file.write(
-            r"""
-#if defined(_WIN32)
-#define TVM_TEST_EXPORT __declspec(dllexport)
-#else
-#define TVM_TEST_EXPORT __attribute__((visibility("default")))
-#endif
-
-extern "C" {
-TVM_TEST_EXPORT void* __TVMBackendGetFuncFromEnv = nullptr;
-TVM_TEST_EXPORT void* __TVMFFIEnvModLookupFromImports = nullptr;
-TVM_TEST_EXPORT void* __TVMFFIHandleInitOnce = nullptr;
-TVM_TEST_EXPORT void* __tvm_ffi__library_ctx = nullptr;
-}
-"""
-        )
-
-    cc.create_shared(library_path, [source_path])
-    loaded_module = tvm.runtime.load_module(library_path)
-    loaded_library = ctypes.CDLL(library_path)
-    assert loaded_module is not None
-    assert ctypes.c_void_p.in_dll(loaded_library, "__TVMBackendGetFuncFromEnv").value
-    assert ctypes.c_void_p.in_dll(loaded_library, "__TVMFFIEnvModLookupFromImports").value
-    assert ctypes.c_void_p.in_dll(loaded_library, "__TVMFFIHandleInitOnce").value
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Generated LLVM modules currently cache imported packed functions through an unsynchronized null check and plain store. Concurrent first calls can therefore race the lookup and cache update.

This change:

- routes generated C and LLVM lookups directly through TVMFFIEnvModLookupFromImports and removes the superseded TVMBackendGetFuncFromEnv wrapper;
- gives each LLVM cached function a readable internal hidden initializer and publishes its module-owned result through TVMFFIHandleInitOnce;
- removes the unused TVMBackendRunOnce export and dead LLVM static-init producer while preserving the live static-handle path.

Validated with the existing LLVM, C-host, common codegen, static-init, and C++ test suites.