### PR TITLE
[CI] Batch Python unittest pytest targets into a single invocation

### DIFF
--- a/tests/scripts/task_python_unittest.sh
+++ b/tests/scripts/task_python_unittest.sh
@@ -60,6 +60,9 @@ TEST_FILES=(
   "relax"
 )
 
-for TEST_FILE in ${TEST_FILES[@]}; do
-    run_pytest ${TEST_FILE}, tests/python/${TEST_FILE}
+PYTEST_TARGETS=()
+for TEST_FILE in "${TEST_FILES[@]}"; do
+    PYTEST_TARGETS+=("tests/python/${TEST_FILE}")
 done
+
+run_pytest "${TVM_UNITTEST_TESTSUITE_NAME}" "${PYTEST_TARGETS[@]}"


### PR DESCRIPTION
The Python unittest CI step previously looped over each collected test directory and invoked `run_pytest` once per directory. Splitting related tests across many pytest invocations fragments Jenkins failure reports.

This change collects the ordered test directory list into a `PYTEST_TARGETS` array first, then passes the full target set to a single `run_pytest` invocation. Target ordering, pytest flags (`--reruns=3`, `-n=1`), `PYTEST_ADDOPTS` environment setup, and per-test failure behavior are unchanged; the platform-minimal run remains a separate invocation with its own JUnit XML.

This keeps related failures within one pytest report for clearer CI output.