### PR TITLE
[TEST] Serialize local GPU execution under pytest-xdist

### DIFF
--- a/docs/contribute/testing.rst
+++ b/docs/contribute/testing.rst
@@ -163,7 +163,7 @@ the callback so no device-backed object outlives the lock.
         executable = tvm.compile(make_add_one_module(), target)
         host_input = np.arange(16, dtype="float32")
 
-        def run():
+        def run_and_check():
             dev = tvm.cuda(0)
             device_input = tvm.runtime.tensor(host_input, dev)
             device_output = tvm.runtime.empty(host_input.shape, "float32", dev)
@@ -171,14 +171,19 @@ the callback so no device-backed object outlives the lock.
             dev.sync()
             tvm.testing.assert_allclose(device_output.numpy(), host_input + 1)
 
-        tvm.testing.run_with_gpu_lock(run)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 The wrapper uses the existing :py:class:`tvm_ffi.utils.FileLock` with a
 persistent machine-local path.  A process exit releases the kernel lock;
 the remaining file is not stale ownership.  Test startup must never
 delete or rotate it, because another process could then lock a different
 inode.  Set ``TVM_TEST_LOCK_DIR`` only when all cooperating processes need
-an explicitly configured shared machine-local directory.
+an explicitly configured shared machine-local directory.  The default
+temporary path coordinates processes running as the same user.  Multi-user
+runners sharing a GPU must use one administrator-provisioned directory and
+persistent lock file that every contender can write, or enforce exclusivity
+through the runner.  A per-user lock path cannot protect a GPU shared across
+users because each user would lock a different file.
 
 There also exists a ``tvm.testing.enabled_targets()`` that returns
 all targets that are enabled and runnable on the current machine,

--- a/docs/contribute/testing.rst
+++ b/docs/contribute/testing.rst
@@ -146,6 +146,40 @@ marks are as follows.
   not installed.  Use this instead of a ``skipif`` for package
   dependencies.
 
+Tests that execute on a local GPU must put the complete live-device
+lifetime in a small callback passed to
+:py:func:`tvm.testing.run_with_gpu_lock`.  Target construction and
+compilation remain outside so that pytest-xdist workers can compile in
+parallel.  Device creation, allocation, execution, synchronization,
+host conversion, result checks, and child-process teardown remain inside
+the callback so no device-backed object outlives the lock.
+
+.. code-block:: python
+
+    @pytest.mark.gpu
+    @pytest.mark.skipif(not tvm.testing.env.has_cuda(), reason="need cuda")
+    def test_cuda_add_one():
+        target = tvm.target.Target("cuda -arch=sm_90")
+        executable = tvm.compile(make_add_one_module(), target)
+        host_input = np.arange(16, dtype="float32")
+
+        def run():
+            dev = tvm.cuda(0)
+            device_input = tvm.runtime.tensor(host_input, dev)
+            device_output = tvm.runtime.empty(host_input.shape, "float32", dev)
+            executable(device_input, device_output)
+            dev.sync()
+            tvm.testing.assert_allclose(device_output.numpy(), host_input + 1)
+
+        tvm.testing.run_with_gpu_lock(run)
+
+The wrapper uses the existing :py:class:`tvm_ffi.utils.FileLock` with a
+persistent machine-local path.  A process exit releases the kernel lock;
+the remaining file is not stale ownership.  Test startup must never
+delete or rotate it, because another process could then lock a different
+inode.  Set ``TVM_TEST_LOCK_DIR`` only when all cooperating processes need
+an explicitly configured shared machine-local directory.
+
 There also exists a ``tvm.testing.enabled_targets()`` that returns
 all targets that are enabled and runnable on the current machine,
 based on the environment variable ``TVM_TEST_TARGETS``, the build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,7 +167,10 @@ addopts = "-v --tb=short"
 python_files = ["test_*.py", "*_test.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
-markers = ["gpu: Mark a test as requiring a GPU"]
+markers = [
+  "gpu: Mark a test as requiring a GPU",
+  "xdist_group(name): Run related tests in one pytest-xdist load group",
+]
 
 [tool.ruff]
 include = [

--- a/python/tvm/testing/__init__.py
+++ b/python/tvm/testing/__init__.py
@@ -25,5 +25,6 @@ from ._ffi_api import (
     test_raise_error,
 )
 from .runner import local_run, rpc_run
+from .locking import run_with_gpu_lock
 from .utils import *
 from . import env

--- a/python/tvm/testing/locking.py
+++ b/python/tvm/testing/locking.py
@@ -1,0 +1,65 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Helpers for tests that use exclusive machine resources."""
+
+import os
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, TypeVar
+
+from tvm_ffi.utils import FileLock
+
+_LOCK_DIR_ENV_VAR = "TVM_TEST_LOCK_DIR"
+_LOCK_DIR_NAME = "tvm-testing-locks"
+_R = TypeVar("_R")
+
+
+def _ensure_test_lock_path(filename: str) -> Path:
+    lock_dir_override = os.environ.get(_LOCK_DIR_ENV_VAR)
+    if lock_dir_override:
+        lock_dir = Path(lock_dir_override).expanduser()
+    else:
+        lock_dir = Path(tempfile.gettempdir()) / _LOCK_DIR_NAME
+
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    return lock_dir / filename
+
+
+def run_with_gpu_lock(func: Callable[..., _R], /, *args: Any, **kwargs: Any) -> _R:
+    """Run a callable while holding the machine-local GPU lock.
+
+    The lock avoids contentious GPU access that may break GPU-related tests.
+
+    Parameters
+    ----------
+    func : Callable
+        Callable containing the complete live local-GPU lifetime.
+    *args : Any
+        Positional arguments forwarded to ``func``.
+    **kwargs : Any
+        Keyword arguments forwarded to ``func``.
+
+    Returns
+    -------
+    result : Any
+        The return value of ``func``.
+    """
+
+    lock_path = _ensure_test_lock_path("gpu.lock")
+    with FileLock(str(lock_path)):
+        return func(*args, **kwargs)

--- a/python/tvm/testing/plugin.py
+++ b/python/tvm/testing/plugin.py
@@ -35,13 +35,6 @@ directory as the test scripts.
 import _pytest
 import pytest
 
-try:
-    from xdist.scheduler.loadscope import LoadScopeScheduling
-
-    HAVE_XDIST = True
-except ImportError:
-    HAVE_XDIST = False
-
 
 def pytest_collection_modifyitems(config, items):
     """Called after all tests are chosen, currently used for bookkeeping."""
@@ -118,36 +111,3 @@ def _sort_tests(items):
         return filename, lineno, test_name
 
     items.sort(key=sort_key)
-
-
-# pytest-xdist isn't required but is used in CI, so guard on its presence
-if HAVE_XDIST:
-
-    def pytest_xdist_make_scheduler(config, log):
-        """
-        Serialize certain tests for pytest-xdist that have inter-test
-        dependencies
-        """
-
-        class TvmTestScheduler(LoadScopeScheduling):
-            """
-            Scheduler to serializer tests
-            """
-
-            def _split_scope(self, nodeid):
-                """
-                Returns a specific string for classes of nodeids
-                """
-                # NOTE: these tests contain inter-test dependencies and must be
-                # serialized
-                items = {
-                    "test_tvm_testing_features": "functional-tests",
-                }
-
-                for nodeid_pattern, suite_name in items.items():
-                    if nodeid_pattern in nodeid:
-                        return suite_name
-
-                return nodeid
-
-        return TvmTestScheduler(config, log)

--- a/tests/python/codegen/test_codegen_error_handling.py
+++ b/tests/python/codegen/test_codegen_error_handling.py
@@ -292,7 +292,7 @@ def test_device_mismatch_error():
     b_ok = tvm.runtime.tensor(np.zeros(128, dtype="float32"))
     lib(a_ok, b_ok)  # correct input should pass
 
-    def run():
+    def run_and_check():
         a_gpu = tvm.runtime.tensor(np.zeros(128, dtype="float32"), device=tvm.cuda(0))
         b = tvm.runtime.tensor(np.zeros(128, dtype="float32"))
 
@@ -306,7 +306,7 @@ def test_device_mismatch_error():
         ):
             lib(a_gpu, b)
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 # ── Scalar type mismatch errors ─────────────────────────────

--- a/tests/python/codegen/test_codegen_error_handling.py
+++ b/tests/python/codegen/test_codegen_error_handling.py
@@ -292,18 +292,21 @@ def test_device_mismatch_error():
     b_ok = tvm.runtime.tensor(np.zeros(128, dtype="float32"))
     lib(a_ok, b_ok)  # correct input should pass
 
-    a_gpu = tvm.runtime.tensor(np.zeros(128, dtype="float32"), device=tvm.cuda(0))
-    b = tvm.runtime.tensor(np.zeros(128, dtype="float32"))
+    def run():
+        a_gpu = tvm.runtime.tensor(np.zeros(128, dtype="float32"), device=tvm.cuda(0))
+        b = tvm.runtime.tensor(np.zeros(128, dtype="float32"))
 
-    with pytest.raises(
-        ValueError,
-        match=re.escape(
-            "Mismatched a.device_type on argument #0 when calling:\n"
-            "  `func(a: Tensor([128], float32), b: Tensor([128], float32))`,\n"
-            "  expected cpu"
-        ),
-    ):
-        lib(a_gpu, b)
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "Mismatched a.device_type on argument #0 when calling:\n"
+                "  `func(a: Tensor([128], float32), b: Tensor([128], float32))`,\n"
+                "  expected cpu"
+            ),
+        ):
+            lib(a_gpu, b)
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 # ── Scalar type mismatch errors ─────────────────────────────

--- a/tests/python/codegen/test_gpu_codegen_allreduce.py
+++ b/tests/python/codegen/test_gpu_codegen_allreduce.py
@@ -87,7 +87,6 @@ dims = tvm.testing.parameter(*generate_param_sets())
 def test_allreduce_sum(dims, target):
     if not tvm.testing.device_enabled(target):
         pytest.skip(f"{target} not enabled")
-    dev = tvm.device(target)
     d1, d2, d3 = dims
     mod = _reduce_sum_module(d1, d2, d3)
     f = tvm.compile(mod, target=target)
@@ -95,12 +94,15 @@ def test_allreduce_sum(dims, target):
     # prepare input and output array
     a_np = np.random.rand(1, d1, d2, d3).astype("float32")
     b_np = a_np.sum(axis=-1).astype("float32")
-    a = tvm.runtime.tensor(a_np, dev)
-    b = tvm.runtime.tensor(np.zeros_like(b_np), dev)
 
-    # launch kernel
-    f(a, b)
-    tvm.testing.assert_allclose(b.numpy(), b_np, rtol=1e-6, atol=1e-6)
+    def run_and_check():
+        dev = tvm.device(target)
+        a = tvm.runtime.tensor(a_np, dev)
+        b = tvm.runtime.tensor(np.zeros_like(b_np), dev)
+        f(a, b)
+        tvm.testing.assert_allclose(b.numpy(), b_np, rtol=1e-6, atol=1e-6)
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 define_metal_compile_callback = tvm.testing.parameter(True, False)
@@ -150,7 +152,6 @@ def test_allreduce_sum_compile(optional_metal_compile_callback):
 def test_allreduce_max(dims, target):
     if not tvm.testing.device_enabled(target):
         pytest.skip(f"{target} not enabled")
-    dev = tvm.device(target)
     d1, d2, d3 = dims
     mod = _reduce_max_module(d1, d2, d3)
     f = tvm.compile(mod, target=target)
@@ -158,12 +159,15 @@ def test_allreduce_max(dims, target):
     # prepare input and output array
     a_np = -np.random.rand(1, d1, d2, d3).astype("float32")
     b_np = a_np.max(axis=-1).astype("float32")
-    a = tvm.runtime.tensor(a_np, dev)
-    b = tvm.runtime.tensor(np.zeros_like(b_np), dev)
 
-    # launch kernel
-    f(a, b)
-    tvm.testing.assert_allclose(b.numpy(), b_np, rtol=1e-6, atol=1e-6)
+    def run_and_check():
+        dev = tvm.device(target)
+        a = tvm.runtime.tensor(a_np, dev)
+        b = tvm.runtime.tensor(np.zeros_like(b_np), dev)
+        f(a, b)
+        tvm.testing.assert_allclose(b.numpy(), b_np, rtol=1e-6, atol=1e-6)
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 if __name__ == "__main__":

--- a/tests/python/codegen/test_inject_ptx_ldg32.py
+++ b/tests/python/codegen/test_inject_ptx_ldg32.py
@@ -53,11 +53,6 @@ def test_inject_ptx_intrin():
         mod = tvm.compile(f, target="cuda")
     A_np = np.random.rand(16).astype("float32")
     B_np = np.zeros(32).astype("float32")
-    dev = tvm.cuda(0)
-    A_nd = tvm.runtime.tensor(A_np, device=dev)
-    B_nd = tvm.runtime.tensor(B_np, device=dev)
-    mod(A_nd, B_nd)
-
     C_np = np.zeros(32).astype("float32")
 
     for i in range(32):
@@ -65,7 +60,14 @@ def test_inject_ptx_intrin():
             C_np[i] = A_np[i // 2]
         C_np[i] += 1.0
 
-    tvm.testing.assert_allclose(B_nd.numpy(), C_np)
+    def run():
+        dev = tvm.cuda(0)
+        A_nd = tvm.runtime.tensor(A_np, device=dev)
+        B_nd = tvm.runtime.tensor(B_np, device=dev)
+        mod(A_nd, B_nd)
+        tvm.testing.assert_allclose(B_nd.numpy(), C_np)
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 if __name__ == "__main__":

--- a/tests/python/codegen/test_inject_ptx_ldg32.py
+++ b/tests/python/codegen/test_inject_ptx_ldg32.py
@@ -60,14 +60,14 @@ def test_inject_ptx_intrin():
             C_np[i] = A_np[i // 2]
         C_np[i] += 1.0
 
-    def run():
+    def run_and_check():
         dev = tvm.cuda(0)
         A_nd = tvm.runtime.tensor(A_np, device=dev)
         B_nd = tvm.runtime.tensor(B_np, device=dev)
         mod(A_nd, B_nd)
         tvm.testing.assert_allclose(B_nd.numpy(), C_np)
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 if __name__ == "__main__":

--- a/tests/python/codegen/test_target_codegen_blob.py
+++ b/tests/python/codegen/test_target_codegen_blob.py
@@ -78,7 +78,7 @@ def test_cuda_multi_lib():
     cc.create_shared(path_dso, ["-Wl,--whole-archive", pathAll, "-Wl,--no-whole-archive"])
 
     def popen_check():
-        def run():
+        def run_and_check():
             # Load dll, will trigger system library registration
             ctypes.CDLL(path_dso)
             # Load the system wide library
@@ -95,7 +95,7 @@ def test_cuda_multi_lib():
             np.testing.assert_equal(a_nd.numpy(), a_np + 1)
             np.testing.assert_equal(b_nd.numpy(), a_np + 2)
 
-        tvm.testing.run_with_gpu_lock(run)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
     # system lib should be loaded in different process
     worker = popen_pool.PopenWorker()

--- a/tests/python/codegen/test_target_codegen_blob.py
+++ b/tests/python/codegen/test_target_codegen_blob.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# ruff: noqa: F821, F841
+# ruff: noqa: F821
 
 import ctypes
 
@@ -34,7 +34,6 @@ def test_cuda_multi_lib():
 
     # test combining two system lib together
     # each contains a fatbin component in cuda
-    dev = tvm.cuda(0)
     for device in ["llvm", "cuda"]:
         if not tvm.testing.device_enabled(device):
             print(f"skip because {device} is not enabled...")
@@ -79,21 +78,24 @@ def test_cuda_multi_lib():
     cc.create_shared(path_dso, ["-Wl,--whole-archive", pathAll, "-Wl,--no-whole-archive"])
 
     def popen_check():
-        # Load dll, will trigger system library registration
-        ctypes.CDLL(path_dso)
-        # Load the system wide library
-        dev = tvm.cuda()
-        a_np = np.random.uniform(size=12).astype("float32")
-        a_nd = tvm.runtime.tensor(a_np, dev)
-        b_nd = tvm.runtime.tensor(a_np, dev)
-        syslibA = tvm.runtime.system_lib("modA_")
-        syslibB = tvm.runtime.system_lib("modB_")
-        # reload same lib twice
-        syslibA = tvm.runtime.system_lib("modA_")
-        syslibA["my_inplace_update"](a_nd)
-        syslibB["my_inplace_update"](b_nd)
-        np.testing.assert_equal(a_nd.numpy(), a_np + 1)
-        np.testing.assert_equal(b_nd.numpy(), a_np + 2)
+        def run():
+            # Load dll, will trigger system library registration
+            ctypes.CDLL(path_dso)
+            # Load the system wide library
+            dev = tvm.cuda()
+            a_np = np.random.uniform(size=12).astype("float32")
+            a_nd = tvm.runtime.tensor(a_np, dev)
+            b_nd = tvm.runtime.tensor(a_np, dev)
+            syslibA = tvm.runtime.system_lib("modA_")
+            syslibB = tvm.runtime.system_lib("modB_")
+            # reload same lib twice
+            syslibA = tvm.runtime.system_lib("modA_")
+            syslibA["my_inplace_update"](a_nd)
+            syslibB["my_inplace_update"](b_nd)
+            np.testing.assert_equal(a_nd.numpy(), a_np + 1)
+            np.testing.assert_equal(b_nd.numpy(), a_np + 2)
+
+        tvm.testing.run_with_gpu_lock(run)
 
     # system lib should be loaded in different process
     worker = popen_pool.PopenWorker()

--- a/tests/python/codegen/test_target_codegen_bool.py
+++ b/tests/python/codegen/test_target_codegen_bool.py
@@ -30,7 +30,6 @@ from tvm.script import tirx as T
 def test_cmp_load_store(target):
     if not tvm.testing.device_enabled(target):
         pytest.skip(f"{target} not enabled")
-    dev = tvm.device(target)
 
     @I.ir_module(s_tir=True)
     class GPUModule:
@@ -88,14 +87,22 @@ def test_cmp_load_store(target):
 
     a_np = np.random.uniform(size=arr_size).astype("float32")
     b_np = np.random.uniform(size=arr_size).astype("float32")
-    a = tvm.runtime.tensor(a_np, dev)
-    b = tvm.runtime.tensor(b_np, dev)
-    d = tvm.runtime.tensor(np.zeros(arr_size, dtype="float32"), dev)
-    f(a, b, d)
-    np.testing.assert_equal(
-        d.numpy(),
-        np.logical_and(a_np > b_np, a_np > 1).astype("float32"),
-    )
+
+    def run_and_check():
+        dev = tvm.device(target)
+        a = tvm.runtime.tensor(a_np, dev)
+        b = tvm.runtime.tensor(b_np, dev)
+        d = tvm.runtime.tensor(np.zeros(arr_size, dtype="float32"), dev)
+        f(a, b, d)
+        np.testing.assert_equal(
+            d.numpy(),
+            np.logical_and(a_np > b_np, a_np > 1).astype("float32"),
+        )
+
+    if is_gpu:
+        tvm.testing.run_with_gpu_lock(run_and_check)
+    else:
+        run_and_check()
 
 
 if __name__ == "__main__":

--- a/tests/python/codegen/test_target_codegen_cuda.py
+++ b/tests/python/codegen/test_target_codegen_cuda.py
@@ -86,11 +86,14 @@ def test_cuda_vectorize_add():
 
         fun = tvm.compile(Module, target="cuda")
 
-        dev = tvm.cuda(0)
-        a = tvm.runtime.empty((n,), vec_dtype, dev).copyfrom(np.random.uniform(size=(n, lanes)))
-        c = tvm.runtime.empty((n,), vec_dtype, dev)
-        fun(a, c)
-        tvm.testing.assert_allclose(c.numpy(), a.numpy() + 1)
+        def run_and_check():
+            dev = tvm.cuda(0)
+            a = tvm.runtime.empty((n,), vec_dtype, dev).copyfrom(np.random.uniform(size=(n, lanes)))
+            c = tvm.runtime.empty((n,), vec_dtype, dev)
+            fun(a, c)
+            tvm.testing.assert_allclose(c.numpy(), a.numpy() + 1)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
     check_cuda("float32", 64, 2)
     check_cuda("float32", 64, 3)
@@ -150,14 +153,18 @@ def test_cuda_bf16_vectorize_add():
             disabled_pass=["tirx.BF16Promote", "tirx.BF16CastElimination", "tirx.BF16TypeLowering"]
         ):
             fun = tvm.compile(Module, target="cuda")
-        dev = tvm.cuda(0)
-        np_a = np.random.uniform(size=(n, lanes)).astype("float32")
-        np_a = np_bf162np_float(np_float2np_bf16(np_a))
-        a = tvm.runtime.empty((n,), vec_dtype, dev).copyfrom(np_float2np_bf16(np_a))
-        c = tvm.runtime.empty((n,), vec_dtype, dev)
-        fun(a, c)
-        c = tvm.runtime.empty((n, lanes), "uint16", dev).copyfrom(c)
-        tvm.testing.assert_allclose(c.numpy(), np_float2np_bf16(np_a + 1))
+
+        def run_and_check():
+            dev = tvm.cuda(0)
+            np_a = np.random.uniform(size=(n, lanes)).astype("float32")
+            np_a = np_bf162np_float(np_float2np_bf16(np_a))
+            a = tvm.runtime.empty((n,), vec_dtype, dev).copyfrom(np_float2np_bf16(np_a))
+            c = tvm.runtime.empty((n,), vec_dtype, dev)
+            fun(a, c)
+            c = tvm.runtime.empty((n, lanes), "uint16", dev).copyfrom(c)
+            tvm.testing.assert_allclose(c.numpy(), np_float2np_bf16(np_a + 1))
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
     check_cuda(64, 2)
     check_cuda(64, 4)
@@ -201,13 +208,17 @@ def test_cuda_multiply_add():
         np_b = np.random.randint(low=-128, high=127, size=(n, lanes))
         np_c = np.random.randint(low=0, high=127, size=(n,))
         np_d = [sum(x * y) + z for x, y, z in zip(np_a, np_b, np_c)]
-        dev = tvm.cuda(0)
-        a = tvm.runtime.empty((n,), vec_dtype, dev).copyfrom(np_a)
-        b = tvm.runtime.empty((n,), vec_dtype, dev).copyfrom(np_b)
-        c = tvm.runtime.empty((n,), "int32", dev).copyfrom(np_c)
-        d = tvm.runtime.empty((n,), "int32", dev)
-        fun(a, b, c, d)
-        tvm.testing.assert_allclose(d.numpy(), np_d)
+
+        def run_and_check():
+            dev = tvm.cuda(0)
+            a = tvm.runtime.empty((n,), vec_dtype, dev).copyfrom(np_a)
+            b = tvm.runtime.empty((n,), vec_dtype, dev).copyfrom(np_b)
+            c = tvm.runtime.empty((n,), "int32", dev).copyfrom(np_c)
+            d = tvm.runtime.empty((n,), "int32", dev)
+            fun(a, b, c, d)
+            tvm.testing.assert_allclose(d.numpy(), np_d)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
     check_cuda("int8", 64, 4)
 
@@ -218,7 +229,6 @@ def test_cuda_vectorize_load():
     num_thread = 8
 
     def check_cuda(dtype, n, lanes):
-        dev = tvm.cuda(0)
         vec_dtype = f"{dtype}x{lanes}"
         num_blocks = n // num_thread
 
@@ -237,11 +247,15 @@ def test_cuda_vectorize_load():
 
         fun = tvm.compile(Module, target="cuda")
 
-        np_a = np.random.randint(low=-128, high=127, size=(n, lanes))
-        a = tvm.runtime.empty((n,), vec_dtype, dev).copyfrom(np_a)
-        b = tvm.runtime.empty((n,), vec_dtype, dev)
-        fun(a, b)
-        tvm.testing.assert_allclose(a.numpy(), b.numpy())
+        def run_and_check():
+            dev = tvm.cuda(0)
+            np_a = np.random.randint(low=-128, high=127, size=(n, lanes))
+            a = tvm.runtime.empty((n,), vec_dtype, dev).copyfrom(np_a)
+            b = tvm.runtime.empty((n,), vec_dtype, dev)
+            fun(a, b)
+            tvm.testing.assert_allclose(a.numpy(), b.numpy())
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
     check_cuda("int8", 64, 2)
     check_cuda("int8", 64, 3)
@@ -255,7 +269,6 @@ def test_cuda_vectorize_load():
 def test_cuda_make_int8():
     def check_cuda(n, value, lanes):
         dtype = "int8"
-        dev = tvm.cuda(0)
         const_value = tvm.tirx.const(value, dtype=dtype)
 
         @I.ir_module(s_tir=True)
@@ -273,10 +286,14 @@ def test_cuda_make_int8():
 
         fun = tvm.compile(Module, target="cuda")
 
-        np_a = np.full((n, lanes), value, dtype=dtype)
-        a = tvm.runtime.empty(np_a.shape, dtype, dev)
-        fun(a)
-        np.testing.assert_equal(a.numpy(), np_a)
+        def run_and_check():
+            dev = tvm.cuda(0)
+            np_a = np.full((n, lanes), value, dtype=dtype)
+            a = tvm.runtime.empty(np_a.shape, dtype, dev)
+            fun(a)
+            np.testing.assert_equal(a.numpy(), np_a)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
     check_cuda(64, np.uint8(0xAB).view(np.int8), 4)
     check_cuda(64, 0, 4)
@@ -292,9 +309,7 @@ def test_cuda_make_int8():
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_cuda(), reason="need cuda")
 def test_cuda_inf_nan():
-    target = "cuda"
-
-    def check_inf_nan(dev, n, value, dtype):
+    def check_inf_nan(n, value, dtype):
         inf_value = tvm.tirx.const(value, dtype=dtype)
 
         @I.ir_module(s_tir=True)
@@ -313,19 +328,20 @@ def test_cuda_inf_nan():
 
         fun = tvm.compile(Module, target="cuda")
 
-        a = tvm.runtime.empty((n,), dtype, dev)
-        c = tvm.runtime.empty((n,), dtype, dev)
-        # Only need to test compiling here
-        fun(a, c)
+        def run():
+            dev = tvm.device("cuda", 0)
+            a = tvm.runtime.empty((n,), dtype, dev)
+            c = tvm.runtime.empty((n,), dtype, dev)
+            fun(a, c)
 
-    dev = tvm.device(target, 0)
+        tvm.testing.run_with_gpu_lock(run)
 
-    check_inf_nan(dev, 1, -float("inf"), "float32")
-    check_inf_nan(dev, 1, -float("inf"), "float64")
-    check_inf_nan(dev, 1, float("inf"), "float32")
-    check_inf_nan(dev, 1, float("inf"), "float64")
-    check_inf_nan(dev, 1, float("nan"), "float32")
-    check_inf_nan(dev, 1, float("nan"), "float64")
+    check_inf_nan(1, -float("inf"), "float32")
+    check_inf_nan(1, -float("inf"), "float64")
+    check_inf_nan(1, float("inf"), "float32")
+    check_inf_nan(1, float("inf"), "float64")
+    check_inf_nan(1, float("nan"), "float32")
+    check_inf_nan(1, float("nan"), "float64")
 
 
 @pytest.mark.parametrize(
@@ -338,7 +354,6 @@ def test_cuda_inf_nan():
 def test_crossthread_reduction1(target):
     if not tvm.testing.device_enabled(target):
         pytest.skip(f"{target} not enabled")
-    dev = tvm.device(target)
 
     def sched(nthd):
         @I.ir_module(s_tir=True)
@@ -370,12 +385,17 @@ def test_crossthread_reduction1(target):
         nn = 3
         # checks three typical cases
         vals = [nthd - 1, nthd, nthd + 1]
-        for kk in [x for x in vals]:
-            size = (nn, kk)
-            a = tvm.runtime.tensor(np.random.uniform(size=size).astype("float32"), dev)
-            b = tvm.runtime.tensor(np.zeros(nn, dtype="float32"), dev)
-            func(a, b)
-            tvm.testing.assert_allclose(b.numpy(), np.sum(a.numpy(), axis=1), rtol=1e-3)
+
+        def run_and_check():
+            dev = tvm.device(target)
+            for kk in vals:
+                size = (nn, kk)
+                a = tvm.runtime.tensor(np.random.uniform(size=size).astype("float32"), dev)
+                b = tvm.runtime.tensor(np.zeros(nn, dtype="float32"), dev)
+                func(a, b)
+                tvm.testing.assert_allclose(b.numpy(), np.sum(a.numpy(), axis=1), rtol=1e-3)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
     verify(16)
     verify(32)
@@ -392,7 +412,6 @@ def test_crossthread_reduction1(target):
 def test_crossthread_reduction2(target):
     if not tvm.testing.device_enabled(target):
         pytest.skip(f"{target} not enabled")
-    dev = tvm.device(target)
 
     def sched(nthdx, nthdy):
         @I.ir_module(s_tir=True)
@@ -435,12 +454,17 @@ def test_crossthread_reduction2(target):
         # checks three typical cases
         vx = [nthdx - 1, nthdx, nthdx + 1]
         vy = [nthdy - 1, nthdy, nthdy + 1]
-        for kk0, kk1 in [(x, y) for x in vx for y in vy]:
-            size = (nn, kk0, kk1)
-            a = tvm.runtime.tensor(np.random.uniform(size=size).astype("float32"), dev)
-            b = tvm.runtime.tensor(np.zeros(nn, dtype="float32"), dev)
-            func(a, b)
-            tvm.testing.assert_allclose(b.numpy(), np.sum(a.numpy(), axis=(1, 2)), rtol=1e-3)
+
+        def run_and_check():
+            dev = tvm.device(target)
+            for kk0, kk1 in [(x, y) for x in vx for y in vy]:
+                size = (nn, kk0, kk1)
+                a = tvm.runtime.tensor(np.random.uniform(size=size).astype("float32"), dev)
+                b = tvm.runtime.tensor(np.zeros(nn, dtype="float32"), dev)
+                func(a, b)
+                tvm.testing.assert_allclose(b.numpy(), np.sum(a.numpy(), axis=(1, 2)), rtol=1e-3)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
     verify(16, 16)
     verify(32, 32)
@@ -497,14 +521,18 @@ def test_cuda_const_float_to_half():
 
     func = tvm.compile(Module, target="cuda")
 
-    dev = tvm.cuda(0)
     shape = (2, 3, 4)
     a_np = np.random.uniform(size=shape).astype("float16")
     c_np = np.zeros(shape=shape, dtype="bool")
-    a = tvm.runtime.tensor(a_np, dev)
-    c = tvm.runtime.tensor(c_np, dev)
-    func(a, c)
-    np.testing.assert_equal(c.numpy(), a_np > 0.5)
+
+    def run_and_check():
+        dev = tvm.cuda(0)
+        a = tvm.runtime.tensor(a_np, dev)
+        c = tvm.runtime.tensor(c_np, dev)
+        func(a, c)
+        np.testing.assert_equal(c.numpy(), a_np > 0.5)
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -531,13 +559,16 @@ def test_cuda_floordiv_with_vectorization():
 
         func = tvm.compile(Module, target="cuda")
 
-        dev = tvm.cuda(0)
-        a_np = np.random.uniform(size=(n,)).astype("float32")
-        b_np = np.array([a_np[i // k] for i in range(0, n)])
-        a_nd = tvm.runtime.tensor(a_np, dev)
-        b_nd = tvm.runtime.tensor(np.zeros(b_np.shape, dtype=b_np.dtype), dev)
-        func(a_nd, b_nd)
-        tvm.testing.assert_allclose(b_nd.numpy(), b_np, rtol=1e-3)
+        def run_and_check():
+            dev = tvm.cuda(0)
+            a_np = np.random.uniform(size=(n,)).astype("float32")
+            b_np = np.array([a_np[i // k] for i in range(0, n)])
+            a_nd = tvm.runtime.tensor(a_np, dev)
+            b_nd = tvm.runtime.tensor(np.zeros(b_np.shape, dtype=b_np.dtype), dev)
+            func(a_nd, b_nd)
+            tvm.testing.assert_allclose(b_nd.numpy(), b_np, rtol=1e-3)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -564,13 +595,16 @@ def test_cuda_floormod_with_vectorization():
 
         func = tvm.compile(Module, target="cuda")
 
-        dev = tvm.cuda(0)
-        a_np = np.random.uniform(size=(n,)).astype("float32")
-        b_np = np.array([a_np[i % k] for i in range(0, n)])
-        a_nd = tvm.runtime.tensor(a_np, dev)
-        b_nd = tvm.runtime.tensor(np.zeros(b_np.shape, dtype=b_np.dtype), dev)
-        func(a_nd, b_nd)
-        tvm.testing.assert_allclose(b_nd.numpy(), b_np, rtol=1e-3)
+        def run_and_check():
+            dev = tvm.cuda(0)
+            a_np = np.random.uniform(size=(n,)).astype("float32")
+            b_np = np.array([a_np[i % k] for i in range(0, n)])
+            a_nd = tvm.runtime.tensor(a_np, dev)
+            b_nd = tvm.runtime.tensor(np.zeros(b_np.shape, dtype=b_np.dtype), dev)
+            func(a_nd, b_nd)
+            tvm.testing.assert_allclose(b_nd.numpy(), b_np, rtol=1e-3)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -600,16 +634,19 @@ def test_vectorized_casts():
         func = tvm.compile(Module, target="cuda")
 
         # correctness
-        dev = tvm.cuda(0)
-        low, high = (0, 20) if t0.startswith("u") or t1.startswith("u") else (-10, 10)
-        a_np = np.random.randint(low, high, size=n).astype(t0)
-        b_np = np.random.randint(low, high, size=n).astype(t1)
-        c_np = (a_np + b_np).astype(t0)
-        a_nd = tvm.runtime.tensor(a_np, dev)
-        b_nd = tvm.runtime.tensor(b_np, dev)
-        c_nd = tvm.runtime.tensor(np.zeros(c_np.shape, dtype=c_np.dtype), dev)
-        func(a_nd, b_nd, c_nd)
-        tvm.testing.assert_allclose(c_nd.numpy(), c_np, rtol=1e-3)
+        def run_and_check():
+            dev = tvm.cuda(0)
+            low, high = (0, 20) if t0.startswith("u") or t1.startswith("u") else (-10, 10)
+            a_np = np.random.randint(low, high, size=n).astype(t0)
+            b_np = np.random.randint(low, high, size=n).astype(t1)
+            c_np = (a_np + b_np).astype(t0)
+            a_nd = tvm.runtime.tensor(a_np, dev)
+            b_nd = tvm.runtime.tensor(b_np, dev)
+            c_nd = tvm.runtime.tensor(np.zeros(c_np.shape, dtype=c_np.dtype), dev)
+            func(a_nd, b_nd, c_nd)
+            tvm.testing.assert_allclose(c_nd.numpy(), c_np, rtol=1e-3)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
     def skip(t0, t1):
         if t0 == t1:
@@ -713,11 +750,15 @@ def test_vectorized_intrin1():
 
         n = 128
         f = sched(tvm_intrin, dtype, n)
-        dev = tvm.cuda(0)
-        a = tvm.runtime.tensor(np.random.uniform(0, 1, size=n).astype(dtype), dev)
-        b = tvm.runtime.tensor(np.zeros(shape=(n,)).astype(dtype), dev)
-        f(a, b)
-        tvm.testing.assert_allclose(b.numpy(), np_func(a.numpy()), atol=1e-3, rtol=1e-3)
+
+        def run_and_check():
+            dev = tvm.cuda(0)
+            a = tvm.runtime.tensor(np.random.uniform(0, 1, size=n).astype(dtype), dev)
+            b = tvm.runtime.tensor(np.zeros(shape=(n,)).astype(dtype), dev)
+            f(a, b)
+            tvm.testing.assert_allclose(b.numpy(), np_func(a.numpy()), atol=1e-3, rtol=1e-3)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
     for func in test_funcs:
         run_test(*func, "float32")
@@ -736,11 +777,15 @@ def test_vectorized_intrin2(dtype="float32"):
     def run_test(tvm_intrin, np_func):
         n = 128
         f = sched(lambda x: tvm_intrin(x, c2), dtype, n)
-        dev = tvm.cuda(0)
-        a = tvm.runtime.tensor(np.random.uniform(0, 1, size=n).astype(dtype), dev)
-        b = tvm.runtime.tensor(np.zeros(shape=(n,)).astype(dtype), dev)
-        f(a, b)
-        tvm.testing.assert_allclose(b.numpy(), np_func(a.numpy()), atol=1e-3, rtol=1e-3)
+
+        def run_and_check():
+            dev = tvm.cuda(0)
+            a = tvm.runtime.tensor(np.random.uniform(0, 1, size=n).astype(dtype), dev)
+            b = tvm.runtime.tensor(np.zeros(shape=(n,)).astype(dtype), dev)
+            f(a, b)
+            tvm.testing.assert_allclose(b.numpy(), np_func(a.numpy()), atol=1e-3, rtol=1e-3)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
     for func in test_funcs:
         run_test(*func)
@@ -759,12 +804,16 @@ def test_vectorized_popcount():
     def run_test(dtype):
         n = 128
         f = sched(lambda x: tvm.tirx.popcount(x), dtype, n)
-        dev = tvm.cuda(0)
-        a = tvm.runtime.tensor(np.random.randint(0, 100000, size=n).astype(dtype), dev)
-        b = tvm.runtime.tensor(np.zeros(shape=(n,)).astype(dtype), dev)
-        f(a, b)
-        ref = np.vectorize(ref_popcount)(a.numpy())
-        tvm.testing.assert_allclose(b.numpy(), ref)
+
+        def run_and_check():
+            dev = tvm.cuda(0)
+            a = tvm.runtime.tensor(np.random.randint(0, 100000, size=n).astype(dtype), dev)
+            b = tvm.runtime.tensor(np.zeros(shape=(n,)).astype(dtype), dev)
+            f(a, b)
+            ref = np.vectorize(ref_popcount)(a.numpy())
+            tvm.testing.assert_allclose(b.numpy(), ref)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
     run_test("uint32")
     run_test("uint64")
@@ -778,7 +827,6 @@ def test_cuda_vectorize_load_permute_pad():
             print("Skip because gpu does not have fp16 support")
             return
 
-        dev = tvm.cuda(0)
         zero = tvm.tirx.const(0, dtype)
         dim0 = n // lanes
         dim1 = l + 2 * padding
@@ -804,14 +852,19 @@ def test_cuda_vectorize_load_permute_pad():
         fun = tvm.compile(Module, target="cuda")
 
         np_a = np.random.randint(low=-128, high=127, size=(n, l)).astype(dtype)
-        a = tvm.runtime.empty((n, l), dtype, dev).copyfrom(np_a)
-        b = tvm.runtime.empty((dim0, dim1, lanes), dtype, dev)
-        fun(a, b)
         np_a_reshape = np_a.reshape(n // lanes, lanes, l).transpose(0, 2, 1)
         ref = np.pad(
             np_a_reshape, ((0, 0), (padding, padding), (0, 0)), mode="constant", constant_values=0
         )
-        tvm.testing.assert_allclose(b.numpy(), ref)
+
+        def run_and_check():
+            dev = tvm.cuda(0)
+            a = tvm.runtime.empty((n, l), dtype, dev).copyfrom(np_a)
+            b = tvm.runtime.empty((dim0, dim1, lanes), dtype, dev)
+            fun(a, b)
+            tvm.testing.assert_allclose(b.numpy(), ref)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
     check_cuda("int8", 64, 16, 3, 2)
     check_cuda("uint8", 64, 16, 3, 2)
@@ -842,13 +895,17 @@ def test_try_unaligned_vector_load():
         f = tvm.tirx.build(Module, target="cuda")
 
         kernel_source = f.imports[0].inspect_source()
-        dev = tvm.cuda()
         a_data = np.arange(0, N).astype("float16")
-        a = tvm.runtime.tensor(a_data, dev)
-        c = tvm.runtime.tensor(np.zeros(C_N, dtype="float16"), dev)
-        f(a, c)
 
-        return a_data, c.numpy(), kernel_source
+        def run_and_check():
+            dev = tvm.cuda()
+            a = tvm.runtime.tensor(a_data, dev)
+            c = tvm.runtime.tensor(np.zeros(C_N, dtype="float16"), dev)
+            f(a, c)
+            return c.numpy()
+
+        c = tvm.testing.run_with_gpu_lock(run_and_check)
+        return a_data, c, kernel_source
 
     # Unaligned case: N=3, C_N=2, offset=1
     a_data, c, kernel_source = build(3, 2, 1)
@@ -1032,14 +1089,18 @@ def test_device_host_call_same_func():
     assert 'extern "C" __device__ int add(int a, int b) {\n  return (a + b);\n}' in cuda_code
 
     # Run a simple test
-    dev = tvm.cuda(0)
     a_np = np.random.randint(0, 10, (128, 128), dtype="int32")
     b_np = np.random.randint(0, 10, (128, 128), dtype="int32")
-    a_tvm = tvm.runtime.tensor(a_np, device=dev)
-    b_tvm = tvm.runtime.tensor(b_np, device=dev)
-    c_tvm = tvm.runtime.empty((128, 128), dtype="int32", device=dev)
-    lib["main"](a_tvm, b_tvm, c_tvm)
-    tvm.testing.assert_allclose(c_tvm.numpy(), a_np + b_np)
+
+    def run_and_check():
+        dev = tvm.cuda(0)
+        a_tvm = tvm.runtime.tensor(a_np, device=dev)
+        b_tvm = tvm.runtime.tensor(b_np, device=dev)
+        c_tvm = tvm.runtime.empty((128, 128), dtype="int32", device=dev)
+        lib["main"](a_tvm, b_tvm, c_tvm)
+        tvm.testing.assert_allclose(c_tvm.numpy(), a_np + b_np)
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -1081,15 +1142,19 @@ def test_cuda_loop_step():
 
     cuda_src = lib.mod.imports[0].inspect_source()
     assert "i += 96" in cuda_src
-    dev = tvm.cuda(0)
     a_np = np.random.uniform(1, 100, (1024,)).astype("float32")
     b_np = np.random.uniform(1, 100, (1024,)).astype("float32")
     c_np = np.zeros((1024,), dtype="float32")
-    a_nd = tvm.runtime.tensor(a_np, dev)
-    b_nd = tvm.runtime.tensor(b_np, dev)
-    c_nd = tvm.runtime.tensor(c_np, dev)
-    lib["main"](a_nd, b_nd, c_nd)
-    tvm.testing.assert_allclose(c_nd.numpy(), a_np + b_np)
+
+    def run_and_check():
+        dev = tvm.cuda(0)
+        a_nd = tvm.runtime.tensor(a_np, dev)
+        b_nd = tvm.runtime.tensor(b_np, dev)
+        c_nd = tvm.runtime.tensor(c_np, dev)
+        lib["main"](a_nd, b_nd, c_nd)
+        tvm.testing.assert_allclose(c_nd.numpy(), a_np + b_np)
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -1119,13 +1184,17 @@ def test_export_load_with_fallback(monkeypatch, tmp_path):
     host_lib.export_library(lib_path)
     reloaded = tvm.runtime.load_module(lib_path)
 
-    dev = tvm.cuda(0)
     a_np = np.random.uniform(size=(n,)).astype("float32")
     b_np = np.zeros((n,), dtype="float32")
-    a = tvm.runtime.tensor(a_np, dev)
-    b = tvm.runtime.tensor(b_np, dev)
-    reloaded["main"](a, b)
-    np.testing.assert_allclose(b.numpy(), a_np + 1.0, rtol=1e-5)
+
+    def run_and_check():
+        dev = tvm.cuda(0)
+        a = tvm.runtime.tensor(a_np, dev)
+        b = tvm.runtime.tensor(b_np, dev)
+        reloaded["main"](a, b)
+        np.testing.assert_allclose(b.numpy(), a_np + 1.0, rtol=1e-5)
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 if __name__ == "__main__":

--- a/tests/python/codegen/test_target_codegen_cuda.py
+++ b/tests/python/codegen/test_target_codegen_cuda.py
@@ -328,13 +328,13 @@ def test_cuda_inf_nan():
 
         fun = tvm.compile(Module, target="cuda")
 
-        def run():
+        def run_and_check():
             dev = tvm.device("cuda", 0)
             a = tvm.runtime.empty((n,), dtype, dev)
             c = tvm.runtime.empty((n,), dtype, dev)
             fun(a, c)
 
-        tvm.testing.run_with_gpu_lock(run)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
     check_inf_nan(1, -float("inf"), "float32")
     check_inf_nan(1, -float("inf"), "float64")

--- a/tests/python/codegen/test_target_codegen_cuda_fastmath.py
+++ b/tests/python/codegen/test_target_codegen_cuda_fastmath.py
@@ -266,20 +266,21 @@ def make_numpy_inputs(dtype: str, case: MathCase):
 
 def check_runtime(dtype: str, case: MathCase, executable: Executable):
     """Check the runtime for the given dtype and case."""
-    dev = tvm.cuda(0)
-
     np_inputs = make_numpy_inputs(dtype, case)
     expected = case.np_ref(*[arr.astype(dtype) for arr in np_inputs]).astype(dtype)
 
-    tvm_inputs = [tvm.runtime.tensor(arr, device=dev) for arr in np_inputs]
-    output = tvm.runtime.empty((VECTOR_N_INPUTS,), dtype, dev)
+    def run():
+        dev = tvm.cuda(0)
+        tvm_inputs = [tvm.runtime.tensor(arr, device=dev) for arr in np_inputs]
+        output = tvm.runtime.empty((VECTOR_N_INPUTS,), dtype, dev)
 
-    executable(*tvm_inputs, output)
-    dev.sync()
+        executable(*tvm_inputs, output)
+        dev.sync()
 
-    actual = output.numpy()
+        actual = output.numpy()
+        np.testing.assert_allclose(actual, expected, rtol=case.rtol, atol=case.atol)
 
-    np.testing.assert_allclose(actual, expected, rtol=case.rtol, atol=case.atol)
+    tvm.testing.run_with_gpu_lock(run)
 
 
 @pytest.mark.parametrize("enable_fast_math", [False, True], ids=["default", "fast_math"])

--- a/tests/python/codegen/test_target_codegen_cuda_fastmath.py
+++ b/tests/python/codegen/test_target_codegen_cuda_fastmath.py
@@ -269,18 +269,17 @@ def check_runtime(dtype: str, case: MathCase, executable: Executable):
     np_inputs = make_numpy_inputs(dtype, case)
     expected = case.np_ref(*[arr.astype(dtype) for arr in np_inputs]).astype(dtype)
 
-    def run():
+    def run_and_check():
         dev = tvm.cuda(0)
         tvm_inputs = [tvm.runtime.tensor(arr, device=dev) for arr in np_inputs]
         output = tvm.runtime.empty((VECTOR_N_INPUTS,), dtype, dev)
 
         executable(*tvm_inputs, output)
-        dev.sync()
 
         actual = output.numpy()
         np.testing.assert_allclose(actual, expected, rtol=case.rtol, atol=case.atol)
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.parametrize("enable_fast_math", [False, True], ids=["default", "fast_math"])

--- a/tests/python/codegen/test_target_codegen_cuda_fp4.py
+++ b/tests/python/codegen/test_target_codegen_cuda_fp4.py
@@ -63,7 +63,6 @@ def test_e2m1_vector_conversions(promoted_dtype):
 
     target = "cuda"
     fadd = tvm.compile(Module, target=target)
-    dev = tvm.device(target, 0)
 
     if "x" in native_dtype:
         lanes = int(native_dtype.split("x")[-1])
@@ -88,27 +87,29 @@ def test_e2m1_vector_conversions(promoted_dtype):
         a_np = np.random.choice(valid_fp4_values, size=np_shape).astype(np.int8)
         b_np = np.random.choice(valid_fp4_values, size=np_shape).astype(np.int8)
 
-    a = tvm.runtime.empty(shape=(vector_length,), dtype=native_dtype, device=dev)
-    a.copyfrom(a_np)
-    b = tvm.runtime.empty(shape=(vector_length,), dtype=native_dtype, device=dev)
-    b.copyfrom(b_np)
-    c = tvm.runtime.empty(shape=(vector_length,), dtype=native_dtype, device=dev)
-    fadd(a, b, c)
+    def run_and_check():
+        dev = tvm.device(target, 0)
+        a = tvm.runtime.empty(shape=(vector_length,), dtype=native_dtype, device=dev)
+        a.copyfrom(a_np)
+        b = tvm.runtime.empty(shape=(vector_length,), dtype=native_dtype, device=dev)
+        b.copyfrom(b_np)
+        c = tvm.runtime.empty(shape=(vector_length,), dtype=native_dtype, device=dev)
+        fadd(a, b, c)
+        # For the comparison, we will convert result to the promoted dtype and compare
+        # Note: When ml_dtypes is not available, we skip the numpy-level computation comparison
+        # and just verify that the CUDA kernel compiles and executes without error
+        c_result = c.numpy().astype(promoted_base_dtype)
+        if ML_DTYPES_AVAILABLE:
+            # Full comparison when ml_dtypes is available
+            expected = (a_np + b_np).astype(promoted_base_dtype)
+            tvm.testing.assert_allclose(c_result, expected)
+        else:
+            # When ml_dtypes is not available, we just verify the comparison ran successfully
+            # by checking that we got a result with the expected shape and dtype
+            assert c_result.shape == np_shape
+            assert c_result.dtype == promoted_base_dtype
 
-    # For the comparison, we will convert result to the promoted dtype and compare
-    # Note: When ml_dtypes is not available, we skip the numpy-level computation comparison
-    # and just verify that the CUDA kernel compiles and executes without error
-    c_result = c.numpy().astype(promoted_base_dtype)
-
-    if ML_DTYPES_AVAILABLE:
-        # Full comparison when ml_dtypes is available
-        expected = (a_np + b_np).astype(promoted_base_dtype)
-        tvm.testing.assert_allclose(c_result, expected)
-    else:
-        # When ml_dtypes is not available, we just verify the comparison ran successfully
-        # by checking that we got a result with the expected shape and dtype
-        assert c_result.shape == np_shape
-        assert c_result.dtype == promoted_base_dtype
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 def _shuffle_reinterpret_module(n, num_blocks, vector_length, num_elem_per_storage):
@@ -242,7 +243,6 @@ def test_e2m1_scalar_buffer_offset():
     sch.bind(tx, "threadIdx.x")
 
     target = "cuda"
-    dev = tvm.device(target, 0)
     fadd = tvm.compile(sch.mod, target=target)
 
     # float4_e2m1fn: 4-bit values 0..15, two packed per byte.
@@ -263,13 +263,15 @@ def test_e2m1_scalar_buffer_offset():
 
     expected = fp4_to_fp16[fp4_elements]
 
-    a = tvm.runtime.empty(shape=(n // 2,), dtype="uint8", device=dev)
-    a.copyfrom(packed)
-    b = tvm.runtime.empty(shape=(n,), dtype="float16", device=dev)
-    fadd(a, b)
+    def run_and_check():
+        dev = tvm.device(target, 0)
+        a = tvm.runtime.empty(shape=(n // 2,), dtype="uint8", device=dev)
+        a.copyfrom(packed)
+        b = tvm.runtime.empty(shape=(n,), dtype="float16", device=dev)
+        fadd(a, b)
+        tvm.testing.assert_allclose(b.numpy(), expected)
 
-    result = b.numpy()
-    tvm.testing.assert_allclose(result, expected)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 if __name__ == "__main__":

--- a/tests/python/codegen/test_target_codegen_cuda_fp8.py
+++ b/tests/python/codegen/test_target_codegen_cuda_fp8.py
@@ -953,24 +953,25 @@ def test_moe_gemv_shfl_down_illegal_instr():
     with tvm.transform.PassContext(config={"relax.backend.use_cuda_graph": False}) and target:
         mod = _pipeline(mod)
         rt_mod = tvm.compile(mod, target=target)
-    dev = tvm.cuda(0)
 
     x_data = np.zeros((1, reduce_size), dtype=np.float16)
-    x = tvm.runtime.tensor(x_data, device=dev)
-
     indptr_data = np.zeros((1, 2), dtype=np.int32)
-    indptr = tvm.runtime.tensor(indptr_data, device=dev)
-
     weight_data = np.zeros((num_experts, spatial_size, reduce_size), dtype="float8_e4m3fn")
-    weight = tvm.runtime.tensor(weight_data, device=dev)
-
     scale_data = np.zeros((1,), dtype=np.float32)
-    scale = tvm.runtime.tensor(scale_data, device=dev)
 
-    vm = relax.VirtualMachine(rt_mod, dev)
-    # Ensure this runs without failure. Utilizing dlight thread extents TS, TR = 4, 64
-    # in GEMV scheduling will yield: CUDA: an illegal instruction was encountered.
-    vm["main"](x, indptr, weight, scale)
+    def run():
+        dev = tvm.cuda(0)
+        x = tvm.runtime.tensor(x_data, device=dev)
+        indptr = tvm.runtime.tensor(indptr_data, device=dev)
+        weight = tvm.runtime.tensor(weight_data, device=dev)
+        scale = tvm.runtime.tensor(scale_data, device=dev)
+        vm = relax.VirtualMachine(rt_mod, dev)
+        # Ensure this runs without failure. Utilizing dlight thread extents TS, TR = 4, 64
+        # in GEMV scheduling will yield: CUDA: an illegal instruction was encountered.
+        vm["main"](x, indptr, weight, scale)
+        dev.sync()
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 @pytest.mark.parametrize("vec_length", [2, 4])
@@ -998,21 +999,25 @@ def test_fp8_fp16_bf16_vectorize_arith(vec_length, dtype):
         return Module
 
     mod = _create_mod(vec_length, dtype)
-    device = tvm.cuda()
-    target = tvm.target.Target.from_device(device)
+    target = tvm.target.Target.from_device(tvm.cuda())
     f = tvm.tirx.build(mod, target=target)
 
     a_np = np.random.rand(128).astype("float8_e4m3fn")
     b_np = np.random.rand(128).astype(dtype)
     c_np = (a_np.astype(dtype) * b_np) + 3
-    a_tvm = tvm.runtime.tensor(a_np, device=device)
-    b_tvm = tvm.runtime.tensor(b_np, device=device)
-    c_tvm = tvm.runtime.empty((128,), dtype=dtype, device=device)
-    f(a_tvm, b_tvm, c_tvm)
-    c_tvm = c_tvm.numpy()
-    tvm.testing.assert_allclose(
-        c_tvm.astype(np.float32), c_np.astype(np.float32), atol=5e-1, rtol=1e-2
-    )
+
+    def run():
+        device = tvm.cuda()
+        a_tvm = tvm.runtime.tensor(a_np, device=device)
+        b_tvm = tvm.runtime.tensor(b_np, device=device)
+        c_tvm = tvm.runtime.empty((128,), dtype=dtype, device=device)
+        f(a_tvm, b_tvm, c_tvm)
+        actual = c_tvm.numpy()
+        tvm.testing.assert_allclose(
+            actual.astype(np.float32), c_np.astype(np.float32), atol=5e-1, rtol=1e-2
+        )
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 if __name__ == "__main__":

--- a/tests/python/codegen/test_target_codegen_cuda_fp8.py
+++ b/tests/python/codegen/test_target_codegen_cuda_fp8.py
@@ -959,7 +959,7 @@ def test_moe_gemv_shfl_down_illegal_instr():
     weight_data = np.zeros((num_experts, spatial_size, reduce_size), dtype="float8_e4m3fn")
     scale_data = np.zeros((1,), dtype=np.float32)
 
-    def run():
+    def run_and_check():
         dev = tvm.cuda(0)
         x = tvm.runtime.tensor(x_data, device=dev)
         indptr = tvm.runtime.tensor(indptr_data, device=dev)
@@ -971,7 +971,7 @@ def test_moe_gemv_shfl_down_illegal_instr():
         vm["main"](x, indptr, weight, scale)
         dev.sync()
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.parametrize("vec_length", [2, 4])
@@ -1006,7 +1006,7 @@ def test_fp8_fp16_bf16_vectorize_arith(vec_length, dtype):
     b_np = np.random.rand(128).astype(dtype)
     c_np = (a_np.astype(dtype) * b_np) + 3
 
-    def run():
+    def run_and_check():
         device = tvm.cuda()
         a_tvm = tvm.runtime.tensor(a_np, device=device)
         b_tvm = tvm.runtime.tensor(b_np, device=device)
@@ -1017,7 +1017,7 @@ def test_fp8_fp16_bf16_vectorize_arith(vec_length, dtype):
             actual.astype(np.float32), c_np.astype(np.float32), atol=5e-1, rtol=1e-2
         )
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 if __name__ == "__main__":

--- a/tests/python/codegen/test_target_codegen_device.py
+++ b/tests/python/codegen/test_target_codegen_device.py
@@ -47,12 +47,15 @@ def test_large_uint_imm():
         target_kind = target["kind"] if isinstance(target, dict) else target
         if not tvm.testing.device_enabled(target_kind):
             return
-        dev = tvm.device(target_kind, 0)
         f = tvm.compile(Module, target=target)
-        # launch the kernel.
-        a = tvm.runtime.empty((12,), dtype="uint64", device=dev)
-        f(a)
-        assert a.numpy()[0] == value + 3
+
+        def run_and_check():
+            dev = tvm.device(target_kind, 0)
+            a = tvm.runtime.empty((12,), dtype="uint64", device=dev)
+            f(a)
+            assert a.numpy()[0] == value + 3
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
     check_target("cuda")
     check_target({"kind": "vulkan", "from_device": 0})
@@ -90,17 +93,20 @@ def test_add_pipeline():
     def check_target(device, host):
         if not tvm.testing.device_enabled(device) or not tvm.testing.device_enabled(host):
             return
-        dev = tvm.device(device, 0)
         target = tvm.target.Target(device, host)
         mhost = tvm.tirx.build(Module, target=target)
         f = mhost.main
-        # launch the kernel.
         n = 1027
-        a = tvm.runtime.tensor(np.random.uniform(size=n).astype("float32"), dev)
-        b = tvm.runtime.tensor(np.random.uniform(size=()).astype("float32"), dev)
-        d = tvm.runtime.tensor(np.zeros(n, dtype="float32"), dev)
-        f(a, b, d)
-        tvm.testing.assert_allclose(d.numpy(), a.numpy() + b.numpy() + 1)
+
+        def run_and_check():
+            dev = tvm.device(device, 0)
+            a = tvm.runtime.tensor(np.random.uniform(size=n).astype("float32"), dev)
+            b = tvm.runtime.tensor(np.random.uniform(size=()).astype("float32"), dev)
+            d = tvm.runtime.tensor(np.zeros(n, dtype="float32"), dev)
+            f(a, b, d)
+            tvm.testing.assert_allclose(d.numpy(), a.numpy() + b.numpy() + 1)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
     check_target("cuda", host="llvm")
     # check_target("nvptx", host="llvm")  # nvptx kernel entry-point lookup not wired here

--- a/tests/python/codegen/test_target_codegen_extern.py
+++ b/tests/python/codegen/test_target_codegen_extern.py
@@ -55,13 +55,19 @@ def test_add_pipeline():
         mod = ModuleGPU if target in ["opencl", "cuda"] else ModuleCPU
         # build and invoke the kernel.
         f = tvm.compile(mod, target=target)
-        dev = tvm.device(target, 0)
-        # launch the kernel.
         n = nn
-        a = tvm.runtime.tensor(np.random.uniform(size=n).astype("float32"), dev)
-        c = tvm.runtime.tensor(np.zeros(n, dtype="float32"), dev)
-        f(a, c)
-        tvm.testing.assert_allclose(c.numpy(), a.numpy() + 1)
+
+        def run_and_check():
+            dev = tvm.device(target, 0)
+            a = tvm.runtime.tensor(np.random.uniform(size=n).astype("float32"), dev)
+            c = tvm.runtime.tensor(np.zeros(n, dtype="float32"), dev)
+            f(a, c)
+            tvm.testing.assert_allclose(c.numpy(), a.numpy() + 1)
+
+        if target == "llvm":
+            run_and_check()
+        else:
+            tvm.testing.run_with_gpu_lock(run_and_check)
 
     check_target("llvm")
     check_target("opencl")

--- a/tests/python/codegen/test_target_codegen_gpu_common.py
+++ b/tests/python/codegen/test_target_codegen_gpu_common.py
@@ -41,7 +41,6 @@ from tvm.testing import env
 def test_int_intrin(target, dtype):
     if not tvm.testing.device_enabled(target):
         pytest.skip(f"{target} not enabled")
-    dev = tvm.device(target["kind"] if isinstance(target, dict) else target)
     test_funcs = [
         (T.clz, lambda x, dtype: int(dtype[-2:]) - (len(bin(x)) - 2)),
     ]
@@ -65,11 +64,16 @@ def test_int_intrin(target, dtype):
                         B[v_i0] = tvm_intrin(A[v_i0])
 
         f = tvm.compile(Module, target=target)
-        a = tvm.runtime.tensor(np.random.randint(0, 100000, size=n).astype(dtype), dev)
-        b = tvm.runtime.tensor(np.zeros(shape=(n,)).astype(dtype), dev)
-        f(a, b)
-        ref = np.vectorize(partial(np_func, dtype=dtype))(a.numpy())
-        tvm.testing.assert_allclose(b.numpy(), ref)
+
+        def run_and_check():
+            dev = tvm.device(target["kind"] if isinstance(target, dict) else target)
+            a = tvm.runtime.tensor(np.random.randint(0, 100000, size=n).astype(dtype), dev)
+            b = tvm.runtime.tensor(np.zeros(shape=(n,)).astype(dtype), dev)
+            f(a, b)
+            ref = np.vectorize(partial(np_func, dtype=dtype))(a.numpy())
+            tvm.testing.assert_allclose(b.numpy(), ref)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 if __name__ == "__main__":

--- a/tests/python/codegen/test_target_codegen_metal.py
+++ b/tests/python/codegen/test_target_codegen_metal.py
@@ -29,7 +29,7 @@ from tvm.testing import env
 def test_metal_inf_nan():
     target = "metal"
 
-    def check_inf_nan(dev, n, value, dtype):
+    def check_inf_nan(n, value, dtype):
         @I.ir_module(s_tir=True)
         class Module:
             @T.prim_func(s_tir=True)
@@ -46,19 +46,21 @@ def test_metal_inf_nan():
                         C[v_i] = T.Cast(dtype, value)
 
         fun = tvm.compile(Module, target=target)
-        a = tvm.runtime.empty((n,), dtype, dev)
-        c = tvm.runtime.empty((n,), dtype, dev)
-        # Only need to test compiling here
-        fun(a, c)
 
-    dev = tvm.device(target, 0)
+        def run():
+            dev = tvm.device(target, 0)
+            a = tvm.runtime.empty((n,), dtype, dev)
+            c = tvm.runtime.empty((n,), dtype, dev)
+            fun(a, c)
 
-    check_inf_nan(dev, 1, -float("inf"), "float32")
-    check_inf_nan(dev, 1, -float("inf"), "float16")
-    check_inf_nan(dev, 1, float("inf"), "float32")
-    check_inf_nan(dev, 1, float("inf"), "float16")
-    check_inf_nan(dev, 1, float("nan"), "float32")
-    check_inf_nan(dev, 1, float("nan"), "float16")
+        tvm.testing.run_with_gpu_lock(run)
+
+    check_inf_nan(1, -float("inf"), "float32")
+    check_inf_nan(1, -float("inf"), "float16")
+    check_inf_nan(1, float("inf"), "float32")
+    check_inf_nan(1, float("inf"), "float16")
+    check_inf_nan(1, float("nan"), "float32")
+    check_inf_nan(1, float("nan"), "float16")
 
 
 @pytest.mark.gpu
@@ -76,14 +78,17 @@ def test_unaligned_vectorize():
                         B[vi0] = A[vi0 // 3, vi0 % 3]
 
     target = "metal"
-    dev = tvm.metal()
-
     a = (np.arange(6).reshape(2, 3)).astype("float32")
-    a_nd = tvm.runtime.tensor(a, dev)
-    b_nd = tvm.runtime.empty((6,), "float32", dev)
     f = tvm.compile(IRModule, target=target)
-    f(a_nd, b_nd)
-    tvm.testing.assert_allclose(b_nd.numpy(), a.reshape(6), atol=1e-5, rtol=1e-5)
+
+    def run():
+        dev = tvm.metal()
+        a_nd = tvm.runtime.tensor(a, dev)
+        b_nd = tvm.runtime.empty((6,), "float32", dev)
+        f(a_nd, b_nd)
+        tvm.testing.assert_allclose(b_nd.numpy(), a.reshape(6), atol=1e-5, rtol=1e-5)
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 @pytest.mark.gpu
@@ -91,7 +96,7 @@ def test_unaligned_vectorize():
 def test_metal_erf():
     target = "metal"
 
-    def check_erf(dev, n, dtype):
+    def check_erf(n, dtype):
         @I.ir_module(s_tir=True)
         class Module:
             @T.prim_func(s_tir=True)
@@ -108,15 +113,17 @@ def test_metal_erf():
                         C[v_i0] = T.erf(A[v_i0])
 
         fun = tvm.compile(Module, target=target)
-        a = tvm.runtime.empty((n,), dtype, dev)
-        c = tvm.runtime.empty((n,), dtype, dev)
-        # Only need to test compiling here
-        fun(a, c)
 
-    dev = tvm.device(target, 0)
+        def run():
+            dev = tvm.device(target, 0)
+            a = tvm.runtime.empty((n,), dtype, dev)
+            c = tvm.runtime.empty((n,), dtype, dev)
+            fun(a, c)
 
-    check_erf(dev, 1, "float32")
-    check_erf(dev, 1, "float16")
+        tvm.testing.run_with_gpu_lock(run)
+
+    check_erf(1, "float32")
+    check_erf(1, "float16")
 
 
 @pytest.mark.gpu
@@ -136,10 +143,14 @@ def test_ramp():
                     A[0, T.ramp(0, 1, 2)] = r
 
     f = tvm.compile(IRModule, target=target)
-    dev = tvm.metal()
-    a_nd = tvm.runtime.empty((1, 2), "int32", dev)
-    f(a_nd)
-    assert tuple(a_nd.numpy()[0, :]) == (0, 3)
+
+    def run():
+        dev = tvm.metal()
+        a_nd = tvm.runtime.empty((1, 2), "int32", dev)
+        f(a_nd)
+        assert tuple(a_nd.numpy()[0, :]) == (0, 3)
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 @pytest.mark.gpu
@@ -157,14 +168,18 @@ def test_select_vectorize():
                         B[vi0] = T.Select((vi0 % 2) == 0, A[vi0], T.float32(0))
 
     target = "metal"
-    dev = tvm.metal()
     a = np.arange(6).astype("float32")
-    a_nd = tvm.runtime.tensor(a, dev)
-    b_nd = tvm.runtime.empty((6,), "float32", dev)
     f = tvm.compile(IRModule, target=target)
-    f(a_nd, b_nd)
     a.reshape(3, 2)[:, 1] = 0
-    tvm.testing.assert_allclose(b_nd.numpy(), a, atol=1e-5, rtol=1e-5)
+
+    def run():
+        dev = tvm.metal()
+        a_nd = tvm.runtime.tensor(a, dev)
+        b_nd = tvm.runtime.empty((6,), "float32", dev)
+        f(a_nd, b_nd)
+        tvm.testing.assert_allclose(b_nd.numpy(), a, atol=1e-5, rtol=1e-5)
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 @pytest.mark.gpu
@@ -178,13 +193,17 @@ def test_vectorized_uint8():
                     vi = T.axis.spatial(16, i * 4 + j)
                     B[vi] = T.Cast("float32", A[vi])
 
-    dev = tvm.metal()
     a = np.arange(16).astype("uint8")
-    a_nd = tvm.runtime.tensor(a, dev)
-    b_nd = tvm.runtime.empty((16,), "float32", dev)
     f = tvm.compile(func, target="metal")
-    f(a_nd, b_nd)
-    tvm.testing.assert_allclose(b_nd.numpy(), a.astype("float32"), atol=1e-5, rtol=1e-5)
+
+    def run():
+        dev = tvm.metal()
+        a_nd = tvm.runtime.tensor(a, dev)
+        b_nd = tvm.runtime.empty((16,), "float32", dev)
+        f(a_nd, b_nd)
+        tvm.testing.assert_allclose(b_nd.numpy(), a.astype("float32"), atol=1e-5, rtol=1e-5)
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 @pytest.mark.gpu

--- a/tests/python/codegen/test_target_codegen_metal.py
+++ b/tests/python/codegen/test_target_codegen_metal.py
@@ -47,13 +47,13 @@ def test_metal_inf_nan():
 
         fun = tvm.compile(Module, target=target)
 
-        def run():
+        def run_and_check():
             dev = tvm.device(target, 0)
             a = tvm.runtime.empty((n,), dtype, dev)
             c = tvm.runtime.empty((n,), dtype, dev)
             fun(a, c)
 
-        tvm.testing.run_with_gpu_lock(run)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
     check_inf_nan(1, -float("inf"), "float32")
     check_inf_nan(1, -float("inf"), "float16")
@@ -81,14 +81,14 @@ def test_unaligned_vectorize():
     a = (np.arange(6).reshape(2, 3)).astype("float32")
     f = tvm.compile(IRModule, target=target)
 
-    def run():
+    def run_and_check():
         dev = tvm.metal()
         a_nd = tvm.runtime.tensor(a, dev)
         b_nd = tvm.runtime.empty((6,), "float32", dev)
         f(a_nd, b_nd)
         tvm.testing.assert_allclose(b_nd.numpy(), a.reshape(6), atol=1e-5, rtol=1e-5)
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -114,13 +114,13 @@ def test_metal_erf():
 
         fun = tvm.compile(Module, target=target)
 
-        def run():
+        def run_and_check():
             dev = tvm.device(target, 0)
             a = tvm.runtime.empty((n,), dtype, dev)
             c = tvm.runtime.empty((n,), dtype, dev)
             fun(a, c)
 
-        tvm.testing.run_with_gpu_lock(run)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
     check_erf(1, "float32")
     check_erf(1, "float16")
@@ -144,13 +144,13 @@ def test_ramp():
 
     f = tvm.compile(IRModule, target=target)
 
-    def run():
+    def run_and_check():
         dev = tvm.metal()
         a_nd = tvm.runtime.empty((1, 2), "int32", dev)
         f(a_nd)
         assert tuple(a_nd.numpy()[0, :]) == (0, 3)
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -172,14 +172,14 @@ def test_select_vectorize():
     f = tvm.compile(IRModule, target=target)
     a.reshape(3, 2)[:, 1] = 0
 
-    def run():
+    def run_and_check():
         dev = tvm.metal()
         a_nd = tvm.runtime.tensor(a, dev)
         b_nd = tvm.runtime.empty((6,), "float32", dev)
         f(a_nd, b_nd)
         tvm.testing.assert_allclose(b_nd.numpy(), a, atol=1e-5, rtol=1e-5)
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -196,14 +196,14 @@ def test_vectorized_uint8():
     a = np.arange(16).astype("uint8")
     f = tvm.compile(func, target="metal")
 
-    def run():
+    def run_and_check():
         dev = tvm.metal()
         a_nd = tvm.runtime.tensor(a, dev)
         b_nd = tvm.runtime.empty((16,), "float32", dev)
         f(a_nd, b_nd)
         tvm.testing.assert_allclose(b_nd.numpy(), a.astype("float32"), atol=1e-5, rtol=1e-5)
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu

--- a/tests/python/codegen/test_target_codegen_opencl.py
+++ b/tests/python/codegen/test_target_codegen_opencl.py
@@ -53,13 +53,13 @@ def test_opencl_ternary_expression():
 
         fun = tvm.tirx.build(Module, target=target)
 
-        def run():
+        def run_and_check():
             dev = tvm.device(target, 0)
             a = tvm.runtime.empty((n,), dtype, dev)
             c = tvm.runtime.empty((n,), dtype, dev)
             fun(a, c)
 
-        tvm.testing.run_with_gpu_lock(run)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
     def check_select(n, dtype):
         @I.ir_module(s_tir=True)
@@ -83,13 +83,13 @@ def test_opencl_ternary_expression():
 
         fun = tvm.tirx.build(Module, target=target)
 
-        def run():
+        def run_and_check():
             dev = tvm.device(target, 0)
             a = tvm.runtime.empty((n,), dtype, dev)
             c = tvm.runtime.empty((n,), dtype, dev)
             fun(a, c)
 
-        tvm.testing.run_with_gpu_lock(run)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
     check_if_then_else(1, "int8")
     check_if_then_else(1, "uint8")
@@ -119,13 +119,13 @@ def test_opencl_inf_nan():
 
         fun = tvm.tirx.build(Module, target=target)
 
-        def run():
+        def run_and_check():
             dev = tvm.device(target, 0)
             a = tvm.runtime.empty((n,), dtype, dev)
             c = tvm.runtime.empty((n,), dtype, dev)
             fun(a, c)
 
-        tvm.testing.run_with_gpu_lock(run)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
     check_inf_nan(1, -float("inf"), "float32")
     check_inf_nan(1, -float("inf"), "float64")
@@ -153,13 +153,13 @@ def test_opencl_max():
 
         fun = tvm.tirx.build(Module, target=target)
 
-        def run():
+        def run_and_check():
             dev = tvm.device(target, 0)
             a = tvm.runtime.empty((n,), dtype, dev)
             c = tvm.runtime.empty((n,), dtype, dev)
             fun(a, c)
 
-        tvm.testing.run_with_gpu_lock(run)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
     check_max(1, "int8")
     check_max(1, "uint8")
@@ -220,12 +220,12 @@ def test_opencl_type_casting():
         pattern_cond = f"({lcond} && {rcond})"
         assert assembly.count(pattern_cond) != 0
 
-        def run():
+        def run_and_check():
             dev = tvm.device(target, 0)
             c = tvm.runtime.empty((n,), dtype, dev)
             fun(c)
 
-        tvm.testing.run_with_gpu_lock(run)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
     check_type_casting(32, "float32")
     # fp16 is not yet supported in ci

--- a/tests/python/codegen/test_target_codegen_opencl.py
+++ b/tests/python/codegen/test_target_codegen_opencl.py
@@ -31,7 +31,7 @@ target = "opencl"
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_opencl(), reason="need opencl")
 def test_opencl_ternary_expression():
-    def check_if_then_else(dev, n, dtype):
+    def check_if_then_else(n, dtype):
         @I.ir_module(s_tir=True)
         class Module:
             @T.prim_func(s_tir=True)
@@ -52,12 +52,16 @@ def test_opencl_ternary_expression():
                         )
 
         fun = tvm.tirx.build(Module, target=target)
-        a = tvm.runtime.empty((n,), dtype, dev)
-        c = tvm.runtime.empty((n,), dtype, dev)
-        # Only need to test compiling here
-        fun(a, c)
 
-    def check_select(dev, n, dtype):
+        def run():
+            dev = tvm.device(target, 0)
+            a = tvm.runtime.empty((n,), dtype, dev)
+            c = tvm.runtime.empty((n,), dtype, dev)
+            fun(a, c)
+
+        tvm.testing.run_with_gpu_lock(run)
+
+    def check_select(n, dtype):
         @I.ir_module(s_tir=True)
         class Module:
             @T.prim_func(s_tir=True)
@@ -78,27 +82,29 @@ def test_opencl_ternary_expression():
                         )
 
         fun = tvm.tirx.build(Module, target=target)
-        a = tvm.runtime.empty((n,), dtype, dev)
-        c = tvm.runtime.empty((n,), dtype, dev)
-        # Only need to test compiling here
-        fun(a, c)
 
-    dev = tvm.device(target, 0)
+        def run():
+            dev = tvm.device(target, 0)
+            a = tvm.runtime.empty((n,), dtype, dev)
+            c = tvm.runtime.empty((n,), dtype, dev)
+            fun(a, c)
 
-    check_if_then_else(dev, 1, "int8")
-    check_if_then_else(dev, 1, "uint8")
-    check_if_then_else(dev, 1, "int16")
-    check_if_then_else(dev, 1, "uint16")
-    check_select(dev, 1, "int8")
-    check_select(dev, 1, "uint8")
-    check_select(dev, 1, "int16")
-    check_select(dev, 1, "uint16")
+        tvm.testing.run_with_gpu_lock(run)
+
+    check_if_then_else(1, "int8")
+    check_if_then_else(1, "uint8")
+    check_if_then_else(1, "int16")
+    check_if_then_else(1, "uint16")
+    check_select(1, "int8")
+    check_select(1, "uint8")
+    check_select(1, "int16")
+    check_select(1, "uint16")
 
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_opencl(), reason="need opencl")
 def test_opencl_inf_nan():
-    def check_inf_nan(dev, n, value, dtype):
+    def check_inf_nan(n, value, dtype):
         @I.ir_module(s_tir=True)
         class Module:
             @T.prim_func(s_tir=True)
@@ -112,25 +118,27 @@ def test_opencl_inf_nan():
                         C[v_i] = T.Cast(dtype, value)
 
         fun = tvm.tirx.build(Module, target=target)
-        a = tvm.runtime.empty((n,), dtype, dev)
-        c = tvm.runtime.empty((n,), dtype, dev)
-        # Only need to test compiling here
-        fun(a, c)
 
-    dev = tvm.device(target, 0)
+        def run():
+            dev = tvm.device(target, 0)
+            a = tvm.runtime.empty((n,), dtype, dev)
+            c = tvm.runtime.empty((n,), dtype, dev)
+            fun(a, c)
 
-    check_inf_nan(dev, 1, -float("inf"), "float32")
-    check_inf_nan(dev, 1, -float("inf"), "float64")
-    check_inf_nan(dev, 1, float("inf"), "float32")
-    check_inf_nan(dev, 1, float("inf"), "float64")
-    check_inf_nan(dev, 1, float("nan"), "float32")
-    check_inf_nan(dev, 1, float("nan"), "float64")
+        tvm.testing.run_with_gpu_lock(run)
+
+    check_inf_nan(1, -float("inf"), "float32")
+    check_inf_nan(1, -float("inf"), "float64")
+    check_inf_nan(1, float("inf"), "float32")
+    check_inf_nan(1, float("inf"), "float64")
+    check_inf_nan(1, float("nan"), "float32")
+    check_inf_nan(1, float("nan"), "float64")
 
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_opencl(), reason="need opencl")
 def test_opencl_max():
-    def check_max(dev, n, dtype):
+    def check_max(n, dtype):
         @I.ir_module(s_tir=True)
         class Module:
             @T.prim_func(s_tir=True)
@@ -144,23 +152,25 @@ def test_opencl_max():
                         C[v_i] = T.max(A[0] + T.Cast(dtype, 1), T.Cast(dtype, 0))
 
         fun = tvm.tirx.build(Module, target=target)
-        a = tvm.runtime.empty((n,), dtype, dev)
-        c = tvm.runtime.empty((n,), dtype, dev)
-        # Only need to test compiling here
-        fun(a, c)
 
-    dev = tvm.device(target, 0)
+        def run():
+            dev = tvm.device(target, 0)
+            a = tvm.runtime.empty((n,), dtype, dev)
+            c = tvm.runtime.empty((n,), dtype, dev)
+            fun(a, c)
 
-    check_max(dev, 1, "int8")
-    check_max(dev, 1, "uint8")
-    check_max(dev, 1, "int16")
-    check_max(dev, 1, "uint16")
-    check_max(dev, 1, "float32")
-    check_max(dev, 1, "float64")
+        tvm.testing.run_with_gpu_lock(run)
+
+    check_max(1, "int8")
+    check_max(1, "uint8")
+    check_max(1, "int16")
+    check_max(1, "uint16")
+    check_max(1, "float32")
+    check_max(1, "float64")
 
 
 def test_opencl_erf():
-    def check_erf(dev, n, dtype):
+    def check_erf(n, dtype):
         @I.ir_module(s_tir=True)
         class Module:
             @T.prim_func(s_tir=True)
@@ -180,10 +190,8 @@ def test_opencl_erf():
         error_matches = re.findall("erff", source_str)
         assert len(matches) == 1 and len(error_matches) == 0
 
-    dev = tvm.device(target, 0)
-
-    check_erf(dev, 1, "float32")
-    check_erf(dev, 1, "float64")
+    check_erf(1, "float32")
+    check_erf(1, "float64")
 
 
 @pytest.mark.gpu
@@ -204,19 +212,22 @@ def test_opencl_type_casting():
                             v_i // 4 == 3 and v_i % 3 == 1, T.float32(1.0), T.float32(0.0)
                         )
 
-    def check_type_casting(ctx, n, dtype):
+    def check_type_casting(n, dtype):
         fun = tvm.tirx.build(Module, target=target)
-        c = tvm.runtime.empty((n,), dtype, ctx)
         assembly = fun.imports[0].inspect_source()
         lcond = "convert_int4(((convert_uint4(((uint4)(((convert_int(get_local_id(0))) == 3), ((convert_int(get_local_id(0))) == 3), ((convert_int(get_local_id(0))) == 3), ((convert_int(get_local_id(0))) == 3)))))"
         rcond = "(convert_uint4(((((int4)(((convert_int(get_local_id(0))))+(1*0), ((convert_int(get_local_id(0))))+(1*1), ((convert_int(get_local_id(0))))+(1*2), ((convert_int(get_local_id(0))))+(1*3))) % ((int4)(3, 3, 3, 3))) == ((int4)(1, 1, 1, 1))))))))"
         pattern_cond = f"({lcond} && {rcond})"
         assert assembly.count(pattern_cond) != 0
-        fun(c)
 
-    dev = tvm.device(target, 0)
+        def run():
+            dev = tvm.device(target, 0)
+            c = tvm.runtime.empty((n,), dtype, dev)
+            fun(c)
 
-    check_type_casting(dev, 32, "float32")
+        tvm.testing.run_with_gpu_lock(run)
+
+    check_type_casting(32, "float32")
     # fp16 is not yet supported in ci
     # check_type_casting(dev, 16, "float16")
 
@@ -306,13 +317,17 @@ def test_export_load_with_fallback(monkeypatch, tmp_path):
     host_lib.export_library(lib_path)
     reloaded = tvm.runtime.load_module(lib_path)
 
-    dev = tvm.device(target, 0)
     a_np = np.random.uniform(size=(n,)).astype("float32")
     b_np = np.zeros((n,), dtype="float32")
-    a = tvm.runtime.tensor(a_np, dev)
-    b = tvm.runtime.tensor(b_np, dev)
-    reloaded["main"](a, b)
-    np.testing.assert_allclose(b.numpy(), a_np + 1.0, rtol=1e-5)
+
+    def run_and_check():
+        dev = tvm.device(target, 0)
+        a = tvm.runtime.tensor(a_np, dev)
+        b = tvm.runtime.tensor(b_np, dev)
+        reloaded["main"](a, b)
+        np.testing.assert_allclose(b.numpy(), a_np + 1.0, rtol=1e-5)
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 if __name__ == "__main__":

--- a/tests/python/codegen/test_target_codegen_rocm.py
+++ b/tests/python/codegen/test_target_codegen_rocm.py
@@ -28,7 +28,7 @@ from tvm.testing import env
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_rocm(), reason="need rocm")
 def test_rocm_inf_nan():
-    def check_inf_nan(dev, n, value, dtype):
+    def check_inf_nan(n, value, dtype):
         @I.ir_module(s_tir=True)
         class Module:
             @T.prim_func(s_tir=True)
@@ -44,31 +44,36 @@ def test_rocm_inf_nan():
                             C[v_i] = T.Cast(dtype, value)
 
         fun = tvm.compile(Module, "rocm")
-        a = tvm.runtime.empty((n,), dtype, dev)
-        c = tvm.runtime.empty((n,), dtype, dev)
-        # Only need to test compiling here
-        fun(a, c)
 
-    dev = tvm.rocm(0)
+        def run():
+            dev = tvm.rocm(0)
+            a = tvm.runtime.empty((n,), dtype, dev)
+            c = tvm.runtime.empty((n,), dtype, dev)
+            fun(a, c)
 
-    check_inf_nan(dev, 1, -float("inf"), "float32")
-    check_inf_nan(dev, 1, -float("inf"), "float64")
-    check_inf_nan(dev, 1, float("inf"), "float32")
-    check_inf_nan(dev, 1, float("inf"), "float64")
-    check_inf_nan(dev, 1, float("nan"), "float32")
-    check_inf_nan(dev, 1, float("nan"), "float64")
+        tvm.testing.run_with_gpu_lock(run)
+
+    check_inf_nan(1, -float("inf"), "float32")
+    check_inf_nan(1, -float("inf"), "float64")
+    check_inf_nan(1, float("inf"), "float32")
+    check_inf_nan(1, float("inf"), "float64")
+    check_inf_nan(1, float("nan"), "float32")
+    check_inf_nan(1, float("nan"), "float64")
 
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_rocm(), reason="need rocm")
 def test_rocm_copy():
     def check_rocm(dtype, n):
-        dev = tvm.rocm(0)
-        a_np = np.random.uniform(size=(n,)).astype(dtype)
-        a = tvm.runtime.empty((n,), dtype, dev).copyfrom(a_np)
-        b_np = a.numpy()
-        tvm.testing.assert_allclose(a_np, b_np)
-        tvm.testing.assert_allclose(a_np, a.numpy())
+        def run():
+            dev = tvm.rocm(0)
+            a_np = np.random.uniform(size=(n,)).astype(dtype)
+            a = tvm.runtime.empty((n,), dtype, dev).copyfrom(a_np)
+            b_np = a.numpy()
+            tvm.testing.assert_allclose(a_np, b_np)
+            tvm.testing.assert_allclose(a_np, a.numpy())
+
+        tvm.testing.run_with_gpu_lock(run)
 
     for _ in range(100):
         dtype = np.random.choice(["float32", "float16", "int8", "int32"])
@@ -99,11 +104,14 @@ def test_rocm_vectorize_add():
 
         fun = tvm.compile(Module, target="rocm")
 
-        dev = tvm.rocm(0)
-        a = tvm.runtime.empty((n,), vec_dtype, dev).copyfrom(np.random.uniform(size=(n, lanes)))
-        c = tvm.runtime.empty((n,), vec_dtype, dev)
-        fun(a, c)
-        tvm.testing.assert_allclose(c.numpy(), a.numpy() + 1)
+        def run():
+            dev = tvm.rocm(0)
+            a = tvm.runtime.empty((n,), vec_dtype, dev).copyfrom(np.random.uniform(size=(n, lanes)))
+            c = tvm.runtime.empty((n,), vec_dtype, dev)
+            fun(a, c)
+            tvm.testing.assert_allclose(c.numpy(), a.numpy() + 1)
+
+        tvm.testing.run_with_gpu_lock(run)
 
     check_rocm("float32", 64, 2)
     check_rocm("float16", 64, 2)
@@ -130,10 +138,14 @@ def test_rocm_warp_shuffle():
                     A[tx] = A_local[0]
 
     mod = tvm.compile(func, target="rocm")
-    dev = tvm.rocm(0)
-    a = tvm.runtime.tensor(np.random.uniform(size=(32,)).astype("float32"), dev)
-    mod(a)
-    tvm.testing.assert_allclose(a.numpy(), np.ones((32,)) * a.numpy()[0])
+
+    def run():
+        dev = tvm.rocm(0)
+        a = tvm.runtime.tensor(np.random.uniform(size=(32,)).astype("float32"), dev)
+        mod(a)
+        tvm.testing.assert_allclose(a.numpy(), np.ones((32,)) * a.numpy()[0])
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 @pytest.mark.gpu
@@ -154,11 +166,15 @@ def test_rocm_vectorized_exp():
                         B[i] = T.exp2(A[i])
 
     mod = tvm.compile(func, target="rocm")
-    dev = tvm.rocm(0)
-    a = tvm.runtime.tensor(np.ones((4,)).astype("float32"), dev)
-    b = tvm.runtime.tensor(np.zeros((4,)).astype("float32"), dev)
-    mod(a, b)
-    tvm.testing.assert_allclose(b.numpy(), np.exp2(a.numpy()))
+
+    def run():
+        dev = tvm.rocm(0)
+        a = tvm.runtime.tensor(np.ones((4,)).astype("float32"), dev)
+        b = tvm.runtime.tensor(np.zeros((4,)).astype("float32"), dev)
+        mod(a, b)
+        tvm.testing.assert_allclose(b.numpy(), np.exp2(a.numpy()))
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 @pytest.mark.gpu
@@ -188,13 +204,17 @@ def test_export_load_with_fallback(monkeypatch, tmp_path):
     host_lib.export_library(lib_path)
     reloaded = tvm.runtime.load_module(lib_path)
 
-    dev = tvm.rocm(0)
     a_np = np.random.uniform(size=(n,)).astype("float32")
     b_np = np.zeros((n,), dtype="float32")
-    a = tvm.runtime.tensor(a_np, dev)
-    b = tvm.runtime.tensor(b_np, dev)
-    reloaded["main"](a, b)
-    np.testing.assert_allclose(b.numpy(), a_np + 1.0, rtol=1e-5)
+
+    def run():
+        dev = tvm.rocm(0)
+        a = tvm.runtime.tensor(a_np, dev)
+        b = tvm.runtime.tensor(b_np, dev)
+        reloaded["main"](a, b)
+        np.testing.assert_allclose(b.numpy(), a_np + 1.0, rtol=1e-5)
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 if __name__ == "__main__":

--- a/tests/python/codegen/test_target_codegen_rocm.py
+++ b/tests/python/codegen/test_target_codegen_rocm.py
@@ -45,13 +45,13 @@ def test_rocm_inf_nan():
 
         fun = tvm.compile(Module, "rocm")
 
-        def run():
+        def run_and_check():
             dev = tvm.rocm(0)
             a = tvm.runtime.empty((n,), dtype, dev)
             c = tvm.runtime.empty((n,), dtype, dev)
             fun(a, c)
 
-        tvm.testing.run_with_gpu_lock(run)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
     check_inf_nan(1, -float("inf"), "float32")
     check_inf_nan(1, -float("inf"), "float64")
@@ -65,7 +65,7 @@ def test_rocm_inf_nan():
 @pytest.mark.skipif(not env.has_rocm(), reason="need rocm")
 def test_rocm_copy():
     def check_rocm(dtype, n):
-        def run():
+        def run_and_check():
             dev = tvm.rocm(0)
             a_np = np.random.uniform(size=(n,)).astype(dtype)
             a = tvm.runtime.empty((n,), dtype, dev).copyfrom(a_np)
@@ -73,7 +73,7 @@ def test_rocm_copy():
             tvm.testing.assert_allclose(a_np, b_np)
             tvm.testing.assert_allclose(a_np, a.numpy())
 
-        tvm.testing.run_with_gpu_lock(run)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
     for _ in range(100):
         dtype = np.random.choice(["float32", "float16", "int8", "int32"])
@@ -104,14 +104,14 @@ def test_rocm_vectorize_add():
 
         fun = tvm.compile(Module, target="rocm")
 
-        def run():
+        def run_and_check():
             dev = tvm.rocm(0)
             a = tvm.runtime.empty((n,), vec_dtype, dev).copyfrom(np.random.uniform(size=(n, lanes)))
             c = tvm.runtime.empty((n,), vec_dtype, dev)
             fun(a, c)
             tvm.testing.assert_allclose(c.numpy(), a.numpy() + 1)
 
-        tvm.testing.run_with_gpu_lock(run)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
     check_rocm("float32", 64, 2)
     check_rocm("float16", 64, 2)
@@ -139,13 +139,13 @@ def test_rocm_warp_shuffle():
 
     mod = tvm.compile(func, target="rocm")
 
-    def run():
+    def run_and_check():
         dev = tvm.rocm(0)
         a = tvm.runtime.tensor(np.random.uniform(size=(32,)).astype("float32"), dev)
         mod(a)
         tvm.testing.assert_allclose(a.numpy(), np.ones((32,)) * a.numpy()[0])
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -167,14 +167,14 @@ def test_rocm_vectorized_exp():
 
     mod = tvm.compile(func, target="rocm")
 
-    def run():
+    def run_and_check():
         dev = tvm.rocm(0)
         a = tvm.runtime.tensor(np.ones((4,)).astype("float32"), dev)
         b = tvm.runtime.tensor(np.zeros((4,)).astype("float32"), dev)
         mod(a, b)
         tvm.testing.assert_allclose(b.numpy(), np.exp2(a.numpy()))
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -207,14 +207,14 @@ def test_export_load_with_fallback(monkeypatch, tmp_path):
     a_np = np.random.uniform(size=(n,)).astype("float32")
     b_np = np.zeros((n,), dtype="float32")
 
-    def run():
+    def run_and_check():
         dev = tvm.rocm(0)
         a = tvm.runtime.tensor(a_np, dev)
         b = tvm.runtime.tensor(b_np, dev)
         reloaded["main"](a, b)
         np.testing.assert_allclose(b.numpy(), a_np + 1.0, rtol=1e-5)
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 if __name__ == "__main__":

--- a/tests/python/codegen/test_target_codegen_vulkan.py
+++ b/tests/python/codegen/test_target_codegen_vulkan.py
@@ -101,16 +101,21 @@ def test_vector_comparison(dtype):
 def test_array_copy(target, dtype, fuzz_seed):
     if not tvm.testing.device_enabled(target):
         pytest.skip(f"{target} not enabled")
-    dev = tvm.device(target)
     np.random.seed(fuzz_seed)
 
     log_arr_size = np.random.uniform(low=np.log(1), high=np.log(32768))
     arr_size = np.exp(log_arr_size).astype(int)
     a_np = np.random.uniform(size=(arr_size,)).astype(dtype)
-    a = tvm.runtime.empty((arr_size,), dtype, dev).copyfrom(a_np)
-    b_np = a.numpy()
-    tvm.testing.assert_allclose(a_np, b_np)
-    tvm.testing.assert_allclose(a_np, a.numpy())
+
+    def run_and_check():
+        dev = tvm.device(target)
+        a = tvm.runtime.empty((arr_size,), dtype, dev).copyfrom(a_np)
+        tvm.testing.assert_allclose(a_np, a.numpy())
+
+    if target == "llvm":
+        run_and_check()
+    else:
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -120,7 +125,6 @@ def test_array_copy(target, dtype, fuzz_seed):
 )
 def test_array_vectorize_add(dtype):
     target = {"kind": "vulkan", "from_device": 0}
-    dev = tvm.device(target["kind"])
     target = tvm.target.Target(target)
     arr_size = 64
     lanes = 2
@@ -140,12 +144,16 @@ def test_array_vectorize_add(dtype):
 
     f = tvm.compile(Module, target=target)
 
-    a = tvm.runtime.empty((arr_size,), vec_dtype, dev).copyfrom(
-        np.random.uniform(size=(arr_size, lanes))
-    )
-    c = tvm.runtime.empty((arr_size,), vec_dtype, dev)
-    f(a, c)
-    tvm.testing.assert_allclose(c.numpy(), a.numpy() + 1)
+    def run_and_check():
+        dev = tvm.device(target.kind.name)
+        a = tvm.runtime.empty((arr_size,), vec_dtype, dev).copyfrom(
+            np.random.uniform(size=(arr_size, lanes))
+        )
+        c = tvm.runtime.empty((arr_size,), vec_dtype, dev)
+        f(a, c)
+        tvm.testing.assert_allclose(c.numpy(), a.numpy() + 1)
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -155,7 +163,6 @@ def test_array_vectorize_add(dtype):
 )
 def test_vulkan_bool_load():
     target = {"kind": "vulkan", "from_device": 0}
-    dev = tvm.device(target["kind"])
     target = tvm.target.Target(target)
     arr_size = 1024
 
@@ -173,11 +180,16 @@ def test_vulkan_bool_load():
 
     a_np = np.random.uniform(size=arr_size) > 0.5
     b_np = np.zeros((arr_size,), dtype="int32")
-    a = tvm.runtime.tensor(a_np, dev)
-    b = tvm.runtime.tensor(b_np, dev)
-    f(a, b)
     ref = a_np.astype(np.int32)
-    tvm.testing.assert_allclose(b.numpy(), ref)
+
+    def run_and_check():
+        dev = tvm.device(target.kind.name)
+        a = tvm.runtime.tensor(a_np, dev)
+        b = tvm.runtime.tensor(b_np, dev)
+        f(a, b)
+        tvm.testing.assert_allclose(b.numpy(), ref)
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 vulkan_parameter_impl = tvm.testing.parameter("push_constants", "ubo")
@@ -193,7 +205,6 @@ vulkan_parameter_dtype = tvm.testing.parameter("int32", "float32", "int64")
 )
 def test_vulkan_constant_passing(vulkan_parameter_impl, vulkan_parameter_dtype):
     target = {"kind": "vulkan", "from_device": 0}
-    dev = tvm.device(target["kind"])
     target = tvm.target.Target(target)
     dtype = vulkan_parameter_dtype
 
@@ -247,11 +258,15 @@ def test_vulkan_constant_passing(vulkan_parameter_impl, vulkan_parameter_dtype):
 
     n = 1024
     scalars = np.array([1 for _ in range(num_int_params)]).astype(dtype)
-    a = tvm.runtime.tensor(np.random.uniform(size=n).astype(dtype), dev)
-    b = tvm.runtime.tensor(np.zeros(n, dtype=dtype), dev)
-    f_add(*scalars, a, b)
 
-    tvm.testing.assert_allclose(a.numpy() + sum(scalars), b.numpy())
+    def run_and_check():
+        dev = tvm.device(target.kind.name)
+        a = tvm.runtime.tensor(np.random.uniform(size=n).astype(dtype), dev)
+        b = tvm.runtime.tensor(np.zeros(n, dtype=dtype), dev)
+        f_add(*scalars, a, b)
+        tvm.testing.assert_allclose(a.numpy() + sum(scalars), b.numpy())
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -261,7 +276,6 @@ def test_vulkan_constant_passing(vulkan_parameter_impl, vulkan_parameter_dtype):
 )
 def test_vulkan_while_if():
     target = {"kind": "vulkan", "from_device": 0}
-    dev = tvm.device(target["kind"])
     target = tvm.target.Target(target)
     n = 1
     dtype = "int32"
@@ -279,15 +293,15 @@ def test_vulkan_while_if():
     mod = tvm.IRModule.from_expr(while_if_gpu.with_attr("target", target))
     compiled_func = tvm.compile(mod, target=target)
 
-    a = tvm.runtime.tensor(np.array([5], dtype=dtype), dev)
-    b = tvm.runtime.tensor(np.zeros(n, dtype=dtype), dev)
-    compiled_func(a, b)
-    tvm.testing.assert_allclose(b.numpy(), [55])
+    def run_and_check():
+        dev = tvm.device(target.kind.name)
+        for input_value, expected in [(5, [55]), (-5, [210])]:
+            a = tvm.runtime.tensor(np.array([input_value], dtype=dtype), dev)
+            b = tvm.runtime.tensor(np.zeros(n, dtype=dtype), dev)
+            compiled_func(a, b)
+            tvm.testing.assert_allclose(b.numpy(), expected)
 
-    a = tvm.runtime.tensor(np.array([-5], dtype=dtype), dev)
-    b = tvm.runtime.tensor(np.zeros(n, dtype=dtype), dev)
-    compiled_func(a, b)
-    tvm.testing.assert_allclose(b.numpy(), [210])
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -297,7 +311,6 @@ def test_vulkan_while_if():
 )
 def test_vulkan_local_threadidx():
     target = {"kind": "vulkan", "from_device": 0}
-    dev = tvm.device(target["kind"])
     target = tvm.target.Target(target)
     n = 32
 
@@ -317,10 +330,15 @@ def test_vulkan_local_threadidx():
 
     a_np = np.arange(n).astype(dtype="int32")
     b_np = np.zeros((n,), dtype="int32")
-    a = tvm.runtime.tensor(a_np, dev)
-    b = tvm.runtime.tensor(b_np, dev)
-    func(a, b)
-    tvm.testing.assert_allclose(b.numpy(), a_np)
+
+    def run_and_check():
+        dev = tvm.device(target.kind.name)
+        a = tvm.runtime.tensor(a_np, dev)
+        b = tvm.runtime.tensor(b_np, dev)
+        func(a, b)
+        tvm.testing.assert_allclose(b.numpy(), a_np)
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -331,7 +349,6 @@ def test_vulkan_local_threadidx():
 def test_vectorized_index_ramp():
     """Test vectorized copy with ramp indices (load N values, write to N locations)"""
     target = {"kind": "vulkan", "from_device": 0}
-    dev = tvm.device(target["kind"])
     n = 4
     ramp_index = tvm.tirx.Ramp(0, 1, 4)
 
@@ -353,10 +370,14 @@ def test_vectorized_index_ramp():
     a_np = np.random.randint(np.iinfo("int32").max, size=n).astype("int32")
     b_np = np.zeros(n, dtype="int32")
 
-    a = tvm.runtime.tensor(a_np, dev)
-    b = tvm.runtime.tensor(b_np, dev)
-    f(a, b)
-    tvm.testing.assert_allclose(b.numpy(), a_np)
+    def run_and_check():
+        dev = tvm.device(target["kind"])
+        a = tvm.runtime.tensor(a_np, dev)
+        b = tvm.runtime.tensor(b_np, dev)
+        f(a, b)
+        tvm.testing.assert_allclose(b.numpy(), a_np)
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -367,7 +388,6 @@ def test_vectorized_index_ramp():
 def test_vectorized_index_broadcast():
     """Test broadcast index (load 1 value, write to N locations)"""
     target = {"kind": "vulkan", "from_device": 0}
-    dev = tvm.device(target["kind"])
     n = 4
     broadcast_index = tvm.tirx.Broadcast(0, 4)
     ramp_index = tvm.tirx.Ramp(0, 1, 4)
@@ -391,11 +411,15 @@ def test_vectorized_index_broadcast():
     a_np = np.random.randint(np.iinfo("int32").max, size=n).astype("int32")
     b_np = np.zeros(n, dtype="int32")
 
-    a = tvm.runtime.tensor(a_np, dev)
-    b = tvm.runtime.tensor(b_np, dev)
-    f(a, b)
-    # All elements of b should be a[0] (broadcast load)
-    tvm.testing.assert_allclose(b.numpy(), np.full(n, a_np[0]))
+    def run_and_check():
+        dev = tvm.device(target["kind"])
+        a = tvm.runtime.tensor(a_np, dev)
+        b = tvm.runtime.tensor(b_np, dev)
+        f(a, b)
+        # All elements of b should be a[0] (broadcast load)
+        tvm.testing.assert_allclose(b.numpy(), np.full(n, a_np[0]))
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -417,7 +441,6 @@ def test_negative_operand_divmod():
     Vulkan: https://registry.khronos.org/vulkan/specs/1.3/html/chap37.html#spirvenv-op-prec
     """
     target = {"kind": "vulkan", "from_device": 0}
-    dev = tvm.device(target["kind"])
 
     N = 32
     offset = 16
@@ -433,12 +456,15 @@ def test_negative_operand_divmod():
 
     built = tvm.compile(func, target=target)
 
-    a_dev = tvm.runtime.empty([N, 2], "int32", dev)
-    built(a_dev)
-    a = a_dev.numpy()
+    def run_and_check():
+        dev = tvm.device(target["kind"])
+        a_dev = tvm.runtime.empty([N, 2], "int32", dev)
+        built(a_dev)
+        a = a_dev.numpy()
+        np.testing.assert_array_equal(a[:, 0], (np.arange(N) - offset) // divisor)
+        np.testing.assert_array_equal(a[:, 1], (np.arange(N) - offset) % divisor)
 
-    np.testing.assert_array_equal(a[:, 0], (np.arange(N) - offset) // divisor)
-    np.testing.assert_array_equal(a[:, 1], (np.arange(N) - offset) % divisor)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.parametrize("out_dtype", ["float32", "float16"])
@@ -529,19 +555,18 @@ def test_cooperative_matrix(out_dtype):
     if tgt_attrs.get("supports_cooperative_matrix"):
         f = tvm.compile(Module, target=target)
 
-        dev = tvm.device("vulkan", 0)
+        def run_and_check():
+            dev = tvm.device("vulkan", 0)
+            A = tvm.runtime.tensor(np.random.randn(M, K).astype("float16"), dev)
+            B = tvm.runtime.tensor(np.random.randn(K, N).astype("float16"), dev)
+            C = tvm.runtime.tensor(np.random.randn(M, N).astype(out_dtype), dev)
+            f(A, B, C)
+            A_np = A.numpy()
+            B_np = B.numpy()
+            ref = np.dot(A_np.astype("float32"), B_np.astype("float32"))
+            tvm.testing.assert_allclose(C.numpy(), ref, rtol=1e-2, atol=1e-2)
 
-        A = tvm.runtime.tensor(np.random.randn(M, K).astype("float16"), dev)
-        B = tvm.runtime.tensor(np.random.randn(K, N).astype("float16"), dev)
-        C = tvm.runtime.tensor(np.random.randn(M, N).astype(out_dtype), dev)
-
-        f(A, B, C)
-
-        A_np = A.numpy()
-        B_np = B.numpy()
-        ref = np.dot(A_np.astype("float32"), B_np.astype("float32"))
-
-        tvm.testing.assert_allclose(C.numpy(), ref, rtol=1e-2, atol=1e-2)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -619,7 +644,6 @@ def test_unary():
                             B[v_i] = tvm_intrin(A[v_i])
 
         target = tvm.target.Target("vulkan")
-        dev = tvm.device(target.kind.name, 0)
         func = tvm.compile(Module, target=target)
 
         if tvm_intrin in [tvm.tirx.asin, tvm.tirx.acos]:
@@ -631,10 +655,14 @@ def test_unary():
         else:
             data = np.random.uniform(0.1, 0.9, size=n)
 
-        a = tvm.runtime.tensor(data.astype("float32"), dev)
-        b = tvm.runtime.tensor(np.zeros(n, dtype="float32"), dev)
-        func(a, b)
-        tvm.testing.assert_allclose(b.numpy(), np_func(a.numpy()), atol=1e-3, rtol=1e-3)
+        def run_and_check():
+            dev = tvm.device(target.kind.name, 0)
+            a = tvm.runtime.tensor(data.astype("float32"), dev)
+            b = tvm.runtime.tensor(np.zeros(n, dtype="float32"), dev)
+            func(a, b)
+            tvm.testing.assert_allclose(b.numpy(), np_func(a.numpy()), atol=1e-3, rtol=1e-3)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
     for func in test_funcs:
         run_test(*func)

--- a/tests/python/contrib/test_cutlass_gemm.py
+++ b/tests/python/contrib/test_cutlass_gemm.py
@@ -59,18 +59,22 @@ def verify_group_gemm(
         return mapping.get(dtype, dtype)
 
     a_np, b_np, indptr_np, c_np = get_ref_data()
-    dev = tvm.cuda(0)
-    a_nd = tvm.runtime.tensor(a_np.astype(to_numpy_dtype(x_dtype)), device=dev)
-    b_nd = tvm.runtime.tensor(b_np.astype(to_numpy_dtype(weight_dtype)), device=dev)
-    c_nd = tvm.runtime.empty(c_np.shape, dtype=out_dtype, device=dev)
-    indptr_nd = tvm.runtime.tensor(indptr_np, device=dev)
-    workspace = tvm.runtime.empty((4096 * 1024,), dtype="uint8", device=dev)
-    if use_scale:
-        scale = tvm.runtime.tensor(np.array([1.0], dtype="float32"), device=dev)
-        group_gemm_func(a_nd, b_nd, indptr_nd, workspace, scale, c_nd)
-    else:
-        group_gemm_func(a_nd, b_nd, indptr_nd, workspace, c_nd)
-    tvm.testing.assert_allclose(c_nd.numpy(), c_np, rtol=rtol, atol=atol)
+
+    def run():
+        dev = tvm.cuda(0)
+        a_nd = tvm.runtime.tensor(a_np.astype(to_numpy_dtype(x_dtype)), device=dev)
+        b_nd = tvm.runtime.tensor(b_np.astype(to_numpy_dtype(weight_dtype)), device=dev)
+        c_nd = tvm.runtime.empty(c_np.shape, dtype=out_dtype, device=dev)
+        indptr_nd = tvm.runtime.tensor(indptr_np, device=dev)
+        workspace = tvm.runtime.empty((4096 * 1024,), dtype="uint8", device=dev)
+        if use_scale:
+            scale = tvm.runtime.tensor(np.array([1.0], dtype="float32"), device=dev)
+            group_gemm_func(a_nd, b_nd, indptr_nd, workspace, scale, c_nd)
+        else:
+            group_gemm_func(a_nd, b_nd, indptr_nd, workspace, c_nd)
+        tvm.testing.assert_allclose(c_nd.numpy(), c_np, rtol=rtol, atol=atol)
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 @pytest.mark.skipif(not env.build_flag_enabled("USE_CUTLASS"), reason="need cutlass")
@@ -318,22 +322,32 @@ def test_fp8_e4m3_groupwise_scaled_gemm():
         print(f"Skipped as {func_name} is not available")
         return
 
-    device = tvm.cuda(0)
     dtype = "bfloat16"
     x_np, x_scale_np = rowwise_quant_fp8_e4m3((M, K), block_size, dtype)
     w_np, w_scale_np = blockwise_quant_fp8_e4m3((N, K), block_size, dtype)
     o_np = blockwise_matmul(x_np, x_scale_np, w_np, w_scale_np, block_size, dtype)
-    x_tvm = tvm.runtime.tensor(x_np, device=device)
-    x_scale_tvm = tvm.runtime.tensor(x_scale_np.T, device=device)
-    w_tvm = tvm.runtime.tensor(w_np, device=device)
-    w_scale_tvm = tvm.runtime.tensor(w_scale_np, device=device)
-    workspace = tvm.runtime.empty((4096 * 1024,), dtype="uint8", device=device)
-    o_tvm = tvm.runtime.empty((M, N), dtype=dtype, device=device)
-    gemm_func(
-        x_tvm, w_tvm, x_scale_tvm, w_scale_tvm, workspace, block_size[0], block_size[1], o_tvm
-    )
-    o_tvm = o_tvm.numpy()
-    tvm.testing.assert_allclose(o_tvm, o_np, rtol=1e-4, atol=0.5)
+
+    def run():
+        device = tvm.cuda(0)
+        x_tvm = tvm.runtime.tensor(x_np, device=device)
+        x_scale_tvm = tvm.runtime.tensor(x_scale_np.T, device=device)
+        w_tvm = tvm.runtime.tensor(w_np, device=device)
+        w_scale_tvm = tvm.runtime.tensor(w_scale_np, device=device)
+        workspace = tvm.runtime.empty((4096 * 1024,), dtype="uint8", device=device)
+        o_tvm = tvm.runtime.empty((M, N), dtype=dtype, device=device)
+        gemm_func(
+            x_tvm,
+            w_tvm,
+            x_scale_tvm,
+            w_scale_tvm,
+            workspace,
+            block_size[0],
+            block_size[1],
+            o_tvm,
+        )
+        tvm.testing.assert_allclose(o_tvm.numpy(), o_np, rtol=1e-4, atol=0.5)
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 @pytest.mark.skipif(not env.build_flag_enabled("USE_CUTLASS"), reason="need cutlass")
@@ -353,22 +367,32 @@ def test_fp8_e4m3_groupwise_scaled_bmm():
         print(f"Skipped as {func_name} is not available")
         return
 
-    device = tvm.cuda(0)
     dtype = "bfloat16"
     x_np, x_scale_np = rowwise_quant_fp8_e4m3((B, M, K), block_size, dtype)
     w_np, w_scale_np = blockwise_quant_fp8_e4m3((B, N, K), block_size, dtype)
     o_np = blockwise_bmm(x_np, x_scale_np, w_np, w_scale_np, block_size, dtype)
-    x_tvm = tvm.runtime.tensor(x_np, device=device)
-    x_scale_tvm = tvm.runtime.tensor(x_scale_np.transpose(0, 2, 1), device=device)
-    w_tvm = tvm.runtime.tensor(w_np, device=device)
-    w_scale_tvm = tvm.runtime.tensor(w_scale_np, device=device)
-    workspace = tvm.runtime.empty((4096 * 1024,), dtype="uint8", device=device)
-    o_tvm = tvm.runtime.empty((B, M, N), dtype=dtype, device=device)
-    gemm_func(
-        x_tvm, w_tvm, x_scale_tvm, w_scale_tvm, workspace, block_size[0], block_size[1], o_tvm
-    )
-    o_tvm = o_tvm.numpy()
-    tvm.testing.assert_allclose(o_tvm, o_np, rtol=1e-4, atol=0.5)
+
+    def run():
+        device = tvm.cuda(0)
+        x_tvm = tvm.runtime.tensor(x_np, device=device)
+        x_scale_tvm = tvm.runtime.tensor(x_scale_np.transpose(0, 2, 1), device=device)
+        w_tvm = tvm.runtime.tensor(w_np, device=device)
+        w_scale_tvm = tvm.runtime.tensor(w_scale_np, device=device)
+        workspace = tvm.runtime.empty((4096 * 1024,), dtype="uint8", device=device)
+        o_tvm = tvm.runtime.empty((B, M, N), dtype=dtype, device=device)
+        gemm_func(
+            x_tvm,
+            w_tvm,
+            x_scale_tvm,
+            w_scale_tvm,
+            workspace,
+            block_size[0],
+            block_size[1],
+            o_tvm,
+        )
+        tvm.testing.assert_allclose(o_tvm.numpy(), o_np, rtol=1e-4, atol=0.5)
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 if __name__ == "__main__":

--- a/tests/python/contrib/test_cutlass_gemm.py
+++ b/tests/python/contrib/test_cutlass_gemm.py
@@ -60,7 +60,7 @@ def verify_group_gemm(
 
     a_np, b_np, indptr_np, c_np = get_ref_data()
 
-    def run():
+    def run_and_check():
         dev = tvm.cuda(0)
         a_nd = tvm.runtime.tensor(a_np.astype(to_numpy_dtype(x_dtype)), device=dev)
         b_nd = tvm.runtime.tensor(b_np.astype(to_numpy_dtype(weight_dtype)), device=dev)
@@ -74,7 +74,7 @@ def verify_group_gemm(
             group_gemm_func(a_nd, b_nd, indptr_nd, workspace, c_nd)
         tvm.testing.assert_allclose(c_nd.numpy(), c_np, rtol=rtol, atol=atol)
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.skipif(not env.build_flag_enabled("USE_CUTLASS"), reason="need cutlass")
@@ -327,7 +327,7 @@ def test_fp8_e4m3_groupwise_scaled_gemm():
     w_np, w_scale_np = blockwise_quant_fp8_e4m3((N, K), block_size, dtype)
     o_np = blockwise_matmul(x_np, x_scale_np, w_np, w_scale_np, block_size, dtype)
 
-    def run():
+    def run_and_check():
         device = tvm.cuda(0)
         x_tvm = tvm.runtime.tensor(x_np, device=device)
         x_scale_tvm = tvm.runtime.tensor(x_scale_np.T, device=device)
@@ -347,7 +347,7 @@ def test_fp8_e4m3_groupwise_scaled_gemm():
         )
         tvm.testing.assert_allclose(o_tvm.numpy(), o_np, rtol=1e-4, atol=0.5)
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.skipif(not env.build_flag_enabled("USE_CUTLASS"), reason="need cutlass")
@@ -372,7 +372,7 @@ def test_fp8_e4m3_groupwise_scaled_bmm():
     w_np, w_scale_np = blockwise_quant_fp8_e4m3((B, N, K), block_size, dtype)
     o_np = blockwise_bmm(x_np, x_scale_np, w_np, w_scale_np, block_size, dtype)
 
-    def run():
+    def run_and_check():
         device = tvm.cuda(0)
         x_tvm = tvm.runtime.tensor(x_np, device=device)
         x_scale_tvm = tvm.runtime.tensor(x_scale_np.transpose(0, 2, 1), device=device)
@@ -392,7 +392,7 @@ def test_fp8_e4m3_groupwise_scaled_bmm():
         )
         tvm.testing.assert_allclose(o_tvm.numpy(), o_np, rtol=1e-4, atol=0.5)
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 if __name__ == "__main__":

--- a/tests/python/contrib/test_hipblas.py
+++ b/tests/python/contrib/test_hipblas.py
@@ -39,7 +39,7 @@ def verify_matmul_add(in_dtype, out_dtype, rtol=1e-5):
             return
         f = tvm.compile(te.create_prim_func([A, B, C]), target=target)
 
-        def run():
+        def run_and_check():
             dev = tvm.rocm(0)
             a = tvm.runtime.tensor(np.random.uniform(0, 128, size=(n, l)).astype(A.dtype), dev)
             b = tvm.runtime.tensor(np.random.uniform(0, 128, size=(l, m)).astype(B.dtype), dev)
@@ -51,7 +51,7 @@ def verify_matmul_add(in_dtype, out_dtype, rtol=1e-5):
                 rtol=rtol,
             )
 
-        tvm.testing.run_with_gpu_lock(run)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
     verify()
 
@@ -67,7 +67,7 @@ def verify_batch_matmul(Ashape, Bshape, Cshape, in_dtype, out_dtype, rtol=1e-5):
 
     f = tvm.compile(te.create_prim_func([A, B, C]), target="rocm")
 
-    def run():
+    def run_and_check():
         dev = tvm.rocm(0)
         if "int" in in_dtype:
             a = tvm.runtime.tensor(np.random.uniform(1, 10, size=Ashape).astype(in_dtype), dev)
@@ -84,7 +84,7 @@ def verify_batch_matmul(Ashape, Bshape, Cshape, in_dtype, out_dtype, rtol=1e-5):
             rtol=rtol,
         )
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu

--- a/tests/python/contrib/test_hipblas.py
+++ b/tests/python/contrib/test_hipblas.py
@@ -37,15 +37,21 @@ def verify_matmul_add(in_dtype, out_dtype, rtol=1e-5):
         if not tvm.get_global_func("tvm.contrib.hipblas.matmul", True):
             print("skip because extern function is not available")
             return
-        dev = tvm.rocm(0)
         f = tvm.compile(te.create_prim_func([A, B, C]), target=target)
-        a = tvm.runtime.tensor(np.random.uniform(0, 128, size=(n, l)).astype(A.dtype), dev)
-        b = tvm.runtime.tensor(np.random.uniform(0, 128, size=(l, m)).astype(B.dtype), dev)
-        c = tvm.runtime.tensor(np.zeros((n, m), dtype=C.dtype), dev)
-        f(a, b, c)
-        tvm.testing.assert_allclose(
-            c.numpy(), np.dot(a.numpy().astype(C.dtype), b.numpy().astype(C.dtype)), rtol=rtol
-        )
+
+        def run():
+            dev = tvm.rocm(0)
+            a = tvm.runtime.tensor(np.random.uniform(0, 128, size=(n, l)).astype(A.dtype), dev)
+            b = tvm.runtime.tensor(np.random.uniform(0, 128, size=(l, m)).astype(B.dtype), dev)
+            c = tvm.runtime.tensor(np.zeros((n, m), dtype=C.dtype), dev)
+            f(a, b, c)
+            tvm.testing.assert_allclose(
+                c.numpy(),
+                np.dot(a.numpy().astype(C.dtype), b.numpy().astype(C.dtype)),
+                rtol=rtol,
+            )
+
+        tvm.testing.run_with_gpu_lock(run)
 
     verify()
 
@@ -59,23 +65,26 @@ def verify_batch_matmul(Ashape, Bshape, Cshape, in_dtype, out_dtype, rtol=1e-5):
     B = te.placeholder(Bshape, name="B", dtype=in_dtype)
     C = hipblas.batch_matmul(A, B, dtype=out_dtype)
 
-    dev = tvm.rocm(0)
     f = tvm.compile(te.create_prim_func([A, B, C]), target="rocm")
 
-    if "int" in in_dtype:
-        a = tvm.runtime.tensor(np.random.uniform(1, 10, size=Ashape).astype(in_dtype), dev)
-        b = tvm.runtime.tensor(np.random.uniform(1, 10, size=Bshape).astype(in_dtype), dev)
-    else:
-        a = tvm.runtime.tensor(np.random.uniform(size=Ashape).astype(A.dtype), dev)
-        b = tvm.runtime.tensor(np.random.uniform(size=Bshape).astype(B.dtype), dev)
+    def run():
+        dev = tvm.rocm(0)
+        if "int" in in_dtype:
+            a = tvm.runtime.tensor(np.random.uniform(1, 10, size=Ashape).astype(in_dtype), dev)
+            b = tvm.runtime.tensor(np.random.uniform(1, 10, size=Bshape).astype(in_dtype), dev)
+        else:
+            a = tvm.runtime.tensor(np.random.uniform(size=Ashape).astype(A.dtype), dev)
+            b = tvm.runtime.tensor(np.random.uniform(size=Bshape).astype(B.dtype), dev)
 
-    c = tvm.runtime.tensor(np.zeros(Cshape, dtype=C.dtype), dev)
-    f(a, b, c)
-    tvm.testing.assert_allclose(
-        c.numpy(),
-        np.matmul(a.numpy().astype(C.dtype), b.numpy().astype(C.dtype)).astype(C.dtype),
-        rtol=rtol,
-    )
+        c = tvm.runtime.tensor(np.zeros(Cshape, dtype=C.dtype), dev)
+        f(a, b, c)
+        tvm.testing.assert_allclose(
+            c.numpy(),
+            np.matmul(a.numpy().astype(C.dtype), b.numpy().astype(C.dtype)).astype(C.dtype),
+            rtol=rtol,
+        )
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 @pytest.mark.gpu

--- a/tests/python/contrib/test_random.py
+++ b/tests/python/contrib/test_random.py
@@ -158,8 +158,11 @@ def test_random_fill():
         "float32",
         "float64",
     ]:
-        for _, dev in tvm.testing.enabled_targets():
-            test_local(dev, dtype)
+        for target, dev in tvm.testing.enabled_targets():
+            if tvm.target.Target(target).kind.name == "llvm":
+                test_local(dev, dtype)
+            else:
+                tvm.testing.run_with_gpu_lock(test_local, dev, dtype)
         test_rpc(dtype)
 
 

--- a/tests/python/contrib/test_tir_triton_integration.py
+++ b/tests/python/contrib/test_tir_triton_integration.py
@@ -120,12 +120,15 @@ def test_tir_triton_integration():
     tvm.ir.assert_structural_equal(Module["add"], Parsed["add"])
     assert len(Module.get_attr("external_mods")) == 1
 
-    device = tvm.cuda(0)
-    x_nd = tvm.runtime.tensor(np.random.rand(256).astype(np.float32), device)
-    y_nd = tvm.runtime.tensor(np.random.rand(256).astype(np.float32), device)
-    output_np = x_nd.numpy() + y_nd.numpy()
-
     with tvm.target.Target("cuda"):
         lib = tvm.compile(Module)
+
+    def run_and_check():
+        device = tvm.cuda(0)
+        x_nd = tvm.runtime.tensor(np.random.rand(256).astype(np.float32), device)
+        y_nd = tvm.runtime.tensor(np.random.rand(256).astype(np.float32), device)
+        output_np = x_nd.numpy() + y_nd.numpy()
         output_nd = tvm.runtime.vm.VirtualMachine(lib, device)["main"](x_nd, y_nd)
         tvm.testing.assert_allclose(output_nd.numpy(), output_np, rtol=1e-5)
+
+    tvm.testing.run_with_gpu_lock(run_and_check)

--- a/tests/python/disco/test_callback.py
+++ b/tests/python/disco/test_callback.py
@@ -71,15 +71,6 @@ def test_callback():
 
     num_shards = 2
 
-    session = tvm.runtime.disco.ProcessSession(num_workers=num_shards)
-    session.import_python_module("tvm.exec.disco_worker")
-    session.init_ccl("nccl", *range(num_shards))
-
-    worker_device = session.get_global_func("runtime.disco.device")()
-    worker_id = session.get_global_func("runtime.disco.worker_rank")()
-    callback_maker = session.get_global_func("tests.disco.test_callback")
-    fget_item = callback_maker(worker_device)
-
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_dir = pathlib.Path(temp_dir)
 
@@ -88,46 +79,61 @@ def test_callback():
         # need for a temporary file.
         shlib_path = temp_dir.joinpath("libtemp.so")
         built.export_library(shlib_path)
-        vm = session.load_vm_module(shlib_path.as_posix())
-        transform_params = vm["transform_params"]
 
-        params = transform_params(worker_id, fget_item)
+        def run_and_check():
+            session = tvm.runtime.disco.ProcessSession(num_workers=num_shards)
+            try:
+                session.import_python_module("tvm.exec.disco_worker")
+                session.init_ccl("nccl", *range(num_shards))
 
-        # Worker 0 is the same PID as the controlling scope, so
-        # `debug_get_from_remote(0)` returns the Tensor containing
-        # the output.
-        params_gpu0 = params.debug_get_from_remote(0)
-        assert params_gpu0[0].device == tvm.cuda(0)
-        assert params_gpu0[1].device == tvm.cuda(0)
-        np.testing.assert_array_equal(
-            params_gpu0[0].numpy(),
-            [
-                [0, 1, 2, 3],
-                [4, 5, 6, 7],
-            ],
-        )
-        np.testing.assert_array_equal(
-            params_gpu0[1].numpy(),
-            [[0], [2]],
-        )
+                worker_device = session.get_global_func("runtime.disco.device")()
+                worker_id = session.get_global_func("runtime.disco.worker_rank")()
+                callback_maker = session.get_global_func("tests.disco.test_callback")
+                fget_item = callback_maker(worker_device)
+                vm = session.load_vm_module(shlib_path.as_posix())
+                transform_params = vm["transform_params"]
 
-        # Worker 1 is a different PID altogether, so
-        # `debug_get_from_remote(1)` returns a new Tensor within the
-        # calling scope's PID.
-        params_gpu1 = params.debug_get_from_remote(1)
-        assert params_gpu1[0].device == tvm.cpu()
-        assert params_gpu1[1].device == tvm.cpu()
-        np.testing.assert_array_equal(
-            params_gpu1[0].numpy(),
-            [
-                [8, 9, 10, 11],
-                [12, 13, 14, 15],
-            ],
-        )
-        np.testing.assert_array_equal(
-            params_gpu1[1].numpy(),
-            [[1], [3]],
-        )
+                params = transform_params(worker_id, fget_item)
+
+                # Worker 0 is the same PID as the controlling scope, so
+                # `debug_get_from_remote(0)` returns the Tensor containing
+                # the output.
+                params_gpu0 = params.debug_get_from_remote(0)
+                assert params_gpu0[0].device == tvm.cuda(0)
+                assert params_gpu0[1].device == tvm.cuda(0)
+                np.testing.assert_array_equal(
+                    params_gpu0[0].numpy(),
+                    [
+                        [0, 1, 2, 3],
+                        [4, 5, 6, 7],
+                    ],
+                )
+                np.testing.assert_array_equal(
+                    params_gpu0[1].numpy(),
+                    [[0], [2]],
+                )
+
+                # Worker 1 is a different PID altogether, so
+                # `debug_get_from_remote(1)` returns a new Tensor within the
+                # calling scope's PID.
+                params_gpu1 = params.debug_get_from_remote(1)
+                assert params_gpu1[0].device == tvm.cpu()
+                assert params_gpu1[1].device == tvm.cpu()
+                np.testing.assert_array_equal(
+                    params_gpu1[0].numpy(),
+                    [
+                        [8, 9, 10, 11],
+                        [12, 13, 14, 15],
+                    ],
+                )
+                np.testing.assert_array_equal(
+                    params_gpu1[1].numpy(),
+                    [[1], [3]],
+                )
+            finally:
+                session.shutdown()
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 if __name__ == "__main__":

--- a/tests/python/disco/test_ccl.py
+++ b/tests/python/disco/test_ccl.py
@@ -47,134 +47,153 @@ def create_device_target(ccl):
     return (dev, target)
 
 
+def _run_with_ccl_session(session_kind, ccl, devices, func, *, num_groups=1):
+    def run():
+        sess = session_kind(num_workers=len(devices), num_groups=num_groups)
+        try:
+            sess.init_ccl(ccl, *devices)
+            return func(sess)
+        finally:
+            sess.shutdown()
+
+    return tvm.testing.run_with_gpu_lock(run)
+
+
 @pytest.mark.parametrize("session_kind", _all_session_kinds)
 @pytest.mark.parametrize("ccl", _ccl)
 def test_init(session_kind, ccl):
     devices = [0, 1]
-    sess = session_kind(num_workers=len(devices))
-    sess.init_ccl(ccl, *devices)
+
+    def run_test(_sess):
+        pass
+
+    _run_with_ccl_session(session_kind, ccl, devices, run_test)
 
 
 @pytest.mark.parametrize("session_kind", _all_session_kinds)
 @pytest.mark.parametrize("ccl", _ccl)
 def test_allreduce(session_kind, ccl):
     devices = [0, 1]
-    sess = session_kind(num_workers=len(devices))
-    sess.init_ccl(ccl, *devices)
-
     array_1 = np.arange(12, dtype="float32").reshape(3, 4)
     array_2 = np.arange(start=1, stop=-11, step=-1, dtype="float32").reshape(3, 4)
-    d_array = sess.empty((3, 4), "float32")
-    d_array.debug_copy_from(0, array_1)
-    d_array.debug_copy_from(1, array_2)
-    for op, np_op in [  # pylint: disable=invalid-name
-        ("sum", np.add),
-        ("prod", np.multiply),
-        ("min", np.minimum),
-        ("max", np.maximum),
-        ("avg", lambda a, b: (a + b) * 0.5),
-    ]:
-        dst_array = sess.empty((3, 4), "float32")
-        sess.allreduce(d_array, dst_array, op=op)
-        result = dst_array.debug_get_from_remote(0).numpy()
-        expected = np_op(array_1, array_2)
-        np.testing.assert_equal(result, expected)
+
+    def run_test(sess):
+        d_array = sess.empty((3, 4), "float32")
+        d_array.debug_copy_from(0, array_1)
+        d_array.debug_copy_from(1, array_2)
+        for op, np_op in [  # pylint: disable=invalid-name
+            ("sum", np.add),
+            ("prod", np.multiply),
+            ("min", np.minimum),
+            ("max", np.maximum),
+            ("avg", lambda a, b: (a + b) * 0.5),
+        ]:
+            dst_array = sess.empty((3, 4), "float32")
+            sess.allreduce(d_array, dst_array, op=op)
+            result = dst_array.debug_get_from_remote(0).numpy()
+            expected = np_op(array_1, array_2)
+            np.testing.assert_equal(result, expected)
+
+    _run_with_ccl_session(session_kind, ccl, devices, run_test)
 
 
 @pytest.mark.parametrize("session_kind", _all_session_kinds)
 @pytest.mark.parametrize("ccl", _ccl)
 def test_group_allreduce(session_kind, ccl):
     devices = [0, 1, 2, 3]
-    sess = session_kind(num_workers=len(devices), num_groups=2)
-    sess.init_ccl(ccl, *devices)
-
     array_1 = np.arange(12, dtype="float32").reshape(3, 4)
     array_2 = np.arange(start=1, stop=-11, step=-1, dtype="float32").reshape(3, 4)
     array_3 = np.arange(30, dtype="float32").reshape(5, 6)
     array_4 = np.arange(start=1, stop=-29, step=-1, dtype="float32").reshape(5, 6)
-    d_array_1 = sess.empty((3, 4), "float32")
-    d_array_2 = sess.empty((5, 6), "float32")
-    d_array_1.debug_copy_from(0, array_1)
-    d_array_1.debug_copy_from(1, array_2)
-    d_array_2.debug_copy_from(2, array_3)
-    d_array_2.debug_copy_from(3, array_4)
-    for op, np_op in [  # pylint: disable=invalid-name
-        ("sum", np.add),
-        ("prod", np.multiply),
-        ("min", np.minimum),
-        ("max", np.maximum),
-        ("avg", lambda a, b: (a + b) * 0.5),
-    ]:
-        dst_array_1 = sess.empty((3, 4), "float32")
-        dst_array_2 = sess.empty((5, 6), "float32")
-        sess.allreduce(d_array_1, dst_array_1, op=op, in_group=True)
-        sess.allreduce(d_array_2, dst_array_2, op=op, in_group=True)
-        result_1 = dst_array_1.debug_get_from_remote(0).numpy()
-        result_2 = dst_array_2.debug_get_from_remote(2).numpy()
-        expected_1 = np_op(array_1, array_2)
-        expected_2 = np_op(array_3, array_4)
-        np.testing.assert_equal(result_1, expected_1)
-        np.testing.assert_equal(result_2, expected_2)
+
+    def run_test(sess):
+        d_array_1 = sess.empty((3, 4), "float32")
+        d_array_2 = sess.empty((5, 6), "float32")
+        d_array_1.debug_copy_from(0, array_1)
+        d_array_1.debug_copy_from(1, array_2)
+        d_array_2.debug_copy_from(2, array_3)
+        d_array_2.debug_copy_from(3, array_4)
+        for op, np_op in [  # pylint: disable=invalid-name
+            ("sum", np.add),
+            ("prod", np.multiply),
+            ("min", np.minimum),
+            ("max", np.maximum),
+            ("avg", lambda a, b: (a + b) * 0.5),
+        ]:
+            dst_array_1 = sess.empty((3, 4), "float32")
+            dst_array_2 = sess.empty((5, 6), "float32")
+            sess.allreduce(d_array_1, dst_array_1, op=op, in_group=True)
+            sess.allreduce(d_array_2, dst_array_2, op=op, in_group=True)
+            result_1 = dst_array_1.debug_get_from_remote(0).numpy()
+            result_2 = dst_array_2.debug_get_from_remote(2).numpy()
+            expected_1 = np_op(array_1, array_2)
+            expected_2 = np_op(array_3, array_4)
+            np.testing.assert_equal(result_1, expected_1)
+            np.testing.assert_equal(result_2, expected_2)
+
+    _run_with_ccl_session(session_kind, ccl, devices, run_test, num_groups=2)
 
 
 @pytest.mark.parametrize("session_kind", _all_session_kinds)
 @pytest.mark.parametrize("ccl", _ccl)
 def test_allgather(session_kind, ccl):
     devices = [0, 1]
-    sess = session_kind(num_workers=len(devices))
-    sess.init_ccl(ccl, *devices)
-
     array = np.arange(36, dtype="float32")
-    d_src = sess.empty((3, 3, 2), "float32")
-    d_dst = sess.empty((3, 4, 3), "float32")
-    d_src.debug_copy_from(0, array[:18])
-    d_src.debug_copy_from(1, array[18:])
-    sess.allgather(d_src, d_dst)
-    np.testing.assert_equal(
-        d_dst.debug_get_from_remote(0).numpy(),
-        array.reshape(3, 4, 3),
-    )
-    np.testing.assert_equal(
-        d_dst.debug_get_from_remote(1).numpy(),
-        array.reshape(3, 4, 3),
-    )
+
+    def run_test(sess):
+        d_src = sess.empty((3, 3, 2), "float32")
+        d_dst = sess.empty((3, 4, 3), "float32")
+        d_src.debug_copy_from(0, array[:18])
+        d_src.debug_copy_from(1, array[18:])
+        sess.allgather(d_src, d_dst)
+        np.testing.assert_equal(
+            d_dst.debug_get_from_remote(0).numpy(),
+            array.reshape(3, 4, 3),
+        )
+        np.testing.assert_equal(
+            d_dst.debug_get_from_remote(1).numpy(),
+            array.reshape(3, 4, 3),
+        )
+
+    _run_with_ccl_session(session_kind, ccl, devices, run_test)
 
 
 @pytest.mark.parametrize("session_kind", _all_session_kinds)
 @pytest.mark.parametrize("ccl", _ccl)
 def test_group_allgather(session_kind, ccl):
     devices = [0, 1, 2, 3]
-    sess = session_kind(num_workers=len(devices), num_groups=2)
-    sess.init_ccl(ccl, *devices)
-
     array_1 = np.arange(36, dtype="float32")
     array_2 = np.arange(48, dtype="float32")
-    d_src_1 = sess.empty((3, 3, 2), "float32")
-    d_dst_1 = sess.empty((3, 4, 3), "float32")
-    d_src_2 = sess.empty((2, 4, 3), "float32")
-    d_dst_2 = sess.empty((2, 6, 4), "float32")
-    d_src_1.debug_copy_from(0, array_1[:18])
-    d_src_1.debug_copy_from(1, array_1[18:])
-    d_src_2.debug_copy_from(2, array_2[:24])
-    d_src_2.debug_copy_from(3, array_2[24:])
-    sess.allgather(d_src_1, d_dst_1, in_group=True)
-    sess.allgather(d_src_2, d_dst_2, in_group=True)
-    np.testing.assert_equal(
-        d_dst_1.debug_get_from_remote(0).numpy(),
-        array_1.reshape(3, 4, 3),
-    )
-    np.testing.assert_equal(
-        d_dst_1.debug_get_from_remote(1).numpy(),
-        array_1.reshape(3, 4, 3),
-    )
-    np.testing.assert_equal(
-        d_dst_2.debug_get_from_remote(2).numpy(),
-        array_2.reshape(2, 6, 4),
-    )
-    np.testing.assert_equal(
-        d_dst_2.debug_get_from_remote(3).numpy(),
-        array_2.reshape(2, 6, 4),
-    )
+
+    def run_test(sess):
+        d_src_1 = sess.empty((3, 3, 2), "float32")
+        d_dst_1 = sess.empty((3, 4, 3), "float32")
+        d_src_2 = sess.empty((2, 4, 3), "float32")
+        d_dst_2 = sess.empty((2, 6, 4), "float32")
+        d_src_1.debug_copy_from(0, array_1[:18])
+        d_src_1.debug_copy_from(1, array_1[18:])
+        d_src_2.debug_copy_from(2, array_2[:24])
+        d_src_2.debug_copy_from(3, array_2[24:])
+        sess.allgather(d_src_1, d_dst_1, in_group=True)
+        sess.allgather(d_src_2, d_dst_2, in_group=True)
+        np.testing.assert_equal(
+            d_dst_1.debug_get_from_remote(0).numpy(),
+            array_1.reshape(3, 4, 3),
+        )
+        np.testing.assert_equal(
+            d_dst_1.debug_get_from_remote(1).numpy(),
+            array_1.reshape(3, 4, 3),
+        )
+        np.testing.assert_equal(
+            d_dst_2.debug_get_from_remote(2).numpy(),
+            array_2.reshape(2, 6, 4),
+        )
+        np.testing.assert_equal(
+            d_dst_2.debug_get_from_remote(3).numpy(),
+            array_2.reshape(2, 6, 4),
+        )
+
+    _run_with_ccl_session(session_kind, ccl, devices, run_test, num_groups=2)
 
 
 @pytest.mark.parametrize("session_kind", _all_session_kinds)
@@ -182,44 +201,44 @@ def test_group_allgather(session_kind, ccl):
 @pytest.mark.parametrize("use_explicit_output", [True, False])
 def test_broadcast(session_kind, ccl, use_explicit_output):
     devices = [0, 1]
-    sess = session_kind(num_workers=len(devices))
-    sess.init_ccl(ccl, *devices)
-
     array = np.arange(12, dtype="float32").reshape(3, 4)
 
-    if use_explicit_output:
-        src_array = sess.empty((3, 4), "float32", worker0_only=True)
-        src_array.debug_copy_from(0, array)
-        dst_array = sess.empty((3, 4), "float32")
-        sess.broadcast_from_worker0(src_array, dst_array)
-    else:
-        dst_array = sess.broadcast(array)
+    def run_test(sess):
+        if use_explicit_output:
+            src_array = sess.empty((3, 4), "float32", worker0_only=True)
+            src_array.debug_copy_from(0, array)
+            dst_array = sess.empty((3, 4), "float32")
+            sess.broadcast_from_worker0(src_array, dst_array)
+        else:
+            dst_array = sess.broadcast(array)
 
-    result = dst_array.debug_get_from_remote(1).numpy()
-    np.testing.assert_equal(result, array)
+        result = dst_array.debug_get_from_remote(1).numpy()
+        np.testing.assert_equal(result, array)
+
+    _run_with_ccl_session(session_kind, ccl, devices, run_test)
 
 
 @pytest.mark.parametrize("session_kind", _all_session_kinds)
 @pytest.mark.parametrize("ccl", _ccl)
 def test_group_broadcast(session_kind, ccl):
     devices = [0, 1, 2, 3]
-    sess = session_kind(num_workers=len(devices), num_groups=2)
-    sess.init_ccl(ccl, *devices)
-
     array_1 = np.arange(12, dtype="float32").reshape(3, 4)
     array_2 = np.multiply(array_1, -1)
 
-    src_array = sess.empty((3, 4), "float32", worker0_only=True, in_group=True)
-    src_array.debug_copy_from(0, array_1)
-    src_array.debug_copy_from(2, array_2)
-    dst_array = sess.empty((3, 4), "float32")
-    sess.broadcast_from_worker0(src_array, dst_array)
+    def run_test(sess):
+        src_array = sess.empty((3, 4), "float32", worker0_only=True, in_group=True)
+        src_array.debug_copy_from(0, array_1)
+        src_array.debug_copy_from(2, array_2)
+        dst_array = sess.empty((3, 4), "float32")
+        sess.broadcast_from_worker0(src_array, dst_array)
 
-    result_1 = dst_array.debug_get_from_remote(1).numpy()
-    np.testing.assert_equal(result_1, array_1)
+        result_1 = dst_array.debug_get_from_remote(1).numpy()
+        np.testing.assert_equal(result_1, array_1)
 
-    result_3 = dst_array.debug_get_from_remote(3).numpy()
-    np.testing.assert_equal(result_3, array_2)
+        result_3 = dst_array.debug_get_from_remote(3).numpy()
+        np.testing.assert_equal(result_3, array_2)
+
+    _run_with_ccl_session(session_kind, ccl, devices, run_test, num_groups=2)
 
 
 @pytest.mark.parametrize("session_kind", _all_session_kinds)
@@ -227,71 +246,71 @@ def test_group_broadcast(session_kind, ccl):
 @pytest.mark.parametrize("use_explicit_output", [True, False])
 def test_scatter(session_kind, ccl, use_explicit_output, capfd):
     devices = [0, 1]
-    sess = session_kind(num_workers=len(devices))
-    sess.init_ccl(ccl, *devices)
-
     array = np.arange(36, dtype="float32").reshape(2, 6, 3)
 
-    if use_explicit_output:
-        d_src = sess.empty((2, 6, 3), "float32", worker0_only=True)
-        d_dst = sess.empty((6, 3), "float32")
-        d_src.debug_copy_from(0, array)
-        sess.scatter_from_worker0(d_src, d_dst)
-    else:
-        d_dst = sess.scatter(array)
+    def run_test(sess):
+        if use_explicit_output:
+            d_src = sess.empty((2, 6, 3), "float32", worker0_only=True)
+            d_dst = sess.empty((6, 3), "float32")
+            d_src.debug_copy_from(0, array)
+            sess.scatter_from_worker0(d_src, d_dst)
+        else:
+            d_dst = sess.scatter(array)
 
-    np.testing.assert_equal(
-        d_dst.debug_get_from_remote(0).numpy(),
-        array[0, :, :],
-    )
-    np.testing.assert_equal(
-        d_dst.debug_get_from_remote(1).numpy(),
-        array[1, :, :],
-    )
+        np.testing.assert_equal(
+            d_dst.debug_get_from_remote(0).numpy(),
+            array[0, :, :],
+        )
+        np.testing.assert_equal(
+            d_dst.debug_get_from_remote(1).numpy(),
+            array[1, :, :],
+        )
 
-    captured = capfd.readouterr()
-    assert not captured.err, (
-        "No warning messages should be generated from disco.Session.scatter_from_worker0"
-    )
+        captured = capfd.readouterr()
+        assert not captured.err, (
+            "No warning messages should be generated from disco.Session.scatter_from_worker0"
+        )
+
+    _run_with_ccl_session(session_kind, ccl, devices, run_test)
 
 
 @pytest.mark.parametrize("session_kind", _all_session_kinds)
 @pytest.mark.parametrize("ccl", _ccl)
 def test_group_scatter(session_kind, ccl, capfd):
     devices = [0, 1, 2, 3]
-    sess = session_kind(num_workers=len(devices), num_groups=2)
-    sess.init_ccl(ccl, *devices)
-
     array_1 = np.arange(36, dtype="float32").reshape(2, 6, 3)
     array_2 = np.multiply(array_1, -1)
 
-    d_src = sess.empty((2, 6, 3), "float32", worker0_only=True, in_group=True)
-    d_src.debug_copy_from(0, array_1)
-    d_src.debug_copy_from(2, array_2)
-    d_dst = sess.empty((6, 3), "float32")
-    sess.scatter_from_worker0(d_src, d_dst)
+    def run_test(sess):
+        d_src = sess.empty((2, 6, 3), "float32", worker0_only=True, in_group=True)
+        d_src.debug_copy_from(0, array_1)
+        d_src.debug_copy_from(2, array_2)
+        d_dst = sess.empty((6, 3), "float32")
+        sess.scatter_from_worker0(d_src, d_dst)
 
-    np.testing.assert_equal(
-        d_dst.debug_get_from_remote(0).numpy(),
-        array_1[0, :, :],
-    )
-    np.testing.assert_equal(
-        d_dst.debug_get_from_remote(1).numpy(),
-        array_1[1, :, :],
-    )
-    np.testing.assert_equal(
-        d_dst.debug_get_from_remote(2).numpy(),
-        array_2[0, :, :],
-    )
-    np.testing.assert_equal(
-        d_dst.debug_get_from_remote(3).numpy(),
-        array_2[1, :, :],
-    )
+        np.testing.assert_equal(
+            d_dst.debug_get_from_remote(0).numpy(),
+            array_1[0, :, :],
+        )
+        np.testing.assert_equal(
+            d_dst.debug_get_from_remote(1).numpy(),
+            array_1[1, :, :],
+        )
+        np.testing.assert_equal(
+            d_dst.debug_get_from_remote(2).numpy(),
+            array_2[0, :, :],
+        )
+        np.testing.assert_equal(
+            d_dst.debug_get_from_remote(3).numpy(),
+            array_2[1, :, :],
+        )
 
-    captured = capfd.readouterr()
-    assert not captured.err, (
-        "No warning messages should be generated from disco.Session.scatter_from_worker0"
-    )
+        captured = capfd.readouterr()
+        assert not captured.err, (
+            "No warning messages should be generated from disco.Session.scatter_from_worker0"
+        )
+
+    _run_with_ccl_session(session_kind, ccl, devices, run_test, num_groups=2)
 
 
 @pytest.mark.parametrize("session_kind", _all_session_kinds)
@@ -314,130 +333,132 @@ def test_scatter_with_implicit_reshape(session_kind, ccl, capfd):
 
     """
     devices = [0, 1]
-    sess = session_kind(num_workers=len(devices))
-    sess.init_ccl(ccl, *devices)
-
     array = np.arange(36, dtype="float32").reshape(3, 4, 3)
 
-    d_src = sess.empty((3, 4, 3), "float32", worker0_only=True)
-    d_dst = sess.empty((3, 3, 2), "float32")
-    d_src.debug_copy_from(0, array)
-    sess.scatter_from_worker0(d_src, d_dst)
+    def run_test(sess):
+        d_src = sess.empty((3, 4, 3), "float32", worker0_only=True)
+        d_dst = sess.empty((3, 3, 2), "float32")
+        d_src.debug_copy_from(0, array)
+        sess.scatter_from_worker0(d_src, d_dst)
 
-    np.testing.assert_equal(
-        d_dst.debug_get_from_remote(0).numpy(),
-        array.flat[:18].reshape(3, 3, 2),
-    )
-    np.testing.assert_equal(
-        d_dst.debug_get_from_remote(1).numpy(),
-        array.flat[18:].reshape(3, 3, 2),
-    )
+        np.testing.assert_equal(
+            d_dst.debug_get_from_remote(0).numpy(),
+            array.flat[:18].reshape(3, 3, 2),
+        )
+        np.testing.assert_equal(
+            d_dst.debug_get_from_remote(1).numpy(),
+            array.flat[18:].reshape(3, 3, 2),
+        )
 
-    captured = capfd.readouterr()
-    assert not captured.err, (
-        "No warning messages should be generated from disco.Session.scatter_from_worker0"
-    )
+        captured = capfd.readouterr()
+        assert not captured.err, (
+            "No warning messages should be generated from disco.Session.scatter_from_worker0"
+        )
+
+    _run_with_ccl_session(session_kind, ccl, devices, run_test)
 
 
 @pytest.mark.parametrize("session_kind", _all_session_kinds)
 @pytest.mark.parametrize("ccl", _ccl)
 def test_gather(session_kind, ccl, capfd):
     devices = [0, 1]
-    sess = session_kind(num_workers=len(devices))
-    sess.init_ccl(ccl, *devices)
-
     array = np.arange(36, dtype="float32")
-    d_src = sess.empty((3, 3, 2), "float32")
-    d_dst = sess.empty((3, 4, 3), "float32", worker0_only=True)
-    d_src.debug_copy_from(0, array[:18])
-    d_src.debug_copy_from(1, array[18:])
-    sess.gather_to_worker0(d_src, d_dst)
-    np.testing.assert_equal(
-        d_dst.debug_get_from_remote(0).numpy(),
-        array.reshape(3, 4, 3),
-    )
 
-    captured = capfd.readouterr()
-    assert not captured.err, (
-        "No warning messages should be generated from disco.Session.gather_to_worker0"
-    )
+    def run_test(sess):
+        d_src = sess.empty((3, 3, 2), "float32")
+        d_dst = sess.empty((3, 4, 3), "float32", worker0_only=True)
+        d_src.debug_copy_from(0, array[:18])
+        d_src.debug_copy_from(1, array[18:])
+        sess.gather_to_worker0(d_src, d_dst)
+        np.testing.assert_equal(
+            d_dst.debug_get_from_remote(0).numpy(),
+            array.reshape(3, 4, 3),
+        )
+
+        captured = capfd.readouterr()
+        assert not captured.err, (
+            "No warning messages should be generated from disco.Session.gather_to_worker0"
+        )
+
+    _run_with_ccl_session(session_kind, ccl, devices, run_test)
 
 
 @pytest.mark.parametrize("session_kind", _all_session_kinds)
 @pytest.mark.parametrize("ccl", _ccl)
 def test_group_gather(session_kind, ccl, capfd):
     devices = [0, 1, 2, 3]
-    sess = session_kind(num_workers=len(devices), num_groups=2)
-    sess.init_ccl(ccl, *devices)
-
     array_1 = np.arange(36, dtype="float32")
     array_2 = np.multiply(array_1, -1)
-    d_src = sess.empty((3, 3, 2), "float32")
-    d_dst = sess.empty((3, 4, 3), "float32", worker0_only=True, in_group=True)
-    d_src.debug_copy_from(0, array_1[:18])
-    d_src.debug_copy_from(1, array_1[18:])
-    d_src.debug_copy_from(2, array_2[:18])
-    d_src.debug_copy_from(3, array_2[18:])
-    sess.gather_to_worker0(d_src, d_dst)
-    np.testing.assert_equal(
-        d_dst.debug_get_from_remote(0).numpy(),
-        array_1.reshape(3, 4, 3),
-    )
-    np.testing.assert_equal(
-        d_dst.debug_get_from_remote(2).numpy(),
-        array_2.reshape(3, 4, 3),
-    )
 
-    captured = capfd.readouterr()
-    assert not captured.err, (
-        "No warning messages should be generated from disco.Session.gather_to_worker0"
-    )
+    def run_test(sess):
+        d_src = sess.empty((3, 3, 2), "float32")
+        d_dst = sess.empty((3, 4, 3), "float32", worker0_only=True, in_group=True)
+        d_src.debug_copy_from(0, array_1[:18])
+        d_src.debug_copy_from(1, array_1[18:])
+        d_src.debug_copy_from(2, array_2[:18])
+        d_src.debug_copy_from(3, array_2[18:])
+        sess.gather_to_worker0(d_src, d_dst)
+        np.testing.assert_equal(
+            d_dst.debug_get_from_remote(0).numpy(),
+            array_1.reshape(3, 4, 3),
+        )
+        np.testing.assert_equal(
+            d_dst.debug_get_from_remote(2).numpy(),
+            array_2.reshape(3, 4, 3),
+        )
+
+        captured = capfd.readouterr()
+        assert not captured.err, (
+            "No warning messages should be generated from disco.Session.gather_to_worker0"
+        )
+
+    _run_with_ccl_session(session_kind, ccl, devices, run_test, num_groups=2)
 
 
 @pytest.mark.parametrize("session_kind", _all_session_kinds)
 @pytest.mark.parametrize("ccl", _ccl)
 def test_send_to_next_group_receive_from_prev_group(session_kind, ccl):
     devices = [0, 1, 2, 3]
-    sess = session_kind(num_workers=len(devices), num_groups=2)
-    sess.init_ccl(ccl, *devices)
-
     array_1 = np.arange(12, dtype="float32").reshape(3, 4)
     array_2 = np.arange(start=1, stop=-11, step=-1, dtype="float32").reshape(3, 4)
-    d_array = sess.empty((3, 4), "float32")
-    d_array.debug_copy_from(0, array_1)
-    d_array.debug_copy_from(1, array_2)
-    sess.get_global_func("runtime.disco." + ccl + ".test_send_to_next_group_recv_from_prev_group")(
-        d_array
-    )
 
-    result_1 = d_array.debug_get_from_remote(2).numpy()
-    result_2 = d_array.debug_get_from_remote(3).numpy()
-    np.testing.assert_equal(result_1, array_1)
-    np.testing.assert_equal(result_2, array_2)
+    def run_test(sess):
+        d_array = sess.empty((3, 4), "float32")
+        d_array.debug_copy_from(0, array_1)
+        d_array.debug_copy_from(1, array_2)
+        sess.get_global_func(
+            "runtime.disco." + ccl + ".test_send_to_next_group_recv_from_prev_group"
+        )(d_array)
+
+        result_1 = d_array.debug_get_from_remote(2).numpy()
+        result_2 = d_array.debug_get_from_remote(3).numpy()
+        np.testing.assert_equal(result_1, array_1)
+        np.testing.assert_equal(result_2, array_2)
+
+    _run_with_ccl_session(session_kind, ccl, devices, run_test, num_groups=2)
 
 
 @pytest.mark.parametrize("session_kind", _all_session_kinds)
 @pytest.mark.parametrize("ccl", _ccl)
 def test_worker2_send_to_worker0(session_kind, ccl):
     devices = [0, 1, 2, 3]
-    sess = session_kind(num_workers=len(devices), num_groups=2)
-    sess.init_ccl(ccl, *devices)
-
     array = np.arange(start=1, stop=-11, step=-1, dtype="float32").reshape(3, 4)
-    d_array = sess.empty((3, 4), "float32")
-    d_array.debug_copy_from(2, array)
-    sess.get_global_func("runtime.disco." + ccl + ".test_worker2_sends_to_worker0")(d_array)
 
-    result = d_array.debug_get_from_remote(0).numpy()
-    np.testing.assert_equal(result, array)
+    def run_test(sess):
+        d_array = sess.empty((3, 4), "float32")
+        d_array.debug_copy_from(2, array)
+        sess.get_global_func("runtime.disco." + ccl + ".test_worker2_sends_to_worker0")(d_array)
+
+        result = d_array.debug_get_from_remote(0).numpy()
+        np.testing.assert_equal(result, array)
+
+    _run_with_ccl_session(session_kind, ccl, devices, run_test, num_groups=2)
 
 
 @pytest.mark.parametrize("session_kind", _all_session_kinds)
 @pytest.mark.parametrize("ccl", _ccl)
 def test_mlp(session_kind, ccl):  # pylint: disable=too-many-locals
     devices = [0, 1]
-    sess = session_kind(num_workers=len(devices))
-    sess.init_ccl(ccl, *devices)
 
     # pylint: disable=invalid-name
     @tvm.script.ir_module
@@ -493,42 +514,45 @@ def test_mlp(session_kind, ccl):  # pylint: disable=too-many-locals
     X = np.random.randn(128, 128).astype("float32")
     W1 = np.random.randn(128, 128).astype("float32")
     W2 = np.random.randn(128, 128).astype("float32")
-    Y_expected = VirtualMachine(relax_build(MLP, target), device=dev)["main"](
-        tvm.runtime.tensor(X, device=dev),
-        tvm.runtime.tensor(W1, device=dev),
-        tvm.runtime.tensor(W2, device=dev),
-    ).numpy()
+    expected_ex = relax_build(MLP, target)
+    sharded_ex = relax_build(ShardedMLP, target)
 
     with tempfile.TemporaryDirectory() as tmpdir:
         path = tmpdir + "/test.so"
-        relax_build(ShardedMLP, target).export_library(path)
+        sharded_ex.export_library(path)
 
-        mod = sess.load_vm_module(path)
+        def run_test(sess):
+            Y_expected = VirtualMachine(expected_ex, device=dev)["main"](
+                tvm.runtime.tensor(X, device=dev),
+                tvm.runtime.tensor(W1, device=dev),
+                tvm.runtime.tensor(W2, device=dev),
+            ).numpy()
 
-        d_X = sess.empty((128, 128), "float32")
-        d_W1 = sess.empty((128, 64), "float32")
-        d_W2 = sess.empty((64, 128), "float32")
+            mod = sess.load_vm_module(path)
+            d_X = sess.empty((128, 128), "float32")
+            d_W1 = sess.empty((128, 64), "float32")
+            d_W2 = sess.empty((64, 128), "float32")
 
-        d_X.debug_copy_from(0, X)
-        d_W1.debug_copy_from(0, W1[:, :64])
-        d_W1.debug_copy_from(1, W1[:, 64:])
-        d_W2.debug_copy_from(0, W2[:64, :])
-        d_W2.debug_copy_from(1, W2[64:, :])
-        d_Y = mod["main"](d_X, d_W1, d_W2)
-        Y_result = tvm.runtime.empty((128, 128), "float32", device=dev)
-        sess.copy_from_worker_0(Y_result, d_Y)
-        sess.sync_worker_0()
-        Y_result = Y_result.numpy()
+            d_X.debug_copy_from(0, X)
+            d_W1.debug_copy_from(0, W1[:, :64])
+            d_W1.debug_copy_from(1, W1[:, 64:])
+            d_W2.debug_copy_from(0, W2[:64, :])
+            d_W2.debug_copy_from(1, W2[64:, :])
+            d_Y = mod["main"](d_X, d_W1, d_W2)
+            Y_result = tvm.runtime.empty((128, 128), "float32", device=dev)
+            sess.copy_from_worker_0(Y_result, d_Y)
+            sess.sync_worker_0()
+            Y_result = Y_result.numpy()
+            tvm.testing.assert_allclose(Y_result, Y_expected, rtol=1e-4, atol=1e-4)
+
+        _run_with_ccl_session(session_kind, ccl, devices, run_test)
     # pylint: enable=invalid-name
-    tvm.testing.assert_allclose(Y_result, Y_expected, rtol=1e-4, atol=1e-4)
 
 
 @pytest.mark.parametrize("session_kind", _all_session_kinds)
 @pytest.mark.parametrize("ccl", _ccl)
 def test_attention(session_kind, ccl):  # pylint: disable=too-many-locals,too-many-statements
     devices = [0, 1]
-    sess = session_kind(num_workers=len(devices))
-    sess.init_ccl(ccl, *devices)
 
     # pylint: disable=invalid-name
     @tvm.script.ir_module
@@ -634,42 +658,47 @@ def test_attention(session_kind, ccl):  # pylint: disable=too-many-locals,too-ma
     Wk = np.random.randn(128, 512).astype("float32")
     Wv = np.random.randn(128, 512).astype("float32")
     Wo = np.random.randn(512, 128).astype("float32")
-    Y_expected = VirtualMachine(relax_build(Attention, target), device=dev)["main"](
-        tvm.runtime.tensor(X, device=dev),
-        tvm.runtime.tensor(Wq, device=dev),
-        tvm.runtime.tensor(Wk, device=dev),
-        tvm.runtime.tensor(Wv, device=dev),
-        tvm.runtime.tensor(Wo, device=dev),
-    ).numpy()
+    expected_ex = relax_build(Attention, target)
+    sharded_ex = relax_build(ShardedAttention, target)
 
     with tempfile.TemporaryDirectory() as tmpdir:
         path = tmpdir + "/test.so"
-        relax_build(ShardedAttention, target).export_library(path)
+        sharded_ex.export_library(path)
 
-        mod = sess.load_vm_module(path)
+        def run_test(sess):
+            Y_expected = VirtualMachine(expected_ex, device=dev)["main"](
+                tvm.runtime.tensor(X, device=dev),
+                tvm.runtime.tensor(Wq, device=dev),
+                tvm.runtime.tensor(Wk, device=dev),
+                tvm.runtime.tensor(Wv, device=dev),
+                tvm.runtime.tensor(Wo, device=dev),
+            ).numpy()
 
-        d_X = sess.empty((1, 10, 128), "float32")
-        d_Wq = sess.empty((128, 256), "float32")
-        d_Wk = sess.empty((128, 256), "float32")
-        d_Wv = sess.empty((128, 256), "float32")
-        d_Wo = sess.empty((256, 128), "float32")
+            mod = sess.load_vm_module(path)
+            d_X = sess.empty((1, 10, 128), "float32")
+            d_Wq = sess.empty((128, 256), "float32")
+            d_Wk = sess.empty((128, 256), "float32")
+            d_Wv = sess.empty((128, 256), "float32")
+            d_Wo = sess.empty((256, 128), "float32")
 
-        d_X.debug_copy_from(0, X)
-        d_Wq.debug_copy_from(0, Wq[:, :256])
-        d_Wq.debug_copy_from(1, Wq[:, 256:])
-        d_Wk.debug_copy_from(0, Wk[:, :256])
-        d_Wk.debug_copy_from(1, Wk[:, 256:])
-        d_Wv.debug_copy_from(0, Wv[:, :256])
-        d_Wv.debug_copy_from(1, Wv[:, 256:])
-        d_Wo.debug_copy_from(0, Wo[:256, :])
-        d_Wo.debug_copy_from(1, Wo[256:, :])
-        d_Y = mod["main"](d_X, d_Wq, d_Wk, d_Wv, d_Wo)
-        Y_result = tvm.runtime.empty((1, 10, 128), "float32", device=dev)
-        sess.copy_from_worker_0(Y_result, d_Y)
-        sess.sync_worker_0()
-        Y_result = Y_result.numpy()
+            d_X.debug_copy_from(0, X)
+            d_Wq.debug_copy_from(0, Wq[:, :256])
+            d_Wq.debug_copy_from(1, Wq[:, 256:])
+            d_Wk.debug_copy_from(0, Wk[:, :256])
+            d_Wk.debug_copy_from(1, Wk[:, 256:])
+            d_Wv.debug_copy_from(0, Wv[:, :256])
+            d_Wv.debug_copy_from(1, Wv[:, 256:])
+            d_Wo.debug_copy_from(0, Wo[:256, :])
+            d_Wo.debug_copy_from(1, Wo[256:, :])
+            d_Y = mod["main"](d_X, d_Wq, d_Wk, d_Wv, d_Wo)
+            Y_result = tvm.runtime.empty((1, 10, 128), "float32", device=dev)
+            sess.copy_from_worker_0(Y_result, d_Y)
+            sess.sync_worker_0()
+            Y_result = Y_result.numpy()
+            tvm.testing.assert_allclose(Y_result, Y_expected, rtol=1e-3, atol=1e-3)
+
+        _run_with_ccl_session(session_kind, ccl, devices, run_test)
     # pylint: enable=invalid-name
-    tvm.testing.assert_allclose(Y_result, Y_expected, rtol=1e-3, atol=1e-3)
 
 
 if __name__ == "__main__":

--- a/tests/python/disco/test_ccl.py
+++ b/tests/python/disco/test_ccl.py
@@ -48,7 +48,7 @@ def create_device_target(ccl):
 
 
 def _run_with_ccl_session(session_kind, ccl, devices, func, *, num_groups=1):
-    def run():
+    def run_and_check():
         sess = session_kind(num_workers=len(devices), num_groups=num_groups)
         try:
             sess.init_ccl(ccl, *devices)
@@ -56,7 +56,7 @@ def _run_with_ccl_session(session_kind, ccl, devices, func, *, num_groups=1):
         finally:
             sess.shutdown()
 
-    return tvm.testing.run_with_gpu_lock(run)
+    return tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.parametrize("session_kind", _all_session_kinds)

--- a/tests/python/disco/test_loader.py
+++ b/tests/python/disco/test_loader.py
@@ -49,7 +49,7 @@ pytestmark = [
 
 
 def _run_with_nccl_session(devices, func):
-    def run():
+    def run_and_check():
         sess = di.ThreadedSession(num_workers=len(devices))
         try:
             sess.init_ccl("nccl", *devices)
@@ -57,7 +57,7 @@ def _run_with_nccl_session(devices, func):
         finally:
             sess.shutdown()
 
-    return tvm.testing.run_with_gpu_lock(run)
+    return tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @register_global_func("tests.disco.shard_dim_0", override=True)

--- a/tests/python/disco/test_loader.py
+++ b/tests/python/disco/test_loader.py
@@ -48,6 +48,18 @@ pytestmark = [
 ]
 
 
+def _run_with_nccl_session(devices, func):
+    def run():
+        sess = di.ThreadedSession(num_workers=len(devices))
+        try:
+            sess.init_ccl("nccl", *devices)
+            return func(sess)
+        finally:
+            sess.shutdown()
+
+    return tvm.testing.run_with_gpu_lock(run)
+
+
 @register_global_func("tests.disco.shard_dim_0", override=True)
 def _shard_dim_0(src, num_shards, tgt):
     s_0, s_1 = src.shape
@@ -158,28 +170,30 @@ def test_load_shard():
         ],
     }
     with tempfile.TemporaryDirectory() as path:
-        sess = di.ThreadedSession(num_workers=len(devices))
-        sess.init_ccl("nccl", *devices)
-        loader = _create_loader(sess, path, param_dict, shard_info)
-        loader_load = sess.get_global_func("runtime.disco.ShardLoaderLoad")
-        d_0 = loader_load(loader, Shape([0]))
-        d_1 = loader_load(loader, Shape([1]))
-        np.testing.assert_equal(
-            param_dict["x_0"][:, 0:64],
-            d_0.debug_get_from_remote(0).numpy(),
-        )
-        np.testing.assert_equal(
-            param_dict["x_0"][:, 64:128],
-            d_0.debug_get_from_remote(1).numpy(),
-        )
-        np.testing.assert_equal(
-            param_dict["x_1"][0:16, :],
-            d_1.debug_get_from_remote(0).numpy(),
-        )
-        np.testing.assert_equal(
-            param_dict["x_1"][16:32, :],
-            d_1.debug_get_from_remote(1).numpy(),
-        )
+
+        def run_test(sess):
+            loader = _create_loader(sess, path, param_dict, shard_info)
+            loader_load = sess.get_global_func("runtime.disco.ShardLoaderLoad")
+            d_0 = loader_load(loader, Shape([0]))
+            d_1 = loader_load(loader, Shape([1]))
+            np.testing.assert_equal(
+                param_dict["x_0"][:, 0:64],
+                d_0.debug_get_from_remote(0).numpy(),
+            )
+            np.testing.assert_equal(
+                param_dict["x_0"][:, 64:128],
+                d_0.debug_get_from_remote(1).numpy(),
+            )
+            np.testing.assert_equal(
+                param_dict["x_1"][0:16, :],
+                d_1.debug_get_from_remote(0).numpy(),
+            )
+            np.testing.assert_equal(
+                param_dict["x_1"][16:32, :],
+                d_1.debug_get_from_remote(1).numpy(),
+            )
+
+        _run_with_nccl_session(devices, run_test)
 
 
 def _create_presharded_loader(sess, path):
@@ -204,31 +218,32 @@ def test_load_presharded():
 
     with tempfile.TemporaryDirectory() as path:
         _simulate_presharded_weights(path, param_dict, len(devices), shard_info)
-        sess = di.ThreadedSession(num_workers=len(devices))
-        sess.init_ccl("nccl", *devices)
 
-        loader = _create_presharded_loader(sess, path)
-        loader_load = sess.get_global_func("runtime.disco.ShardLoaderLoadPresharded")
+        def run_test(sess):
+            loader = _create_presharded_loader(sess, path)
+            loader_load = sess.get_global_func("runtime.disco.ShardLoaderLoadPresharded")
 
-        d_0 = loader_load(loader, Shape([0]))
-        d_1 = loader_load(loader, Shape([1]))
+            d_0 = loader_load(loader, Shape([0]))
+            d_1 = loader_load(loader, Shape([1]))
 
-        np.testing.assert_equal(
-            param_dict["x_0"][:, 0:64],
-            d_0.debug_get_from_remote(0).numpy(),
-        )
-        np.testing.assert_equal(
-            param_dict["x_0"][:, 64:128],
-            d_0.debug_get_from_remote(1).numpy(),
-        )
-        np.testing.assert_equal(
-            param_dict["x_1"][0:16, :],
-            d_1.debug_get_from_remote(0).numpy(),
-        )
-        np.testing.assert_equal(
-            param_dict["x_1"][16:32, :],
-            d_1.debug_get_from_remote(1).numpy(),
-        )
+            np.testing.assert_equal(
+                param_dict["x_0"][:, 0:64],
+                d_0.debug_get_from_remote(0).numpy(),
+            )
+            np.testing.assert_equal(
+                param_dict["x_0"][:, 64:128],
+                d_0.debug_get_from_remote(1).numpy(),
+            )
+            np.testing.assert_equal(
+                param_dict["x_1"][0:16, :],
+                d_1.debug_get_from_remote(0).numpy(),
+            )
+            np.testing.assert_equal(
+                param_dict["x_1"][16:32, :],
+                d_1.debug_get_from_remote(1).numpy(),
+            )
+
+        _run_with_nccl_session(devices, run_test)
 
 
 def test_load_shard_in_relax():
@@ -298,29 +313,30 @@ def test_load_shard_in_relax():
     )
     with tempfile.TemporaryDirectory() as tmpdir:
         dso_path = tmpdir + "/test.so"
-        sess = di.ThreadedSession(num_workers=len(devices))
-        sess.init_ccl("nccl", *devices)
         relax_build(Module, target).export_library(dso_path)
 
-        mod = sess.load_vm_module(dso_path)
-        loader = _create_loader(sess, tmpdir, param_dict, shard_info)
-        result = mod["main"](loader)
-        np.testing.assert_equal(
-            param_dict["x_0"][:, 0:64],
-            result.debug_get_from_remote(0)[0].numpy(),
-        )
-        np.testing.assert_equal(
-            param_dict["x_0"][:, 64:128],
-            result.debug_get_from_remote(1)[0].numpy(),
-        )
-        np.testing.assert_equal(
-            param_dict["x_1"][0:16, :],
-            result.debug_get_from_remote(0)[1].numpy(),
-        )
-        np.testing.assert_equal(
-            param_dict["x_1"][16:32, :],
-            result.debug_get_from_remote(1)[1].numpy(),
-        )
+        def run_test(sess):
+            mod = sess.load_vm_module(dso_path)
+            loader = _create_loader(sess, tmpdir, param_dict, shard_info)
+            result = mod["main"](loader)
+            np.testing.assert_equal(
+                param_dict["x_0"][:, 0:64],
+                result.debug_get_from_remote(0)[0].numpy(),
+            )
+            np.testing.assert_equal(
+                param_dict["x_0"][:, 64:128],
+                result.debug_get_from_remote(1)[0].numpy(),
+            )
+            np.testing.assert_equal(
+                param_dict["x_1"][0:16, :],
+                result.debug_get_from_remote(0)[1].numpy(),
+            )
+            np.testing.assert_equal(
+                param_dict["x_1"][16:32, :],
+                result.debug_get_from_remote(1)[1].numpy(),
+            )
+
+        _run_with_nccl_session(devices, run_test)
 
 
 def test_load_shard_all():
@@ -347,17 +363,19 @@ def test_load_shard_all():
         ],
     }
     with tempfile.TemporaryDirectory() as path:
-        sess = di.ThreadedSession(num_workers=len(devices))
-        sess.init_ccl("nccl", *devices)
-        loader = _create_loader(sess, path, param_dict, shard_info)
-        loader_load = sess.get_global_func("runtime.disco.ShardLoaderLoadAll")
-        params = loader_load(loader)
-        p_0 = params.debug_get_from_remote(0)
-        p_1 = params.debug_get_from_remote(1)
-        np.testing.assert_equal(param_dict["param_0"][:, 0:64], p_0[0].numpy())
-        np.testing.assert_equal(param_dict["param_0"][:, 64:128], p_1[0].numpy())
-        np.testing.assert_equal(param_dict["param_1"][0:16, :], p_0[1].numpy())
-        np.testing.assert_equal(param_dict["param_1"][16:32, :], p_1[1].numpy())
+
+        def run_test(sess):
+            loader = _create_loader(sess, path, param_dict, shard_info)
+            loader_load = sess.get_global_func("runtime.disco.ShardLoaderLoadAll")
+            params = loader_load(loader)
+            p_0 = params.debug_get_from_remote(0)
+            p_1 = params.debug_get_from_remote(1)
+            np.testing.assert_equal(param_dict["param_0"][:, 0:64], p_0[0].numpy())
+            np.testing.assert_equal(param_dict["param_0"][:, 64:128], p_1[0].numpy())
+            np.testing.assert_equal(param_dict["param_1"][0:16, :], p_0[1].numpy())
+            np.testing.assert_equal(param_dict["param_1"][16:32, :], p_1[1].numpy())
+
+        _run_with_nccl_session(devices, run_test)
 
 
 def test_load_all_presharded():
@@ -374,19 +392,20 @@ def test_load_all_presharded():
     with tempfile.TemporaryDirectory() as path:
         _simulate_presharded_weights(path, param_dict, len(devices), shard_info)
 
-        sess = di.ThreadedSession(num_workers=len(devices))
-        sess.init_ccl("nccl", *devices)
-        loader = _create_presharded_loader(sess, path)
-        loader_load = sess.get_global_func("runtime.disco.ShardLoaderLoadAllPresharded")
-        params = loader_load(loader)
+        def run_test(sess):
+            loader = _create_presharded_loader(sess, path)
+            loader_load = sess.get_global_func("runtime.disco.ShardLoaderLoadAllPresharded")
+            params = loader_load(loader)
 
-        p_0 = params.debug_get_from_remote(0)
-        p_1 = params.debug_get_from_remote(1)
+            p_0 = params.debug_get_from_remote(0)
+            p_1 = params.debug_get_from_remote(1)
 
-        np.testing.assert_equal(param_dict["param_0"][0:32, :], p_0[0].numpy())
-        np.testing.assert_equal(param_dict["param_0"][32:64, :], p_1[0].numpy())
-        np.testing.assert_equal(param_dict["param_1"][:, 0:64], p_0[1].numpy())
-        np.testing.assert_equal(param_dict["param_1"][:, 64:128], p_1[1].numpy())
+            np.testing.assert_equal(param_dict["param_0"][0:32, :], p_0[0].numpy())
+            np.testing.assert_equal(param_dict["param_0"][32:64, :], p_1[0].numpy())
+            np.testing.assert_equal(param_dict["param_1"][:, 0:64], p_0[1].numpy())
+            np.testing.assert_equal(param_dict["param_1"][:, 64:128], p_1[1].numpy())
+
+        _run_with_nccl_session(devices, run_test)
 
 
 def test_load_shard_broadcast():
@@ -397,17 +416,19 @@ def test_load_shard_broadcast():
     }
     shard_info = {}
     with tempfile.TemporaryDirectory() as path:
-        sess = di.ThreadedSession(num_workers=len(devices))
-        sess.init_ccl("nccl", *devices)
-        loader = _create_loader(sess, path, param_dict, shard_info)
-        loader_load = sess.get_global_func("runtime.disco.ShardLoaderLoadAll")
-        params = loader_load(loader)
-        p_0 = params.debug_get_from_remote(0)
-        p_1 = params.debug_get_from_remote(1)
-        np.testing.assert_equal(param_dict["param_0"], p_0[0].numpy())
-        np.testing.assert_equal(param_dict["param_0"], p_1[0].numpy())
-        np.testing.assert_equal(param_dict["param_1"], p_0[1].numpy())
-        np.testing.assert_equal(param_dict["param_1"], p_1[1].numpy())
+
+        def run_test(sess):
+            loader = _create_loader(sess, path, param_dict, shard_info)
+            loader_load = sess.get_global_func("runtime.disco.ShardLoaderLoadAll")
+            params = loader_load(loader)
+            p_0 = params.debug_get_from_remote(0)
+            p_1 = params.debug_get_from_remote(1)
+            np.testing.assert_equal(param_dict["param_0"], p_0[0].numpy())
+            np.testing.assert_equal(param_dict["param_0"], p_1[0].numpy())
+            np.testing.assert_equal(param_dict["param_1"], p_0[1].numpy())
+            np.testing.assert_equal(param_dict["param_1"], p_1[1].numpy())
+
+        _run_with_nccl_session(devices, run_test)
 
 
 def test_load_qkv_proj_shard():  # pylint: disable=too-many-locals
@@ -454,19 +475,21 @@ def test_load_qkv_proj_shard():  # pylint: disable=too-many-locals
     }
 
     with tempfile.TemporaryDirectory() as path:
-        sess = di.ThreadedSession(num_workers=len(devices))
-        sess.init_ccl("nccl", *devices)
-        loader = _create_loader(sess, path, param_dict, shard_info)
-        loader_load = sess.get_global_func("runtime.disco.ShardLoaderLoad")
-        d_0 = loader_load(loader, Shape([0]))
-        np.testing.assert_equal(
-            np_qkv[0],
-            d_0.debug_get_from_remote(0).numpy(),
-        )
-        np.testing.assert_equal(
-            np_qkv[1],
-            d_0.debug_get_from_remote(1).numpy(),
-        )
+
+        def run_test(sess):
+            loader = _create_loader(sess, path, param_dict, shard_info)
+            loader_load = sess.get_global_func("runtime.disco.ShardLoaderLoad")
+            d_0 = loader_load(loader, Shape([0]))
+            np.testing.assert_equal(
+                np_qkv[0],
+                d_0.debug_get_from_remote(0).numpy(),
+            )
+            np.testing.assert_equal(
+                np_qkv[1],
+                d_0.debug_get_from_remote(1).numpy(),
+            )
+
+        _run_with_nccl_session(devices, run_test)
 
 
 if __name__ == "__main__":

--- a/tests/python/disco/test_nvshmem.py
+++ b/tests/python/disco/test_nvshmem.py
@@ -156,7 +156,7 @@ def _run_in_fresh_process(target, *args):
     inheriting CUDA state from this process.
     """
 
-    def run():
+    def run_and_check():
         proc = multiprocessing.get_context("spawn").Process(target=target, args=args)
         proc.start()
         proc.join(timeout=_SUBPROCESS_TIMEOUT_SEC)
@@ -168,7 +168,7 @@ def _run_in_fresh_process(target, *args):
             )
         assert proc.exitcode == 0, f"{target.__name__}{args} failed with exit code {proc.exitcode}"
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 def _require_cuda_devices(num_workers):

--- a/tests/python/disco/test_nvshmem.py
+++ b/tests/python/disco/test_nvshmem.py
@@ -155,14 +155,20 @@ def _run_in_fresh_process(target, *args):
     body must run in its own process. The 'spawn' start method avoids
     inheriting CUDA state from this process.
     """
-    proc = multiprocessing.get_context("spawn").Process(target=target, args=args)
-    proc.start()
-    proc.join(timeout=_SUBPROCESS_TIMEOUT_SEC)
-    if proc.is_alive():
-        proc.kill()
-        proc.join()
-        pytest.fail(f"{target.__name__}{args} timed out after {_SUBPROCESS_TIMEOUT_SEC} seconds")
-    assert proc.exitcode == 0, f"{target.__name__}{args} failed with exit code {proc.exitcode}"
+
+    def run():
+        proc = multiprocessing.get_context("spawn").Process(target=target, args=args)
+        proc.start()
+        proc.join(timeout=_SUBPROCESS_TIMEOUT_SEC)
+        if proc.is_alive():
+            proc.kill()
+            proc.join()
+            pytest.fail(
+                f"{target.__name__}{args} timed out after {_SUBPROCESS_TIMEOUT_SEC} seconds"
+            )
+        assert proc.exitcode == 0, f"{target.__name__}{args} failed with exit code {proc.exitcode}"
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 def _require_cuda_devices(num_workers):

--- a/tests/python/nightly/test_nnapi/test_from_exported_to_cuda.py
+++ b/tests/python/nightly/test_nnapi/test_from_exported_to_cuda.py
@@ -48,23 +48,25 @@ def assert_torch_output_vs_tvm_from_exported_to_cuda(raw_data, torch_module, tar
 
     relax_pipeline = relax.get_default_pipeline(tvm.target.Target.from_device(tvm.cuda()))
     ex = relax.build(tvm_mod, target=target, relax_pipeline=relax_pipeline)
-    vm = relax.VirtualMachine(ex, dev)
-
-    gpu_data = tvm.runtime.tensor(raw_data_for_tvm, dev)
-    gpu_params = [tvm.runtime.tensor(p, dev) for p in tvm_params["main"]]
-    gpu_out = vm["main"](gpu_data, *gpu_params)
-
     pytorch_out = torch_module(torch_data)
 
-    if isinstance(pytorch_out, tuple):
-        for i in range(len(pytorch_out)):
-            actual = gpu_out[i].numpy()
-            desired = pytorch_out[i].detach().numpy()
+    def run_and_check():
+        vm = relax.VirtualMachine(ex, dev)
+        gpu_data = tvm.runtime.tensor(raw_data_for_tvm, dev)
+        gpu_params = [tvm.runtime.tensor(p, dev) for p in tvm_params["main"]]
+        gpu_out = vm["main"](gpu_data, *gpu_params)
+
+        if isinstance(pytorch_out, tuple):
+            for i in range(len(pytorch_out)):
+                actual = gpu_out[i].numpy()
+                desired = pytorch_out[i].detach().numpy()
+                tvm.testing.assert_allclose(actual=actual, desired=desired, rtol=1e-5, atol=1e-5)
+        else:
+            actual = gpu_out[0].numpy()
+            desired = pytorch_out.detach().numpy()
             tvm.testing.assert_allclose(actual=actual, desired=desired, rtol=1e-5, atol=1e-5)
-    else:
-        actual = gpu_out[0].numpy()
-        desired = pytorch_out.detach().numpy()
-        tvm.testing.assert_allclose(actual=actual, desired=desired, rtol=1e-5, atol=1e-5)
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu

--- a/tests/python/relax/backend/adreno/utils.py
+++ b/tests/python/relax/backend/adreno/utils.py
@@ -171,7 +171,7 @@ def build_and_run(mod, inputs, tgt):
 
     ex = tvm.compile(mod, tgt, tir_pipeline=tir_pipeline)
 
-    def execute():
+    def run_and_check():
         with SessionManager() as sess:
             rexec = sess.load_module(ex)
             dev = sess.device(tgt.kind.name)
@@ -190,8 +190,8 @@ def build_and_run(mod, inputs, tgt):
             return (tvm_output.numpy(),)
 
     if SessionManager.is_target_rpc():
-        return execute()
-    return tvm.testing.run_with_gpu_lock(execute)
+        return run_and_check()
+    return tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 def verify_results(mod, target, ref_target):

--- a/tests/python/relax/backend/adreno/utils.py
+++ b/tests/python/relax/backend/adreno/utils.py
@@ -171,27 +171,27 @@ def build_and_run(mod, inputs, tgt):
 
     ex = tvm.compile(mod, tgt, tir_pipeline=tir_pipeline)
 
-    with SessionManager() as sess:
-        rexec = sess.load_module(ex)
-        dev = sess.device(tgt.kind.name)
+    def execute():
+        with SessionManager() as sess:
+            rexec = sess.load_module(ex)
+            dev = sess.device(tgt.kind.name)
 
-        if "vdevice" in mod.global_infos:
-            device_arr = [dev for ii in range(len(mod.global_infos["vdevice"]))]
-        else:
-            device_arr = [dev]
-        vm = relax.VirtualMachine(rexec, device_arr)
-        inputs = [tvm.runtime.tensor(ip, dev) for ip in inputs]
-        vm.set_input("main", *inputs)
+            if "vdevice" in mod.global_infos:
+                device_arr = [dev for _ in range(len(mod.global_infos["vdevice"]))]
+            else:
+                device_arr = [dev]
+            vm = relax.VirtualMachine(rexec, device_arr)
+            device_inputs = [tvm.runtime.tensor(ip, dev) for ip in inputs]
+            vm.set_input("main", *device_inputs)
+            vm.invoke_stateful("main")
+            tvm_output = vm.get_outputs("main")
+            if isinstance(tvm_output, tuple):
+                return tuple(out.numpy() for out in tvm_output)
+            return (tvm_output.numpy(),)
 
-        vm.invoke_stateful("main")
-
-        tvm_output = vm.get_outputs("main")
-        if isinstance(tvm_output, tuple):
-            tvm_output = tuple(out.numpy() for out in tvm_output)
-        else:
-            tvm_output = (tvm_output.numpy(),)
-
-    return tvm_output
+    if SessionManager.is_target_rpc():
+        return execute()
+    return tvm.testing.run_with_gpu_lock(execute)
 
 
 def verify_results(mod, target, ref_target):

--- a/tests/python/relax/nvshmem/test_runtime_builtin_kv_cache_transfer.py
+++ b/tests/python/relax/nvshmem/test_runtime_builtin_kv_cache_transfer.py
@@ -16,6 +16,7 @@
 # under the License.
 # ruff: noqa: E501, E741, F401
 import enum
+import functools
 import itertools
 from typing import Optional, Union
 
@@ -76,7 +77,7 @@ rope_theta = 1e4
 rope_scaling = {}
 dtype = None
 dtype_torch = None
-device = tvm.cuda(rank)
+device = None
 device_torch = torch.device(f"cuda:{rank}")
 
 fclear = None
@@ -112,7 +113,7 @@ fcopy_single_page = None
 fcompact_copy = None
 
 
-def set_global_func(head_dim, dtype):
+def set_global_func(head_dim, dtype, target):
     global fclear, fadd_sequence, fremove_sequence, ffork_sequence, fenable_sliding_window_for_seq
     global fpopn, fbegin_forward, fend_forward, fcommit_accepted_token_tree_nodes
     global fattention_with_fuse_qkv, fis_empty, fdebug_get_kv
@@ -149,7 +150,6 @@ def set_global_func(head_dim, dtype):
     fdisagg_mark_send = tvm.get_global_func("vm.builtin.kv_cache_disagg_mark_send")
     fdisagg_prepare_recv = tvm.get_global_func("vm.builtin.kv_cache_disagg_prepare_recv")
 
-    target = tvm.target.Target.from_device(device)
     builts = []
     for tir_func in [
         _kv_cache_transpose_append(num_kv_heads, head_dim, dtype),
@@ -260,8 +260,43 @@ def kv_cache_and_config(request):
     global head_dim, sm_scale, dtype
     head_dim, dtype, rope_mode, support_sliding_window = request.param
     sm_scale = head_dim ** (-0.5)
-    set_global_func(head_dim, dtype)
-    return create_kv_cache(*request.param), rope_mode, support_sliding_window
+    target = tvm.testing.run_with_gpu_lock(_get_cuda_target)
+    set_global_func(head_dim, dtype, target)
+    return request.param
+
+
+def _get_cuda_target():
+    return tvm.target.Target.from_device(tvm.cuda(rank))
+
+
+def _run_with_kv_cache(test):
+    @functools.wraps(test)
+    def wrapper(kv_cache_and_config):
+        def run():
+            global device
+            device = tvm.cuda(rank)
+            head_dim, dtype, rope_mode, support_sliding_window = kv_cache_and_config
+            try:
+                cache = create_kv_cache(head_dim, dtype, rope_mode, support_sliding_window)
+                return test((cache, rope_mode, support_sliding_window))
+            finally:
+                device = None
+
+        if comm is None:
+            return tvm.testing.run_with_gpu_lock(run)
+
+        def run_rank_group():
+            comm.Barrier()
+            try:
+                return run()
+            finally:
+                comm.Barrier()
+
+        if rank == 0:
+            return tvm.testing.run_with_gpu_lock(run_rank_group)
+        return run_rank_group()
+
+    return wrapper
 
 
 def verify_cached_kv(kv_cache, seq_ids, expected_k, expected_v):
@@ -631,6 +666,7 @@ def apply_attention(
 
 
 @pytest.mark.skip(reason="Require NVSHMEM")
+@_run_with_kv_cache
 def test_paged_attention_kv_cache_prefill_and_decode(kv_cache_and_config):
     kv_cache, rope_mode, support_sliding_window = kv_cache_and_config
     if support_sliding_window and rope_mode == RopeMode.NORMAL:
@@ -655,6 +691,7 @@ def test_paged_attention_kv_cache_prefill_and_decode(kv_cache_and_config):
 
 
 @pytest.mark.skip(reason="Require NVSHMEM")
+@_run_with_kv_cache
 def test_paged_attention_kv_cache_transfer(kv_cache_and_config):
     kv_cache, rope_mode, support_sliding_window = kv_cache_and_config
     if support_sliding_window:
@@ -729,17 +766,4 @@ def init_nvshmem(num_workers, pe_offset):
 
 
 if __name__ == "__main__":
-    # To run this test, install mpi4py first, and then run
-    # mpirun -np 2 python tests/python/relax/nvshmem/test_runtime_builtin_kv_cache_transfer.py
-    HEAD_DIMS = [128]
-    DTYPES = ["float16"]
-    ROPE_MODES = [RopeMode.NONE]
-    SUPPORT_SLIDING_WINDOW = [False]
-    init_nvshmem(2, rank)
-    for head_dim, dtype, rope_mode, support_sliding_window in itertools.product(
-        HEAD_DIMS, DTYPES, ROPE_MODES, SUPPORT_SLIDING_WINDOW
-    ):
-        set_global_func(head_dim, dtype)
-        cache = create_kv_cache(head_dim, dtype, rope_mode, support_sliding_window)
-        cache_and_config = (cache, rope_mode, support_sliding_window)
-        test_paged_attention_kv_cache_transfer(cache_and_config)
+    tvm.testing.main()

--- a/tests/python/relax/nvshmem/test_runtime_builtin_kv_cache_transfer.py
+++ b/tests/python/relax/nvshmem/test_runtime_builtin_kv_cache_transfer.py
@@ -272,7 +272,7 @@ def _get_cuda_target():
 def _run_with_kv_cache(test):
     @functools.wraps(test)
     def wrapper(kv_cache_and_config):
-        def run():
+        def run_device_session():
             global device
             device = tvm.cuda(rank)
             head_dim, dtype, rope_mode, support_sliding_window = kv_cache_and_config
@@ -282,19 +282,18 @@ def _run_with_kv_cache(test):
             finally:
                 device = None
 
-        if comm is None:
-            return tvm.testing.run_with_gpu_lock(run)
-
-        def run_rank_group():
+        def run_and_check():
+            if comm is None:
+                return run_device_session()
             comm.Barrier()
             try:
-                return run()
+                return run_device_session()
             finally:
                 comm.Barrier()
 
-        if rank == 0:
-            return tvm.testing.run_with_gpu_lock(run_rank_group)
-        return run_rank_group()
+        if comm is None or rank == 0:
+            return tvm.testing.run_with_gpu_lock(run_and_check)
+        return run_and_check()
 
     return wrapper
 

--- a/tests/python/relax/nvshmem/test_runtime_builtin_kv_cache_transfer_kernel.py
+++ b/tests/python/relax/nvshmem/test_runtime_builtin_kv_cache_transfer_kernel.py
@@ -14,7 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# ruff: noqa: E501
+import functools
+
 import numpy as np
 import pytest
 from tvm_ffi import Shape
@@ -40,7 +41,27 @@ def get_comm_rank():
     return comm, rank
 
 
+def _run_rank_group_with_gpu_lock(test):
+    @functools.wraps(test)
+    def wrapper():
+        comm, rank = get_comm_rank()
+
+        def run_rank_group():
+            comm.Barrier()
+            try:
+                return test()
+            finally:
+                comm.Barrier()
+
+        if rank == 0:
+            return tvm.testing.run_with_gpu_lock(run_rank_group)
+        return run_rank_group()
+
+    return wrapper
+
+
 @pytest.mark.skip(reason="Require NVSHMEM")
+@_run_rank_group_with_gpu_lock
 def test_kv_transfer_without_disco():
     comm, rank = get_comm_rank()
     layer_id = 1
@@ -95,6 +116,7 @@ def test_kv_transfer_without_disco():
 
 
 @pytest.mark.skip(reason="Require NVSHMEM")
+@_run_rank_group_with_gpu_lock
 def test_kv_transfer_page_to_page_without_disco():
     comm, rank = get_comm_rank()
     layer_id = 1
@@ -161,6 +183,7 @@ def test_kv_transfer_page_to_page_without_disco():
 
 
 @pytest.mark.skip(reason="Require NVSHMEM")
+@_run_rank_group_with_gpu_lock
 def test_kv_transfer_with_disco():
     comm, rank = get_comm_rank()
     layer_id = 1
@@ -241,12 +264,8 @@ def test_kv_transfer_with_disco():
     finalize_dfunc()
     for i in range(2):
         sess._sync_worker(i)
+    sess.shutdown()
 
 
 if __name__ == "__main__":
-    # To run this test, install mpi4py first, and then run
-    # mpirun -np 2 python tests/python/relax/nvshmem/test_runtime_builtin_kv_cache_transfer_kernel.py  # pylint: disable=line-too-long
-    # FIXME: only one test can be run at a time
-    test_kv_transfer_without_disco()
-    # test_kv_transfer_with_disco()
-    # test_kv_transfer_page_to_page_without_disco()
+    tvm.testing.main()

--- a/tests/python/relax/nvshmem/test_runtime_builtin_kv_cache_transfer_kernel.py
+++ b/tests/python/relax/nvshmem/test_runtime_builtin_kv_cache_transfer_kernel.py
@@ -46,7 +46,7 @@ def _run_rank_group_with_gpu_lock(test):
     def wrapper():
         comm, rank = get_comm_rank()
 
-        def run_rank_group():
+        def run_and_check():
             comm.Barrier()
             try:
                 return test()
@@ -54,8 +54,8 @@ def _run_rank_group_with_gpu_lock(test):
                 comm.Barrier()
 
         if rank == 0:
-            return tvm.testing.run_with_gpu_lock(run_rank_group)
-        return run_rank_group()
+            return tvm.testing.run_with_gpu_lock(run_and_check)
+        return run_and_check()
 
     return wrapper
 

--- a/tests/python/relax/test_backend_dispatch_sort_scan.py
+++ b/tests/python/relax/test_backend_dispatch_sort_scan.py
@@ -438,14 +438,14 @@ def test_dispatch_cumsum_gpu(target):
         mod = DispatchSortScan()(Module)
         ex = tvm.compile(mod, target)
 
-    def run():
+    def run_and_check():
         dev = tvm.device(target["kind"] if isinstance(target, dict) else target)
         vm = tvm.relax.VirtualMachine(ex, dev)
         tvm_data = tvm.runtime.tensor(np_data, dev)
         cumsum = vm["main"](tvm_data)
         tvm.testing.assert_allclose(cumsum.numpy(), np_cumsum)
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_backend_dispatch_sort_scan.py
+++ b/tests/python/relax/test_backend_dispatch_sort_scan.py
@@ -421,7 +421,6 @@ def test_dispatch_cumsum_gpu(target):
     """Test cumsum kernel dispatch and numerical correctness"""
     if not tvm.testing.device_enabled(target):
         pytest.skip(f"{target} not enabled")
-    dev = tvm.device(target["kind"] if isinstance(target, dict) else target)
 
     @I.ir_module
     class Module:
@@ -438,10 +437,15 @@ def test_dispatch_cumsum_gpu(target):
     with tvm.target.Target(target):
         mod = DispatchSortScan()(Module)
         ex = tvm.compile(mod, target)
+
+    def run():
+        dev = tvm.device(target["kind"] if isinstance(target, dict) else target)
         vm = tvm.relax.VirtualMachine(ex, dev)
         tvm_data = tvm.runtime.tensor(np_data, dev)
         cumsum = vm["main"](tvm_data)
         tvm.testing.assert_allclose(cumsum.numpy(), np_cumsum)
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_base_py_module.py
+++ b/tests/python/relax/test_base_py_module.py
@@ -64,7 +64,7 @@ class TestBasePyModule:
 
         if tvm.cuda().exist:
 
-            def run():
+            def run_and_check():
                 device = tvm.cuda(0)
                 py_mod = BasePyModule(ir_mod, device)
 
@@ -75,7 +75,7 @@ class TestBasePyModule:
                 # Check if target contains "cuda" instead of exact match
                 assert "cuda" in str(py_mod.target)
 
-            tvm.testing.run_with_gpu_lock(run)
+            tvm.testing.run_with_gpu_lock(run_and_check)
         else:
             pytest.skip("CUDA not available")
 
@@ -117,7 +117,7 @@ class TestBasePyModule:
     def test_call_tir_with_pytorch_tensors_gpu(self):
         if tvm.cuda().exist:
 
-            def run():
+            def run_and_check():
                 # Create a simple IRModule without TIR functions for GPU testing
                 ir_mod = tvm.IRModule({})
                 device = tvm.cuda(0)
@@ -136,7 +136,7 @@ class TestBasePyModule:
                 assert input_tensor.device.type == "cuda"
                 assert input_tensor.shape == (4,)
 
-            tvm.testing.run_with_gpu_lock(run)
+            tvm.testing.run_with_gpu_lock(run_and_check)
         else:
             pytest.skip("CUDA not available")
 

--- a/tests/python/relax/test_base_py_module.py
+++ b/tests/python/relax/test_base_py_module.py
@@ -63,15 +63,19 @@ class TestBasePyModule:
         ir_mod = tvm.IRModule({"simple_func": simple_func})
 
         if tvm.cuda().exist:
-            device = tvm.cuda(0)
-            py_mod = BasePyModule(ir_mod, device)
 
-            assert isinstance(py_mod, BasePyModule)
-            assert hasattr(py_mod, "call_tir")
-            assert hasattr(py_mod, "call_dps_packed")
-            assert hasattr(py_mod, "compiled_tir_funcs")
-            # Check if target contains "cuda" instead of exact match
-            assert "cuda" in str(py_mod.target)
+            def run():
+                device = tvm.cuda(0)
+                py_mod = BasePyModule(ir_mod, device)
+
+                assert isinstance(py_mod, BasePyModule)
+                assert hasattr(py_mod, "call_tir")
+                assert hasattr(py_mod, "call_dps_packed")
+                assert hasattr(py_mod, "compiled_tir_funcs")
+                # Check if target contains "cuda" instead of exact match
+                assert "cuda" in str(py_mod.target)
+
+            tvm.testing.run_with_gpu_lock(run)
         else:
             pytest.skip("CUDA not available")
 
@@ -112,21 +116,27 @@ class TestBasePyModule:
 
     def test_call_tir_with_pytorch_tensors_gpu(self):
         if tvm.cuda().exist:
-            # Create a simple IRModule without TIR functions for GPU testing
-            ir_mod = tvm.IRModule({})
-            device = tvm.cuda(0)
-            py_mod = BasePyModule(ir_mod, device)
 
-            # Test basic GPU functionality without TIR compilation issues
-            assert isinstance(py_mod, BasePyModule)
-            assert hasattr(py_mod, "call_tir")
-            assert hasattr(py_mod, "call_dps_packed")
-            assert "cuda" in str(py_mod.target)
+            def run():
+                # Create a simple IRModule without TIR functions for GPU testing
+                ir_mod = tvm.IRModule({})
+                device = tvm.cuda(0)
+                py_mod = BasePyModule(ir_mod, device)
 
-            # Test that we can create GPU tensors and they work
-            input_tensor = torch.tensor([1.0, 2.0, 3.0, 4.0], dtype=torch.float32, device="cuda")
-            assert input_tensor.device.type == "cuda"
-            assert input_tensor.shape == (4,)
+                # Test basic GPU functionality without TIR compilation issues
+                assert isinstance(py_mod, BasePyModule)
+                assert hasattr(py_mod, "call_tir")
+                assert hasattr(py_mod, "call_dps_packed")
+                assert "cuda" in str(py_mod.target)
+
+                # Test that we can create GPU tensors and they work
+                input_tensor = torch.tensor(
+                    [1.0, 2.0, 3.0, 4.0], dtype=torch.float32, device="cuda"
+                )
+                assert input_tensor.device.type == "cuda"
+                assert input_tensor.shape == (4,)
+
+            tvm.testing.run_with_gpu_lock(run)
         else:
             pytest.skip("CUDA not available")
 

--- a/tests/python/relax/test_codegen_cublas.py
+++ b/tests/python/relax/test_codegen_cublas.py
@@ -50,7 +50,6 @@ pytestmark = [
 
 
 def build_and_run(mod, inputs_np, target, legalize=False, cuda_graph=False):
-    dev = tvm.device(target, 0)
     with tvm.transform.PassContext(
         config={
             "relax.backend.use_cuda_graph": cuda_graph,
@@ -58,16 +57,23 @@ def build_and_run(mod, inputs_np, target, legalize=False, cuda_graph=False):
         }
     ):
         ex = tvm.compile(mod, target)
-    vm = relax.VirtualMachine(ex, dev)
-    f = vm["main"]
-    inputs = [tvm.runtime.tensor(inp, dev) for inp in inputs_np]
 
-    # For cuda graph, run the compiled function twice to make sure that we can launch the cached
-    # graph on the second run.
-    if cuda_graph:
-        f(*inputs)
+    def run():
+        dev = tvm.device(target, 0)
+        vm = relax.VirtualMachine(ex, dev)
+        f = vm["main"]
+        inputs = [tvm.runtime.tensor(inp, dev) for inp in inputs_np]
 
-    return f(*inputs).numpy()
+        # For cuda graph, run the compiled function twice to make sure that we can launch the
+        # cached graph on the second run.
+        if cuda_graph:
+            f(*inputs)
+
+        return f(*inputs).numpy()
+
+    if tvm.target.Target(target).kind.name == "cuda":
+        return tvm.testing.run_with_gpu_lock(run)
+    return run()
 
 
 def get_result_with_relax_cublas_offload(mod, np_inputs, cuda_graph=False, bind_constants=False):

--- a/tests/python/relax/test_codegen_cublas.py
+++ b/tests/python/relax/test_codegen_cublas.py
@@ -58,7 +58,7 @@ def build_and_run(mod, inputs_np, target, legalize=False, cuda_graph=False):
     ):
         ex = tvm.compile(mod, target)
 
-    def run():
+    def run_and_check():
         dev = tvm.device(target, 0)
         vm = relax.VirtualMachine(ex, dev)
         f = vm["main"]
@@ -72,8 +72,8 @@ def build_and_run(mod, inputs_np, target, legalize=False, cuda_graph=False):
         return f(*inputs).numpy()
 
     if tvm.target.Target(target).kind.name == "cuda":
-        return tvm.testing.run_with_gpu_lock(run)
-    return run()
+        return tvm.testing.run_with_gpu_lock(run_and_check)
+    return run_and_check()
 
 
 def get_result_with_relax_cublas_offload(mod, np_inputs, cuda_graph=False, bind_constants=False):

--- a/tests/python/relax/test_codegen_cudnn.py
+++ b/tests/python/relax/test_codegen_cudnn.py
@@ -111,7 +111,6 @@ def get_result_with_relax_cudnn_offload(mod, np_inputs, cuda_graph=False):
 
 
 def build_and_run(mod, inputs_np, target, legalize=False, cuda_graph=False):
-    dev = tvm.device(target, 0)
     with tvm.transform.PassContext(
         config={
             "relax.backend.use_cuda_graph": cuda_graph,
@@ -119,16 +118,23 @@ def build_and_run(mod, inputs_np, target, legalize=False, cuda_graph=False):
         }
     ):
         ex = tvm.compile(mod, target)
-    vm = relax.VirtualMachine(ex, dev)
-    f = vm["main"]
-    inputs = [tvm.runtime.tensor(inp, dev) for inp in inputs_np]
 
-    # For cuda graph, run the compiled function twice to make sure that we can launch the cached
-    # graph on the second run.
-    if cuda_graph:
-        f(*inputs)
+    def run():
+        dev = tvm.device(target, 0)
+        vm = relax.VirtualMachine(ex, dev)
+        f = vm["main"]
+        inputs = [tvm.runtime.tensor(inp, dev) for inp in inputs_np]
 
-    return f(*inputs).numpy()
+        # For cuda graph, run the compiled function twice to make sure that we can launch the
+        # cached graph on the second run.
+        if cuda_graph:
+            f(*inputs)
+
+        return f(*inputs).numpy()
+
+    if tvm.target.Target(target).kind.name == "cuda":
+        return tvm.testing.run_with_gpu_lock(run)
+    return run()
 
 
 @pytest.mark.parametrize(

--- a/tests/python/relax/test_codegen_cudnn.py
+++ b/tests/python/relax/test_codegen_cudnn.py
@@ -119,7 +119,7 @@ def build_and_run(mod, inputs_np, target, legalize=False, cuda_graph=False):
     ):
         ex = tvm.compile(mod, target)
 
-    def run():
+    def run_and_check():
         dev = tvm.device(target, 0)
         vm = relax.VirtualMachine(ex, dev)
         f = vm["main"]
@@ -133,8 +133,8 @@ def build_and_run(mod, inputs_np, target, legalize=False, cuda_graph=False):
         return f(*inputs).numpy()
 
     if tvm.target.Target(target).kind.name == "cuda":
-        return tvm.testing.run_with_gpu_lock(run)
-    return run()
+        return tvm.testing.run_with_gpu_lock(run_and_check)
+    return run_and_check()
 
 
 @pytest.mark.parametrize(

--- a/tests/python/relax/test_codegen_cutlass.py
+++ b/tests/python/relax/test_codegen_cutlass.py
@@ -98,17 +98,20 @@ def build_and_run(mod, inputs_np, target, legalize=True, cuda_graph=False):
     ):
         ex = tvm.compile(mod, target)
 
-    dev = tvm.device(target, 0)
-    vm = relax.VirtualMachine(ex, dev)
-    f = vm["main"]
-    inputs = [tvm.runtime.tensor(inp, dev) for inp in inputs_np]
+    def run():
+        dev = tvm.device(target, 0)
+        vm = relax.VirtualMachine(ex, dev)
+        f = vm["main"]
+        inputs = [tvm.runtime.tensor(inp, dev) for inp in inputs_np]
 
-    # For cuda graph, run the compiled function twice to make sure that we can launch the cached
-    # graph on the second run.
-    if cuda_graph:
-        f(*inputs)
+        # For cuda graph, run the compiled function twice to make sure that we can launch the
+        # cached graph on the second run.
+        if cuda_graph:
+            f(*inputs)
 
-    return f(*inputs).numpy()
+        return f(*inputs).numpy()
+
+    return tvm.testing.run_with_gpu_lock(run)
 
 
 def build_cutlass(mod, assert_all_bindings_fused=True, num_final_bindings=1):
@@ -1491,30 +1494,30 @@ def test_fp16A_int4B_gemm():
         (tvm.runtime.tensor(y), tvm.runtime.tensor(bias))
     )
 
-    dev = tvm.device("cuda", 0)
-    ex = tvm.compile(mod_deploy, target="cuda")
-    vm = relax.vm.VirtualMachine(ex, dev)
+    ex_cuda = tvm.compile(mod_deploy, target="cuda")
 
-    x_nd = tvm.runtime.tensor(x, dev)
-    residual_nd = tvm.runtime.tensor(residual, dev)
-    params = [packed_weight.copyto(dev), scales.copyto(dev), bias_trans.copyto(dev)]
+    def run():
+        dev = tvm.device("cuda", 0)
+        vm = relax.vm.VirtualMachine(ex_cuda, dev)
+        x_nd = tvm.runtime.tensor(x, dev)
+        residual_nd = tvm.runtime.tensor(residual, dev)
+        params = [packed_weight.copyto(dev), scales.copyto(dev), bias_trans.copyto(dev)]
 
-    for f_name in ["main_bias", "main_cast_bias", "main_residual"]:
-        with_residual = "residual" in f_name
+        for f_name in ["main_bias", "main_cast_bias", "main_residual"]:
+            with_residual = "residual" in f_name
 
-        if with_residual:
-            inp = [x_nd, residual_nd] + params
-        else:
-            inp = [x_nd] + params
+            if with_residual:
+                inp = [x_nd, residual_nd] + params
+            else:
+                inp = [x_nd] + params
 
-        out = vm[f_name](*inp).numpy()
+            out = vm[f_name](*inp).numpy()
+            ref = np.dot(x, y.transpose()) + bias
+            if with_residual:
+                ref += residual
+            tvm.testing.assert_allclose(out, ref, rtol=1e-2, atol=1e-2)
 
-        ref = np.dot(x, y.transpose()) + bias
-
-        if with_residual:
-            ref += residual
-
-        tvm.testing.assert_allclose(out, ref, rtol=1e-2, atol=1e-2)
+    tvm.testing.run_with_gpu_lock(run)
 
 
 def test_fp16A_int8B_gemm():
@@ -1642,13 +1645,7 @@ def test_fp16A_int8B_gemm():
         (tvm.runtime.tensor(y), tvm.runtime.tensor(bias))
     )
 
-    dev = tvm.device("cuda", 0)
-    ex = tvm.compile(mod_deploy, target="cuda")
-    vm = relax.vm.VirtualMachine(ex, dev)
-
-    x_nd = tvm.runtime.tensor(x, dev)
-    inp = [x_nd, packed_weight.copyto(dev), scales.copyto(dev), bias_trans.copyto(dev)]
-    out = vm["main"](*inp).numpy()
+    ex_cuda = tvm.compile(mod_deploy, target="cuda")
 
     def gelu_fp16(x):
         erf_inp = x * (0.5**0.5)
@@ -1657,8 +1654,16 @@ def test_fp16A_int8B_gemm():
         erf_out = erf(erf_inp.astype("float32")).astype("float16")
         return x * 0.5 * (1.0 + erf_out)
 
-    ref = gelu_fp16(np.dot(x, y.transpose()) + bias)
-    tvm.testing.assert_allclose(out, ref, rtol=1e-2, atol=1e-2)
+    def run():
+        dev = tvm.device("cuda", 0)
+        vm = relax.vm.VirtualMachine(ex_cuda, dev)
+        x_nd = tvm.runtime.tensor(x, dev)
+        inp = [x_nd, packed_weight.copyto(dev), scales.copyto(dev), bias_trans.copyto(dev)]
+        out = vm["main"](*inp).numpy()
+        ref = gelu_fp16(np.dot(x, y.transpose()) + bias)
+        tvm.testing.assert_allclose(out, ref, rtol=1e-2, atol=1e-2)
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 def test_rms_norm():
@@ -1914,15 +1919,18 @@ def test_fp16A_int8B_gemm_batched():
 
     packed_weight, scales = vm[transform_func_name]((tvm.runtime.tensor(y),))
 
-    dev = tvm.device("cuda", 0)
-    ex = tvm.compile(mod_deploy, target="cuda")
-    vm = relax.vm.VirtualMachine(ex, dev)
+    ex_cuda = tvm.compile(mod_deploy, target="cuda")
 
-    x_nd = tvm.runtime.tensor(x, dev)
-    inp = [x_nd, packed_weight.copyto(dev), scales.copyto(dev)]
-    out = vm["main"](*inp).numpy()
-    ref = np.dot(x, y.transpose())
-    tvm.testing.assert_allclose(out, ref, rtol=1e-2, atol=1e-2)
+    def run():
+        dev = tvm.device("cuda", 0)
+        vm = relax.vm.VirtualMachine(ex_cuda, dev)
+        x_nd = tvm.runtime.tensor(x, dev)
+        inp = [x_nd, packed_weight.copyto(dev), scales.copyto(dev)]
+        out = vm["main"](*inp).numpy()
+        ref = np.dot(x, y.transpose())
+        tvm.testing.assert_allclose(out, ref, rtol=1e-2, atol=1e-2)
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 def test_fp16A_int8B_gemm_batched_finegrained():
@@ -2069,15 +2077,18 @@ def test_fp16A_int8B_gemm_batched_finegrained():
 
     packed_weight, scales = vm[transform_func_name]((tvm.runtime.tensor(y),))
 
-    dev = tvm.device("cuda", 0)
-    ex = tvm.compile(mod_deploy, target="cuda")
-    vm = relax.vm.VirtualMachine(ex, dev)
+    ex_cuda = tvm.compile(mod_deploy, target="cuda")
 
-    x_nd = tvm.runtime.tensor(x, dev)
-    inp = [x_nd, packed_weight.copyto(dev), scales.copyto(dev)]
-    out = vm["main"](*inp).numpy()
-    ref = np.dot(x, y.transpose())
-    tvm.testing.assert_allclose(out, ref, rtol=1e-2, atol=1e-2)
+    def run():
+        dev = tvm.device("cuda", 0)
+        vm = relax.vm.VirtualMachine(ex_cuda, dev)
+        x_nd = tvm.runtime.tensor(x, dev)
+        inp = [x_nd, packed_weight.copyto(dev), scales.copyto(dev)]
+        out = vm["main"](*inp).numpy()
+        ref = np.dot(x, y.transpose())
+        tvm.testing.assert_allclose(out, ref, rtol=1e-2, atol=1e-2)
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 def test_attention_rewrite_multi_query():

--- a/tests/python/relax/test_codegen_cutlass.py
+++ b/tests/python/relax/test_codegen_cutlass.py
@@ -98,7 +98,7 @@ def build_and_run(mod, inputs_np, target, legalize=True, cuda_graph=False):
     ):
         ex = tvm.compile(mod, target)
 
-    def run():
+    def run_and_check():
         dev = tvm.device(target, 0)
         vm = relax.VirtualMachine(ex, dev)
         f = vm["main"]
@@ -111,7 +111,7 @@ def build_and_run(mod, inputs_np, target, legalize=True, cuda_graph=False):
 
         return f(*inputs).numpy()
 
-    return tvm.testing.run_with_gpu_lock(run)
+    return tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 def build_cutlass(mod, assert_all_bindings_fused=True, num_final_bindings=1):
@@ -1496,7 +1496,7 @@ def test_fp16A_int4B_gemm():
 
     ex_cuda = tvm.compile(mod_deploy, target="cuda")
 
-    def run():
+    def run_and_check():
         dev = tvm.device("cuda", 0)
         vm = relax.vm.VirtualMachine(ex_cuda, dev)
         x_nd = tvm.runtime.tensor(x, dev)
@@ -1517,7 +1517,7 @@ def test_fp16A_int4B_gemm():
                 ref += residual
             tvm.testing.assert_allclose(out, ref, rtol=1e-2, atol=1e-2)
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 def test_fp16A_int8B_gemm():
@@ -1654,7 +1654,7 @@ def test_fp16A_int8B_gemm():
         erf_out = erf(erf_inp.astype("float32")).astype("float16")
         return x * 0.5 * (1.0 + erf_out)
 
-    def run():
+    def run_and_check():
         dev = tvm.device("cuda", 0)
         vm = relax.vm.VirtualMachine(ex_cuda, dev)
         x_nd = tvm.runtime.tensor(x, dev)
@@ -1663,7 +1663,7 @@ def test_fp16A_int8B_gemm():
         ref = gelu_fp16(np.dot(x, y.transpose()) + bias)
         tvm.testing.assert_allclose(out, ref, rtol=1e-2, atol=1e-2)
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 def test_rms_norm():
@@ -1921,7 +1921,7 @@ def test_fp16A_int8B_gemm_batched():
 
     ex_cuda = tvm.compile(mod_deploy, target="cuda")
 
-    def run():
+    def run_and_check():
         dev = tvm.device("cuda", 0)
         vm = relax.vm.VirtualMachine(ex_cuda, dev)
         x_nd = tvm.runtime.tensor(x, dev)
@@ -1930,7 +1930,7 @@ def test_fp16A_int8B_gemm_batched():
         ref = np.dot(x, y.transpose())
         tvm.testing.assert_allclose(out, ref, rtol=1e-2, atol=1e-2)
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 def test_fp16A_int8B_gemm_batched_finegrained():
@@ -2079,7 +2079,7 @@ def test_fp16A_int8B_gemm_batched_finegrained():
 
     ex_cuda = tvm.compile(mod_deploy, target="cuda")
 
-    def run():
+    def run_and_check():
         dev = tvm.device("cuda", 0)
         vm = relax.vm.VirtualMachine(ex_cuda, dev)
         x_nd = tvm.runtime.tensor(x, dev)
@@ -2088,7 +2088,7 @@ def test_fp16A_int8B_gemm_batched_finegrained():
         ref = np.dot(x, y.transpose())
         tvm.testing.assert_allclose(out, ref, rtol=1e-2, atol=1e-2)
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 def test_attention_rewrite_multi_query():

--- a/tests/python/relax/test_codegen_hipblas.py
+++ b/tests/python/relax/test_codegen_hipblas.py
@@ -47,13 +47,17 @@ pytestmark = [
 
 
 def build_and_run(mod, inputs_np, target, legalize=False):
-    dev = tvm.device(target, 0)
     with tvm.transform.PassContext(config={"relax.transform.apply_legalize_ops": legalize}):
         ex = tvm.compile(mod, target)
-    vm = relax.VirtualMachine(ex, dev)
-    f = vm["main"]
-    inputs = [tvm.runtime.tensor(inp, dev) for inp in inputs_np]
-    return f(*inputs).numpy()
+
+    def run():
+        dev = tvm.device(target, 0)
+        vm = relax.VirtualMachine(ex, dev)
+        f = vm["main"]
+        inputs = [tvm.runtime.tensor(inp, dev) for inp in inputs_np]
+        return f(*inputs).numpy()
+
+    return tvm.testing.run_with_gpu_lock(run)
 
 
 def get_result_with_relax_cublas_offload(mod, np_inputs):

--- a/tests/python/relax/test_codegen_hipblas.py
+++ b/tests/python/relax/test_codegen_hipblas.py
@@ -50,14 +50,14 @@ def build_and_run(mod, inputs_np, target, legalize=False):
     with tvm.transform.PassContext(config={"relax.transform.apply_legalize_ops": legalize}):
         ex = tvm.compile(mod, target)
 
-    def run():
+    def run_and_check():
         dev = tvm.device(target, 0)
         vm = relax.VirtualMachine(ex, dev)
         f = vm["main"]
         inputs = [tvm.runtime.tensor(inp, dev) for inp in inputs_np]
         return f(*inputs).numpy()
 
-    return tvm.testing.run_with_gpu_lock(run)
+    return tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 def get_result_with_relax_cublas_offload(mod, np_inputs):

--- a/tests/python/relax/test_codegen_tensorrt.py
+++ b/tests/python/relax/test_codegen_tensorrt.py
@@ -68,7 +68,7 @@ def build_and_run(mod, inputs_np, target, legalize=False):
     with tvm.transform.PassContext(config={"relax.transform.apply_legalize_ops": legalize}):
         ex = tvm.compile(mod, target)
 
-    def run():
+    def run_and_check():
         dev = tvm.device(target, 0)
         vm = relax.VirtualMachine(ex, dev)
         f = vm["main"]
@@ -76,8 +76,8 @@ def build_and_run(mod, inputs_np, target, legalize=False):
         return f(*inputs).numpy()
 
     if tvm.target.Target(target).kind.name == "cuda":
-        return tvm.testing.run_with_gpu_lock(run)
-    return run()
+        return tvm.testing.run_with_gpu_lock(run_and_check)
+    return run_and_check()
 
 
 def test_tensorrt_offload():
@@ -317,7 +317,7 @@ def test_tensorrt_int8_calibration(monkeypatch):
 
     ex = tvm.compile(offloaded, "cuda")
 
-    def run_and_check_calibration():
+    def run_and_check():
         dev = tvm.device("cuda", 0)
         vm = relax.VirtualMachine(ex, dev)
         data_trt = tvm.runtime.tensor(data, dev)
@@ -330,7 +330,7 @@ def test_tensorrt_int8_calibration(monkeypatch):
         # completed without a CUDA error.
         tvm.testing.assert_allclose(out, ref, rtol=0.2, atol=0.1 * float(np.abs(ref).max()))
 
-    tvm.testing.run_with_gpu_lock(run_and_check_calibration)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 def test_tensorrt_matmul():

--- a/tests/python/relax/test_codegen_tensorrt.py
+++ b/tests/python/relax/test_codegen_tensorrt.py
@@ -65,13 +65,19 @@ pytestmark = [
 
 
 def build_and_run(mod, inputs_np, target, legalize=False):
-    dev = tvm.device(target, 0)
     with tvm.transform.PassContext(config={"relax.transform.apply_legalize_ops": legalize}):
         ex = tvm.compile(mod, target)
-    vm = relax.VirtualMachine(ex, dev)
-    f = vm["main"]
-    inputs = [tvm.runtime.tensor(inp, dev) for inp in inputs_np]
-    return f(*inputs).numpy()
+
+    def run():
+        dev = tvm.device(target, 0)
+        vm = relax.VirtualMachine(ex, dev)
+        f = vm["main"]
+        inputs = [tvm.runtime.tensor(inp, dev) for inp in inputs_np]
+        return f(*inputs).numpy()
+
+    if tvm.target.Target(target).kind.name == "cuda":
+        return tvm.testing.run_with_gpu_lock(run)
+    return run()
 
 
 def test_tensorrt_offload():
@@ -309,17 +315,22 @@ def test_tensorrt_int8_calibration(monkeypatch):
     monkeypatch.setenv("TVM_TENSORRT_USE_INT8", "1")
     monkeypatch.setenv("TENSORRT_NUM_CALI_INT8", str(num_calibration_batches))
 
-    dev = tvm.device("cuda", 0)
-    vm = relax.VirtualMachine(tvm.compile(offloaded, "cuda"), dev)
-    data_trt = tvm.runtime.tensor(data, dev)
-    out = None
-    for _ in range(num_calibration_batches + 1):
-        out = vm["main"](data_trt).numpy()
+    ex = tvm.compile(offloaded, "cuda")
 
-    assert np.isfinite(out).all()
-    # INT8 is lossy, so use a generous tolerance; the key assertion is that calibration completed
-    # without a CUDA error.
-    tvm.testing.assert_allclose(out, ref, rtol=0.2, atol=0.1 * float(np.abs(ref).max()))
+    def run_and_check_calibration():
+        dev = tvm.device("cuda", 0)
+        vm = relax.VirtualMachine(ex, dev)
+        data_trt = tvm.runtime.tensor(data, dev)
+        out = None
+        for _ in range(num_calibration_batches + 1):
+            out = vm["main"](data_trt).numpy()
+
+        assert np.isfinite(out).all()
+        # INT8 is lossy, so use a generous tolerance; the key assertion is that calibration
+        # completed without a CUDA error.
+        tvm.testing.assert_allclose(out, ref, rtol=0.2, atol=0.1 * float(np.abs(ref).max()))
+
+    tvm.testing.run_with_gpu_lock(run_and_check_calibration)
 
 
 def test_tensorrt_matmul():

--- a/tests/python/relax/test_contrib_vllm.py
+++ b/tests/python/relax/test_contrib_vllm.py
@@ -755,34 +755,36 @@ def test_reconstruct_from_cache():
     num_tokens = 8
     num_blocks = 1
 
-    dev = tvm.device("cuda", 0)
-
-    key = tvm.runtime.tensor(
-        np.random.randn(num_tokens, num_heads, head_dim).astype("float16"), dev
-    )
-    value = tvm.runtime.tensor(
-        np.random.randn(num_tokens, num_heads, head_dim).astype("float16"), dev
-    )
-    slot_mapping = tvm.runtime.tensor(np.arange(num_tokens).astype("int32"), dev)
-
-    k_cache = tvm.runtime.tensor(
-        np.random.randn(num_blocks, num_heads, head_dim // vec_size, block_size, vec_size).astype(
-            "float16"
-        ),
-        dev,
-    )
-    v_cache = tvm.runtime.tensor(
-        np.random.randn(num_blocks, num_heads, head_dim, block_size).astype("float16"), dev
-    )
-
     reshape_and_cache_func = tvm.get_global_func("tvm.contrib.vllm.reshape_and_cache")
     reconstruct_from_cache_func = tvm.get_global_func("tvm.contrib.vllm.reconstruct_from_cache")
 
-    reshape_and_cache_func(key, value, k_cache, v_cache, slot_mapping)
-    out = reconstruct_from_cache_func(k_cache, v_cache, slot_mapping)
+    def run():
+        dev = tvm.device("cuda", 0)
+        key = tvm.runtime.tensor(
+            np.random.randn(num_tokens, num_heads, head_dim).astype("float16"), dev
+        )
+        value = tvm.runtime.tensor(
+            np.random.randn(num_tokens, num_heads, head_dim).astype("float16"), dev
+        )
+        slot_mapping = tvm.runtime.tensor(np.arange(num_tokens).astype("int32"), dev)
 
-    np.testing.assert_equal(key.numpy(), out[0].numpy())
-    np.testing.assert_equal(value.numpy(), out[1].numpy())
+        k_cache = tvm.runtime.tensor(
+            np.random.randn(
+                num_blocks, num_heads, head_dim // vec_size, block_size, vec_size
+            ).astype("float16"),
+            dev,
+        )
+        v_cache = tvm.runtime.tensor(
+            np.random.randn(num_blocks, num_heads, head_dim, block_size).astype("float16"), dev
+        )
+
+        reshape_and_cache_func(key, value, k_cache, v_cache, slot_mapping)
+        out = reconstruct_from_cache_func(k_cache, v_cache, slot_mapping)
+
+        np.testing.assert_equal(key.numpy(), out[0].numpy())
+        np.testing.assert_equal(value.numpy(), out[1].numpy())
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_contrib_vllm.py
+++ b/tests/python/relax/test_contrib_vllm.py
@@ -758,7 +758,7 @@ def test_reconstruct_from_cache():
     reshape_and_cache_func = tvm.get_global_func("tvm.contrib.vllm.reshape_and_cache")
     reconstruct_from_cache_func = tvm.get_global_func("tvm.contrib.vllm.reconstruct_from_cache")
 
-    def run():
+    def run_and_check():
         dev = tvm.device("cuda", 0)
         key = tvm.runtime.tensor(
             np.random.randn(num_tokens, num_heads, head_dim).astype("float16"), dev
@@ -784,7 +784,7 @@ def test_reconstruct_from_cache():
         np.testing.assert_equal(key.numpy(), out[0].numpy())
         np.testing.assert_equal(value.numpy(), out[1].numpy())
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_dlpack_integration.py
+++ b/tests/python/relax/test_dlpack_integration.py
@@ -53,21 +53,25 @@ class TestDLPackIntegration:
 
     def test_dlpack_pytorch_to_tvm_conversion_gpu(self):
         if tvm.cuda().exist:
-            pytorch_tensor = torch.tensor(
-                [1.0, 2.0, 3.0, 4.0, 5.0], dtype=torch.float32, device="cuda"
-            )
 
-            tvm_tensor = tvm.runtime.from_dlpack(pytorch_tensor)
+            def run():
+                pytorch_tensor = torch.tensor(
+                    [1.0, 2.0, 3.0, 4.0, 5.0], dtype=torch.float32, device="cuda"
+                )
 
-            assert isinstance(tvm_tensor, tvm.runtime.Tensor)
-            assert tvm_tensor.shape == pytorch_tensor.shape
-            assert str(tvm_tensor.dtype) == str(pytorch_tensor.dtype).replace("torch.", "")
-            assert str(tvm_tensor.device) == "cuda:0"
+                tvm_tensor = tvm.runtime.from_dlpack(pytorch_tensor)
 
-            # Move to CPU for numpy conversion
-            tvm_numpy = tvm_tensor.numpy()
-            pytorch_numpy = pytorch_tensor.cpu().numpy()
-            tvm.testing.assert_allclose(tvm_numpy, pytorch_numpy, atol=1e-5)
+                assert isinstance(tvm_tensor, tvm.runtime.Tensor)
+                assert tvm_tensor.shape == pytorch_tensor.shape
+                assert str(tvm_tensor.dtype) == str(pytorch_tensor.dtype).replace("torch.", "")
+                assert str(tvm_tensor.device) == "cuda:0"
+
+                # Move to CPU for numpy conversion
+                tvm_numpy = tvm_tensor.numpy()
+                pytorch_numpy = pytorch_tensor.cpu().numpy()
+                tvm.testing.assert_allclose(tvm_numpy, pytorch_numpy, atol=1e-5)
+
+            tvm.testing.run_with_gpu_lock(run)
         else:
             pytest.skip("CUDA not available")
 
@@ -92,18 +96,22 @@ class TestDLPackIntegration:
             import numpy as np
 
             data = np.array([1.0, 2.0, 3.0, 4.0, 5.0], dtype="float32")
-            tvm_tensor = tvm.runtime.tensor(data, device=tvm.cuda(0))
 
-            pytorch_tensor = torch.from_dlpack(tvm_tensor)
+            def run():
+                tvm_tensor = tvm.runtime.tensor(data, device=tvm.cuda(0))
 
-            assert isinstance(pytorch_tensor, torch.Tensor)
-            assert pytorch_tensor.shape == tvm_tensor.shape
-            assert pytorch_tensor.dtype == torch.float32
-            assert pytorch_tensor.device.type == "cuda"
+                pytorch_tensor = torch.from_dlpack(tvm_tensor)
 
-            tvm_numpy = tvm_tensor.numpy()
-            pytorch_numpy = pytorch_tensor.cpu().numpy()
-            tvm.testing.assert_allclose(tvm_numpy, pytorch_numpy, atol=1e-5)
+                assert isinstance(pytorch_tensor, torch.Tensor)
+                assert pytorch_tensor.shape == tvm_tensor.shape
+                assert pytorch_tensor.dtype == torch.float32
+                assert pytorch_tensor.device.type == "cuda"
+
+                tvm_numpy = tvm_tensor.numpy()
+                pytorch_numpy = pytorch_tensor.cpu().numpy()
+                tvm.testing.assert_allclose(tvm_numpy, pytorch_numpy, atol=1e-5)
+
+            tvm.testing.run_with_gpu_lock(run)
         else:
             pytest.skip("CUDA not available")
 

--- a/tests/python/relax/test_dlpack_integration.py
+++ b/tests/python/relax/test_dlpack_integration.py
@@ -54,7 +54,7 @@ class TestDLPackIntegration:
     def test_dlpack_pytorch_to_tvm_conversion_gpu(self):
         if tvm.cuda().exist:
 
-            def run():
+            def run_and_check():
                 pytorch_tensor = torch.tensor(
                     [1.0, 2.0, 3.0, 4.0, 5.0], dtype=torch.float32, device="cuda"
                 )
@@ -71,7 +71,7 @@ class TestDLPackIntegration:
                 pytorch_numpy = pytorch_tensor.cpu().numpy()
                 tvm.testing.assert_allclose(tvm_numpy, pytorch_numpy, atol=1e-5)
 
-            tvm.testing.run_with_gpu_lock(run)
+            tvm.testing.run_with_gpu_lock(run_and_check)
         else:
             pytest.skip("CUDA not available")
 
@@ -97,7 +97,7 @@ class TestDLPackIntegration:
 
             data = np.array([1.0, 2.0, 3.0, 4.0, 5.0], dtype="float32")
 
-            def run():
+            def run_and_check():
                 tvm_tensor = tvm.runtime.tensor(data, device=tvm.cuda(0))
 
                 pytorch_tensor = torch.from_dlpack(tvm_tensor)
@@ -111,7 +111,7 @@ class TestDLPackIntegration:
                 pytorch_numpy = pytorch_tensor.cpu().numpy()
                 tvm.testing.assert_allclose(tvm_numpy, pytorch_numpy, atol=1e-5)
 
-            tvm.testing.run_with_gpu_lock(run)
+            tvm.testing.run_with_gpu_lock(run_and_check)
         else:
             pytest.skip("CUDA not available")
 

--- a/tests/python/relax/test_frontend_nn_llm_sequence_prefill_masked.py
+++ b/tests/python/relax/test_frontend_nn_llm_sequence_prefill_masked.py
@@ -155,33 +155,33 @@ def _run_case(
     valid_np = np.asarray(valid_lens, dtype=np.int32)
     out_np = np.zeros((batch, seq, h_q, d), dtype=np_dtype)
     lse_np = np.zeros((batch, seq, h_q), dtype=np_dtype)
-
-    q_nd = tvm.runtime.tensor(q_np, device=dev)
-    k_nd = tvm.runtime.tensor(k_np, device=dev)
-    v_nd = tvm.runtime.tensor(v_np, device=dev)
-    valid_nd = tvm.runtime.tensor(valid_np, device=dev)
-    out_nd = tvm.runtime.tensor(out_np, device=dev)
-    lse_nd = tvm.runtime.tensor(lse_np, device=dev)
-
-    built.main(q_nd, k_nd, v_nd, valid_nd, out_nd, lse_nd)
-
-    got = out_nd.numpy().astype(np.float32)
     if mask_mode == "padded":
         ref = _reference_masked_attention(q_np, k_np, v_np, valid_np, sm_scale)
     else:
         ref = _reference_masked_attention_causal_padded_left(q_np, k_np, v_np, valid_np, sm_scale)
 
-    # Only compare valid rows. Padding rows are undefined by design.
-    rtol, atol = (2e-2, 2e-2) if dtype == "float16" else (1e-4, 1e-4)
-    for b in range(batch):
-        L = int(valid_np[b])
-        if L == 0:
-            continue
-        if mask_mode == "padded":
-            np.testing.assert_allclose(got[b, :L], ref[b, :L], rtol=rtol, atol=atol)
-        else:
-            pad_q = seq - L
-            np.testing.assert_allclose(got[b, pad_q:], ref[b, pad_q:], rtol=rtol, atol=atol)
+    def run_and_check():
+        q_nd = tvm.runtime.tensor(q_np, device=dev)
+        k_nd = tvm.runtime.tensor(k_np, device=dev)
+        v_nd = tvm.runtime.tensor(v_np, device=dev)
+        valid_nd = tvm.runtime.tensor(valid_np, device=dev)
+        out_nd = tvm.runtime.tensor(out_np, device=dev)
+        lse_nd = tvm.runtime.tensor(lse_np, device=dev)
+        built.main(q_nd, k_nd, v_nd, valid_nd, out_nd, lse_nd)
+        dev.sync()
+        got = out_nd.numpy().astype(np.float32)
+        rtol, atol = (2e-2, 2e-2) if dtype == "float16" else (1e-4, 1e-4)
+        for b in range(batch):
+            length = int(valid_np[b])
+            if length == 0:
+                continue
+            if mask_mode == "padded":
+                np.testing.assert_allclose(got[b, :length], ref[b, :length], rtol=rtol, atol=atol)
+            else:
+                pad_q = seq - length
+                np.testing.assert_allclose(got[b, pad_q:], ref[b, pad_q:], rtol=rtol, atol=atol)
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu

--- a/tests/python/relax/test_frontend_nn_llm_sequence_prefill_masked.py
+++ b/tests/python/relax/test_frontend_nn_llm_sequence_prefill_masked.py
@@ -168,7 +168,6 @@ def _run_case(
         out_nd = tvm.runtime.tensor(out_np, device=dev)
         lse_nd = tvm.runtime.tensor(lse_np, device=dev)
         built.main(q_nd, k_nd, v_nd, valid_nd, out_nd, lse_nd)
-        dev.sync()
         got = out_nd.numpy().astype(np.float32)
         rtol, atol = (2e-2, 2e-2) if dtype == "float16" else (1e-4, 1e-4)
         for b in range(batch):

--- a/tests/python/relax/test_frontend_nn_op.py
+++ b/tests/python/relax/test_frontend_nn_op.py
@@ -1117,7 +1117,7 @@ def test_sample_top_p_top_k_from_sorted_prob():
 
     ex = tvm.compile(mod, target)
 
-    def run():
+    def run_and_check():
         dev = tvm.cuda(0)
         vm = relax.VirtualMachine(ex, dev)
         effects = vm["_initialize_effect"]()
@@ -1133,7 +1133,7 @@ def test_sample_top_p_top_k_from_sorted_prob():
         res = vm["foo"](*inputs)
         tvm.testing.assert_allclose(res[0].numpy(), np.array([[2], [0], [0]]).astype(np.int64))
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -1237,7 +1237,7 @@ def test_renormalize_top_p_top_k_prob():
 
     ex = tvm.compile(mod, target)
 
-    def run():
+    def run_and_check():
         dev = tvm.cuda(0)
         vm = relax.VirtualMachine(ex, dev)
         effects = vm["_initialize_effect"]()
@@ -1256,7 +1256,7 @@ def test_renormalize_top_p_top_k_prob():
             np.array([[0, 0.375, 0.625], [0.3, 0.3, 0.4]]).astype(np.float32),
         )
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 def test_sort_argsort_topk():

--- a/tests/python/relax/test_frontend_nn_op.py
+++ b/tests/python/relax/test_frontend_nn_op.py
@@ -1116,23 +1116,24 @@ def test_sample_top_p_top_k_from_sorted_prob():
         mod = s_tir.transform.DefaultGPUSchedule()(mod)
 
     ex = tvm.compile(mod, target)
-    dev = tvm.cuda(0)
-    vm = relax.VirtualMachine(ex, dev)
 
-    effects = vm["_initialize_effect"]()
-    sorted_prob = tvm.runtime.tensor(
-        np.array([[0.5, 0.4, 0.1], [0.4, 0.3, 0.3]]).astype(np.float32), dev
-    )
-    indices = tvm.runtime.tensor(np.array([[2, 1, 0], [2, 0, 1]]).astype(np.int64), dev)
-    top_p = tvm.runtime.tensor(np.array([[0.6], [0.9]]).astype(np.float32), dev)
-    top_k = tvm.runtime.tensor(np.array([[3], [2]]).astype(np.int64), dev)
-    usample = tvm.runtime.tensor(np.array([[0.5], [0.6], [0.7]]).astype(np.float32), dev)
-    sample_indices = tvm.runtime.tensor(np.array([[0], [1], [1]]).astype(np.int64), dev)
+    def run():
+        dev = tvm.cuda(0)
+        vm = relax.VirtualMachine(ex, dev)
+        effects = vm["_initialize_effect"]()
+        sorted_prob = tvm.runtime.tensor(
+            np.array([[0.5, 0.4, 0.1], [0.4, 0.3, 0.3]]).astype(np.float32), dev
+        )
+        indices = tvm.runtime.tensor(np.array([[2, 1, 0], [2, 0, 1]]).astype(np.int64), dev)
+        top_p = tvm.runtime.tensor(np.array([[0.6], [0.9]]).astype(np.float32), dev)
+        top_k = tvm.runtime.tensor(np.array([[3], [2]]).astype(np.int64), dev)
+        usample = tvm.runtime.tensor(np.array([[0.5], [0.6], [0.7]]).astype(np.float32), dev)
+        sample_indices = tvm.runtime.tensor(np.array([[0], [1], [1]]).astype(np.int64), dev)
+        inputs = [sorted_prob, indices, top_p, top_k, usample, sample_indices, effects]
+        res = vm["foo"](*inputs)
+        tvm.testing.assert_allclose(res[0].numpy(), np.array([[2], [0], [0]]).astype(np.int64))
 
-    inputs = [sorted_prob, indices, top_p, top_k, usample, sample_indices, effects]
-
-    res = vm["foo"](*inputs)
-    tvm.testing.assert_allclose(res[0].numpy(), np.array([[2], [0], [0]]).astype(np.int64))
+    tvm.testing.run_with_gpu_lock(run)
 
 
 @pytest.mark.gpu
@@ -1235,23 +1236,27 @@ def test_renormalize_top_p_top_k_prob():
         mod = s_tir.transform.DefaultGPUSchedule()(mod)
 
     ex = tvm.compile(mod, target)
-    dev = tvm.cuda(0)
-    vm = relax.VirtualMachine(ex, dev)
 
-    effects = vm["_initialize_effect"]()
-    prob = tvm.runtime.tensor(np.array([[0.2, 0.3, 0.5], [0.3, 0.3, 0.4]]).astype(np.float32), dev)
-    sorted_prob = tvm.runtime.tensor(
-        np.array([[0.5, 0.3, 0.2], [0.4, 0.3, 0.3]]).astype(np.float32), dev
-    )
-    top_p = tvm.runtime.tensor(np.array([[0.6], [0.9]]).astype(np.float32), dev)
-    top_k = tvm.runtime.tensor(np.array([[3], [2]]).astype(np.int64), dev)
+    def run():
+        dev = tvm.cuda(0)
+        vm = relax.VirtualMachine(ex, dev)
+        effects = vm["_initialize_effect"]()
+        prob = tvm.runtime.tensor(
+            np.array([[0.2, 0.3, 0.5], [0.3, 0.3, 0.4]]).astype(np.float32), dev
+        )
+        sorted_prob = tvm.runtime.tensor(
+            np.array([[0.5, 0.3, 0.2], [0.4, 0.3, 0.3]]).astype(np.float32), dev
+        )
+        top_p = tvm.runtime.tensor(np.array([[0.6], [0.9]]).astype(np.float32), dev)
+        top_k = tvm.runtime.tensor(np.array([[3], [2]]).astype(np.int64), dev)
+        inputs = [prob, sorted_prob, top_p, top_k, effects]
+        res = vm["foo"](*inputs)
+        tvm.testing.assert_allclose(
+            res[0].numpy(),
+            np.array([[0, 0.375, 0.625], [0.3, 0.3, 0.4]]).astype(np.float32),
+        )
 
-    inputs = [prob, sorted_prob, top_p, top_k, effects]
-
-    res = vm["foo"](*inputs)
-    tvm.testing.assert_allclose(
-        res[0].numpy(), np.array([[0, 0.375, 0.625], [0.3, 0.3, 0.4]]).astype(np.float32)
-    )
+    tvm.testing.run_with_gpu_lock(run)
 
 
 def test_sort_argsort_topk():

--- a/tests/python/relax/test_group_gemm_flashinfer.py
+++ b/tests/python/relax/test_group_gemm_flashinfer.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# ruff: noqa: E501, F401, F841, RUF005
+# ruff: noqa: E501, F401, RUF005
 
 """Test for FlashInfer GroupedGemm TVM integration"""
 
@@ -391,8 +391,7 @@ def test_grouped_gemm_correctness(
     test_case,
 ):
     """Test correctness of GroupedGemm operations"""
-    device = tvm.cuda(0)
-    target = tvm.target.Target.from_device(device)
+    target = tvm.target.Target.from_device(tvm.cuda(0))
 
     # Generate the module
     mod = relax.backend.cuda.flashinfer.gen_grouped_gemm_module(target=target)[0]
@@ -400,80 +399,68 @@ def test_grouped_gemm_correctness(
     # Load the module
     grouped_gemm_fn = mod["group_gemm_fp8_nt_groupwise"]
 
-    # Generate test data
-    test_data = generate_test_data(
-        batch_size=test_case["batch_size"],
-        m_sizes=test_case["m_sizes"],
-        n=test_case["n"],
-        k=test_case["k"],
-        dtype_a=dtype_a,
-        dtype_b=dtype_b,
-        dtype_out=dtype_out,
-        scale_granularity_m=scale_granularity_m,
-        scale_granularity_n=scale_granularity_n,
-        scale_granularity_k=scale_granularity_k,
-        scale_major_mode=scale_major_mode,
-        device=device,
-    )
+    def run():
+        device = tvm.cuda(0)
+        test_data = generate_test_data(
+            batch_size=test_case["batch_size"],
+            m_sizes=test_case["m_sizes"],
+            n=test_case["n"],
+            k=test_case["k"],
+            dtype_a=dtype_a,
+            dtype_b=dtype_b,
+            dtype_out=dtype_out,
+            scale_granularity_m=scale_granularity_m,
+            scale_granularity_n=scale_granularity_n,
+            scale_granularity_k=scale_granularity_k,
+            scale_major_mode=scale_major_mode,
+            device=device,
+        )
 
-    # Prepare output buffer
-    output_shape = (test_data["total_m"], test_data["n"])
-    if dtype_out == "bfloat16":
-        output = tvm.runtime.empty(output_shape, dtype="bfloat16", device=device)
-    elif dtype_out == "float16":
-        output = tvm.runtime.empty(output_shape, dtype="float16", device=device)
-    else:
-        output = tvm.runtime.empty(output_shape, dtype="float32", device=device)
+        output_shape = (test_data["total_m"], test_data["n"])
+        if dtype_out == "bfloat16":
+            output = tvm.runtime.empty(output_shape, dtype="bfloat16", device=device)
+        elif dtype_out == "float16":
+            output = tvm.runtime.empty(output_shape, dtype="float16", device=device)
+        else:
+            output = tvm.runtime.empty(output_shape, dtype="float32", device=device)
 
-    # Create workspace buffers (required by the interface)
-    int_workspace = tvm.runtime.empty((DEFAULT_WORKSPACE_SIZE,), dtype="int32", device=device)
-    float_workspace = tvm.runtime.empty((DEFAULT_WORKSPACE_SIZE,), dtype="float32", device=device)
+        int_workspace = tvm.runtime.empty((DEFAULT_WORKSPACE_SIZE,), dtype="int32", device=device)
+        float_workspace = tvm.runtime.empty(
+            (DEFAULT_WORKSPACE_SIZE,), dtype="float32", device=device
+        )
 
-    grouped_gemm_fn(
-        int_workspace,  # int_workspace_buffer
-        float_workspace,  # float_workspace_buffer
-        test_data["a"],  # A
-        test_data["b"],  # B
-        test_data["scale_a"],  # SFA
-        test_data["scale_b"],  # SFB
-        output,  # D
-        test_data["m_indptr"],  # m_indptr
-        test_data["n"],  # n (scalar)
-        test_data["k"],  # k (scalar)
-        scale_granularity_m,
-        scale_granularity_n,
-        scale_granularity_k,
-        scale_major_mode,
-        mma_sm,
-    )
+        grouped_gemm_fn(
+            int_workspace,
+            float_workspace,
+            test_data["a"],
+            test_data["b"],
+            test_data["scale_a"],
+            test_data["scale_b"],
+            output,
+            test_data["m_indptr"],
+            test_data["n"],
+            test_data["k"],
+            scale_granularity_m,
+            scale_granularity_n,
+            scale_granularity_k,
+            scale_major_mode,
+            mma_sm,
+        )
 
-    # Compute reference result
-    reference = compute_reference_grouped_gemm(
-        test_data["torch_a"],
-        test_data["torch_b"],
-        test_data["torch_m_indptr"],
-        dtype_out,
-    )
+        reference = compute_reference_grouped_gemm(
+            test_data["torch_a"],
+            test_data["torch_b"],
+            test_data["torch_m_indptr"],
+            dtype_out,
+        )
+        output_torch = torch.as_tensor(output, device=test_data["torch_a"].device)
+        assert output_torch.shape == reference.shape, (
+            f"Shape mismatch: got {output_torch.shape}, expected {reference.shape}"
+        )
+        diff = calc_diff(output_torch.cpu().double().numpy(), reference.cpu().double().numpy())
+        assert diff < 1e-3, f"diff too large {diff}"
 
-    # Convert TVM output to PyTorch for comparison
-    output_torch = torch.as_tensor(output, device=test_data["torch_a"].device)
-    output_torch
-
-    # Compare results with appropriate tolerance
-    if dtype_out == "bfloat16":
-        rtol, atol = 1e-2, 1e-2
-    elif dtype_out == "float16":
-        rtol, atol = 1e-3, 1e-3
-    else:
-        rtol, atol = 1e-4, 1e-4
-
-    # Check shapes match
-    assert output_torch.shape == reference.shape, (
-        f"Shape mismatch: got {output_torch.shape}, expected {reference.shape}"
-    )
-
-    diff = calc_diff(output_torch.cpu().double().numpy(), reference.cpu().double().numpy())
-    assert diff < 1e-3, f"diff too large {diff}"
+    tvm.testing.run_with_gpu_lock(run)
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_group_gemm_flashinfer.py
+++ b/tests/python/relax/test_group_gemm_flashinfer.py
@@ -399,7 +399,7 @@ def test_grouped_gemm_correctness(
     # Load the module
     grouped_gemm_fn = mod["group_gemm_fp8_nt_groupwise"]
 
-    def run():
+    def run_and_check():
         device = tvm.cuda(0)
         test_data = generate_test_data(
             batch_size=test_case["batch_size"],
@@ -460,7 +460,7 @@ def test_grouped_gemm_correctness(
         diff = calc_diff(output_torch.cpu().double().numpy(), reference.cpu().double().numpy())
         assert diff < 1e-3, f"diff too large {diff}"
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_op_view.py
+++ b/tests/python/relax/test_op_view.py
@@ -669,7 +669,6 @@ def test_lower_runtime_builtin_view_with_multiple_updated_fields():
 def test_execute_no_op_view(target):
     if not tvm.testing.device_enabled(target):
         pytest.skip(f"{target} not enabled")
-    dev = tvm.device(target)
 
     @I.ir_module
     class Module:
@@ -679,21 +678,26 @@ def test_execute_no_op_view(target):
             return B
 
     built = tvm.compile(Module, target=target)
-    vm = tvm.relax.VirtualMachine(built, device=dev)
-
     np_input = np.random.random([4096]).astype("float32")
-    tvm_input = tvm.runtime.tensor(np_input, dev)
-    tvm_output = vm["main"](tvm_input)
     np_expected = np_input
 
-    tvm.testing.assert_allclose(tvm_output.numpy(), np_expected)
+    def run():
+        dev = tvm.device(target)
+        vm = tvm.relax.VirtualMachine(built, device=dev)
+        tvm_input = tvm.runtime.tensor(np_input, dev)
+        tvm_output = vm["main"](tvm_input)
+        tvm.testing.assert_allclose(tvm_output.numpy(), np_expected)
+
+    if target == "llvm":
+        run()
+    else:
+        tvm.testing.run_with_gpu_lock(run)
 
 
 @pytest.mark.parametrize("target", ["llvm", pytest.param("cuda", marks=pytest.mark.gpu)])
 def test_execute_view_with_new_shape(target):
     if not tvm.testing.device_enabled(target):
         pytest.skip(f"{target} not enabled")
-    dev = tvm.device(target)
 
     @I.ir_module
     class Module:
@@ -703,21 +707,26 @@ def test_execute_view_with_new_shape(target):
             return B
 
     built = tvm.compile(Module, target=target)
-    vm = tvm.relax.VirtualMachine(built, device=dev)
-
     np_input = np.random.random([4096]).astype("float32")
-    tvm_input = tvm.runtime.tensor(np_input, dev)
-    tvm_output = vm["main"](tvm_input)
     np_expected = np_input.reshape(64, 64)
 
-    tvm.testing.assert_allclose(tvm_output.numpy(), np_expected)
+    def run():
+        dev = tvm.device(target)
+        vm = tvm.relax.VirtualMachine(built, device=dev)
+        tvm_input = tvm.runtime.tensor(np_input, dev)
+        tvm_output = vm["main"](tvm_input)
+        tvm.testing.assert_allclose(tvm_output.numpy(), np_expected)
+
+    if target == "llvm":
+        run()
+    else:
+        tvm.testing.run_with_gpu_lock(run)
 
 
 @pytest.mark.parametrize("target", ["llvm", pytest.param("cuda", marks=pytest.mark.gpu)])
 def test_execute_view_with_new_byte_offset(target):
     if not tvm.testing.device_enabled(target):
         pytest.skip(f"{target} not enabled")
-    dev = tvm.device(target)
 
     @I.ir_module
     class Module:
@@ -731,21 +740,26 @@ def test_execute_view_with_new_byte_offset(target):
             return B
 
     built = tvm.compile(Module, target=target)
-    vm = tvm.relax.VirtualMachine(built, device=dev)
-
     np_input = np.random.random([4096]).astype("float32")
-    tvm_input = tvm.runtime.tensor(np_input, dev)
-    tvm_output = vm["main"](tvm_input)
     np_expected = np_input.reshape(64, 64)[32:48, :]
 
-    tvm.testing.assert_allclose(tvm_output.numpy(), np_expected)
+    def run():
+        dev = tvm.device(target)
+        vm = tvm.relax.VirtualMachine(built, device=dev)
+        tvm_input = tvm.runtime.tensor(np_input, dev)
+        tvm_output = vm["main"](tvm_input)
+        tvm.testing.assert_allclose(tvm_output.numpy(), np_expected)
+
+    if target == "llvm":
+        run()
+    else:
+        tvm.testing.run_with_gpu_lock(run)
 
 
 @pytest.mark.parametrize("target", ["llvm", pytest.param("cuda", marks=pytest.mark.gpu)])
 def test_execute_view_with_new_dtype(target):
     if not tvm.testing.device_enabled(target):
         pytest.skip(f"{target} not enabled")
-    dev = tvm.device(target)
 
     @I.ir_module
     class Module:
@@ -755,21 +769,26 @@ def test_execute_view_with_new_dtype(target):
             return B
 
     built = tvm.compile(Module, target=target)
-    vm = tvm.relax.VirtualMachine(built, device=dev)
-
     np_input = np.random.random([4096]).astype("float32")
-    tvm_input = tvm.runtime.tensor(np_input, dev)
-    tvm_output = vm["main"](tvm_input)
     np_expected = np_input.view("uint32")
 
-    tvm.testing.assert_allclose(tvm_output.numpy(), np_expected)
+    def run():
+        dev = tvm.device(target)
+        vm = tvm.relax.VirtualMachine(built, device=dev)
+        tvm_input = tvm.runtime.tensor(np_input, dev)
+        tvm_output = vm["main"](tvm_input)
+        tvm.testing.assert_allclose(tvm_output.numpy(), np_expected)
+
+    if target == "llvm":
+        run()
+    else:
+        tvm.testing.run_with_gpu_lock(run)
 
 
 @pytest.mark.parametrize("target", ["llvm", pytest.param("cuda", marks=pytest.mark.gpu)])
 def test_execute_view_with_multiple_updated_fields(target):
     if not tvm.testing.device_enabled(target):
         pytest.skip(f"{target} not enabled")
-    dev = tvm.device(target)
 
     @I.ir_module
     class Module:
@@ -789,18 +808,24 @@ def test_execute_view_with_multiple_updated_fields(target):
             return (B, C)
 
     built = tvm.compile(Module, target=target)
-    vm = tvm.relax.VirtualMachine(built, device=dev)
-
     np_input = np.random.randint(0, 255, size=[4096]).astype("uint8")
-    tvm_input = tvm.runtime.tensor(np_input, dev)
-    tvm_output = vm["main"](tvm_input)
     np_expected = [
         np_input[:2048].view("int32"),
         np_input[2048:].view("float16").reshape(16, 64),
     ]
 
-    tvm.testing.assert_allclose(tvm_output[0].numpy(), np_expected[0])
-    tvm.testing.assert_allclose(tvm_output[1].numpy(), np_expected[1])
+    def run():
+        dev = tvm.device(target)
+        vm = tvm.relax.VirtualMachine(built, device=dev)
+        tvm_input = tvm.runtime.tensor(np_input, dev)
+        tvm_output = vm["main"](tvm_input)
+        tvm.testing.assert_allclose(tvm_output[0].numpy(), np_expected[0])
+        tvm.testing.assert_allclose(tvm_output[1].numpy(), np_expected[1])
+
+    if target == "llvm":
+        run()
+    else:
+        tvm.testing.run_with_gpu_lock(run)
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_op_view.py
+++ b/tests/python/relax/test_op_view.py
@@ -681,7 +681,7 @@ def test_execute_no_op_view(target):
     np_input = np.random.random([4096]).astype("float32")
     np_expected = np_input
 
-    def run():
+    def run_and_check():
         dev = tvm.device(target)
         vm = tvm.relax.VirtualMachine(built, device=dev)
         tvm_input = tvm.runtime.tensor(np_input, dev)
@@ -689,9 +689,9 @@ def test_execute_no_op_view(target):
         tvm.testing.assert_allclose(tvm_output.numpy(), np_expected)
 
     if target == "llvm":
-        run()
+        run_and_check()
     else:
-        tvm.testing.run_with_gpu_lock(run)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.parametrize("target", ["llvm", pytest.param("cuda", marks=pytest.mark.gpu)])
@@ -710,7 +710,7 @@ def test_execute_view_with_new_shape(target):
     np_input = np.random.random([4096]).astype("float32")
     np_expected = np_input.reshape(64, 64)
 
-    def run():
+    def run_and_check():
         dev = tvm.device(target)
         vm = tvm.relax.VirtualMachine(built, device=dev)
         tvm_input = tvm.runtime.tensor(np_input, dev)
@@ -718,9 +718,9 @@ def test_execute_view_with_new_shape(target):
         tvm.testing.assert_allclose(tvm_output.numpy(), np_expected)
 
     if target == "llvm":
-        run()
+        run_and_check()
     else:
-        tvm.testing.run_with_gpu_lock(run)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.parametrize("target", ["llvm", pytest.param("cuda", marks=pytest.mark.gpu)])
@@ -743,7 +743,7 @@ def test_execute_view_with_new_byte_offset(target):
     np_input = np.random.random([4096]).astype("float32")
     np_expected = np_input.reshape(64, 64)[32:48, :]
 
-    def run():
+    def run_and_check():
         dev = tvm.device(target)
         vm = tvm.relax.VirtualMachine(built, device=dev)
         tvm_input = tvm.runtime.tensor(np_input, dev)
@@ -751,9 +751,9 @@ def test_execute_view_with_new_byte_offset(target):
         tvm.testing.assert_allclose(tvm_output.numpy(), np_expected)
 
     if target == "llvm":
-        run()
+        run_and_check()
     else:
-        tvm.testing.run_with_gpu_lock(run)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.parametrize("target", ["llvm", pytest.param("cuda", marks=pytest.mark.gpu)])
@@ -772,7 +772,7 @@ def test_execute_view_with_new_dtype(target):
     np_input = np.random.random([4096]).astype("float32")
     np_expected = np_input.view("uint32")
 
-    def run():
+    def run_and_check():
         dev = tvm.device(target)
         vm = tvm.relax.VirtualMachine(built, device=dev)
         tvm_input = tvm.runtime.tensor(np_input, dev)
@@ -780,9 +780,9 @@ def test_execute_view_with_new_dtype(target):
         tvm.testing.assert_allclose(tvm_output.numpy(), np_expected)
 
     if target == "llvm":
-        run()
+        run_and_check()
     else:
-        tvm.testing.run_with_gpu_lock(run)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.parametrize("target", ["llvm", pytest.param("cuda", marks=pytest.mark.gpu)])
@@ -814,7 +814,7 @@ def test_execute_view_with_multiple_updated_fields(target):
         np_input[2048:].view("float16").reshape(16, 64),
     ]
 
-    def run():
+    def run_and_check():
         dev = tvm.device(target)
         vm = tvm.relax.VirtualMachine(built, device=dev)
         tvm_input = tvm.runtime.tensor(np_input, dev)
@@ -823,9 +823,9 @@ def test_execute_view_with_multiple_updated_fields(target):
         tvm.testing.assert_allclose(tvm_output[1].numpy(), np_expected[1])
 
     if target == "llvm":
-        run()
+        run_and_check()
     else:
-        tvm.testing.run_with_gpu_lock(run)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_pytorch_integration.py
+++ b/tests/python/relax/test_pytorch_integration.py
@@ -106,7 +106,7 @@ class TestPyTorchIntegration:
 
         if tvm.cuda().exist:
 
-            def run():
+            def run_and_check():
                 assert hasattr(module, "__call__"), "Module should be callable"
 
                 device = tvm.cuda(0)
@@ -118,7 +118,7 @@ class TestPyTorchIntegration:
                     assert hasattr(instance, method), f"Instance should have method: {method}"
                 assert "cuda" in str(instance.target)
 
-            tvm.testing.run_with_gpu_lock(run)
+            tvm.testing.run_with_gpu_lock(run_and_check)
         else:
             pytest.skip("CUDA not available")
 
@@ -235,7 +235,7 @@ class TestPyTorchIntegration:
 
         if tvm.cuda().exist:
 
-            def run():
+            def run_and_check():
                 device = tvm.cuda(0)
                 instance = module(device)
 
@@ -260,7 +260,7 @@ class TestPyTorchIntegration:
                 assert result.dtype == torch.float32
                 assert result.device.type == "cuda"
 
-            tvm.testing.run_with_gpu_lock(run)
+            tvm.testing.run_with_gpu_lock(run_and_check)
         else:
             pytest.skip("CUDA not available")
 

--- a/tests/python/relax/test_pytorch_integration.py
+++ b/tests/python/relax/test_pytorch_integration.py
@@ -105,16 +105,20 @@ class TestPyTorchIntegration:
         module = PyTorchIntegrationModule
 
         if tvm.cuda().exist:
-            assert hasattr(module, "__call__"), "Module should be callable"
 
-            device = tvm.cuda(0)
-            instance = module(device)
+            def run():
+                assert hasattr(module, "__call__"), "Module should be callable"
 
-            assert isinstance(instance, BasePyModule), "Instance should be BasePyModule"
-            required_methods = ["main", "call_tir", "call_dps_packed"]
-            for method in required_methods:
-                assert hasattr(instance, method), f"Instance should have method: {method}"
-            assert "cuda" in str(instance.target)
+                device = tvm.cuda(0)
+                instance = module(device)
+
+                assert isinstance(instance, BasePyModule), "Instance should be BasePyModule"
+                required_methods = ["main", "call_tir", "call_dps_packed"]
+                for method in required_methods:
+                    assert hasattr(instance, method), f"Instance should have method: {method}"
+                assert "cuda" in str(instance.target)
+
+            tvm.testing.run_with_gpu_lock(run)
         else:
             pytest.skip("CUDA not available")
 
@@ -230,29 +234,33 @@ class TestPyTorchIntegration:
         module = PyTorchIntegrationModule
 
         if tvm.cuda().exist:
-            device = tvm.cuda(0)
-            instance = module(device)
 
-            # Test basic GPU functionality without complex TIR operations
-            assert isinstance(instance, BasePyModule)
-            assert "cuda" in str(instance.target)
+            def run():
+                device = tvm.cuda(0)
+                instance = module(device)
 
-            # Test that we can create and work with GPU tensors
-            n = 5
-            x = torch.randn(n, 16, dtype=torch.float32, device="cuda")
-            w = torch.randn(16, 20, dtype=torch.float32, device="cuda")
+                # Test basic GPU functionality without complex TIR operations
+                assert isinstance(instance, BasePyModule)
+                assert "cuda" in str(instance.target)
 
-            assert x.device.type == "cuda"
-            assert w.device.type == "cuda"
-            assert x.shape == (n, 16)
-            assert w.shape == (16, 20)
+                # Test that we can create and work with GPU tensors
+                n = 5
+                x = torch.randn(n, 16, dtype=torch.float32, device="cuda")
+                w = torch.randn(16, 20, dtype=torch.float32, device="cuda")
 
-            # Test basic PyTorch operations on GPU
-            result = torch.matmul(x, w)
-            assert isinstance(result, torch.Tensor)
-            assert result.shape == (n, 20)
-            assert result.dtype == torch.float32
-            assert result.device.type == "cuda"
+                assert x.device.type == "cuda"
+                assert w.device.type == "cuda"
+                assert x.shape == (n, 16)
+                assert w.shape == (16, 20)
+
+                # Test basic PyTorch operations on GPU
+                result = torch.matmul(x, w)
+                assert isinstance(result, torch.Tensor)
+                assert result.shape == (n, 20)
+                assert result.dtype == torch.float32
+                assert result.device.type == "cuda"
+
+            tvm.testing.run_with_gpu_lock(run)
         else:
             pytest.skip("CUDA not available")
 

--- a/tests/python/relax/test_runtime_builtin_paged_attention_kv_cache_flashinfer.py
+++ b/tests/python/relax/test_runtime_builtin_paged_attention_kv_cache_flashinfer.py
@@ -226,7 +226,7 @@ def _get_cuda_target():
 def _run_with_kv_cache(test):
     @functools.wraps(test)
     def wrapper(kv_cache_and_rope_mode):
-        def run():
+        def run_and_check():
             global device
             device = tvm.cuda()
             try:
@@ -235,7 +235,7 @@ def _run_with_kv_cache(test):
             finally:
                 device = None
 
-        return tvm.testing.run_with_gpu_lock(run)
+        return tvm.testing.run_with_gpu_lock(run_and_check)
 
     return wrapper
 

--- a/tests/python/relax/test_runtime_builtin_paged_attention_kv_cache_flashinfer.py
+++ b/tests/python/relax/test_runtime_builtin_paged_attention_kv_cache_flashinfer.py
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import functools
+
 # ruff: noqa: E741
 import pytest
 import torch
@@ -59,7 +61,7 @@ rope_scale = 1.0
 rope_theta = 1e4
 dtype = "float16"
 dtype_torch = getattr(torch, dtype)
-device = tvm.cuda()
+device = None
 device_torch = torch.device("cuda")
 
 fclear = None
@@ -88,7 +90,7 @@ fcopy_cache = None
 fcompact_copy = None
 
 
-def set_global_func(rope_mode: RopeMode):
+def set_global_func(rope_mode: RopeMode, target):
     global fclear, fadd_sequence, fremove_sequence, ffork_sequence, fpopn
     global fbegin_forward, fend_forward, fattention, fattention_with_fuse_qkv, fdebug_get_kv
     global fattention_prefill, fattention_decode, fattention_prefill_ragged
@@ -108,7 +110,6 @@ def set_global_func(rope_mode: RopeMode):
     )
     fdebug_get_kv = tvm.get_global_func("vm.builtin.attention_kv_cache_debug_get_kv")
 
-    target = tvm.target.Target.from_device(device)
     flashinfer_prefill_mod = relax.backend.cuda.flashinfer.gen_flashinfer_prefill_module(
         dtype_q=dtype,
         dtype_kv=dtype,
@@ -213,8 +214,30 @@ def kv_cache_and_rope_mode(request):
         # tvm/relax/frontend/nn/llm/kv_cache.py); models pair FlashInfer with
         # NORMAL/NONE rope and apply rotary embedding in a separate kernel.
         pytest.skip("FlashInfer does not support inline RoPE mode")
-    set_global_func(request.param)
-    return create_kv_cache(request.param), request.param
+    target = tvm.testing.run_with_gpu_lock(_get_cuda_target)
+    set_global_func(request.param, target)
+    return request.param
+
+
+def _get_cuda_target():
+    return tvm.target.Target.from_device(tvm.cuda())
+
+
+def _run_with_kv_cache(test):
+    @functools.wraps(test)
+    def wrapper(kv_cache_and_rope_mode):
+        def run():
+            global device
+            device = tvm.cuda()
+            try:
+                cache = create_kv_cache(kv_cache_and_rope_mode)
+                return test((cache, kv_cache_and_rope_mode))
+            finally:
+                device = None
+
+        return tvm.testing.run_with_gpu_lock(run)
+
+    return wrapper
 
 
 def verify_cached_kv(kv_cache, seq_ids, expected_k, expected_v):
@@ -428,6 +451,7 @@ def apply_attention(
     verify_cached_kv(kv_cache, seq_ids, cached_k, cached_v)
 
 
+@_run_with_kv_cache
 def test_paged_attention_kv_cache_prefill_and_decode(kv_cache_and_rope_mode):
     kv_cache, rope_mode = kv_cache_and_rope_mode
     fclear(kv_cache)
@@ -448,6 +472,7 @@ def test_paged_attention_kv_cache_prefill_and_decode(kv_cache_and_rope_mode):
         apply_attention(kv_cache, rope_mode, batch, cached_k, cached_v)
 
 
+@_run_with_kv_cache
 def test_paged_attention_kv_cache_remove_sequence(kv_cache_and_rope_mode):
     kv_cache, rope_mode = kv_cache_and_rope_mode
     fclear(kv_cache)
@@ -470,6 +495,7 @@ def test_paged_attention_kv_cache_remove_sequence(kv_cache_and_rope_mode):
         )
 
 
+@_run_with_kv_cache
 def test_paged_attention_kv_cache_fork_sequence(kv_cache_and_rope_mode):
     kv_cache, rope_mode = kv_cache_and_rope_mode
     fclear(kv_cache)
@@ -535,6 +561,7 @@ def test_paged_attention_kv_cache_fork_sequence(kv_cache_and_rope_mode):
     apply_attention(kv_cache, rope_mode, [(10, 1), (12, 1)], cached_k, cached_v)
 
 
+@_run_with_kv_cache
 def test_paged_attention_kv_cache_popn(kv_cache_and_rope_mode):
     kv_cache, rope_mode = kv_cache_and_rope_mode
     fclear(kv_cache)
@@ -555,10 +582,4 @@ def test_paged_attention_kv_cache_popn(kv_cache_and_rope_mode):
 
 
 if __name__ == "__main__":
-    for rope_mode in [RopeMode.NONE, RopeMode.NORMAL]:
-        set_global_func(rope_mode)
-        cache = create_kv_cache(rope_mode)
-        test_paged_attention_kv_cache_prefill_and_decode((cache, rope_mode))
-        test_paged_attention_kv_cache_remove_sequence((cache, rope_mode))
-        test_paged_attention_kv_cache_fork_sequence((cache, rope_mode))
-        test_paged_attention_kv_cache_popn((cache, rope_mode))
+    tvm.testing.main()

--- a/tests/python/relax/test_runtime_builtin_paged_attention_kv_cache_mla_flashinfer.py
+++ b/tests/python/relax/test_runtime_builtin_paged_attention_kv_cache_mla_flashinfer.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import functools
 import itertools
 
 import numpy as np
@@ -61,7 +62,7 @@ sm_scale = (qk_nope_head_dim + qk_rope_head_dim) ** (-0.5)
 kv_lora_rank = 512
 dtype = "float16"
 dtype_torch = getattr(torch, dtype)
-device = tvm.cuda()
+device = None
 device_torch = torch.device("cuda")
 
 fclear = None
@@ -99,7 +100,7 @@ def _dumb_function():
     raise RuntimeError("Dumb function isn't supposed to be accessed.")
 
 
-def set_global_func(dtype):
+def set_global_func(dtype, target):
     global fclear, fadd_sequence, fremove_sequence, ffork_sequence
     global fpopn, fbegin_forward, fend_forward
     global fself_attn, fcross_attn, fappend_mla_kv, fkv_merge_attn_output
@@ -107,7 +108,6 @@ def set_global_func(dtype):
     global ftranspose_append, fcopy_cache, fmla_prefill, fmla_prefill_plan
     global fattn_prefill_ragged, fattn_prefill_ragged_plan
     global fmerge_state, fmerge_state_additional, fcopy_single_page
-    global w_kv, w_uk, w_uv
 
     fclear = tvm.get_global_func("vm.builtin.kv_state_clear")
     fadd_sequence = tvm.get_global_func("vm.builtin.kv_state_add_sequence")
@@ -125,7 +125,6 @@ def set_global_func(dtype):
     fis_empty = tvm.get_global_func("vm.builtin.attention_kv_cache_empty")
     fdebug_get_kv = tvm.get_global_func("vm.builtin.attention_kv_cache_debug_get_kv_mla")
 
-    target = tvm.target.Target.from_device(device)
     flashinfer_prefill_mod = relax.backend.cuda.flashinfer.gen_flashinfer_prefill_module(
         dtype_q=dtype,
         dtype_kv=dtype,
@@ -169,6 +168,9 @@ def set_global_func(dtype):
         fcopy_single_page,
     ) = builts
 
+
+def _initialize_weights():
+    global w_kv, w_uk, w_uv
     w_kv = torch.empty(
         (kv_lora_rank, num_attention_heads * (qk_nope_head_dim + v_head_dim)),
         device=device_torch,
@@ -241,8 +243,35 @@ def kv_cache_and_config(request):
     global dtype, dtype_torch
     (dtype,) = request.param
     dtype_torch = getattr(torch, dtype)
-    set_global_func(dtype)
-    return (create_kv_cache(dtype),)
+    target = tvm.testing.run_with_gpu_lock(_get_cuda_target)
+    set_global_func(dtype, target)
+    return request.param
+
+
+def _get_cuda_target():
+    return tvm.target.Target.from_device(tvm.cuda())
+
+
+def _run_with_kv_cache(test):
+    @functools.wraps(test)
+    def wrapper(kv_cache_and_config):
+        def run():
+            global device, w_kv, w_uk, w_uv
+            device = tvm.cuda()
+            (dtype,) = kv_cache_and_config
+            try:
+                _initialize_weights()
+                cache = create_kv_cache(dtype)
+                return test((cache,))
+            finally:
+                device = None
+                w_kv = None
+                w_uk = None
+                w_uv = None
+
+        return tvm.testing.run_with_gpu_lock(run)
+
+    return wrapper
 
 
 def verify_cached_kv(kv_cache, seq_ids, expected_kv):
@@ -443,6 +472,7 @@ def apply_attention(
     verify_cached_kv(kv_cache, seq_ids, cached_kv)
 
 
+@_run_with_kv_cache
 def test_paged_attention_kv_cache_prefill_and_decode(kv_cache_and_config):
     (kv_cache,) = kv_cache_and_config
     fclear(kv_cache)
@@ -462,6 +492,7 @@ def test_paged_attention_kv_cache_prefill_and_decode(kv_cache_and_config):
         apply_attention(kv_cache, batch, cached_kv)
 
 
+@_run_with_kv_cache
 def test_paged_attention_kv_cache_remove_sequence(kv_cache_and_config):
     (kv_cache,) = kv_cache_and_config
     fclear(kv_cache)
@@ -481,6 +512,7 @@ def test_paged_attention_kv_cache_remove_sequence(kv_cache_and_config):
         )
 
 
+@_run_with_kv_cache
 def test_paged_attention_kv_cache_fork_sequence(kv_cache_and_config):
     (kv_cache,) = kv_cache_and_config
     fclear(kv_cache)
@@ -549,6 +581,7 @@ def test_paged_attention_kv_cache_fork_sequence(kv_cache_and_config):
     apply_attention(kv_cache, [(10, 1), (12, 1)], cached_kv)
 
 
+@_run_with_kv_cache
 def test_paged_attention_kv_cache_popn(kv_cache_and_config):
     (kv_cache,) = kv_cache_and_config
     fclear(kv_cache)
@@ -578,10 +611,4 @@ def test_paged_attention_kv_cache_popn(kv_cache_and_config):
 
 
 if __name__ == "__main__":
-    set_global_func(dtype)
-    cache = create_kv_cache(dtype)
-    cache_and_config = (cache,)
-    test_paged_attention_kv_cache_prefill_and_decode(cache_and_config)
-    test_paged_attention_kv_cache_remove_sequence(cache_and_config)
-    test_paged_attention_kv_cache_fork_sequence(cache_and_config)
-    test_paged_attention_kv_cache_popn(cache_and_config)
+    tvm.testing.main()

--- a/tests/python/relax/test_runtime_builtin_paged_attention_kv_cache_mla_flashinfer.py
+++ b/tests/python/relax/test_runtime_builtin_paged_attention_kv_cache_mla_flashinfer.py
@@ -255,7 +255,7 @@ def _get_cuda_target():
 def _run_with_kv_cache(test):
     @functools.wraps(test)
     def wrapper(kv_cache_and_config):
-        def run():
+        def run_and_check():
             global device, w_kv, w_uk, w_uv
             device = tvm.cuda()
             (dtype,) = kv_cache_and_config
@@ -269,7 +269,7 @@ def _run_with_kv_cache(test):
                 w_uk = None
                 w_uv = None
 
-        return tvm.testing.run_with_gpu_lock(run)
+        return tvm.testing.run_with_gpu_lock(run_and_check)
 
     return wrapper
 

--- a/tests/python/relax/test_runtime_builtin_paged_attention_kv_cache_mla_tir.py
+++ b/tests/python/relax/test_runtime_builtin_paged_attention_kv_cache_mla_tir.py
@@ -50,7 +50,7 @@ sm_scale = (qk_nope_head_dim + qk_rope_head_dim) ** (-0.5)
 kv_lora_rank = 512
 dtype = "float16"
 dtype_torch = getattr(torch, dtype)
-device = tvm.cuda()
+device = None
 device_torch = torch.device("cuda")
 
 fclear = None
@@ -85,14 +85,13 @@ def _dumb_function():
     raise RuntimeError("Dumb function isn't supposed to be accessed.")
 
 
-def set_global_func(dtype):
+def set_global_func(dtype, target):
     global fclear, fadd_sequence, fremove_sequence, ffork_sequence
     global fpopn, fbegin_forward, fend_forward
     global fself_attn, fcross_attn, fappend_mla_kv, fkv_merge_attn_output
     global fis_empty, fdebug_get_kv
     global ftranspose_append, fcopy_cache, fmla_prefill, fmla_prefill_ragged
     global fmerge_state, fmerge_state_additional, fcopy_single_page
-    global w_kv, w_uk, w_uv
 
     fclear = tvm.get_global_func("vm.builtin.kv_state_clear")
     fadd_sequence = tvm.get_global_func("vm.builtin.kv_state_add_sequence")
@@ -110,7 +109,6 @@ def set_global_func(dtype):
     fis_empty = tvm.get_global_func("vm.builtin.attention_kv_cache_empty")
     fdebug_get_kv = tvm.get_global_func("vm.builtin.attention_kv_cache_debug_get_kv_mla")
 
-    target = tvm.target.Target.from_device(device)
     builts = []
     for tir_func in [
         _kv_cache_transpose_append_mla(kv_lora_rank + qk_rope_head_dim, dtype),
@@ -146,20 +144,6 @@ def set_global_func(dtype):
         fmerge_state_additional,
         fcopy_single_page,
     ) = builts
-
-    w_kv = torch.empty(
-        (kv_lora_rank, num_attention_heads * (qk_nope_head_dim + v_head_dim)),
-        device=device_torch,
-        dtype=dtype_torch,
-    )
-    w_kv.uniform_(-0.1, 0.1)
-    w_uk, w_uv = torch.split(
-        w_kv.view(kv_lora_rank, num_attention_heads, qk_nope_head_dim + v_head_dim),
-        [qk_nope_head_dim, v_head_dim],
-        dim=2,
-    )
-    w_uk = w_uk.permute(1, 2, 0)
-    w_uv = w_uv.permute(1, 0, 2)
 
 
 def create_kv_cache(dtype):
@@ -211,8 +195,13 @@ def kv_cache_and_config(request):
     global dtype, dtype_torch
     (dtype,) = request.param
     dtype_torch = getattr(torch, dtype)
-    set_global_func(dtype)
-    return (create_kv_cache(dtype),)
+
+    def get_cuda_target():
+        return tvm.target.Target.from_device(tvm.cuda())
+
+    target = tvm.testing.run_with_gpu_lock(get_cuda_target)
+    set_global_func(dtype, target)
+    return request.param
 
 
 def verify_cached_kv(kv_cache, seq_ids, expected_kv):
@@ -416,150 +405,255 @@ def apply_attention(
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_cuda(), reason="need cuda")
 def test_paged_attention_kv_cache_prefill_and_decode(kv_cache_and_config):
-    (kv_cache,) = kv_cache_and_config
-    fclear(kv_cache)
+    def run():
+        global device, w_kv, w_uk, w_uv
+        device = tvm.cuda()
+        (dtype,) = kv_cache_and_config
+        try:
+            w_kv = torch.empty(
+                (kv_lora_rank, num_attention_heads * (qk_nope_head_dim + v_head_dim)),
+                device=device_torch,
+                dtype=dtype_torch,
+            )
+            w_kv.uniform_(-0.1, 0.1)
+            w_uk, w_uv = torch.split(
+                w_kv.view(kv_lora_rank, num_attention_heads, qk_nope_head_dim + v_head_dim),
+                [qk_nope_head_dim, v_head_dim],
+                dim=2,
+            )
+            w_uk = w_uk.permute(1, 2, 0)
+            w_uv = w_uv.permute(1, 0, 2)
+            kv_cache = create_kv_cache(dtype)
+            fclear(kv_cache)
 
-    # Prefill.
-    operation_seq = [[(0, 6)], [(1, 8)], [(2, 11)], [(3, 16)], [(4, 19), (5, 20)]]
-    operation_seq += [[(6, 21), (7, 24)], [(2, 5), (4, 7), (8, 24)]]
-    operation_seq += [[(6, 13)], [(8, 19)], [(0, 1)], [(1, 3), (3, 8), (5, 12), (7, 11)]]
-    # Decode
-    operation_seq += [[(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1), (6, 1), (7, 1), (8, 1)]]
-    operation_seq += [[(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1), (6, 1), (7, 1), (8, 1)]]
-    operation_seq += [[(0, 1), (2, 1), (4, 1), (6, 1), (8, 1)]]
-    operation_seq += [[(4, 1), (5, 1), (6, 1), (7, 1), (8, 1)]]
+            # Prefill.
+            operation_seq = [[(0, 6)], [(1, 8)], [(2, 11)], [(3, 16)], [(4, 19), (5, 20)]]
+            operation_seq += [[(6, 21), (7, 24)], [(2, 5), (4, 7), (8, 24)]]
+            operation_seq += [
+                [(6, 13)],
+                [(8, 19)],
+                [(0, 1)],
+                [(1, 3), (3, 8), (5, 12), (7, 11)],
+            ]
+            # Decode
+            operation_seq += [
+                [(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1), (6, 1), (7, 1), (8, 1)]
+            ]
+            operation_seq += [
+                [(0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1), (6, 1), (7, 1), (8, 1)]
+            ]
+            operation_seq += [[(0, 1), (2, 1), (4, 1), (6, 1), (8, 1)]]
+            operation_seq += [[(4, 1), (5, 1), (6, 1), (7, 1), (8, 1)]]
 
-    cached_kv = {}
-    for batch in operation_seq:
-        apply_attention(kv_cache, batch, cached_kv)
+            cached_kv = {}
+            for batch in operation_seq:
+                apply_attention(kv_cache, batch, cached_kv)
+        finally:
+            device = None
+            w_kv = None
+            w_uk = None
+            w_uv = None
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_cuda(), reason="need cuda")
 def test_paged_attention_kv_cache_remove_sequence(kv_cache_and_config):
-    (kv_cache,) = kv_cache_and_config
-    fclear(kv_cache)
+    def run():
+        global device, w_kv, w_uk, w_uv
+        device = tvm.cuda()
+        (dtype,) = kv_cache_and_config
+        try:
+            w_kv = torch.empty(
+                (kv_lora_rank, num_attention_heads * (qk_nope_head_dim + v_head_dim)),
+                device=device_torch,
+                dtype=dtype_torch,
+            )
+            w_kv.uniform_(-0.1, 0.1)
+            w_uk, w_uv = torch.split(
+                w_kv.view(kv_lora_rank, num_attention_heads, qk_nope_head_dim + v_head_dim),
+                [qk_nope_head_dim, v_head_dim],
+                dim=2,
+            )
+            w_uk = w_uk.permute(1, 2, 0)
+            w_uv = w_uv.permute(1, 0, 2)
+            kv_cache = create_kv_cache(dtype)
+            fclear(kv_cache)
 
-    num_sequences = 5
-    batch = [(seq_id, 1) for seq_id in range(num_sequences)]
-    cached_kv = {}
-    for seq_id_to_remove in range(num_sequences):
-        apply_attention(kv_cache, batch, cached_kv)
-        # Remove sequence.
-        fremove_sequence(kv_cache, seq_id_to_remove)
-        cached_kv.pop(seq_id_to_remove)
-        verify_cached_kv(
-            kv_cache,
-            seq_ids=[seq_id for seq_id in range(num_sequences) if seq_id != seq_id_to_remove],
-            expected_kv=cached_kv,
-        )
+            num_sequences = 5
+            batch = [(seq_id, 1) for seq_id in range(num_sequences)]
+            cached_kv = {}
+            for seq_id_to_remove in range(num_sequences):
+                apply_attention(kv_cache, batch, cached_kv)
+                # Remove sequence.
+                fremove_sequence(kv_cache, seq_id_to_remove)
+                cached_kv.pop(seq_id_to_remove)
+                verify_cached_kv(
+                    kv_cache,
+                    seq_ids=[
+                        seq_id for seq_id in range(num_sequences) if seq_id != seq_id_to_remove
+                    ],
+                    expected_kv=cached_kv,
+                )
+        finally:
+            device = None
+            w_kv = None
+            w_uk = None
+            w_uv = None
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_cuda(), reason="need cuda")
 def test_paged_attention_kv_cache_fork_sequence(kv_cache_and_config):
-    (kv_cache,) = kv_cache_and_config
-    fclear(kv_cache)
+    def run():
+        global device, w_kv, w_uk, w_uv
+        device = tvm.cuda()
+        (dtype,) = kv_cache_and_config
+        try:
+            w_kv = torch.empty(
+                (kv_lora_rank, num_attention_heads * (qk_nope_head_dim + v_head_dim)),
+                device=device_torch,
+                dtype=dtype_torch,
+            )
+            w_kv.uniform_(-0.1, 0.1)
+            w_uk, w_uv = torch.split(
+                w_kv.view(kv_lora_rank, num_attention_heads, qk_nope_head_dim + v_head_dim),
+                [qk_nope_head_dim, v_head_dim],
+                dim=2,
+            )
+            w_uk = w_uk.permute(1, 2, 0)
+            w_uv = w_uv.permute(1, 0, 2)
+            kv_cache = create_kv_cache(dtype)
+            fclear(kv_cache)
 
-    cached_kv = {}
-    batch = [(0, 60), (1, 88), (2, 17), (3, 4)]
-    apply_attention(kv_cache, batch, cached_kv)
-    # Fork existing sequences.
-    apply_attention(kv_cache, [((4, 3, -1), 35)], cached_kv)
-    apply_attention(kv_cache, [((5, 0, -1), 20)], cached_kv)
-    apply_attention(kv_cache, [((6, 5, -1), 102)], cached_kv)
-    apply_attention(kv_cache, [((7, 0, -1), 3)], cached_kv)
-    apply_attention(kv_cache, [((8, 5, -1), 71), ((9, 5, -1), 20)], cached_kv)
-    # 0 <- 5 <- 6,8,9
-    # 0 <- 7
-    # 3 <- 4
-    # Mixture of decode and prefill.
-    operation_seq = [
-        [(2, 1), (4, 1), (7, 1), (6, 1), (8, 1), (9, 1)],
-        [(7, 1), (6, 1), (8, 1), (9, 1)],
-        [(7, 1), (1, 1), (6, 1), (2, 1), (8, 1), (4, 1), (9, 1)],
-        [(7, 10), (6, 2), (8, 3), (9, 4)],
-    ]
-    for batch in operation_seq:
-        apply_attention(kv_cache, batch, cached_kv)
+            cached_kv = {}
+            batch = [(0, 60), (1, 88), (2, 17), (3, 4)]
+            apply_attention(kv_cache, batch, cached_kv)
+            # Fork existing sequences.
+            apply_attention(kv_cache, [((4, 3, -1), 35)], cached_kv)
+            apply_attention(kv_cache, [((5, 0, -1), 20)], cached_kv)
+            apply_attention(kv_cache, [((6, 5, -1), 102)], cached_kv)
+            apply_attention(kv_cache, [((7, 0, -1), 3)], cached_kv)
+            apply_attention(kv_cache, [((8, 5, -1), 71), ((9, 5, -1), 20)], cached_kv)
+            # 0 <- 5 <- 6,8,9
+            # 0 <- 7
+            # 3 <- 4
+            # Mixture of decode and prefill.
+            operation_seq = [
+                [(2, 1), (4, 1), (7, 1), (6, 1), (8, 1), (9, 1)],
+                [(7, 1), (6, 1), (8, 1), (9, 1)],
+                [(7, 1), (1, 1), (6, 1), (2, 1), (8, 1), (4, 1), (9, 1)],
+                [(7, 10), (6, 2), (8, 3), (9, 4)],
+            ]
+            for batch in operation_seq:
+                apply_attention(kv_cache, batch, cached_kv)
 
-    apply_attention(kv_cache, [((10, 1, 33), 11)], cached_kv)
-    apply_attention(kv_cache, [((11, 0, 60), 45), ((12, 0, 15), 14)], cached_kv)
-    apply_attention(kv_cache, [((13, 0, 16), 19), ((14, 0, 17), 19)], cached_kv)
-    apply_attention(kv_cache, [((15, 5, 60), 8), ((16, 5, 80), 10)], cached_kv)
-    apply_attention(
-        kv_cache,
-        [((17, 5, 75), 11), ((18, 5, 76), 45), ((19, 5, 77), 14)],
-        cached_kv,
-    )
+            apply_attention(kv_cache, [((10, 1, 33), 11)], cached_kv)
+            apply_attention(kv_cache, [((11, 0, 60), 45), ((12, 0, 15), 14)], cached_kv)
+            apply_attention(kv_cache, [((13, 0, 16), 19), ((14, 0, 17), 19)], cached_kv)
+            apply_attention(kv_cache, [((15, 5, 60), 8), ((16, 5, 80), 10)], cached_kv)
+            apply_attention(
+                kv_cache,
+                [((17, 5, 75), 11), ((18, 5, 76), 45), ((19, 5, 77), 14)],
+                cached_kv,
+            )
 
-    operation_seq = [
-        [(6, 1), (11, 1), (13, 1), (9, 1)],
-        [(10, 1), (16, 1), (18, 1), (19, 1)],
-        [(8, 1), (15, 1), (17, 1), (12, 1), (14, 1)],
-        [(10, 10), (6, 2), (8, 3), (19, 4)],
-    ]
-    for batch in operation_seq:
-        apply_attention(kv_cache, batch, cached_kv)
+            operation_seq = [
+                [(6, 1), (11, 1), (13, 1), (9, 1)],
+                [(10, 1), (16, 1), (18, 1), (19, 1)],
+                [(8, 1), (15, 1), (17, 1), (12, 1), (14, 1)],
+                [(10, 10), (6, 2), (8, 3), (19, 4)],
+            ]
+            for batch in operation_seq:
+                apply_attention(kv_cache, batch, cached_kv)
 
-    num_sequence = 20
-    for i in range(num_sequence):
-        fremove_sequence(kv_cache, i)
-        cached_kv.pop(i)
-        verify_cached_kv(
-            kv_cache,
-            seq_ids=list(range(i + 1, num_sequence)),
-            expected_kv=cached_kv,
-        )
+            num_sequence = 20
+            for i in range(num_sequence):
+                fremove_sequence(kv_cache, i)
+                cached_kv.pop(i)
+                verify_cached_kv(
+                    kv_cache,
+                    seq_ids=list(range(i + 1, num_sequence)),
+                    expected_kv=cached_kv,
+                )
 
-    assert fis_empty(kv_cache), "The KV cache is not empty after removing all sequences"
+            assert fis_empty(kv_cache), "The KV cache is not empty after removing all sequences"
 
-    # Test fork after page recycle
-    apply_attention(kv_cache, [(0, 7), (1, 24)], cached_kv)
-    apply_attention(kv_cache, [((2, 1, -1), 10)], cached_kv)
-    apply_attention(kv_cache, [((3, 0, -1), 20)], cached_kv)
-    apply_attention(kv_cache, [(2, 1), (3, 1)], cached_kv)
+            # Test fork after page recycle
+            apply_attention(kv_cache, [(0, 7), (1, 24)], cached_kv)
+            apply_attention(kv_cache, [((2, 1, -1), 10)], cached_kv)
+            apply_attention(kv_cache, [((3, 0, -1), 20)], cached_kv)
+            apply_attention(kv_cache, [(2, 1), (3, 1)], cached_kv)
 
-    apply_attention(kv_cache, [(10, 7), (11, 24)], cached_kv)
-    apply_attention(kv_cache, [((12, 11, -1), 200)], cached_kv)
-    apply_attention(kv_cache, [(10, 1), (12, 1)], cached_kv)
+            apply_attention(kv_cache, [(10, 7), (11, 24)], cached_kv)
+            apply_attention(kv_cache, [((12, 11, -1), 200)], cached_kv)
+            apply_attention(kv_cache, [(10, 1), (12, 1)], cached_kv)
+        finally:
+            device = None
+            w_kv = None
+            w_uk = None
+            w_uv = None
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_cuda(), reason="need cuda")
 def test_paged_attention_kv_cache_popn(kv_cache_and_config):
-    (kv_cache,) = kv_cache_and_config
-    fclear(kv_cache)
+    def run():
+        global device, w_kv, w_uk, w_uv
+        device = tvm.cuda()
+        (dtype,) = kv_cache_and_config
+        try:
+            w_kv = torch.empty(
+                (kv_lora_rank, num_attention_heads * (qk_nope_head_dim + v_head_dim)),
+                device=device_torch,
+                dtype=dtype_torch,
+            )
+            w_kv.uniform_(-0.1, 0.1)
+            w_uk, w_uv = torch.split(
+                w_kv.view(kv_lora_rank, num_attention_heads, qk_nope_head_dim + v_head_dim),
+                [qk_nope_head_dim, v_head_dim],
+                dim=2,
+            )
+            w_uk = w_uk.permute(1, 2, 0)
+            w_uv = w_uv.permute(1, 0, 2)
+            kv_cache = create_kv_cache(dtype)
+            fclear(kv_cache)
 
-    cached_kv = {}
-    batch = [(0, 35), (1, 88), (2, 17), (3, 4)]
-    apply_attention(kv_cache, batch, cached_kv)
-    apply_attention(kv_cache, [((4, 3, -1), 35)], cached_kv)
+            cached_kv = {}
+            batch = [(0, 35), (1, 88), (2, 17), (3, 4)]
+            apply_attention(kv_cache, batch, cached_kv)
+            apply_attention(kv_cache, [((4, 3, -1), 35)], cached_kv)
 
-    popn_operations = [(0, 17), (1, 57), (2, 16), (3, 0), (4, 37)]
-    for seq_id, pop_length in popn_operations:
-        fpopn(kv_cache, seq_id, pop_length)
-        if pop_length != 0:
-            cached_kv[seq_id] = cached_kv[seq_id][:, :-pop_length, ...]
-        verify_cached_kv(kv_cache, seq_ids=list(range(4)), expected_kv=cached_kv)
+            popn_operations = [(0, 17), (1, 57), (2, 16), (3, 0), (4, 37)]
+            for seq_id, pop_length in popn_operations:
+                fpopn(kv_cache, seq_id, pop_length)
+                if pop_length != 0:
+                    cached_kv[seq_id] = cached_kv[seq_id][:, :-pop_length, ...]
+                verify_cached_kv(kv_cache, seq_ids=list(range(4)), expected_kv=cached_kv)
 
-    num_sequence = 5
-    for seq_id in range(num_sequence):
-        fremove_sequence(kv_cache, seq_id)
-        verify_cached_kv(
-            kv_cache,
-            seq_ids=list(range(seq_id + 1, num_sequence)),
-            expected_kv=cached_kv,
-        )
+            num_sequence = 5
+            for seq_id in range(num_sequence):
+                fremove_sequence(kv_cache, seq_id)
+                verify_cached_kv(
+                    kv_cache,
+                    seq_ids=list(range(seq_id + 1, num_sequence)),
+                    expected_kv=cached_kv,
+                )
 
-    assert fis_empty(kv_cache), "The KV cache is not empty after removing all sequences"
+            assert fis_empty(kv_cache), "The KV cache is not empty after removing all sequences"
+        finally:
+            device = None
+            w_kv = None
+            w_uk = None
+            w_uv = None
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 if __name__ == "__main__":
-    set_global_func(dtype)
-    cache = create_kv_cache(dtype)
-    cache_and_config = (cache,)
-    test_paged_attention_kv_cache_prefill_and_decode(cache_and_config)
-    test_paged_attention_kv_cache_remove_sequence(cache_and_config)
-    test_paged_attention_kv_cache_fork_sequence(cache_and_config)
-    test_paged_attention_kv_cache_popn(cache_and_config)
+    tvm.testing.main()

--- a/tests/python/relax/test_runtime_builtin_paged_attention_kv_cache_mla_tir.py
+++ b/tests/python/relax/test_runtime_builtin_paged_attention_kv_cache_mla_tir.py
@@ -196,10 +196,10 @@ def kv_cache_and_config(request):
     (dtype,) = request.param
     dtype_torch = getattr(torch, dtype)
 
-    def get_cuda_target():
+    def run_and_check():
         return tvm.target.Target.from_device(tvm.cuda())
 
-    target = tvm.testing.run_with_gpu_lock(get_cuda_target)
+    target = tvm.testing.run_with_gpu_lock(run_and_check)
     set_global_func(dtype, target)
     return request.param
 
@@ -405,7 +405,7 @@ def apply_attention(
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_cuda(), reason="need cuda")
 def test_paged_attention_kv_cache_prefill_and_decode(kv_cache_and_config):
-    def run():
+    def run_and_check():
         global device, w_kv, w_uk, w_uv
         device = tvm.cuda()
         (dtype,) = kv_cache_and_config
@@ -454,13 +454,13 @@ def test_paged_attention_kv_cache_prefill_and_decode(kv_cache_and_config):
             w_uk = None
             w_uv = None
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_cuda(), reason="need cuda")
 def test_paged_attention_kv_cache_remove_sequence(kv_cache_and_config):
-    def run():
+    def run_and_check():
         global device, w_kv, w_uk, w_uv
         device = tvm.cuda()
         (dtype,) = kv_cache_and_config
@@ -502,13 +502,13 @@ def test_paged_attention_kv_cache_remove_sequence(kv_cache_and_config):
             w_uk = None
             w_uv = None
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_cuda(), reason="need cuda")
 def test_paged_attention_kv_cache_fork_sequence(kv_cache_and_config):
-    def run():
+    def run_and_check():
         global device, w_kv, w_uk, w_uv
         device = tvm.cuda()
         (dtype,) = kv_cache_and_config
@@ -597,13 +597,13 @@ def test_paged_attention_kv_cache_fork_sequence(kv_cache_and_config):
             w_uk = None
             w_uv = None
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_cuda(), reason="need cuda")
 def test_paged_attention_kv_cache_popn(kv_cache_and_config):
-    def run():
+    def run_and_check():
         global device, w_kv, w_uk, w_uv
         device = tvm.cuda()
         (dtype,) = kv_cache_and_config
@@ -652,7 +652,7 @@ def test_paged_attention_kv_cache_popn(kv_cache_and_config):
             w_uk = None
             w_uv = None
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_runtime_builtin_paged_attention_kv_cache_tir.py
+++ b/tests/python/relax/test_runtime_builtin_paged_attention_kv_cache_tir.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 # ruff: noqa: E501, E741
+import functools
 import itertools
 
 import pytest
@@ -56,7 +57,7 @@ rope_theta = 1e4
 rope_scaling = {}
 dtype = None
 dtype_torch = None
-device = tvm.cuda()
+device = None
 device_torch = torch.device("cuda")
 fclear = None
 fadd_sequence = None
@@ -87,7 +88,7 @@ fcopy_single_page = None
 fcompact_copy = None
 
 
-def set_global_func(head_dim, dtype):
+def set_global_func(head_dim, dtype, target):
     global fclear, fadd_sequence, fremove_sequence, ffork_sequence, fenable_sliding_window_for_seq
     global fpopn, fbegin_forward, fend_forward, fcommit_accepted_token_tree_nodes
     global fattention_with_fuse_qkv, fis_empty, fdebug_get_kv
@@ -118,7 +119,6 @@ def set_global_func(head_dim, dtype):
     fis_empty = tvm.get_global_func("vm.builtin.attention_kv_cache_empty")
     fdebug_get_kv = tvm.get_global_func("vm.builtin.attention_kv_cache_debug_get_kv")
 
-    target = tvm.target.Target.from_device(device)
     builts = []
     for tir_func in [
         _kv_cache_transpose_append(num_kv_heads, head_dim, dtype),
@@ -230,8 +230,31 @@ def kv_cache_and_config(request):
     head_dim, dtype, rope_mode, support_sliding_window = request.param
     dtype_torch = getattr(torch, dtype)
     sm_scale = head_dim ** (-0.5)
-    set_global_func(head_dim, dtype)
-    return create_kv_cache(*request.param), rope_mode, support_sliding_window
+    target = tvm.testing.run_with_gpu_lock(_get_cuda_target)
+    set_global_func(head_dim, dtype, target)
+    return request.param
+
+
+def _get_cuda_target():
+    return tvm.target.Target.from_device(tvm.cuda())
+
+
+def _run_with_kv_cache(test):
+    @functools.wraps(test)
+    def wrapper(kv_cache_and_config):
+        def run():
+            global device
+            device = tvm.cuda()
+            head_dim, dtype, rope_mode, support_sliding_window = kv_cache_and_config
+            try:
+                cache = create_kv_cache(head_dim, dtype, rope_mode, support_sliding_window)
+                return test((cache, rope_mode, support_sliding_window))
+            finally:
+                device = None
+
+        return tvm.testing.run_with_gpu_lock(run)
+
+    return wrapper
 
 
 def verify_cached_kv(kv_cache, seq_ids, expected_k, expected_v):
@@ -590,6 +613,7 @@ def apply_attention(
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_cuda(), reason="need cuda")
+@_run_with_kv_cache
 def test_paged_attention_kv_cache_prefill_and_decode(kv_cache_and_config):
     kv_cache, rope_mode, support_sliding_window = kv_cache_and_config
     if support_sliding_window and rope_mode == RopeMode.NORMAL:
@@ -615,6 +639,7 @@ def test_paged_attention_kv_cache_prefill_and_decode(kv_cache_and_config):
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_cuda(), reason="need cuda")
+@_run_with_kv_cache
 def test_paged_attention_kv_cache_remove_sequence(kv_cache_and_config):
     kv_cache, rope_mode, support_sliding_window = kv_cache_and_config
     if support_sliding_window and rope_mode == RopeMode.NORMAL:
@@ -642,6 +667,7 @@ def test_paged_attention_kv_cache_remove_sequence(kv_cache_and_config):
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_cuda(), reason="need cuda")
+@_run_with_kv_cache
 def test_paged_attention_kv_cache_fork_sequence(kv_cache_and_config):
     kv_cache, rope_mode, support_sliding_window = kv_cache_and_config
     if support_sliding_window and rope_mode == RopeMode.NORMAL:
@@ -720,6 +746,7 @@ def test_paged_attention_kv_cache_fork_sequence(kv_cache_and_config):
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_cuda(), reason="need cuda")
+@_run_with_kv_cache
 def test_paged_attention_kv_cache_unlimited_depth(kv_cache_and_config):
     kv_cache, rope_mode, support_sliding_window = kv_cache_and_config
     if support_sliding_window and rope_mode == RopeMode.NORMAL:
@@ -771,6 +798,7 @@ def test_paged_attention_kv_cache_unlimited_depth(kv_cache_and_config):
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_cuda(), reason="need cuda")
+@_run_with_kv_cache
 def test_paged_attention_kv_cache_popn(kv_cache_and_config):
     kv_cache, rope_mode, support_sliding_window = kv_cache_and_config
     if support_sliding_window and rope_mode == RopeMode.NORMAL:
@@ -806,6 +834,7 @@ def test_paged_attention_kv_cache_popn(kv_cache_and_config):
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_cuda(), reason="need cuda")
+@_run_with_kv_cache
 def test_paged_attention_kv_cache_sliding_window(kv_cache_and_config):
     kv_cache, rope_mode, support_sliding_window = kv_cache_and_config
     if not support_sliding_window or rope_mode == RopeMode.NORMAL:
@@ -858,6 +887,7 @@ def test_paged_attention_kv_cache_sliding_window(kv_cache_and_config):
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_cuda(), reason="need cuda")
+@_run_with_kv_cache
 def test_paged_attention_kv_cache_sliding_window_fork(kv_cache_and_config):
     kv_cache, rope_mode, support_sliding_window = kv_cache_and_config
     if not support_sliding_window or rope_mode == RopeMode.NORMAL:
@@ -931,6 +961,7 @@ def test_paged_attention_kv_cache_sliding_window_fork(kv_cache_and_config):
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_cuda(), reason="need cuda")
+@_run_with_kv_cache
 def test_paged_attention_kv_cache_tree_attn(kv_cache_and_config):
     kv_cache, rope_mode, support_sliding_window = kv_cache_and_config
     if support_sliding_window:
@@ -1014,22 +1045,4 @@ def test_paged_attention_kv_cache_tree_attn(kv_cache_and_config):
 
 
 if __name__ == "__main__":
-    HEAD_DIMS = [64, 128]
-    DTYPES = ["float16", "float32"]
-    ROPE_MODES = [RopeMode.NONE, RopeMode.NORMAL, RopeMode.INLINE]
-    SUPPORT_SLIDING_WINDOW = [False, True]
-    for head_dim, dtype, rope_mode, support_sliding_window in itertools.product(
-        HEAD_DIMS, DTYPES, ROPE_MODES, SUPPORT_SLIDING_WINDOW
-    ):
-        dtype_torch = getattr(torch, dtype)
-        sm_scale = head_dim ** (-0.5)
-        set_global_func(head_dim, dtype)
-        cache = create_kv_cache(head_dim, dtype, rope_mode, support_sliding_window)
-        cache_and_config = (cache, rope_mode, support_sliding_window)
-        test_paged_attention_kv_cache_prefill_and_decode(cache_and_config)
-        test_paged_attention_kv_cache_remove_sequence(cache_and_config)
-        test_paged_attention_kv_cache_fork_sequence(cache_and_config)
-        test_paged_attention_kv_cache_popn(cache_and_config)
-        test_paged_attention_kv_cache_sliding_window(cache_and_config)
-        test_paged_attention_kv_cache_tree_attn(cache_and_config)
-        test_paged_attention_kv_cache_unlimited_depth(cache_and_config)
+    tvm.testing.main()

--- a/tests/python/relax/test_runtime_builtin_paged_attention_kv_cache_tir.py
+++ b/tests/python/relax/test_runtime_builtin_paged_attention_kv_cache_tir.py
@@ -242,7 +242,7 @@ def _get_cuda_target():
 def _run_with_kv_cache(test):
     @functools.wraps(test)
     def wrapper(kv_cache_and_config):
-        def run():
+        def run_and_check():
             global device
             device = tvm.cuda()
             head_dim, dtype, rope_mode, support_sliding_window = kv_cache_and_config
@@ -252,7 +252,7 @@ def _run_with_kv_cache(test):
             finally:
                 device = None
 
-        return tvm.testing.run_with_gpu_lock(run)
+        return tvm.testing.run_with_gpu_lock(run_and_check)
 
     return wrapper
 

--- a/tests/python/relax/test_runtime_builtin_rnn_state.py
+++ b/tests/python/relax/test_runtime_builtin_rnn_state.py
@@ -38,7 +38,6 @@ np_three = np.full((32, 32), 3.0, "float32")
 reserved_nseq = 4
 max_history = 4
 num_layers = 1
-device = tvm.cuda()
 # Note that kernels in this test file cannot support 1-dim states.
 states = [((16, 16), "float16"), ((32, 32), "float32")]
 
@@ -94,7 +93,7 @@ def set_global_func():
     f_tir_sets = _f_tir_sets
 
 
-def create_rnn_state():
+def create_rnn_state(device):
     f_create = tvm.get_global_func("vm.builtin.rnn_state_create")
     init_values = [
         tvm.runtime.tensor(np_zero, device=device),
@@ -106,7 +105,7 @@ def create_rnn_state():
 @pytest.fixture
 def rnn_state():
     set_global_func()
-    return create_rnn_state()
+    return create_rnn_state
 
 
 def verify_state(state, seq_ids, expected_values):
@@ -120,71 +119,92 @@ def verify_state(state, seq_ids, expected_values):
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_cuda(), reason="need cuda")
 def test_rnn_state_get(rnn_state):  # pylint: disable=redefined-outer-name
-    state = rnn_state
-    f_clear(state)
-    f_add_sequence(state, 0)
-    f_begin_forward(state, Shape([0]), Shape([1]))
-    tvm_nd_0 = tvm.runtime.tensor(np.empty((1, 16, 16), "float16"), device=device)
-    tvm_nd_1 = tvm.runtime.tensor(np.empty((1, 32, 32), "float32"), device=device)
-    f_get(state, 0, 0, tvm_nd_0)
-    f_get(state, 0, 1, tvm_nd_1)
-    f_end_forward(state)
-    tvm.testing.assert_allclose(tvm_nd_0.numpy(), np.zeros((1, 16, 16), "float16"))
-    tvm.testing.assert_allclose(tvm_nd_1.numpy(), np.ones((1, 32, 32), "float32"))
+    def run_and_check():
+        device = tvm.cuda()
+        state = rnn_state(device)
+        f_clear(state)
+        f_add_sequence(state, 0)
+        f_begin_forward(state, Shape([0]), Shape([1]))
+        tvm_nd_0 = tvm.runtime.tensor(np.empty((1, 16, 16), "float16"), device=device)
+        tvm_nd_1 = tvm.runtime.tensor(np.empty((1, 32, 32), "float32"), device=device)
+        f_get(state, 0, 0, tvm_nd_0)
+        f_get(state, 0, 1, tvm_nd_1)
+        f_end_forward(state)
+        device.sync()
+        tvm.testing.assert_allclose(tvm_nd_0.numpy(), np.zeros((1, 16, 16), "float16"))
+        tvm.testing.assert_allclose(tvm_nd_1.numpy(), np.ones((1, 32, 32), "float32"))
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_cuda(), reason="need cuda")
 def test_rnn_state_set(rnn_state):  # pylint: disable=redefined-outer-name
-    state = rnn_state
-    f_clear(state)
-    for seq_id in range(3):
-        f_add_sequence(state, seq_id)
-    f_begin_forward(state, Shape([0, 2]), Shape([1, 1]))
+    def run_and_check():
+        device = tvm.cuda()
+        state = rnn_state(device)
+        f_clear(state)
+        for seq_id in range(3):
+            f_add_sequence(state, seq_id)
+        f_begin_forward(state, Shape([0, 2]), Shape([1, 1]))
+        f_set(
+            state,
+            0,
+            0,
+            tvm.runtime.tensor(np.full((2, 16, 16), 2.0, "float16"), device=device),
+        )
+        f_set(
+            state,
+            0,
+            1,
+            tvm.runtime.tensor(np.full((2, 32, 32), 3.0, "float32"), device=device),
+        )
+        f_end_forward(state)
+        expected_values = [[np_two, np_three], [np_zero, np_one], [np_two, np_three]]
+        verify_state(state, [0, 1, 2], expected_values)
 
-    f_set(state, 0, 0, tvm.runtime.tensor(np.full((2, 16, 16), 2.0, "float16"), device=device))
-    f_set(state, 0, 1, tvm.runtime.tensor(np.full((2, 32, 32), 3.0, "float32"), device=device))
-    f_end_forward(state)
-
-    expected_values = [[np_two, np_three], [np_zero, np_one], [np_two, np_three]]
-    verify_state(state, [0, 1, 2], expected_values)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_cuda(), reason="need cuda")
 def test_rnn_state_popn(rnn_state):  # pylint: disable=redefined-outer-name
-    state = rnn_state
-    f_clear(state)
+    def run_and_check():
+        device = tvm.cuda()
+        state = rnn_state(device)
+        f_clear(state)
+        f_add_sequence(state, 0)
+        f_begin_forward(state, Shape([0]), Shape([1]))
+        f_set(state, 0, 0, tvm.runtime.tensor(np_two.reshape(1, 16, 16), device=device))
+        f_set(state, 0, 1, tvm.runtime.tensor(np_three.reshape(1, 32, 32), device=device))
+        f_end_forward(state)
+        verify_state(state, [0], [[np_two, np_three]])
+        f_popn(state, 0, 1)
+        verify_state(state, [0], [[np_zero, np_one]])
+        with pytest.raises(RuntimeError):
+            f_popn(state, 0, 1)
 
-    f_add_sequence(state, 0)
-    f_begin_forward(state, Shape([0]), Shape([1]))
-    f_set(state, 0, 0, tvm.runtime.tensor(np_two.reshape(1, 16, 16), device=device))
-    f_set(state, 0, 1, tvm.runtime.tensor(np_three.reshape(1, 32, 32), device=device))
-    f_end_forward(state)
-
-    verify_state(state, [0], [[np_two, np_three]])
-    f_popn(state, 0, 1)
-    verify_state(state, [0], [[np_zero, np_one]])
-    with pytest.raises(RuntimeError):
-        f_popn(state, 0, 1)  # no available history to pop
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_cuda(), reason="need cuda")
 def test_rnn_state_fork_sequence(rnn_state):  # pylint: disable=redefined-outer-name
-    state = rnn_state
-    f_clear(state)
+    def run_and_check():
+        device = tvm.cuda()
+        state = rnn_state(device)
+        f_clear(state)
+        f_add_sequence(state, 0)
+        f_begin_forward(state, Shape([0]), Shape([1]))
+        f_set(state, 0, 0, tvm.runtime.tensor(np_two.reshape(1, 16, 16), device=device))
+        f_set(state, 0, 1, tvm.runtime.tensor(np_three.reshape(1, 32, 32), device=device))
+        f_end_forward(state)
+        f_fork_sequence(state, 0, 1, -1)
+        verify_state(state, [0, 1], [[np_two, np_three], [np_two, np_three]])
+        f_popn(state, 1, 1)
+        verify_state(state, [0, 1], [[np_two, np_three], [np_zero, np_one]])
 
-    f_add_sequence(state, 0)
-    f_begin_forward(state, Shape([0]), Shape([1]))
-    f_set(state, 0, 0, tvm.runtime.tensor(np_two.reshape(1, 16, 16), device=device))
-    f_set(state, 0, 1, tvm.runtime.tensor(np_three.reshape(1, 32, 32), device=device))
-    f_end_forward(state)
-    f_fork_sequence(state, 0, 1, -1)
-    verify_state(state, [0, 1], [[np_two, np_three], [np_two, np_three]])
-    # Verify popn for the forked sequence
-    f_popn(state, 1, 1)
-    verify_state(state, [0, 1], [[np_two, np_three], [np_zero, np_one]])
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 def rnn_state_get(
@@ -263,7 +283,7 @@ def rnn_state_set(
 
 if __name__ == "__main__":
     set_global_func()
-    rnn_state = create_rnn_state()
+    rnn_state = create_rnn_state
     test_rnn_state_get(rnn_state)
     test_rnn_state_set(rnn_state)
     test_rnn_state_popn(rnn_state)

--- a/tests/python/relax/test_runtime_builtin_rnn_state.py
+++ b/tests/python/relax/test_runtime_builtin_rnn_state.py
@@ -130,7 +130,6 @@ def test_rnn_state_get(rnn_state):  # pylint: disable=redefined-outer-name
         f_get(state, 0, 0, tvm_nd_0)
         f_get(state, 0, 1, tvm_nd_1)
         f_end_forward(state)
-        device.sync()
         tvm.testing.assert_allclose(tvm_nd_0.numpy(), np.zeros((1, 16, 16), "float16"))
         tvm.testing.assert_allclose(tvm_nd_1.numpy(), np.ones((1, 32, 32), "float32"))
 

--- a/tests/python/relax/test_runtime_sampling_flashinfer.py
+++ b/tests/python/relax/test_runtime_sampling_flashinfer.py
@@ -14,9 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# ruff: noqa: E501
-
-
 import random
 
 import numpy as np
@@ -52,12 +49,7 @@ def test_sampling():
     # Probability tensor (each row sums to 1)
     probs_np = np.array([[0.1, 0.2, 0.3, 0.2, 0.2] for _ in range(batch_size)], dtype="float32")
 
-    dev = tvm.cuda(0)
-    prob_tvm = tvm.runtime.tensor(probs_np, device=dev)
-    output_tvm = tvm.runtime.empty((batch_size,), "int32", device=dev)
-
-    device = tvm.cuda()
-    target = tvm.target.Target.from_device(device)
+    target = tvm.testing.run_with_gpu_lock(lambda: tvm.target.Target.from_device(tvm.cuda()))
     sampling_mod = load_module(
         "flashinfer_sampling",
         relax.backend.cuda.flashinfer.gen_sampling_module(
@@ -66,28 +58,31 @@ def test_sampling():
     )
     sampling_func = sampling_mod["sampling_from_probs"]
 
-    counts = np.zeros((batch_size, vocab_size), dtype="int32")
+    def run_and_check():
+        dev = tvm.cuda(0)
+        prob_tvm = tvm.runtime.tensor(probs_np, device=dev)
+        output_tvm = tvm.runtime.empty((batch_size,), "int32", device=dev)
+        counts = np.zeros((batch_size, vocab_size), dtype="int32")
 
-    for _ in range(num_iterations):
-        deterministic = False
-        # Generate seed and a random offset.
-        philox_seed = np.uint64(random.getrandbits(63))
-        philox_offset = np.uint64(random.getrandbits(63) % 1000)
+        for _ in range(num_iterations):
+            deterministic = False
+            philox_seed = np.uint64(random.getrandbits(63))
+            philox_offset = np.uint64(random.getrandbits(63) % 1000)
 
-        # the kernel expects (probs, output, maybe_indices, deterministic, philox_seed, philox_offset, cuda_stream)
-        sampling_func(prob_tvm, output_tvm, None, deterministic, philox_seed, philox_offset, 0)
+            sampling_func(prob_tvm, output_tvm, None, deterministic, philox_seed, philox_offset, 0)
 
-        out = output_tvm.numpy()
-        for i in range(batch_size):
-            sampled_token = out[i]
-            counts[i, sampled_token] += 1
+            out = output_tvm.numpy()
+            for i in range(batch_size):
+                sampled_token = out[i]
+                counts[i, sampled_token] += 1
 
-    # Convert counts to frequencies.
-    frequencies = counts / float(num_iterations)
+        frequencies = counts / float(num_iterations)
+        for row in range(batch_size):
+            tvm.testing.assert_allclose(
+                frequencies[row], probs_np[row], rtol=tol_rtol, atol=tol_atol
+            )
 
-    # For each row, check that the empirical frequency is close to the input probability.
-    for row in range(batch_size):
-        tvm.testing.assert_allclose(frequencies[row], probs_np[row], rtol=tol_rtol, atol=tol_atol)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_tir_call_source_kernel.py
+++ b/tests/python/relax/test_tir_call_source_kernel.py
@@ -94,12 +94,15 @@ def test_tir_call_source_kernel():
     tvm.ir.assert_structural_equal(Module["add"], Parsed["add"])
     assert len(Module.get_attr("external_mods")) == 1
 
-    device = tvm.cuda(0)
-    x_nd = tvm.runtime.tensor(np.random.rand(256).astype(np.float32), device)
-    y_nd = tvm.runtime.tensor(np.random.rand(256).astype(np.float32), device)
-    output_np = x_nd.numpy() + y_nd.numpy()
-
     with tvm.target.Target("cuda"):
         lib = tvm.compile(Module)
+
+    def run():
+        device = tvm.cuda(0)
+        x_nd = tvm.runtime.tensor(np.random.rand(256).astype(np.float32), device)
+        y_nd = tvm.runtime.tensor(np.random.rand(256).astype(np.float32), device)
+        output_np = x_nd.numpy() + y_nd.numpy()
         output_nd = tvm.runtime.vm.VirtualMachine(lib, device)["main"](x_nd, y_nd)
         tvm.testing.assert_allclose(output_nd.numpy(), output_np, rtol=1e-5)
+
+    tvm.testing.run_with_gpu_lock(run)

--- a/tests/python/relax/test_tir_call_source_kernel.py
+++ b/tests/python/relax/test_tir_call_source_kernel.py
@@ -97,7 +97,7 @@ def test_tir_call_source_kernel():
     with tvm.target.Target("cuda"):
         lib = tvm.compile(Module)
 
-    def run():
+    def run_and_check():
         device = tvm.cuda(0)
         x_nd = tvm.runtime.tensor(np.random.rand(256).astype(np.float32), device)
         y_nd = tvm.runtime.tensor(np.random.rand(256).astype(np.float32), device)
@@ -105,4 +105,4 @@ def test_tir_call_source_kernel():
         output_nd = tvm.runtime.vm.VirtualMachine(lib, device)["main"](x_nd, y_nd)
         tvm.testing.assert_allclose(output_nd.numpy(), output_np, rtol=1e-5)
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)

--- a/tests/python/relax/test_transform_codegen_pass.py
+++ b/tests/python/relax/test_transform_codegen_pass.py
@@ -55,27 +55,33 @@ pytestmark = [
 # Target gpu
 target_str = "nvidia/nvidia-t4"
 target = tvm.target.Target(target_str)
-dev = tvm.cuda()
 
 
 def check_executable(exec, dev, inputs, expected, entry_func_name):
     vm = relax.VirtualMachine(exec, dev)
     out = vm[entry_func_name](*inputs)
-    tvm.testing.assert_allclose(out.numpy(), expected.numpy(), atol=1e-5, rtol=1e-5)
+    tvm.testing.assert_allclose(out.numpy(), expected, atol=1e-5, rtol=1e-5)
 
 
-def check_roundtrip(exec0, dev, inputs, expected, entry_func_name="main"):
+def check_roundtrip(exec0, reference_exec, input_arrays, entry_func_name="main"):
     with utils.tempdir() as temp:
         exec0.mod.export_library(temp.relpath("exec.so"))
         exec1 = tvm.runtime.load_module(temp.relpath("exec.so"))
     assert exec0.stats() == exec1["stats"]()
     assert exec0.as_text() == exec1["as_text"]()
 
-    check_executable(exec0, dev, inputs, expected, entry_func_name)
-    check_executable(exec1, dev, inputs, expected, entry_func_name)
+    def run_and_check():
+        dev = tvm.cuda()
+        inputs = [tvm.runtime.tensor(array, dev) for array in input_arrays]
+        reference_vm = relax.VirtualMachine(reference_exec, dev)
+        expected = reference_vm["main"](*inputs).numpy()
+        check_executable(exec0, dev, inputs, expected, entry_func_name)
+        check_executable(exec1, dev, inputs, expected, entry_func_name)
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
-def gen_ground_truth(mod, target, dev, inputs):
+def gen_ground_truth(mod, target):
     # Lower and run tuning
     # Since there is no default schedule for GPU in MS yet, this is necessary
     with target:
@@ -84,9 +90,7 @@ def gen_ground_truth(mod, target, dev, inputs):
         )
         new_mod = seq(mod)
     relax.analysis.well_formed(new_mod)
-    exec = tvm.compile(new_mod, target, params={})
-    vm = relax.VirtualMachine(exec, dev)
-    return vm["main"](*inputs)
+    return tvm.compile(new_mod, target, params={})
 
 
 @tvm.script.ir_module
@@ -112,15 +116,13 @@ def setup_test():
 
     np0 = np.random.rand(16, 16).astype(np.float32)
     np1 = np.random.rand(16, 16).astype(np.float32)
-    data0 = tvm.runtime.tensor(np0, dev)
-    data1 = tvm.runtime.tensor(np1, dev)
-    inputs = [data0, data1]
+    inputs = [np0, np1]
 
     # Ground truth should be generated before annotation
     # due to the conflict with MS task extraction
     # TODO(@sunggg): Sort this out
-    expected = gen_ground_truth(mod, target, dev, inputs)
-    return mod, inputs, expected
+    reference_exec = gen_ground_truth(mod, target)
+    return mod, inputs, reference_exec
 
 
 entry_func_name = tvm.testing.parameter("main", "func")
@@ -130,7 +132,7 @@ entry_func_name = tvm.testing.parameter("main", "func")
 @pytest.mark.skipif(not env.has_gpu(), reason="need gpu")
 @requires_tensorrt_runtime
 def test_tensorrt_only(entry_func_name):
-    mod, inputs, expected = setup_test()
+    mod, inputs, reference_exec = setup_test()
 
     if entry_func_name != "main":
         mod[entry_func_name] = mod
@@ -154,14 +156,14 @@ def test_tensorrt_only(entry_func_name):
 
     ex0 = tvm.compile(new_mod, target, params={})
     # Sanity check for the correctness and roundtrip
-    check_roundtrip(ex0, dev, inputs, expected, entry_func_name)
+    check_roundtrip(ex0, reference_exec, inputs, entry_func_name)
 
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_gpu(), reason="need gpu")
 @requires_tensorrt_runtime
 def test_mix_use_tensorrt_and_tvm():
-    mod, inputs, expected = setup_test()
+    mod, inputs, reference_exec = setup_test()
 
     # Define patterns that we want to offload to byoc
     # This test will only offload `add` op to tensorrt
@@ -190,7 +192,7 @@ def test_mix_use_tensorrt_and_tvm():
         ex0 = tvm.compile(new_mod, target, params={})
 
     # Sanity check for the correctness and roundtrip
-    check_roundtrip(ex0, dev, inputs, expected)
+    check_roundtrip(ex0, reference_exec, inputs)
 
 
 @tvm.script.ir_module

--- a/tests/python/relax/test_tvmscript_pyfunc.py
+++ b/tests/python/relax/test_tvmscript_pyfunc.py
@@ -203,7 +203,7 @@ class TestTVMScriptPyFunc:
 
         if tvm.cuda().exist:
 
-            def run():
+            def run_and_check():
                 device = tvm.cuda(0)
                 instance = module(device)
 
@@ -218,7 +218,7 @@ class TestTVMScriptPyFunc:
                 expected = torch.nn.functional.relu(x) * 2.0
                 assert torch.allclose(result, expected, atol=1e-5)
 
-            tvm.testing.run_with_gpu_lock(run)
+            tvm.testing.run_with_gpu_lock(run_and_check)
         else:
             pytest.skip("CUDA not available")
 

--- a/tests/python/relax/test_tvmscript_pyfunc.py
+++ b/tests/python/relax/test_tvmscript_pyfunc.py
@@ -202,19 +202,23 @@ class TestTVMScriptPyFunc:
         module = TestPyFuncModule
 
         if tvm.cuda().exist:
-            device = tvm.cuda(0)
-            instance = module(device)
 
-            assert isinstance(instance, BasePyModule), "Instance should be BasePyModule"
-            assert hasattr(instance, "pyfuncs"), "Instance should have pyfuncs"
+            def run():
+                device = tvm.cuda(0)
+                instance = module(device)
 
-            x = torch.tensor([1.0, 2.0, 3.0], dtype=torch.float32, device="cuda")
-            result = instance.pytorch_processor(x)
+                assert isinstance(instance, BasePyModule), "Instance should be BasePyModule"
+                assert hasattr(instance, "pyfuncs"), "Instance should have pyfuncs"
 
-            assert isinstance(result, torch.Tensor)
-            assert result.device.type == "cuda"
-            expected = torch.nn.functional.relu(x) * 2.0
-            assert torch.allclose(result, expected, atol=1e-5)
+                x = torch.tensor([1.0, 2.0, 3.0], dtype=torch.float32, device="cuda")
+                result = instance.pytorch_processor(x)
+
+                assert isinstance(result, torch.Tensor)
+                assert result.device.type == "cuda"
+                expected = torch.nn.functional.relu(x) * 2.0
+                assert torch.allclose(result, expected, atol=1e-5)
+
+            tvm.testing.run_with_gpu_lock(run)
         else:
             pytest.skip("CUDA not available")
 

--- a/tests/python/relax/test_vm_build.py
+++ b/tests/python/relax/test_vm_build.py
@@ -494,13 +494,13 @@ def test_vm_emit_te_constant_param_gpu(exec_mode):
 
     exec = relax.build(sch.mod, "cuda", exec_mode=exec_mode)
 
-    def run():
+    def run_and_check():
         dev = tvm.cuda()
         vm = relax.VirtualMachine(exec, dev)
         add_res = check_saved_func(vm, "main", tvm.runtime.tensor(x_np, dev))
         tvm.testing.assert_allclose(add_res.numpy(), x_np + c_np, rtol=1e-7, atol=1e-7)
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 def test_vm_relax_symbolic_shape(exec_mode):
@@ -880,7 +880,7 @@ def test_vm_to_device(exec_mode):
     target = tvm.target.Target("llvm", host="llvm")
     ex = relax.build(mod, target, exec_mode=exec_mode)
 
-    def run():
+    def run_and_check():
         vm = relax.VirtualMachine(ex, tvm.cpu())
         x_inp = tvm.runtime.tensor(np.random.rand(2, 3).astype("float32"))
         res_1 = check_saved_func(vm, "foo1", x_inp)
@@ -893,7 +893,7 @@ def test_vm_to_device(exec_mode):
         tvm.testing.assert_allclose(res_1.numpy(), x_inp.numpy())
         tvm.testing.assert_allclose(res_2.numpy(), x_inp.numpy())
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 def test_vm_closure(exec_mode):
@@ -1320,7 +1320,7 @@ def test_relax_module_with_multiple_targets(exec_mode):
 
     tvm.testing.assert_allclose(llvm_output.numpy(), np_C)
 
-    def run_cuda():
+    def run_and_check():
         dev_cuda = tvm.device("cuda")
         vm_cuda = tvm.relax.VirtualMachine(built, device=dev_cuda)
         cuda_output = vm_cuda["func_cuda"](
@@ -1329,7 +1329,7 @@ def test_relax_module_with_multiple_targets(exec_mode):
         )
         tvm.testing.assert_allclose(cuda_output.numpy(), np_C)
 
-    tvm.testing.run_with_gpu_lock(run_cuda)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_vm_build.py
+++ b/tests/python/relax/test_vm_build.py
@@ -493,11 +493,14 @@ def test_vm_emit_te_constant_param_gpu(exec_mode):
     sch.bind(loops[0], "threadIdx.x")
 
     exec = relax.build(sch.mod, "cuda", exec_mode=exec_mode)
-    dev = tvm.cuda()
-    vm = relax.VirtualMachine(exec, dev)
 
-    add_res = check_saved_func(vm, "main", tvm.runtime.tensor(x_np, dev))
-    tvm.testing.assert_allclose(add_res.numpy(), x_np + c_np, rtol=1e-7, atol=1e-7)
+    def run():
+        dev = tvm.cuda()
+        vm = relax.VirtualMachine(exec, dev)
+        add_res = check_saved_func(vm, "main", tvm.runtime.tensor(x_np, dev))
+        tvm.testing.assert_allclose(add_res.numpy(), x_np + c_np, rtol=1e-7, atol=1e-7)
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 def test_vm_relax_symbolic_shape(exec_mode):
@@ -876,17 +879,21 @@ def test_vm_to_device(exec_mode):
     mod = TestToVDevice
     target = tvm.target.Target("llvm", host="llvm")
     ex = relax.build(mod, target, exec_mode=exec_mode)
-    vm = relax.VirtualMachine(ex, tvm.cpu())
-    x_inp = tvm.runtime.tensor(np.random.rand(2, 3).astype("float32"))
-    res_1 = check_saved_func(vm, "foo1", x_inp)
-    res_2 = check_saved_func(vm, "foo2", x_inp)
 
-    # check the copied tensor's device
-    assert res_1.device == tvm.cuda(0)
-    assert res_2.device == tvm.cpu(0)
+    def run():
+        vm = relax.VirtualMachine(ex, tvm.cpu())
+        x_inp = tvm.runtime.tensor(np.random.rand(2, 3).astype("float32"))
+        res_1 = check_saved_func(vm, "foo1", x_inp)
+        res_2 = check_saved_func(vm, "foo2", x_inp)
 
-    tvm.testing.assert_allclose(res_1.numpy(), x_inp.numpy())
-    tvm.testing.assert_allclose(res_2.numpy(), x_inp.numpy())
+        # check the copied tensor's device
+        assert res_1.device == tvm.cuda(0)
+        assert res_2.device == tvm.cpu(0)
+
+        tvm.testing.assert_allclose(res_1.numpy(), x_inp.numpy())
+        tvm.testing.assert_allclose(res_2.numpy(), x_inp.numpy())
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 def test_vm_closure(exec_mode):
@@ -1309,18 +1316,20 @@ def test_relax_module_with_multiple_targets(exec_mode):
         tvm.runtime.tensor(np_B, dev_llvm),
     )
 
-    dev_cuda = tvm.device("cuda")
-    vm_cuda = tvm.relax.VirtualMachine(built, device=dev_cuda)
-
-    cuda_output = vm_cuda["func_cuda"](
-        tvm.runtime.tensor(np_A, dev_cuda),
-        tvm.runtime.tensor(np_B, dev_cuda),
-    )
-
     np_C = np_A + np_B
 
     tvm.testing.assert_allclose(llvm_output.numpy(), np_C)
-    tvm.testing.assert_allclose(cuda_output.numpy(), np_C)
+
+    def run_cuda():
+        dev_cuda = tvm.device("cuda")
+        vm_cuda = tvm.relax.VirtualMachine(built, device=dev_cuda)
+        cuda_output = vm_cuda["func_cuda"](
+            tvm.runtime.tensor(np_A, dev_cuda),
+            tvm.runtime.tensor(np_B, dev_cuda),
+        )
+        tvm.testing.assert_allclose(cuda_output.numpy(), np_C)
+
+    tvm.testing.run_with_gpu_lock(run_cuda)
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_vm_builtin.py
+++ b/tests/python/relax/test_vm_builtin.py
@@ -65,7 +65,6 @@ def test_alloc_tensor_raises_out_of_memory():
     buffer.
     """
     target = "cuda"
-    dev = tvm.device(target)
 
     @I.ir_module
     class Module:
@@ -78,10 +77,14 @@ def test_alloc_tensor_raises_out_of_memory():
             return output
 
     built = tvm.compile(Module, target=target)
-    vm = relax.VirtualMachine(built, dev)
 
-    with pytest.raises(Exception, match="CUDA.*out of memory"):
-        vm["main"]()
+    def run_and_check():
+        dev = tvm.device(target)
+        vm = relax.VirtualMachine(built, dev)
+        with pytest.raises(Exception, match="CUDA.*out of memory"):
+            vm["main"]()
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_vm_cuda_graph.py
+++ b/tests/python/relax/test_vm_cuda_graph.py
@@ -104,14 +104,14 @@ def test_vm_run():
     x_np = np.random.uniform(size=(16, 16)).astype("float32")
     y_np = x_np + 1.0 + 1.0 + 1.0 + 1.0
 
-    def run():
+    def run_and_check():
         dev = tvm.cuda(0)
         vm = relax.VirtualMachine(ex, dev)
         x = tvm.runtime.tensor(x_np, dev)
         y = vm["main"](x)
         tvm.testing.assert_allclose(y.numpy(), y_np, rtol=1e-5, atol=1e-5)
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -168,7 +168,7 @@ def test_capture_error_is_recoverable():
 
     built = tvm.compile(Module, target=target)
 
-    def run():
+    def run_and_check():
         dev = tvm.cuda()
 
         @tvm.register_global_func("test_vm_cuda_graph.invalid_impl_for_cudagraph", override=True)
@@ -186,7 +186,7 @@ def test_capture_error_is_recoverable():
         with pytest.raises(RuntimeError):
             vm["main"](arg)
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_vm_cuda_graph.py
+++ b/tests/python/relax/test_vm_cuda_graph.py
@@ -101,13 +101,17 @@ def test_vm_run():
     mod = Module
     target = tvm.target.Target("cuda", host="llvm")
     ex = codegen(mod, target)
-    dev = tvm.cuda(0)
-    vm = relax.VirtualMachine(ex, dev)
     x_np = np.random.uniform(size=(16, 16)).astype("float32")
-    x = tvm.runtime.tensor(x_np, dev)
-    y = vm["main"](x)
     y_np = x_np + 1.0 + 1.0 + 1.0 + 1.0
-    tvm.testing.assert_allclose(y.numpy(), y_np, rtol=1e-5, atol=1e-5)
+
+    def run():
+        dev = tvm.cuda(0)
+        vm = relax.VirtualMachine(ex, dev)
+        x = tvm.runtime.tensor(x_np, dev)
+        y = vm["main"](x)
+        tvm.testing.assert_allclose(y.numpy(), y_np, rtol=1e-5, atol=1e-5)
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 @pytest.mark.gpu
@@ -131,16 +135,6 @@ def test_capture_error_is_recoverable():
     """
 
     target = tvm.target.Target("cuda")
-    dev = tvm.cuda()
-
-    @tvm.register_global_func("test_vm_cuda_graph.invalid_impl_for_cudagraph", override=True)
-    def invalid_impl_for_cudagraph(arg_tensor):
-        # Memory allocation/deallocation may not be performed while
-        # capturing a cudaGraph.  This passes the warm-up run
-        # performed by "vm.builtin.cuda_graph.run_or_capture", but
-        # throws an exception when the cudaGraph is being captured.
-        _dummy_workspace = tvm.runtime.empty([16], "float16", dev)
-        return arg_tensor
 
     @I.ir_module(s_tir=True)
     class Module:
@@ -173,12 +167,26 @@ def test_capture_error_is_recoverable():
     )
 
     built = tvm.compile(Module, target=target)
-    vm = tvm.relax.VirtualMachine(built, dev)
 
-    arg = tvm.runtime.tensor(np.arange(16).astype("float16"), dev)
+    def run():
+        dev = tvm.cuda()
 
-    with pytest.raises(RuntimeError):
-        vm["main"](arg)
+        @tvm.register_global_func("test_vm_cuda_graph.invalid_impl_for_cudagraph", override=True)
+        def invalid_impl_for_cudagraph(arg_tensor):
+            # Memory allocation/deallocation may not be performed while
+            # capturing a cudaGraph.  This passes the warm-up run
+            # performed by "vm.builtin.cuda_graph.run_or_capture", but
+            # throws an exception when the cudaGraph is being captured.
+            _dummy_workspace = tvm.runtime.empty([16], "float16", dev)
+            return arg_tensor
+
+        vm = tvm.relax.VirtualMachine(built, dev)
+        arg = tvm.runtime.tensor(np.arange(16).astype("float16"), dev)
+
+        with pytest.raises(RuntimeError):
+            vm["main"](arg)
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_vm_multi_device.py
+++ b/tests/python/relax/test_vm_multi_device.py
@@ -23,26 +23,18 @@ import tvm
 import tvm.testing
 from tvm import relax
 from tvm.ir.module import IRModule
-from tvm.runtime import Device
 from tvm.script.parser import ir as I
 from tvm.script.parser import relax as R
 from tvm.testing import env
 
 
-def compile(
-    mod: IRModule,
-    device: list[Device] = [
-        tvm.cpu(),
-    ],
-) -> relax.VirtualMachine:
+def compile(mod: IRModule):
     # compile the model
     mod = relax.transform.RealizeVDevice()(mod)
     mod = relax.transform.LegalizeOps()(mod)
     mod = tvm.s_tir.transform.DefaultGPUSchedule()(mod)
     # no need to feed target argument for mult-target compilation
-    ex = tvm.compile(mod)
-
-    return relax.VirtualMachine(ex, device)
+    return tvm.compile(mod)
 
 
 def test_multi_cpu():
@@ -73,7 +65,7 @@ def test_multi_cpu():
             return gv
 
     devices = [tvm.cpu(0), tvm.cpu(1)]
-    vm = compile(Example, devices)
+    vm = relax.VirtualMachine(compile(Example), devices)
 
     np_ipt0 = np.random.rand(2, 3).astype(np.float32)
     np_ipt1 = np.random.rand(3, 4).astype(np.float32)
@@ -89,9 +81,6 @@ def test_multi_cpu():
 
 @pytest.mark.skipif(not env.has_multi_gpu(), reason="need multiple gpus")
 def test_multi_gpu():
-    if not tvm.cuda(2).exist:
-        pytest.skip("requires at least 3 visible CUDA devices")
-
     @I.ir_module
     class Example:
         I.module_attrs({"attr": 10})
@@ -127,23 +116,27 @@ def test_multi_gpu():
                 R.output(gv)
             return gv
 
-    # The number and ordering of devices should be identical with the vdevice list
-    # defined in global_infos of ir_module
-    devices = [tvm.cuda(1), tvm.cuda(0), tvm.cuda(2)]
-    vm = compile(Example, devices)
-
     np_ipt0 = np.random.rand(2, 3).astype(np.float32)
     np_ipt1 = np.random.rand(3, 4).astype(np.float32)
     np_ipt2 = np.random.rand(4, 5).astype(np.float32)
     np_ipt3 = np.random.rand(5, 6).astype(np.float32)
     np_res = np.matmul(np.matmul(np.matmul(np_ipt0, np_ipt1), np_ipt2), np_ipt3)
 
-    ipt0 = tvm.runtime.tensor(np_ipt0, devices[0])
-    ipt1 = tvm.runtime.tensor(np_ipt1, devices[0])
-    ipt2 = tvm.runtime.tensor(np_ipt2, devices[1])
-    ipt3 = tvm.runtime.tensor(np_ipt3, devices[2])
-    res = vm["foo"](ipt0, ipt1, ipt2, ipt3)
-    tvm.testing.assert_allclose(res.numpy(), np_res)
+    ex = compile(Example)
+
+    def run_and_check():
+        if not tvm.cuda(2).exist:
+            pytest.skip("requires at least 3 visible CUDA devices")
+        devices = [tvm.cuda(1), tvm.cuda(0), tvm.cuda(2)]
+        vm = relax.VirtualMachine(ex, devices)
+        ipt0 = tvm.runtime.tensor(np_ipt0, devices[0])
+        ipt1 = tvm.runtime.tensor(np_ipt1, devices[0])
+        ipt2 = tvm.runtime.tensor(np_ipt2, devices[1])
+        ipt3 = tvm.runtime.tensor(np_ipt3, devices[2])
+        res = vm["foo"](ipt0, ipt1, ipt2, ipt3)
+        tvm.testing.assert_allclose(res.numpy(), np_res)
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -174,21 +167,23 @@ def test_multi_device():
                 R.output(gv)
             return gv
 
-    # The number and ordering of devices should be identical with the vdevice list
-    # defined in global_infos of ir_module
-    devices = [tvm.cuda(0), tvm.cpu(0)]
-    vm = compile(Example, devices)
-
     np_ipt0 = np.random.rand(2, 3).astype(np.float32)
     np_ipt1 = np.random.rand(3, 4).astype(np.float32)
     np_ipt2 = np.random.rand(4, 5).astype(np.float32)
     np_res = np.matmul(np.matmul(np_ipt0, np_ipt1), np_ipt2)
 
-    ipt0 = tvm.runtime.tensor(np_ipt0, devices[1])
-    ipt1 = tvm.runtime.tensor(np_ipt1, devices[1])
-    ipt2 = tvm.runtime.tensor(np_ipt2, devices[0])
-    res = vm["foo"](ipt0, ipt1, ipt2)
-    tvm.testing.assert_allclose(res.numpy(), np_res, rtol=1e-4, atol=1e-4)
+    ex = compile(Example)
+
+    def run_and_check():
+        devices = [tvm.cuda(0), tvm.cpu(0)]
+        vm = relax.VirtualMachine(ex, devices)
+        ipt0 = tvm.runtime.tensor(np_ipt0, devices[1])
+        ipt1 = tvm.runtime.tensor(np_ipt1, devices[1])
+        ipt2 = tvm.runtime.tensor(np_ipt2, devices[0])
+        res = vm["foo"](ipt0, ipt1, ipt2)
+        tvm.testing.assert_allclose(res.numpy(), np_res, rtol=1e-4, atol=1e-4)
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/texture/test_texture_nd.py
+++ b/tests/python/relax/texture/test_texture_nd.py
@@ -168,43 +168,38 @@ def test_texture_copy(backend, dtype, channel_size, read_width):
     ex = relax.build(mod, target)
     load_path = "vm_library.so"
     inputs = [np.random.randint(0, 128, (M, N)).astype(dtype), np.zeros((M, N), dtype)]
+
+    def execute(rexec, remote_session):
+        if remote_session is not None:
+            dev = remote_session.cl()
+        elif "opencl" in backend:
+            dev = tvm.opencl(0)
+        elif "vulkan" in backend:
+            dev = tvm.vulkan(0)
+        else:
+            raise RuntimeError("Unsupported backend")
+
+        if "vdevice" in mod.global_infos:
+            device_arr = [dev for _ in range(len(mod.global_infos["vdevice"]))]
+        else:
+            device_arr = [dev]
+        vm = relax.VirtualMachine(rexec, device_arr)
+        inps = [tvm.runtime.tensor(inp, dev) for inp in inputs]
+        vm["main"](*inps)
+        np.testing.assert_equal(inps[-1].numpy(), inps[0].numpy())
+
     with tempfile.TemporaryDirectory() as temp_dir:
         if remote is not None:
             path = temp_dir + "/" + load_path
             ex.export_library(path, fcompile=ndk.create_shared, options=["-shared", "-fPIC", "-lm"])
             remote.upload(path)
             rexec = remote.load_module(load_path)
-            dev = remote.cl()
-            if "vdevice" in mod.global_infos:
-                device_arr = [dev for ii in range(len(mod.global_infos["vdevice"]))]
-            else:
-                device_arr = [dev]
-            vm = relax.VirtualMachine(rexec, device_arr)
+            try:
+                execute(rexec, remote)
+            finally:
+                remote.get_function("CloseRPCConnection")()
         else:
-            # local execution
-            if "opencl" in backend:
-                dev = tvm.opencl(0)
-            elif "vulkan" in backend:
-                dev = tvm.vulkan(0)
-            else:
-                raise RuntimeError("Unsupported backend")
-
-            if "vdevice" in mod.global_infos:
-                device_arr = [dev for ii in range(len(mod.global_infos["vdevice"]))]
-            else:
-                device_arr = [dev]
-            vm = relax.VirtualMachine(ex, device_arr)
-
-        inps = [tvm.runtime.tensor(inp, dev) for inp in inputs]
-        vm["main"](*inps)
-
-        out1 = inps[-1].numpy()
-        out2 = inps[0].numpy()
-
-        if remote:
-            remote.get_function("CloseRPCConnection")()
-
-        np.testing.assert_equal(out1, out2)
+            tvm.testing.run_with_gpu_lock(execute, ex, None)
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/texture/test_texture_nd.py
+++ b/tests/python/relax/texture/test_texture_nd.py
@@ -169,7 +169,7 @@ def test_texture_copy(backend, dtype, channel_size, read_width):
     load_path = "vm_library.so"
     inputs = [np.random.randint(0, 128, (M, N)).astype(dtype), np.zeros((M, N), dtype)]
 
-    def execute(rexec, remote_session):
+    def run_and_check(rexec, remote_session):
         if remote_session is not None:
             dev = remote_session.cl()
         elif "opencl" in backend:
@@ -195,11 +195,11 @@ def test_texture_copy(backend, dtype, channel_size, read_width):
             remote.upload(path)
             rexec = remote.load_module(load_path)
             try:
-                execute(rexec, remote)
+                run_and_check(rexec, remote)
             finally:
                 remote.get_function("CloseRPCConnection")()
         else:
-            tvm.testing.run_with_gpu_lock(execute, ex, None)
+            tvm.testing.run_with_gpu_lock(run_and_check, ex, None)
 
 
 if __name__ == "__main__":

--- a/tests/python/runtime/test_runtime_module_load.py
+++ b/tests/python/runtime/test_runtime_module_load.py
@@ -115,7 +115,6 @@ def test_device_module_dump():
     sch.bind(tx, "threadIdx.x")
 
     def check_device(device):
-        dev = tvm.device(device, 0)
         if not tvm.testing.device_enabled(device):
             print(f"Skip because {device} is not enabled")
             return
@@ -126,30 +125,41 @@ def test_device_module_dump():
         # test cross compiler function
         f.export_library(path_dso, fcompile=cc.cross_compiler("g++"))
 
-        def popen_check():
-            import tvm
+        def run_and_check():
+            dev = tvm.device(device, 0)
 
-            f1 = tvm.runtime.load_module(path_dso)
-            a = tvm.runtime.tensor(np.random.uniform(size=1024).astype(A.dtype), dev)
-            b = tvm.runtime.tensor(np.zeros(1024, dtype=A.dtype), dev)
-            f1(a, b)
-            np.testing.assert_equal(b.numpy(), a.numpy() + 1)
+            def popen_check():
+                import tvm
 
-        # system lib should be loaded in different process
-        worker = popen_pool.PopenWorker()
-        worker.send(popen_check)
-        worker.recv()
+                f1 = tvm.runtime.load_module(path_dso)
+                a = tvm.runtime.tensor(np.random.uniform(size=1024).astype(A.dtype), dev)
+                b = tvm.runtime.tensor(np.zeros(1024, dtype=A.dtype), dev)
+                f1(a, b)
+                np.testing.assert_equal(b.numpy(), a.numpy() + 1)
+
+            worker = popen_pool.PopenWorker()
+            try:
+                worker.send(popen_check)
+                worker.recv()
+            finally:
+                worker.kill()
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
     def check_c(device):
-        dev = tvm.device(device, 0)
         if not tvm.testing.device_enabled(device):
             print(f"Skip because {device} is not enabled")
             return
         f = tvm.compile(sch.mod, target=tvm.target.Target(device, host="c"))
-        a = tvm.runtime.tensor(np.random.uniform(size=1024).astype(A.dtype), dev)
-        b = tvm.runtime.tensor(np.zeros(1024, dtype=A.dtype), dev)
-        f["main"](a, b)
-        np.testing.assert_equal(b.numpy(), a.numpy() + 1)
+
+        def run_and_check():
+            dev = tvm.device(device, 0)
+            a = tvm.runtime.tensor(np.random.uniform(size=1024).astype(A.dtype), dev)
+            b = tvm.runtime.tensor(np.zeros(1024, dtype=A.dtype), dev)
+            f["main"](a, b)
+            np.testing.assert_equal(b.numpy(), a.numpy() + 1)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
     for device in ["cuda", "vulkan", "opencl", "metal"]:
         check_device(device)

--- a/tests/python/s_tir/meta_schedule/test_meta_schedule_mma_tensorize.py
+++ b/tests/python/s_tir/meta_schedule/test_meta_schedule_mma_tensorize.py
@@ -76,22 +76,25 @@ def test_run_target(mod=None, tgt_str=None, in_dtype="float16", out_dtype="float
     with tvm.transform.PassContext(opt_level=3):
         lib: tvm.runtime.Module = tvm.compile(mod, target=target)
 
-    dev = tvm.device(tgt_str, 0)
     a_np = np.random.rand(M, K).astype(in_dtype)
     b_np = np.random.rand(K, N).astype(in_dtype)
     c_np = np.ones((M, N), dtype=out_dtype)
-    a = tvm.runtime.tensor(a_np, dev)
-    b = tvm.runtime.tensor(b_np, dev)
-    c = tvm.runtime.tensor(c_np, dev)
-
     f = lib["main"]
-    f(a, b, c)
 
-    c_th = torch.matmul(torch.tensor(a_np).to(tgt_str), torch.tensor(b_np).to(tgt_str)).to(
-        torch.float32 if out_dtype == "float32" else torch.float16
-    )
-    c_f = torch.tensor(c.numpy()).to(tgt_str)
-    torch.allclose(c_th, c_f, rtol=0.05, atol=0.05)
+    def run_and_check():
+        dev = tvm.device(tgt_str, 0)
+        a = tvm.runtime.tensor(a_np, dev)
+        b = tvm.runtime.tensor(b_np, dev)
+        c = tvm.runtime.tensor(c_np, dev)
+        f(a, b, c)
+        dev.sync()
+        c_th = torch.matmul(torch.tensor(a_np).to(tgt_str), torch.tensor(b_np).to(tgt_str)).to(
+            torch.float32 if out_dtype == "float32" else torch.float16
+        )
+        c_f = torch.tensor(c.numpy()).to(tgt_str)
+        assert torch.allclose(c_th, c_f, rtol=0.05, atol=0.05)
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu

--- a/tests/python/s_tir/meta_schedule/test_meta_schedule_mma_tensorize.py
+++ b/tests/python/s_tir/meta_schedule/test_meta_schedule_mma_tensorize.py
@@ -87,7 +87,6 @@ def test_run_target(mod=None, tgt_str=None, in_dtype="float16", out_dtype="float
         b = tvm.runtime.tensor(b_np, dev)
         c = tvm.runtime.tensor(c_np, dev)
         f(a, b, c)
-        dev.sync()
         c_th = torch.matmul(torch.tensor(a_np).to(tgt_str), torch.tensor(b_np).to(tgt_str)).to(
             torch.float32 if out_dtype == "float32" else torch.float16
         )

--- a/tests/python/s_tir/schedule/test_tir_schedule_tensorize_ldmatrix_mma_numeric.py
+++ b/tests/python/s_tir/schedule/test_tir_schedule_tensorize_ldmatrix_mma_numeric.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=missing-docstring
-# ruff: noqa: E501
 import numpy as np
 import pytest
 
@@ -122,8 +121,6 @@ def run_test(
 
     f = tvm.compile(sch.mod["main"], target="cuda")
 
-    dev = tvm.device("cuda", 0)
-
     if in_dtype == "float16":
         a_np = np.random.normal(size=(M, K)).astype("float16")
 
@@ -171,18 +168,20 @@ def run_test(
             b_np = np.random.randint(-128, 128, (K, N)).astype("int8")
             c_np = np.dot(a_np.astype("float32"), b_np.astype("float32")).astype("int32")
 
-    a = tvm.runtime.tensor(a_np, dev)
-    b = tvm.runtime.tensor(b_np, dev)
-    c = tvm.runtime.tensor(np.zeros((M, N), dtype=out_dtype), dev)
+    def run(measure=False):
+        dev = tvm.device("cuda", 0)
+        a = tvm.runtime.tensor(a_np, dev)
+        b = tvm.runtime.tensor(b_np, dev)
+        c = tvm.runtime.tensor(np.zeros((M, N), dtype=out_dtype), dev)
+        if measure:
+            return f.time_evaluator(f.entry_name, dev, number=500)(a, b, c)
+        f(a, b, c)
+        dev.sync()
+        if out_dtype != "float16" and in_dtype not in ["float8_e4m3fn", "float8_e5m2"]:
+            tvm.testing.assert_allclose(c.numpy(), c_np, rtol=1e-2, atol=1e-2)
 
-    f(a, b, c)
-
-    if out_dtype != "float16" and in_dtype not in ["float8_e4m3fn", "float8_e5m2"]:
-        # The numpy reference is computed with fp32 precision (otherwise too slow).
-        # So there is non-trivial accuracy difference if TVM result is computed with fp16 accumulation.
-        tvm.testing.assert_allclose(c.numpy(), c_np, rtol=1e-2, atol=1e-2)
-
-    return lambda: f.time_evaluator(f.entry_name, dev, number=500)(a, b, c)
+    tvm.testing.run_with_gpu_lock(run)
+    return lambda: tvm.testing.run_with_gpu_lock(run, True)
 
 
 @pytest.mark.gpu

--- a/tests/python/s_tir/schedule/test_tir_schedule_tensorize_ldmatrix_mma_numeric.py
+++ b/tests/python/s_tir/schedule/test_tir_schedule_tensorize_ldmatrix_mma_numeric.py
@@ -168,7 +168,7 @@ def run_test(
             b_np = np.random.randint(-128, 128, (K, N)).astype("int8")
             c_np = np.dot(a_np.astype("float32"), b_np.astype("float32")).astype("int32")
 
-    def run(measure=False):
+    def run_and_check(measure=False):
         dev = tvm.device("cuda", 0)
         a = tvm.runtime.tensor(a_np, dev)
         b = tvm.runtime.tensor(b_np, dev)
@@ -180,8 +180,8 @@ def run_test(
         if out_dtype != "float16" and in_dtype not in ["float8_e4m3fn", "float8_e5m2"]:
             tvm.testing.assert_allclose(c.numpy(), c_np, rtol=1e-2, atol=1e-2)
 
-    tvm.testing.run_with_gpu_lock(run)
-    return lambda: tvm.testing.run_with_gpu_lock(run, True)
+    tvm.testing.run_with_gpu_lock(run_and_check)
+    return lambda: tvm.testing.run_with_gpu_lock(run_and_check, True)
 
 
 @pytest.mark.gpu

--- a/tests/python/s_tir/schedule/test_tir_schedule_tensorize_mfma_numeric.py
+++ b/tests/python/s_tir/schedule/test_tir_schedule_tensorize_mfma_numeric.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=missing-docstring
-# ruff: noqa: E501
 import numpy as np
 import pytest
 
@@ -113,7 +112,6 @@ def run_test(
 
     f = tvm.compile(sch.mod["main"], target="rocm")
 
-    dev = tvm.device("rocm", 0)
     if in_dtype == "float32":
         a_np = np.random.uniform(size=(M, K)).astype("float32")
 
@@ -148,18 +146,20 @@ def run_test(
             b_np = np.random.randint(-128, 128, (K, N)).astype("int8")
             c_np = np.dot(a_np.astype("float32"), b_np.astype("float32")).astype("int32")
 
-    a = tvm.runtime.tensor(a_np, dev)
-    b = tvm.runtime.tensor(b_np, dev)
-    c = tvm.runtime.tensor(np.zeros((M, N), dtype=out_dtype), dev)
+    def run(measure=False):
+        dev = tvm.device("rocm", 0)
+        a = tvm.runtime.tensor(a_np, dev)
+        b = tvm.runtime.tensor(b_np, dev)
+        c = tvm.runtime.tensor(np.zeros((M, N), dtype=out_dtype), dev)
+        if measure:
+            return f.time_evaluator(f.entry_name, dev, number=500)(a, b, c)
+        f(a, b, c)
+        dev.sync()
+        if in_dtype != "float16":
+            tvm.testing.assert_allclose(c.numpy(), c_np, rtol=1e-2, atol=1e-2)
 
-    f(a, b, c)
-
-    if in_dtype != "float16":
-        # The numpy reference is computed with fp32 precision (otherwise too slow).
-        # So there is non-trivial accuracy difference if TVM result is computed with fp16 accumulation.
-        tvm.testing.assert_allclose(c.numpy(), c_np, rtol=1e-2, atol=1e-2)
-
-    return lambda: f.time_evaluator(f.entry_name, dev, number=500)(a, b, c)
+    tvm.testing.run_with_gpu_lock(run)
+    return lambda: tvm.testing.run_with_gpu_lock(run, True)
 
 
 @pytest.mark.gpu

--- a/tests/python/s_tir/schedule/test_tir_schedule_tensorize_mfma_numeric.py
+++ b/tests/python/s_tir/schedule/test_tir_schedule_tensorize_mfma_numeric.py
@@ -146,7 +146,7 @@ def run_test(
             b_np = np.random.randint(-128, 128, (K, N)).astype("int8")
             c_np = np.dot(a_np.astype("float32"), b_np.astype("float32")).astype("int32")
 
-    def run(measure=False):
+    def run_and_check(measure=False):
         dev = tvm.device("rocm", 0)
         a = tvm.runtime.tensor(a_np, dev)
         b = tvm.runtime.tensor(b_np, dev)
@@ -158,8 +158,8 @@ def run_test(
         if in_dtype != "float16":
             tvm.testing.assert_allclose(c.numpy(), c_np, rtol=1e-2, atol=1e-2)
 
-    tvm.testing.run_with_gpu_lock(run)
-    return lambda: tvm.testing.run_with_gpu_lock(run, True)
+    tvm.testing.run_with_gpu_lock(run_and_check)
+    return lambda: tvm.testing.run_with_gpu_lock(run_and_check, True)
 
 
 @pytest.mark.gpu

--- a/tests/python/s_tir/transform/test_s_tir_transform_inject_ptx_async_copy.py
+++ b/tests/python/s_tir/transform/test_s_tir_transform_inject_ptx_async_copy.py
@@ -167,11 +167,16 @@ def test_inject_async_copy():
 
         A_np = np.random.rand(32, 128).astype(dtype)
         B_np = np.zeros((32, 128)).astype(dtype)
-        dev = tvm.cuda(0)
-        A_nd = tvm.runtime.tensor(A_np, device=dev)
-        B_nd = tvm.runtime.tensor(B_np, device=dev)
-        mod(A_nd, B_nd)
-        tvm.testing.assert_allclose(B_nd.numpy(), A_np)
+
+        def run_and_check():
+            dev = tvm.cuda(0)
+            A_nd = tvm.runtime.tensor(A_np, device=dev)
+            B_nd = tvm.runtime.tensor(B_np, device=dev)
+            mod(A_nd, B_nd)
+            dev.sync()
+            tvm.testing.assert_allclose(B_nd.numpy(), A_np)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -197,12 +202,17 @@ def test_inject_async_copy_shared_dyn():
     A_np = np.random.rand(32, 128).astype("float16")
     B_np = np.random.rand(32, 128).astype("float16")
     C_np = np.zeros((32, 128)).astype("float16")
-    dev = tvm.cuda(0)
-    A_nd = tvm.runtime.tensor(A_np, device=dev)
-    B_nd = tvm.runtime.tensor(B_np, device=dev)
-    C_nd = tvm.runtime.tensor(C_np, device=dev)
-    mod(A_nd, B_nd, C_nd)
-    tvm.testing.assert_allclose(C_nd.numpy(), A_np + B_np)
+
+    def run_and_check():
+        dev = tvm.cuda(0)
+        A_nd = tvm.runtime.tensor(A_np, device=dev)
+        B_nd = tvm.runtime.tensor(B_np, device=dev)
+        C_nd = tvm.runtime.tensor(C_np, device=dev)
+        mod(A_nd, B_nd, C_nd)
+        dev.sync()
+        tvm.testing.assert_allclose(C_nd.numpy(), A_np + B_np)
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 # Note: the test_inject_async_copy_barrier case (and its prim_func helper)

--- a/tests/python/s_tir/transform/test_s_tir_transform_inject_ptx_async_copy.py
+++ b/tests/python/s_tir/transform/test_s_tir_transform_inject_ptx_async_copy.py
@@ -173,7 +173,6 @@ def test_inject_async_copy():
             A_nd = tvm.runtime.tensor(A_np, device=dev)
             B_nd = tvm.runtime.tensor(B_np, device=dev)
             mod(A_nd, B_nd)
-            dev.sync()
             tvm.testing.assert_allclose(B_nd.numpy(), A_np)
 
         tvm.testing.run_with_gpu_lock(run_and_check)
@@ -209,7 +208,6 @@ def test_inject_async_copy_shared_dyn():
         B_nd = tvm.runtime.tensor(B_np, device=dev)
         C_nd = tvm.runtime.tensor(C_np, device=dev)
         mod(A_nd, B_nd, C_nd)
-        dev.sync()
         tvm.testing.assert_allclose(C_nd.numpy(), A_np + B_np)
 
     tvm.testing.run_with_gpu_lock(run_and_check)

--- a/tests/python/s_tir/transform/test_s_tir_transform_inject_software_pipeline.py
+++ b/tests/python/s_tir/transform/test_s_tir_transform_inject_software_pipeline.py
@@ -1537,15 +1537,20 @@ def build_and_run(sch):
         with tvm.transform.PassContext(config={"tirx.use_async_copy": 1}):
             f = tvm.compile(sch.mod["main"], target="cuda")
 
-        dev = tvm.device("cuda", 0)
         a_np = np.random.uniform(size=(N, K)).astype("float16")
         b_np = np.random.uniform(size=(K, M)).astype("float16")
         c_np = np.dot(a_np.astype("float32"), b_np.astype("float32"))
-        a = tvm.runtime.tensor(a_np, dev)
-        b = tvm.runtime.tensor(b_np, dev)
-        c = tvm.runtime.tensor(np.zeros((N, M), dtype="float32"), dev)
-        f(a, b, c)
-        tvm.testing.assert_allclose(c.numpy(), c_np, rtol=1e-3)
+
+        def run_and_check():
+            dev = tvm.device("cuda", 0)
+            a = tvm.runtime.tensor(a_np, dev)
+            b = tvm.runtime.tensor(b_np, dev)
+            c = tvm.runtime.tensor(np.zeros((N, M), dtype="float32"), dev)
+            f(a, b, c)
+            dev.sync()
+            tvm.testing.assert_allclose(c.numpy(), c_np, rtol=1e-3)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu

--- a/tests/python/s_tir/transform/test_s_tir_transform_inject_software_pipeline.py
+++ b/tests/python/s_tir/transform/test_s_tir_transform_inject_software_pipeline.py
@@ -1547,7 +1547,6 @@ def build_and_run(sch):
             b = tvm.runtime.tensor(b_np, dev)
             c = tvm.runtime.tensor(np.zeros((N, M), dtype="float32"), dev)
             f(a, b, c)
-            dev.sync()
             tvm.testing.assert_allclose(c.numpy(), c_np, rtol=1e-3)
 
         tvm.testing.run_with_gpu_lock(run_and_check)

--- a/tests/python/target/test_target_target.py
+++ b/tests/python/target/test_target_target.py
@@ -328,63 +328,71 @@ def test_target_features():
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_cuda(), reason="need cuda")
-@pytest.mark.parametrize("input_device", ["cuda", tvm.cuda()])
-def test_target_from_device_cuda(input_device):
-    target = Target.from_device(input_device)
+@pytest.mark.parametrize("input_form", ["string", "device"])
+def test_target_from_device_cuda(input_form):
+    def run_and_check():
+        dev = tvm.cuda()
+        target = Target.from_device("cuda" if input_form == "string" else dev)
+        assert target.kind.name == "cuda"
+        assert target.attrs["max_threads_per_block"] == dev.max_threads_per_block
+        assert int(target.attrs["max_shared_memory_per_block"]) == dev.max_shared_memory_per_block
+        assert int(target.attrs["thread_warp_size"]) == dev.warp_size
+        assert str(target.attrs.get("arch", "")) == "sm_" + dev.compute_version.replace(".", "")
 
-    dev = tvm.cuda()
-    assert target.kind.name == "cuda"
-    assert target.attrs["max_threads_per_block"] == dev.max_threads_per_block
-    assert int(target.attrs["max_shared_memory_per_block"]) == dev.max_shared_memory_per_block
-    assert int(target.attrs["thread_warp_size"]) == dev.warp_size
-    assert str(target.attrs.get("arch", "")) == "sm_" + dev.compute_version.replace(".", "")
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_rocm(), reason="need rocm")
-@pytest.mark.parametrize("input_device", ["rocm", tvm.rocm()])
-def test_target_from_device_rocm(input_device):
-    target = Target.from_device(input_device)
+@pytest.mark.parametrize("input_form", ["string", "device"])
+def test_target_from_device_rocm(input_form):
+    def run_and_check():
+        dev = tvm.rocm()
+        target = Target.from_device("rocm" if input_form == "string" else dev)
+        assert target.kind.name == "rocm"
+        assert target.attrs["mtriple"] == "amdgcn-and-amdhsa-hcc"
+        assert target.attrs["max_threads_per_block"] == dev.max_threads_per_block
+        assert int(target.attrs["max_shared_memory_per_block"]) == dev.max_shared_memory_per_block
+        assert int(target.attrs["thread_warp_size"]) == dev.warp_size
 
-    dev = tvm.rocm()
-    assert target.kind.name == "rocm"
-    assert target.attrs["mtriple"] == "amdgcn-and-amdhsa-hcc"
-    assert target.attrs["max_threads_per_block"] == dev.max_threads_per_block
-    assert int(target.attrs["max_shared_memory_per_block"]) == dev.max_shared_memory_per_block
-    assert int(target.attrs["thread_warp_size"]) == dev.warp_size
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_vulkan(), reason="need vulkan")
-@pytest.mark.parametrize("input_device", ["vulkan", tvm.vulkan()])
-def test_target_from_device_vulkan(input_device):
-    target = Target.from_device(input_device)
+@pytest.mark.parametrize("input_form", ["string", "device"])
+def test_target_from_device_vulkan(input_form):
+    def run_and_check():
+        dev = tvm.vulkan()
+        target = Target.from_device("vulkan" if input_form == "string" else dev)
+        f_get_target_property = tvm.get_global_func("device_api.vulkan.get_target_property")
+        assert target.kind.name == "vulkan"
+        assert target.attrs["max_threads_per_block"] == dev.max_threads_per_block
+        assert int(target.attrs["max_shared_memory_per_block"]) == dev.max_shared_memory_per_block
+        assert int(target.attrs["thread_warp_size"]) == dev.warp_size
+        assert target.attrs["supports_float16"] == f_get_target_property(dev, "supports_float16")
+        assert target.attrs["supports_int16"] == f_get_target_property(dev, "supports_int16")
+        assert target.attrs["supports_int8"] == f_get_target_property(dev, "supports_int8")
+        assert target.attrs["supports_16bit_buffer"] == f_get_target_property(
+            dev, "supports_16bit_buffer"
+        )
 
-    f_get_target_property = tvm.get_global_func("device_api.vulkan.get_target_property")
-    dev = tvm.vulkan()
-    assert target.kind.name == "vulkan"
-    assert target.attrs["max_threads_per_block"] == dev.max_threads_per_block
-    assert int(target.attrs["max_shared_memory_per_block"]) == dev.max_shared_memory_per_block
-    assert int(target.attrs["thread_warp_size"]) == dev.warp_size
-    assert target.attrs["supports_float16"] == f_get_target_property(dev, "supports_float16")
-    assert target.attrs["supports_int16"] == f_get_target_property(dev, "supports_int16")
-    assert target.attrs["supports_int8"] == f_get_target_property(dev, "supports_int8")
-    assert target.attrs["supports_16bit_buffer"] == f_get_target_property(
-        dev, "supports_16bit_buffer"
-    )
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_opencl(), reason="need opencl")
-@pytest.mark.parametrize("input_device", ["opencl", tvm.opencl()])
-def test_target_from_device_opencl(input_device):
-    target = Target.from_device(input_device)
+@pytest.mark.parametrize("input_form", ["string", "device"])
+def test_target_from_device_opencl(input_form):
+    def run_and_check():
+        dev = tvm.opencl()
+        target = Target.from_device("opencl" if input_form == "string" else dev)
+        assert target.kind.name == "opencl"
+        assert target.attrs["max_threads_per_block"] == dev.max_threads_per_block
+        assert int(target.attrs["max_shared_memory_per_block"]) == dev.max_shared_memory_per_block
+        assert int(target.attrs["thread_warp_size"]) == dev.warp_size
 
-    dev = tvm.opencl()
-    assert target.kind.name == "opencl"
-    assert target.attrs["max_threads_per_block"] == dev.max_threads_per_block
-    assert int(target.attrs["max_shared_memory_per_block"]) == dev.max_shared_memory_per_block
-    assert int(target.attrs["thread_warp_size"]) == dev.warp_size
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 def test_module_dict_from_deserialized_targets():

--- a/tests/python/testing/test_tvm_testing_features.py
+++ b/tests/python/testing/test_tvm_testing_features.py
@@ -23,6 +23,8 @@ import pytest
 
 import tvm.testing
 
+pytestmark = pytest.mark.xdist_group(name="tvm-testing-features")
+
 # This file tests features in tvm.testing, such as verifying that
 # cached fixtures are run an appropriate number of times.  As a
 # result, the order of the tests is important.  Use of --last-failed

--- a/tests/python/tirx-base/test_tir_intrin.py
+++ b/tests/python/tirx-base/test_tir_intrin.py
@@ -283,7 +283,6 @@ dtype = tvm.testing.parameter("int32", "int64")
 def test_clz(target, dtype):
     if not tvm.testing.device_enabled(target):
         pytest.skip(f"{target} not enabled")
-    dev = tvm.device(target["kind"] if isinstance(target, dict) else target)
     target = tvm.target.Target(target)
     if (
         target.kind.name == "vulkan"
@@ -318,19 +317,26 @@ def test_clz(target, dtype):
     # Build from scheduled TIR
     func = tvm.compile(sch.mod, target=target)
 
-    n = 10
-    highs = [10, 100, 1000, 10000, 100000, 1000000]
+    def run():
+        dev = tvm.device(target.kind.name)
+        n = 10
+        highs = [10, 100, 1000, 10000, 100000, 1000000]
 
-    if dtype == "int64":
-        highs.append((1 << 63) - 1)
+        if dtype == "int64":
+            highs.append((1 << 63) - 1)
 
-    for high in highs:
-        a_np = np.random.randint(1, high=high, size=(n,), dtype=dtype)
-        a = tvm.runtime.tensor(a_np, dev)
-        b = tvm.runtime.tensor(np.zeros((n,)).astype("int32"), dev)
-        func(a, b)
-        ref = clz_np(a_np, dtype)
-        np.testing.assert_equal(b.numpy(), ref)
+        for high in highs:
+            a_np = np.random.randint(1, high=high, size=(n,), dtype=dtype)
+            a = tvm.runtime.tensor(a_np, dev)
+            b = tvm.runtime.tensor(np.zeros((n,)).astype("int32"), dev)
+            func(a, b)
+            ref = clz_np(a_np, dtype)
+            np.testing.assert_equal(b.numpy(), ref)
+
+    if target.kind.name == "llvm":
+        run()
+    else:
+        tvm.testing.run_with_gpu_lock(run)
 
 
 @tvm.script.ir_module

--- a/tests/python/tirx-base/test_tir_intrin.py
+++ b/tests/python/tirx-base/test_tir_intrin.py
@@ -317,7 +317,7 @@ def test_clz(target, dtype):
     # Build from scheduled TIR
     func = tvm.compile(sch.mod, target=target)
 
-    def run():
+    def run_and_check():
         dev = tvm.device(target.kind.name)
         n = 10
         highs = [10, 100, 1000, 10000, 100000, 1000000]
@@ -334,9 +334,9 @@ def test_clz(target, dtype):
             np.testing.assert_equal(b.numpy(), ref)
 
     if target.kind.name == "llvm":
-        run()
+        run_and_check()
     else:
-        tvm.testing.run_with_gpu_lock(run)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @tvm.script.ir_module

--- a/tests/python/tirx-base/test_tir_ptx_cp_async.py
+++ b/tests/python/tirx-base/test_tir_ptx_cp_async.py
@@ -59,11 +59,15 @@ def test_ptx_cp_async():
     mod = tvm.compile(f, target="cuda")
     A_np = np.random.rand(32, 128).astype("float16")
     B_np = np.zeros((32, 128)).astype("float16")
-    dev = tvm.cuda(0)
-    A_nd = tvm.runtime.tensor(A_np, device=dev)
-    B_nd = tvm.runtime.tensor(B_np, device=dev)
-    mod(A_nd, B_nd)
-    tvm.testing.assert_allclose(B_nd.numpy(), A_np)
+
+    def run_and_check():
+        dev = tvm.cuda(0)
+        A_nd = tvm.runtime.tensor(A_np, device=dev)
+        B_nd = tvm.runtime.tensor(B_np, device=dev)
+        mod(A_nd, B_nd)
+        tvm.testing.assert_allclose(B_nd.numpy(), A_np)
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 # Note: tests for the indexed barrier API (`create_barriers`,

--- a/tests/python/tirx-base/test_tir_ptx_griddepcontrol.py
+++ b/tests/python/tirx-base/test_tir_ptx_griddepcontrol.py
@@ -46,11 +46,15 @@ def test_ptx_griddepcontrol():
     mod = tvm.compile(f, target="cuda")
     A_np = np.random.default_rng(0).standard_normal(32).astype("float32")
     B_np = np.zeros((32,), dtype="float32")
-    dev = tvm.cuda(0)
-    A_nd = tvm.runtime.tensor(A_np, device=dev)
-    B_nd = tvm.runtime.tensor(B_np, device=dev)
-    mod(A_nd, B_nd)
-    tvm.testing.assert_allclose(B_nd.numpy(), A_np, rtol=0, atol=0)
+
+    def run_and_check():
+        dev = tvm.cuda(0)
+        A_nd = tvm.runtime.tensor(A_np, device=dev)
+        B_nd = tvm.runtime.tensor(B_np, device=dev)
+        mod(A_nd, B_nd)
+        tvm.testing.assert_allclose(B_nd.numpy(), A_np, rtol=0, atol=0)
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 if __name__ == "__main__":

--- a/tests/python/tirx-base/test_tir_ptx_ldmatrix.py
+++ b/tests/python/tirx-base/test_tir_ptx_ldmatrix.py
@@ -90,11 +90,15 @@ def test_ptx_ldmatrix():
                 else:
                     A_mask_np[:16, :16] = A_np[:16, :16]
             B_np = np.zeros((16, 16)).astype("float16")
-            dev = tvm.cuda(0)
-            A_nd = tvm.runtime.tensor(A_np, device=dev)
-            B_nd = tvm.runtime.tensor(B_np, device=dev)
-            mod(A_nd, B_nd)
-            tvm.testing.assert_allclose(B_nd.numpy(), A_mask_np)
+
+            def run_and_check():
+                dev = tvm.cuda(0)
+                A_nd = tvm.runtime.tensor(A_np, device=dev)
+                B_nd = tvm.runtime.tensor(B_np, device=dev)
+                mod(A_nd, B_nd)
+                tvm.testing.assert_allclose(B_nd.numpy(), A_mask_np)
+
+            tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 if __name__ == "__main__":

--- a/tests/python/tirx-base/test_tir_ptx_mma.py
+++ b/tests/python/tirx-base/test_tir_ptx_mma.py
@@ -76,18 +76,18 @@ def test_gemm_mma_m8n8k4_row_col_fp64pf64fp64():
     B_np = np.random.uniform(-1, 1, [8, 4]).astype("float64")
     C_np = np.zeros([8, 8]).astype("float64")
 
-    ctx = tvm.cuda()
-    A_tvm = tvm.runtime.tensor(A_np, ctx)
-    B_tvm = tvm.runtime.tensor(B_np, ctx)
-    C_tvm = tvm.runtime.tensor(C_np, ctx)
-
-    cuda_mod(A_tvm, B_tvm, C_tvm)
-
     golden = np.matmul(A_np.astype("float64"), B_np.astype("float64").T)
 
-    C_numpy = C_tvm.numpy()
+    def run_and_check():
+        ctx = tvm.cuda()
+        A_tvm = tvm.runtime.tensor(A_np, ctx)
+        B_tvm = tvm.runtime.tensor(B_np, ctx)
+        C_tvm = tvm.runtime.tensor(C_np, ctx)
+        cuda_mod(A_tvm, B_tvm, C_tvm)
+        C_numpy = C_tvm.numpy()
+        tvm.testing.assert_allclose(golden, C_numpy, atol=1e-3, rtol=1e-3)
 
-    tvm.testing.assert_allclose(golden, C_numpy, atol=1e-3, rtol=1e-3)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @T.prim_func(s_tir=True)
@@ -153,18 +153,18 @@ def test_gemm_mma_m8n8k4_row_row_fp16fp16fp16():
     B_np = np.random.uniform(-1, 1, [4, 16]).astype("float16")
     C_np = np.zeros([16, 16]).astype("float16")
 
-    ctx = tvm.cuda()
-    A_tvm = tvm.runtime.tensor(A_np, ctx)
-    B_tvm = tvm.runtime.tensor(B_np, ctx)
-    C_tvm = tvm.runtime.tensor(C_np, ctx)
-
-    cuda_mod(A_tvm, B_tvm, C_tvm)
-
     golden = np.matmul(A_np.astype("float16"), B_np.astype("float16"))
 
-    C_numpy = C_tvm.numpy()
+    def run_and_check():
+        ctx = tvm.cuda()
+        A_tvm = tvm.runtime.tensor(A_np, ctx)
+        B_tvm = tvm.runtime.tensor(B_np, ctx)
+        C_tvm = tvm.runtime.tensor(C_np, ctx)
+        cuda_mod(A_tvm, B_tvm, C_tvm)
+        C_numpy = C_tvm.numpy()
+        tvm.testing.assert_allclose(golden, C_numpy, atol=1e-3, rtol=1e-3)
 
-    tvm.testing.assert_allclose(golden, C_numpy, atol=1e-3, rtol=1e-3)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @T.prim_func(s_tir=True)
@@ -237,18 +237,18 @@ def test_gemm_mma_m8n8k4_row_row_fp16fp16fp32():
     B_np = np.random.uniform(-1, 1, [4, 16]).astype("float16")
     C_np = np.zeros([16, 16]).astype("float32")
 
-    ctx = tvm.cuda()
-    A_tvm = tvm.runtime.tensor(A_np, ctx)
-    B_tvm = tvm.runtime.tensor(B_np, ctx)
-    C_tvm = tvm.runtime.tensor(C_np, ctx)
-
-    cuda_mod(A_tvm, B_tvm, C_tvm)
-
     golden = np.matmul(A_np.astype("float32"), B_np.astype("float32"))
 
-    C_numpy = C_tvm.numpy()
+    def run_and_check():
+        ctx = tvm.cuda()
+        A_tvm = tvm.runtime.tensor(A_np, ctx)
+        B_tvm = tvm.runtime.tensor(B_np, ctx)
+        C_tvm = tvm.runtime.tensor(C_np, ctx)
+        cuda_mod(A_tvm, B_tvm, C_tvm)
+        C_numpy = C_tvm.numpy()
+        tvm.testing.assert_allclose(golden, C_numpy, atol=1e-3, rtol=1e-3)
 
-    tvm.testing.assert_allclose(golden, C_numpy, atol=1e-3, rtol=1e-3)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @T.prim_func(s_tir=True)
@@ -309,18 +309,18 @@ def test_gemm_mma_m8n8k16_row_col_s8s8s32():
     B_np = np.random.uniform(-10, 10, [8, 16]).astype("int8")
     C_np = np.zeros([8, 8]).astype("int32")
 
-    ctx = tvm.cuda()
-    A_tvm = tvm.runtime.tensor(A_np, ctx)
-    B_tvm = tvm.runtime.tensor(B_np, ctx)
-    C_tvm = tvm.runtime.tensor(C_np, ctx)
-
-    cuda_mod(A_tvm, B_tvm, C_tvm)
-
     golden = np.matmul(A_np.astype("int32"), B_np.astype("int32").T)
 
-    C_numpy = C_tvm.numpy()
+    def run_and_check():
+        ctx = tvm.cuda()
+        A_tvm = tvm.runtime.tensor(A_np, ctx)
+        B_tvm = tvm.runtime.tensor(B_np, ctx)
+        C_tvm = tvm.runtime.tensor(C_np, ctx)
+        cuda_mod(A_tvm, B_tvm, C_tvm)
+        C_numpy = C_tvm.numpy()
+        tvm.testing.assert_allclose(golden, C_numpy, atol=1e-3, rtol=1e-3)
 
-    tvm.testing.assert_allclose(golden, C_numpy, atol=1e-3, rtol=1e-3)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @T.prim_func(s_tir=True)
@@ -381,18 +381,18 @@ def test_gemm_mma_m8n8k16_row_col_s8u8s32():
     B_np = np.random.uniform(-10, 10, [8, 16]).astype("uint8")
     C_np = np.zeros([8, 8]).astype("int32")
 
-    ctx = tvm.cuda()
-    A_tvm = tvm.runtime.tensor(A_np, ctx)
-    B_tvm = tvm.runtime.tensor(B_np, ctx)
-    C_tvm = tvm.runtime.tensor(C_np, ctx)
-
-    cuda_mod(A_tvm, B_tvm, C_tvm)
-
     golden = np.matmul(A_np.astype("int32"), B_np.astype("int32").T)
 
-    C_numpy = C_tvm.numpy()
+    def run_and_check():
+        ctx = tvm.cuda()
+        A_tvm = tvm.runtime.tensor(A_np, ctx)
+        B_tvm = tvm.runtime.tensor(B_np, ctx)
+        C_tvm = tvm.runtime.tensor(C_np, ctx)
+        cuda_mod(A_tvm, B_tvm, C_tvm)
+        C_numpy = C_tvm.numpy()
+        tvm.testing.assert_allclose(golden, C_numpy, atol=1e-3, rtol=1e-3)
 
-    tvm.testing.assert_allclose(golden, C_numpy, atol=1e-3, rtol=1e-3)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @T.prim_func(s_tir=True)
@@ -449,12 +449,14 @@ def test_gemm_mma_m8n8k32_row_col_s4s4s32():
     sch = tvm.s_tir.Schedule(gemm_mma_m8n8k32_row_col_s4s4s32)
     cuda_mod = tvm.compile(sch.mod, target="cuda")
 
-    ctx = tvm.cuda()
-    A_tvm = tvm.runtime.empty([8, 32], "int4", ctx)
-    B_tvm = tvm.runtime.empty([8, 32], "int4", ctx)
-    C_tvm = tvm.runtime.empty([8, 8], "int32", ctx)
+    def run():
+        ctx = tvm.cuda()
+        A_tvm = tvm.runtime.empty([8, 32], "int4", ctx)
+        B_tvm = tvm.runtime.empty([8, 32], "int4", ctx)
+        C_tvm = tvm.runtime.empty([8, 8], "int32", ctx)
+        cuda_mod(A_tvm, B_tvm, C_tvm)
 
-    cuda_mod(A_tvm, B_tvm, C_tvm)
+    tvm.testing.run_with_gpu_lock(run)
     # Currently the correctness is not checked.
     # TODO: add correctness checking here.
 
@@ -513,12 +515,14 @@ def test_gemm_mma_m8n8k32_row_col_s4u4s32():
     sch = tvm.s_tir.Schedule(gemm_mma_m8n8k32_row_col_s4u4s32)
     cuda_mod = tvm.compile(sch.mod, target="cuda")
 
-    ctx = tvm.cuda()
-    A_tvm = tvm.runtime.empty([8, 32], "int4", ctx)
-    B_tvm = tvm.runtime.empty([8, 32], "uint4", ctx)
-    C_tvm = tvm.runtime.empty([8, 8], "int32", ctx)
+    def run():
+        ctx = tvm.cuda()
+        A_tvm = tvm.runtime.empty([8, 32], "int4", ctx)
+        B_tvm = tvm.runtime.empty([8, 32], "uint4", ctx)
+        C_tvm = tvm.runtime.empty([8, 8], "int32", ctx)
+        cuda_mod(A_tvm, B_tvm, C_tvm)
 
-    cuda_mod(A_tvm, B_tvm, C_tvm)
+    tvm.testing.run_with_gpu_lock(run)
     # Currently the correctness is not checked.
     # TODO: add correctness checking here.
 
@@ -583,18 +587,18 @@ def test_gemm_mma_m16n8k8_row_col_fp16fp16fp32():
     B_np = np.random.uniform(-1, 1, [8, 8]).astype("float16")
     C_np = np.zeros([16, 8]).astype("float32")
 
-    ctx = tvm.cuda()
-    A_tvm = tvm.runtime.tensor(A_np, ctx)
-    B_tvm = tvm.runtime.tensor(B_np, ctx)
-    C_tvm = tvm.runtime.tensor(C_np, ctx)
-
-    cuda_mod(A_tvm, B_tvm, C_tvm)
-
     golden = np.matmul(A_np.astype("float32"), B_np.astype("float32").T)
 
-    C_numpy = C_tvm.numpy()
+    def run_and_check():
+        ctx = tvm.cuda()
+        A_tvm = tvm.runtime.tensor(A_np, ctx)
+        B_tvm = tvm.runtime.tensor(B_np, ctx)
+        C_tvm = tvm.runtime.tensor(C_np, ctx)
+        cuda_mod(A_tvm, B_tvm, C_tvm)
+        C_numpy = C_tvm.numpy()
+        tvm.testing.assert_allclose(golden, C_numpy, atol=1e-3, rtol=1e-3)
 
-    tvm.testing.assert_allclose(golden, C_numpy, atol=1e-3, rtol=1e-3)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @T.prim_func(s_tir=True)
@@ -660,18 +664,18 @@ def test_gemm_mma_m16n8k16_row_col_fp16fp16fp16():
     B_np = np.random.uniform(-1, 1, [8, 16]).astype("float16")
     C_np = np.zeros([16, 8]).astype("float16")
 
-    ctx = tvm.cuda()
-    A_tvm = tvm.runtime.tensor(A_np, ctx)
-    B_tvm = tvm.runtime.tensor(B_np, ctx)
-    C_tvm = tvm.runtime.tensor(C_np, ctx)
-
-    cuda_mod(A_tvm, B_tvm, C_tvm)
-
     golden = np.matmul(A_np.astype("float16"), B_np.astype("float16").T)
 
-    C_numpy = C_tvm.numpy()
+    def run_and_check():
+        ctx = tvm.cuda()
+        A_tvm = tvm.runtime.tensor(A_np, ctx)
+        B_tvm = tvm.runtime.tensor(B_np, ctx)
+        C_tvm = tvm.runtime.tensor(C_np, ctx)
+        cuda_mod(A_tvm, B_tvm, C_tvm)
+        C_numpy = C_tvm.numpy()
+        tvm.testing.assert_allclose(golden, C_numpy, atol=1e-3, rtol=1e-3)
 
-    tvm.testing.assert_allclose(golden, C_numpy, atol=1e-3, rtol=1e-3)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @T.prim_func(s_tir=True)
@@ -737,18 +741,18 @@ def test_gemm_mma_m16n8k16_row_col_fp16fp16fp32():
     B_np = np.random.uniform(-1, 1, [8, 16]).astype("float16")
     C_np = np.zeros([16, 8]).astype("float32")
 
-    ctx = tvm.cuda()
-    A_tvm = tvm.runtime.tensor(A_np, ctx)
-    B_tvm = tvm.runtime.tensor(B_np, ctx)
-    C_tvm = tvm.runtime.tensor(C_np, ctx)
-
-    cuda_mod(A_tvm, B_tvm, C_tvm)
-
     golden = np.matmul(A_np.astype("float32"), B_np.astype("float32").T)
 
-    C_numpy = C_tvm.numpy()
+    def run_and_check():
+        ctx = tvm.cuda()
+        A_tvm = tvm.runtime.tensor(A_np, ctx)
+        B_tvm = tvm.runtime.tensor(B_np, ctx)
+        C_tvm = tvm.runtime.tensor(C_np, ctx)
+        cuda_mod(A_tvm, B_tvm, C_tvm)
+        C_numpy = C_tvm.numpy()
+        tvm.testing.assert_allclose(golden, C_numpy, atol=1e-3, rtol=1e-3)
 
-    tvm.testing.assert_allclose(golden, C_numpy, atol=1e-3, rtol=1e-3)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @T.prim_func(s_tir=True)
@@ -814,18 +818,18 @@ def test_gemm_mma_m16n8k16_row_col_s8s8s32():
     B_np = np.random.uniform(-10, 10, [8, 16]).astype("int8")
     C_np = np.zeros([16, 8]).astype("int32")
 
-    ctx = tvm.cuda()
-    A_tvm = tvm.runtime.tensor(A_np, ctx)
-    B_tvm = tvm.runtime.tensor(B_np, ctx)
-    C_tvm = tvm.runtime.tensor(C_np, ctx)
-
-    cuda_mod(A_tvm, B_tvm, C_tvm)
-
     golden = np.matmul(A_np.astype("int32"), B_np.astype("int32").T)
 
-    C_numpy = C_tvm.numpy()
+    def run_and_check():
+        ctx = tvm.cuda()
+        A_tvm = tvm.runtime.tensor(A_np, ctx)
+        B_tvm = tvm.runtime.tensor(B_np, ctx)
+        C_tvm = tvm.runtime.tensor(C_np, ctx)
+        cuda_mod(A_tvm, B_tvm, C_tvm)
+        C_numpy = C_tvm.numpy()
+        tvm.testing.assert_allclose(golden, C_numpy, atol=1e-3, rtol=1e-3)
 
-    tvm.testing.assert_allclose(golden, C_numpy, atol=1e-3, rtol=1e-3)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @T.prim_func(s_tir=True)
@@ -891,18 +895,18 @@ def test_gemm_mma_m16n8k16_row_col_s8u8s32():
     B_np = np.random.uniform(-10, 10, [8, 16]).astype("uint8")
     C_np = np.zeros([16, 8]).astype("int32")
 
-    ctx = tvm.cuda()
-    A_tvm = tvm.runtime.tensor(A_np, ctx)
-    B_tvm = tvm.runtime.tensor(B_np, ctx)
-    C_tvm = tvm.runtime.tensor(C_np, ctx)
-
-    cuda_mod(A_tvm, B_tvm, C_tvm)
-
     golden = np.matmul(A_np.astype("int32"), B_np.astype("int32").T)
 
-    C_numpy = C_tvm.numpy()
+    def run_and_check():
+        ctx = tvm.cuda()
+        A_tvm = tvm.runtime.tensor(A_np, ctx)
+        B_tvm = tvm.runtime.tensor(B_np, ctx)
+        C_tvm = tvm.runtime.tensor(C_np, ctx)
+        cuda_mod(A_tvm, B_tvm, C_tvm)
+        C_numpy = C_tvm.numpy()
+        tvm.testing.assert_allclose(golden, C_numpy, atol=1e-3, rtol=1e-3)
 
-    tvm.testing.assert_allclose(golden, C_numpy, atol=1e-3, rtol=1e-3)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @T.prim_func(s_tir=True)
@@ -968,18 +972,18 @@ def test_gemm_mma_m16n8k32_row_col_s8s8s32():
     B_np = np.random.uniform(-10, 10, [8, 32]).astype("int8")
     C_np = np.zeros([16, 8]).astype("int32")
 
-    ctx = tvm.cuda()
-    A_tvm = tvm.runtime.tensor(A_np, ctx)
-    B_tvm = tvm.runtime.tensor(B_np, ctx)
-    C_tvm = tvm.runtime.tensor(C_np, ctx)
-
-    cuda_mod(A_tvm, B_tvm, C_tvm)
-
     golden = np.matmul(A_np.astype("int32"), B_np.astype("int32").T)
 
-    C_numpy = C_tvm.numpy()
+    def run_and_check():
+        ctx = tvm.cuda()
+        A_tvm = tvm.runtime.tensor(A_np, ctx)
+        B_tvm = tvm.runtime.tensor(B_np, ctx)
+        C_tvm = tvm.runtime.tensor(C_np, ctx)
+        cuda_mod(A_tvm, B_tvm, C_tvm)
+        C_numpy = C_tvm.numpy()
+        tvm.testing.assert_allclose(golden, C_numpy, atol=1e-3, rtol=1e-3)
 
-    tvm.testing.assert_allclose(golden, C_numpy, atol=1e-3, rtol=1e-3)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @T.prim_func(s_tir=True)
@@ -1045,18 +1049,18 @@ def test_gemm_mma_m16n8k32_row_col_s8u8s32():
     B_np = np.random.uniform(-10, 10, [8, 32]).astype("uint8")
     C_np = np.zeros([16, 8]).astype("int32")
 
-    ctx = tvm.cuda()
-    A_tvm = tvm.runtime.tensor(A_np, ctx)
-    B_tvm = tvm.runtime.tensor(B_np, ctx)
-    C_tvm = tvm.runtime.tensor(C_np, ctx)
-
-    cuda_mod(A_tvm, B_tvm, C_tvm)
-
     golden = np.matmul(A_np.astype("int32"), B_np.astype("int32").T)
 
-    C_numpy = C_tvm.numpy()
+    def run_and_check():
+        ctx = tvm.cuda()
+        A_tvm = tvm.runtime.tensor(A_np, ctx)
+        B_tvm = tvm.runtime.tensor(B_np, ctx)
+        C_tvm = tvm.runtime.tensor(C_np, ctx)
+        cuda_mod(A_tvm, B_tvm, C_tvm)
+        C_numpy = C_tvm.numpy()
+        tvm.testing.assert_allclose(golden, C_numpy, atol=1e-3, rtol=1e-3)
 
-    tvm.testing.assert_allclose(golden, C_numpy, atol=1e-3, rtol=1e-3)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @T.prim_func(s_tir=True)
@@ -1118,12 +1122,14 @@ def test_gemm_mma_m16n8k64_row_col_s4s4s32():
     sch = tvm.s_tir.Schedule(gemm_mma_m16n8k64_row_col_s4s4s32)
     cuda_mod = tvm.compile(sch.mod, target="cuda")
 
-    ctx = tvm.cuda()
-    A_tvm = tvm.runtime.empty([16, 64], "int4", ctx)
-    B_tvm = tvm.runtime.empty([8, 64], "int4", ctx)
-    C_tvm = tvm.runtime.empty([16, 8], "int32", ctx)
+    def run():
+        ctx = tvm.cuda()
+        A_tvm = tvm.runtime.empty([16, 64], "int4", ctx)
+        B_tvm = tvm.runtime.empty([8, 64], "int4", ctx)
+        C_tvm = tvm.runtime.empty([16, 8], "int32", ctx)
+        cuda_mod(A_tvm, B_tvm, C_tvm)
 
-    cuda_mod(A_tvm, B_tvm, C_tvm)
+    tvm.testing.run_with_gpu_lock(run)
     # Currently the correctness is not checked.
     # TODO: add correctness checking here.
 
@@ -1187,12 +1193,14 @@ def test_gemm_mma_m16n8k64_row_col_s4u4s32():
     sch = tvm.s_tir.Schedule(gemm_mma_m16n8k64_row_col_s4u4s32)
     cuda_mod = tvm.compile(sch.mod, target="cuda")
 
-    ctx = tvm.cuda()
-    A_tvm = tvm.runtime.empty([16, 64], "int4", ctx)
-    B_tvm = tvm.runtime.empty([8, 64], "uint4", ctx)
-    C_tvm = tvm.runtime.empty([16, 8], "int32", ctx)
+    def run():
+        ctx = tvm.cuda()
+        A_tvm = tvm.runtime.empty([16, 64], "int4", ctx)
+        B_tvm = tvm.runtime.empty([8, 64], "uint4", ctx)
+        C_tvm = tvm.runtime.empty([16, 8], "int32", ctx)
+        cuda_mod(A_tvm, B_tvm, C_tvm)
 
-    cuda_mod(A_tvm, B_tvm, C_tvm)
+    tvm.testing.run_with_gpu_lock(run)
     # Currently the correctness is not checked.
     # TODO: add correctness checking here.
 
@@ -1257,12 +1265,14 @@ def test_gemm_mma_m16n8k256_row_col_b1b1s32():
     sch = tvm.s_tir.Schedule(gemm_mma_m16n8k256_row_col_b1b1s32)
     cuda_mod = tvm.compile(sch.mod, target="cuda")
 
-    ctx = tvm.cuda()
-    A_tvm = tvm.runtime.empty([16, 256], "int1", ctx)
-    B_tvm = tvm.runtime.empty([8, 256], "int1", ctx)
-    C_tvm = tvm.runtime.empty([16, 8], "int32", ctx)
+    def run():
+        ctx = tvm.cuda()
+        A_tvm = tvm.runtime.empty([16, 256], "int1", ctx)
+        B_tvm = tvm.runtime.empty([8, 256], "int1", ctx)
+        C_tvm = tvm.runtime.empty([16, 8], "int32", ctx)
+        cuda_mod(A_tvm, B_tvm, C_tvm)
 
-    cuda_mod(A_tvm, B_tvm, C_tvm)
+    tvm.testing.run_with_gpu_lock(run)
     # Currently the correctness is not checked.
     # TODO: add correctness checking here.
 

--- a/tests/python/tirx-base/test_tir_ptx_mma.py
+++ b/tests/python/tirx-base/test_tir_ptx_mma.py
@@ -449,14 +449,14 @@ def test_gemm_mma_m8n8k32_row_col_s4s4s32():
     sch = tvm.s_tir.Schedule(gemm_mma_m8n8k32_row_col_s4s4s32)
     cuda_mod = tvm.compile(sch.mod, target="cuda")
 
-    def run():
+    def run_and_check():
         ctx = tvm.cuda()
         A_tvm = tvm.runtime.empty([8, 32], "int4", ctx)
         B_tvm = tvm.runtime.empty([8, 32], "int4", ctx)
         C_tvm = tvm.runtime.empty([8, 8], "int32", ctx)
         cuda_mod(A_tvm, B_tvm, C_tvm)
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
     # Currently the correctness is not checked.
     # TODO: add correctness checking here.
 
@@ -515,14 +515,14 @@ def test_gemm_mma_m8n8k32_row_col_s4u4s32():
     sch = tvm.s_tir.Schedule(gemm_mma_m8n8k32_row_col_s4u4s32)
     cuda_mod = tvm.compile(sch.mod, target="cuda")
 
-    def run():
+    def run_and_check():
         ctx = tvm.cuda()
         A_tvm = tvm.runtime.empty([8, 32], "int4", ctx)
         B_tvm = tvm.runtime.empty([8, 32], "uint4", ctx)
         C_tvm = tvm.runtime.empty([8, 8], "int32", ctx)
         cuda_mod(A_tvm, B_tvm, C_tvm)
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
     # Currently the correctness is not checked.
     # TODO: add correctness checking here.
 
@@ -1122,14 +1122,14 @@ def test_gemm_mma_m16n8k64_row_col_s4s4s32():
     sch = tvm.s_tir.Schedule(gemm_mma_m16n8k64_row_col_s4s4s32)
     cuda_mod = tvm.compile(sch.mod, target="cuda")
 
-    def run():
+    def run_and_check():
         ctx = tvm.cuda()
         A_tvm = tvm.runtime.empty([16, 64], "int4", ctx)
         B_tvm = tvm.runtime.empty([8, 64], "int4", ctx)
         C_tvm = tvm.runtime.empty([16, 8], "int32", ctx)
         cuda_mod(A_tvm, B_tvm, C_tvm)
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
     # Currently the correctness is not checked.
     # TODO: add correctness checking here.
 
@@ -1193,14 +1193,14 @@ def test_gemm_mma_m16n8k64_row_col_s4u4s32():
     sch = tvm.s_tir.Schedule(gemm_mma_m16n8k64_row_col_s4u4s32)
     cuda_mod = tvm.compile(sch.mod, target="cuda")
 
-    def run():
+    def run_and_check():
         ctx = tvm.cuda()
         A_tvm = tvm.runtime.empty([16, 64], "int4", ctx)
         B_tvm = tvm.runtime.empty([8, 64], "uint4", ctx)
         C_tvm = tvm.runtime.empty([16, 8], "int32", ctx)
         cuda_mod(A_tvm, B_tvm, C_tvm)
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
     # Currently the correctness is not checked.
     # TODO: add correctness checking here.
 
@@ -1265,14 +1265,14 @@ def test_gemm_mma_m16n8k256_row_col_b1b1s32():
     sch = tvm.s_tir.Schedule(gemm_mma_m16n8k256_row_col_b1b1s32)
     cuda_mod = tvm.compile(sch.mod, target="cuda")
 
-    def run():
+    def run_and_check():
         ctx = tvm.cuda()
         A_tvm = tvm.runtime.empty([16, 256], "int1", ctx)
         B_tvm = tvm.runtime.empty([8, 256], "int1", ctx)
         C_tvm = tvm.runtime.empty([16, 8], "int32", ctx)
         cuda_mod(A_tvm, B_tvm, C_tvm)
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
     # Currently the correctness is not checked.
     # TODO: add correctness checking here.
 

--- a/tests/python/tirx-base/test_tir_ptx_mma_sp.py
+++ b/tests/python/tirx-base/test_tir_ptx_mma_sp.py
@@ -286,14 +286,16 @@ def test_mma_sp_m16n8k16_f16():
         C_np = np.matmul(A_dense_np, B_np).astype(out_dtype)
         meta = get_meta_m16n8k16_half(mask)
 
-        ctx = tvm.cuda()
-        A_tvm = tvm.runtime.tensor(A_np, ctx)
-        B_tvm = tvm.runtime.tensor(B_np, ctx)
-        C_tvm = tvm.runtime.tensor(np.zeros_like(C_np), ctx)
-        meta_tvm = tvm.runtime.tensor(meta, ctx)
-        cuda_mod(A_tvm, B_tvm, C_tvm, meta_tvm)
+        def run_and_check():
+            ctx = tvm.cuda()
+            A_tvm = tvm.runtime.tensor(A_np, ctx)
+            B_tvm = tvm.runtime.tensor(B_np, ctx)
+            C_tvm = tvm.runtime.tensor(np.zeros_like(C_np), ctx)
+            meta_tvm = tvm.runtime.tensor(meta, ctx)
+            cuda_mod(A_tvm, B_tvm, C_tvm, meta_tvm)
+            tvm.testing.assert_allclose(C_tvm.numpy(), C_np, atol=1e-3, rtol=1e-3)
 
-        tvm.testing.assert_allclose(C_tvm.numpy(), C_np, atol=1e-3, rtol=1e-3)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -326,14 +328,16 @@ def test_mma_sp_m16n8k32_f16():
         C_np = np.matmul(A_dense_np, B_np).astype(out_dtype)
         meta = get_meta_m16n8k32_half(mask)
 
-        ctx = tvm.cuda()
-        A_tvm = tvm.runtime.tensor(A_np, ctx)
-        B_tvm = tvm.runtime.tensor(B_np, ctx)
-        C_tvm = tvm.runtime.tensor(np.zeros_like(C_np), ctx)
-        meta_tvm = tvm.runtime.tensor(meta, ctx)
-        cuda_mod(A_tvm, B_tvm, C_tvm, meta_tvm)
+        def run_and_check():
+            ctx = tvm.cuda()
+            A_tvm = tvm.runtime.tensor(A_np, ctx)
+            B_tvm = tvm.runtime.tensor(B_np, ctx)
+            C_tvm = tvm.runtime.tensor(np.zeros_like(C_np), ctx)
+            meta_tvm = tvm.runtime.tensor(meta, ctx)
+            cuda_mod(A_tvm, B_tvm, C_tvm, meta_tvm)
+            tvm.testing.assert_allclose(C_tvm.numpy(), C_np, atol=1e-3, rtol=1e-3)
 
-    tvm.testing.assert_allclose(C_tvm.numpy(), C_np, atol=1e-3, rtol=1e-3)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 if __name__ == "__main__":

--- a/tests/python/tirx-base/test_tir_ptx_scalar_f32_math.py
+++ b/tests/python/tirx-base/test_tir_ptx_scalar_f32_math.py
@@ -54,16 +54,20 @@ def test_ptx_scalar_f32_math():
     A_np = rng.standard_normal(32).astype("float32")
     B_np = rng.standard_normal(32).astype("float32")
     Z = np.zeros((32,), dtype="float32")
-    dev = tvm.cuda(0)
-    A_nd = tvm.runtime.tensor(A_np, device=dev)
-    B_nd = tvm.runtime.tensor(B_np, device=dev)
-    Cadd = tvm.runtime.tensor(Z.copy(), device=dev)
-    Cmul = tvm.runtime.tensor(Z.copy(), device=dev)
-    Cmax = tvm.runtime.tensor(Z.copy(), device=dev)
-    mod(A_nd, B_nd, Cadd, Cmul, Cmax)
-    tvm.testing.assert_allclose(Cadd.numpy(), A_np + B_np, rtol=0, atol=0)
-    tvm.testing.assert_allclose(Cmul.numpy(), A_np * B_np, rtol=0, atol=0)
-    tvm.testing.assert_allclose(Cmax.numpy(), np.maximum(A_np, B_np), rtol=0, atol=0)
+
+    def run_and_check():
+        dev = tvm.cuda(0)
+        A_nd = tvm.runtime.tensor(A_np, device=dev)
+        B_nd = tvm.runtime.tensor(B_np, device=dev)
+        Cadd = tvm.runtime.tensor(Z.copy(), device=dev)
+        Cmul = tvm.runtime.tensor(Z.copy(), device=dev)
+        Cmax = tvm.runtime.tensor(Z.copy(), device=dev)
+        mod(A_nd, B_nd, Cadd, Cmul, Cmax)
+        tvm.testing.assert_allclose(Cadd.numpy(), A_np + B_np, rtol=0, atol=0)
+        tvm.testing.assert_allclose(Cmul.numpy(), A_np * B_np, rtol=0, atol=0)
+        tvm.testing.assert_allclose(Cmax.numpy(), np.maximum(A_np, B_np), rtol=0, atol=0)
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 if __name__ == "__main__":

--- a/tests/python/tirx/codegen/test_codegen_ampere.py
+++ b/tests/python/tirx/codegen/test_codegen_ampere.py
@@ -37,8 +37,6 @@ import tvm.testing
 from tvm.script import tirx as T
 from tvm.testing import env
 
-DEV = tvm.device("cuda")
-
 
 def _get_source(func: tvm.tirx.PrimFunc):
     target = tvm.target.Target("cuda")
@@ -60,15 +58,21 @@ def _run_mma(mod, K, no_c_ptr, np_in):
     A_np = np.random.randn(16, K).astype(np_in)
     B_np = np.random.randn(K, 8).astype(np_in)
     C_np = np.random.randn(16, 8).astype(np.float32)
-    D = tvm.runtime.tensor(np.zeros((16, 8), np.float32), device=DEV)
-    A = tvm.runtime.tensor(A_np, device=DEV)
-    B = tvm.runtime.tensor(B_np, device=DEV)
-    C = tvm.runtime.tensor(C_np, device=DEV)
-    mod(D, A, B, C)
     ref = A_np.astype(np.float32) @ B_np.astype(np.float32)
     if not no_c_ptr:
         ref = ref + C_np
-    np.testing.assert_allclose(D.numpy(), ref, atol=1e-2, rtol=1e-2)
+
+    def run_and_check():
+        dev = tvm.device("cuda")
+        D = tvm.runtime.tensor(np.zeros((16, 8), np.float32), device=dev)
+        A = tvm.runtime.tensor(A_np, device=dev)
+        B = tvm.runtime.tensor(B_np, device=dev)
+        C = tvm.runtime.tensor(C_np, device=dev)
+        mod(D, A, B, C)
+        dev.sync()
+        np.testing.assert_allclose(D.numpy(), ref, atol=1e-2, rtol=1e-2)
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu

--- a/tests/python/tirx/codegen/test_codegen_ampere.py
+++ b/tests/python/tirx/codegen/test_codegen_ampere.py
@@ -69,7 +69,6 @@ def _run_mma(mod, K, no_c_ptr, np_in):
         B = tvm.runtime.tensor(B_np, device=dev)
         C = tvm.runtime.tensor(C_np, device=dev)
         mod(D, A, B, C)
-        dev.sync()
         np.testing.assert_allclose(D.numpy(), ref, atol=1e-2, rtol=1e-2)
 
     tvm.testing.run_with_gpu_lock(run_and_check)

--- a/tests/python/tirx/codegen/test_codegen_blackwell.py
+++ b/tests/python/tirx/codegen/test_codegen_blackwell.py
@@ -164,18 +164,22 @@ def test_tcgen05_ld_st_roundtrip():
             T.ptx.tcgen05.dealloc(tmem_addr, n_cols=N_COLS, cta_group=cta_group)
     # fmt: on
 
-    DEV = tvm.cuda(0)
     target = tvm.target.Target("cuda")
     with target:
         src, mod = _get_source(test_ld_st)
         assert "tcgen05.ld.sync.aligned.32x32b.x1.b32" in src
         assert "tcgen05.st.sync.aligned.32x32b.x1.b32" in src
+
+    def run():
+        dev = tvm.cuda(0)
         A_np = np.random.randn(HEIGHT, WIDTH).astype("float32")
         B_np = np.zeros((HEIGHT, WIDTH), dtype="float32")
-        A = tvm.runtime.tensor(A_np, device=DEV)
-        B = tvm.runtime.tensor(B_np, device=DEV)
+        A = tvm.runtime.tensor(A_np, device=dev)
+        B = tvm.runtime.tensor(B_np, device=dev)
         mod(A, B)
         np.testing.assert_allclose(A.numpy(), B.numpy())
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 @pytest.mark.gpu
@@ -245,18 +249,22 @@ def test_tcgen05_cp_ld_roundtrip():
             T.ptx.tcgen05.dealloc(tmem_addr, n_cols=N_COLS, cta_group=cta_group)
     # fmt: on
 
-    DEV = tvm.cuda(0)
     target = tvm.target.Target("cuda")
     with target:
         src, mod = _get_source(test_cp_ld)
         assert "tcgen05.cp.cta_group::1.128x256b" in src
         assert "tcgen05.ld.sync.aligned.32x32b.x1.b32" in src
+
+    def run():
+        dev = tvm.cuda(0)
         A_np = np.random.randn(HEIGHT, WIDTH).astype(dtype)
         B_np = np.zeros((HEIGHT, WIDTH), dtype=dtype)
-        A = tvm.runtime.tensor(A_np, device=DEV)
-        B = tvm.runtime.tensor(B_np, device=DEV)
+        A = tvm.runtime.tensor(A_np, device=dev)
+        B = tvm.runtime.tensor(B_np, device=dev)
         mod(A, B)
         np.testing.assert_allclose(A.numpy(), B.numpy())
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 @pytest.mark.parametrize("swizzle", [0, 1, 2, 3])
@@ -377,7 +385,6 @@ def test_tcgen05_mma_ss_no_tma(swizzle):
     import torch
 
     torch.manual_seed(42)
-    DEV = tvm.cuda(0)
     target = tvm.target.Target("cuda")
     with target:
         src, mod = _get_source(test_mma_ss_no_tma)
@@ -386,15 +393,20 @@ def test_tcgen05_mma_ss_no_tma(swizzle):
         assert "tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64" in src
         assert "tcgen05.ld.sync.aligned.32x32b.x1.b32" in src
         assert "tcgen05.wait::ld.sync.aligned" in src
+
+    def run():
+        dev = tvm.cuda(0)
         A_torch = torch.rand((M, K), dtype=torch.float16)
         B_torch = torch.rand((N, K), dtype=torch.float16)
         C_torch = torch.zeros((M, N), dtype=torch.float32)
-        A = tvm.runtime.tensor(A_torch, device=DEV)
-        B = tvm.runtime.tensor(B_torch, device=DEV)
-        C = tvm.runtime.tensor(C_torch, device=DEV)
+        A = tvm.runtime.tensor(A_torch, device=dev)
+        B = tvm.runtime.tensor(B_torch, device=dev)
+        C = tvm.runtime.tensor(C_torch, device=dev)
         mod(A, B, C)
         ref = torch.matmul(A_torch, B_torch.T)
         np.testing.assert_allclose(C.numpy(), ref.numpy(), rtol=1e-3, atol=1e-2)
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 if __name__ == "__main__":

--- a/tests/python/tirx/codegen/test_codegen_blackwell.py
+++ b/tests/python/tirx/codegen/test_codegen_blackwell.py
@@ -170,7 +170,7 @@ def test_tcgen05_ld_st_roundtrip():
         assert "tcgen05.ld.sync.aligned.32x32b.x1.b32" in src
         assert "tcgen05.st.sync.aligned.32x32b.x1.b32" in src
 
-    def run():
+    def run_and_check():
         dev = tvm.cuda(0)
         A_np = np.random.randn(HEIGHT, WIDTH).astype("float32")
         B_np = np.zeros((HEIGHT, WIDTH), dtype="float32")
@@ -179,7 +179,7 @@ def test_tcgen05_ld_st_roundtrip():
         mod(A, B)
         np.testing.assert_allclose(A.numpy(), B.numpy())
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -255,7 +255,7 @@ def test_tcgen05_cp_ld_roundtrip():
         assert "tcgen05.cp.cta_group::1.128x256b" in src
         assert "tcgen05.ld.sync.aligned.32x32b.x1.b32" in src
 
-    def run():
+    def run_and_check():
         dev = tvm.cuda(0)
         A_np = np.random.randn(HEIGHT, WIDTH).astype(dtype)
         B_np = np.zeros((HEIGHT, WIDTH), dtype=dtype)
@@ -264,7 +264,7 @@ def test_tcgen05_cp_ld_roundtrip():
         mod(A, B)
         np.testing.assert_allclose(A.numpy(), B.numpy())
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.parametrize("swizzle", [0, 1, 2, 3])
@@ -394,7 +394,7 @@ def test_tcgen05_mma_ss_no_tma(swizzle):
         assert "tcgen05.ld.sync.aligned.32x32b.x1.b32" in src
         assert "tcgen05.wait::ld.sync.aligned" in src
 
-    def run():
+    def run_and_check():
         dev = tvm.cuda(0)
         A_torch = torch.rand((M, K), dtype=torch.float16)
         B_torch = torch.rand((N, K), dtype=torch.float16)
@@ -406,7 +406,7 @@ def test_tcgen05_mma_ss_no_tma(swizzle):
         ref = torch.matmul(A_torch, B_torch.T)
         np.testing.assert_allclose(C.numpy(), ref.numpy(), rtol=1e-3, atol=1e-2)
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 if __name__ == "__main__":

--- a/tests/python/tirx/codegen/test_codegen_cuda.py
+++ b/tests/python/tirx/codegen/test_codegen_cuda.py
@@ -23,8 +23,6 @@ import tvm.testing
 from tvm.script import tirx as T
 from tvm.testing import env
 
-DEV = tvm.device("cuda")
-
 
 def _get_source(func: tvm.tirx.PrimFunc) -> str:
     target = tvm.target.Target("cuda")
@@ -135,11 +133,17 @@ def test_cuda_atomic_add():
     assert "tvm_builtin_cuda_atomic_add" in src
     A_np = np.zeros(1, dtype="int32")
     B_np = np.zeros(1, dtype="float32")
-    A_tvm = tvm.runtime.tensor(A_np, device=DEV)
-    B_tvm = tvm.runtime.tensor(B_np, device=DEV)
-    mod["main"](A_tvm, B_tvm)
-    np.testing.assert_allclose(A_tvm.numpy(), 1)
-    np.testing.assert_allclose(B_tvm.numpy(), 1.0)
+
+    def run_and_check():
+        dev = tvm.device("cuda")
+        A_tvm = tvm.runtime.tensor(A_np, device=dev)
+        B_tvm = tvm.runtime.tensor(B_np, device=dev)
+        mod["main"](A_tvm, B_tvm)
+        dev.sync()
+        np.testing.assert_allclose(A_tvm.numpy(), 1)
+        np.testing.assert_allclose(B_tvm.numpy(), 1.0)
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 def test_ptx_ld_acquire_and_volatile_codegen():
@@ -469,10 +473,16 @@ __device__ int32_t add_one(int32_t a) {
         src, mod = _get_source(main)
         A = np.random.randint(0, 10, (16, 16)).astype("int32")
         B = np.zeros((16, 16), dtype="int32")
-        A_tvm = tvm.runtime.tensor(A, device=DEV)
-        B_tvm = tvm.runtime.tensor(B, device=DEV)
-        mod["main"](A_tvm, B_tvm)
-        np.testing.assert_allclose(B_tvm.numpy(), A + 1)
+
+        def run_and_check():
+            dev = tvm.device("cuda")
+            A_tvm = tvm.runtime.tensor(A, device=dev)
+            B_tvm = tvm.runtime.tensor(B, device=dev)
+            mod["main"](A_tvm, B_tvm)
+            dev.sync()
+            np.testing.assert_allclose(B_tvm.numpy(), A + 1)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
         print(src)
 
     test_add_one()
@@ -495,8 +505,14 @@ __device__ void print(int32_t a) {
 
         src, mod = _get_source(main)
         A = np.random.randint(0, 10, (16, 16)).astype("int32")
-        A_tvm = tvm.runtime.tensor(A, device=DEV)
-        mod["main"](A_tvm)
+
+        def run():
+            dev = tvm.device("cuda")
+            A_tvm = tvm.runtime.tensor(A, device=dev)
+            mod["main"](A_tvm)
+            dev.sync()
+
+        tvm.testing.run_with_gpu_lock(run)
         print(src)
 
     test_print()
@@ -527,16 +543,21 @@ def test_warp_shuffle_xor_sync():
         A[lane_id] = A_local[0]
         # fmt: on
 
-    DEV = tvm.cuda(0)
     target = tvm.target.Target("cuda")
     mod = tvm.IRModule({"main": func})
     mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
     A_np = np.zeros(32, dtype="float32")
-    A = tvm.runtime.tensor(A_np, device=DEV)
-    mod(A)
     assert "__shfl_xor_sync" in mod.mod.imports[0].inspect_source()
     A_ref = np.ones(32, dtype="float32") * 496
-    np.testing.assert_allclose(A.numpy(), A_ref)
+
+    def run_and_check():
+        dev = tvm.cuda(0)
+        A = tvm.runtime.tensor(A_np, device=dev)
+        mod(A)
+        dev.sync()
+        np.testing.assert_allclose(A.numpy(), A_ref)
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -571,8 +592,6 @@ def test_ptx_cp_async(cp_size, cache_hint, prefetch_size, predicate, fill_mode):
 
     src, mod = _get_source(main)
     A_np = np.ones(N, dtype="float16")
-    A = tvm.runtime.tensor(A_np, device=DEV)
-    mod(A)
     A_ref = np.ones(N, dtype="float16") * 2
     if int(predicate) == 0:
         if fill_mode == "zero":
@@ -580,7 +599,14 @@ def test_ptx_cp_async(cp_size, cache_hint, prefetch_size, predicate, fill_mode):
         else:
             A_ref = np.ones(N, dtype="float16") * 6
 
-    np.testing.assert_allclose(A.numpy(), A_ref)
+    def run_and_check():
+        dev = tvm.device("cuda")
+        A = tvm.runtime.tensor(A_np, device=dev)
+        mod(A)
+        dev.sync()
+        np.testing.assert_allclose(A.numpy(), A_ref)
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
     print(src)
 
 
@@ -637,12 +663,8 @@ def test_ptx_ldmatrix(trans, num):
 
     src, mod = _get_source(main)
     A_np = np.arange(16 * 16, dtype="float16").reshape((16, 16))
-    A = tvm.runtime.tensor(A_np, device=DEV)
     B_np = np.zeros((16, 16), dtype="float16")
     B_ref = np.zeros((16, 16), dtype="float16")
-    B = tvm.runtime.tensor(B_np, device=DEV)
-
-    mod(A, B)
     if num == 1:
         B_ref[0:8, 0:8] = A_np[0:8, 0:8] if not trans else A_np[0:8, 0:8].T
     elif num == 2:
@@ -654,7 +676,15 @@ def test_ptx_ldmatrix(trans, num):
         B_ref[8:16, 0:8] = A_np[8:16, 0:8] if not trans else A_np[8:16, 0:8].T
         B_ref[8:16, 8:16] = A_np[8:16, 8:16] if not trans else A_np[8:16, 8:16].T
 
-    np.testing.assert_allclose(B.numpy(), B_ref)
+    def run_and_check():
+        dev = tvm.device("cuda")
+        A = tvm.runtime.tensor(A_np, device=dev)
+        B = tvm.runtime.tensor(B_np, device=dev)
+        mod(A, B)
+        dev.sync()
+        np.testing.assert_allclose(B.numpy(), B_ref)
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 if __name__ == "__main__":

--- a/tests/python/tirx/codegen/test_codegen_cuda.py
+++ b/tests/python/tirx/codegen/test_codegen_cuda.py
@@ -139,7 +139,6 @@ def test_cuda_atomic_add():
         A_tvm = tvm.runtime.tensor(A_np, device=dev)
         B_tvm = tvm.runtime.tensor(B_np, device=dev)
         mod["main"](A_tvm, B_tvm)
-        dev.sync()
         np.testing.assert_allclose(A_tvm.numpy(), 1)
         np.testing.assert_allclose(B_tvm.numpy(), 1.0)
 
@@ -479,7 +478,6 @@ __device__ int32_t add_one(int32_t a) {
             A_tvm = tvm.runtime.tensor(A, device=dev)
             B_tvm = tvm.runtime.tensor(B, device=dev)
             mod["main"](A_tvm, B_tvm)
-            dev.sync()
             np.testing.assert_allclose(B_tvm.numpy(), A + 1)
 
         tvm.testing.run_with_gpu_lock(run_and_check)
@@ -506,13 +504,13 @@ __device__ void print(int32_t a) {
         src, mod = _get_source(main)
         A = np.random.randint(0, 10, (16, 16)).astype("int32")
 
-        def run():
+        def run_and_check():
             dev = tvm.device("cuda")
             A_tvm = tvm.runtime.tensor(A, device=dev)
             mod["main"](A_tvm)
             dev.sync()
 
-        tvm.testing.run_with_gpu_lock(run)
+        tvm.testing.run_with_gpu_lock(run_and_check)
         print(src)
 
     test_print()
@@ -554,7 +552,6 @@ def test_warp_shuffle_xor_sync():
         dev = tvm.cuda(0)
         A = tvm.runtime.tensor(A_np, device=dev)
         mod(A)
-        dev.sync()
         np.testing.assert_allclose(A.numpy(), A_ref)
 
     tvm.testing.run_with_gpu_lock(run_and_check)
@@ -603,7 +600,6 @@ def test_ptx_cp_async(cp_size, cache_hint, prefetch_size, predicate, fill_mode):
         dev = tvm.device("cuda")
         A = tvm.runtime.tensor(A_np, device=dev)
         mod(A)
-        dev.sync()
         np.testing.assert_allclose(A.numpy(), A_ref)
 
     tvm.testing.run_with_gpu_lock(run_and_check)
@@ -681,7 +677,6 @@ def test_ptx_ldmatrix(trans, num):
         A = tvm.runtime.tensor(A_np, device=dev)
         B = tvm.runtime.tensor(B_np, device=dev)
         mod(A, B)
-        dev.sync()
         np.testing.assert_allclose(B.numpy(), B_ref)
 
     tvm.testing.run_with_gpu_lock(run_and_check)

--- a/tests/python/tirx/codegen/test_codegen_hopper.py
+++ b/tests/python/tirx/codegen/test_codegen_hopper.py
@@ -53,11 +53,11 @@ def _run_tensormap_encode(shape, dtype, encode_args):
     target = tvm.target.Target("cuda")
     mod = tvm.IRModule({"main": main})
     mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
-    def run():
+    def run_and_check():
         A = tvm.runtime.tensor(np.zeros(shape, dtype=dtype), device=tvm.cuda(0))
         mod(A)
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.parametrize("inc", [False, True])
@@ -114,7 +114,7 @@ def test_stmatrix_sync_aligned(trans):
             assert "stmatrix.sync.aligned.m8n8.x4.shared.b16" in src
         else:
             assert "stmatrix.sync.aligned.m8n8.x4.trans.shared.b16" in src
-    def run():
+    def run_and_check():
         dev = tvm.cuda(0)
         A_np = np.zeros((16, 16), dtype="float16")
         A = tvm.runtime.tensor(A_np, device=dev)
@@ -143,7 +143,7 @@ def test_stmatrix_sync_aligned(trans):
                 A_ref[col + 9, row + 8] = tx * 8 + 7
         np.testing.assert_allclose(A.numpy(), A_ref)
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.parametrize("trans", [False, True])
@@ -199,12 +199,12 @@ def test_ptx_stmatrix(trans, num):
         A_ref[8:16, 0:8] = A_full[8:16, 0:8] if not trans else A_full[8:16, 0:8].T
         A_ref[8:16, 8:16] = A_full[8:16, 8:16] if not trans else A_full[8:16, 8:16].T
 
-    def run():
+    def run_and_check():
         A = tvm.runtime.tensor(A_np, device=tvm.cuda(0))
         mod(A)
         np.testing.assert_allclose(A.numpy(), A_ref)
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.parametrize("trans", [False, True])
@@ -273,12 +273,12 @@ def test_ptx_stmatrix_noncontiguous(trans, num):
         A_ref[0:8, 8:16] = A_full[0:8, 8:16] if not trans else A_full[0:8, 8:16].T
         A_ref[8:16, 8:16] = A_full[8:16, 8:16] if not trans else A_full[8:16, 8:16].T
 
-    def run():
+    def run_and_check():
         A = tvm.runtime.tensor(A_np, device=tvm.cuda(0))
         mod(A)
         np.testing.assert_allclose(A.numpy(), A_ref)
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -464,14 +464,14 @@ def test_cp_async_bulk_tensor_global_to_shared_unicast(dtype, inputs):
     A_np = np.array(A_np).reshape(shape).astype(get_np_dtype(dtype))
     B_np = np.zeros(shape).astype(get_np_dtype(dtype))
 
-    def run():
+    def run_and_check():
         dev = tvm.cuda(0)
         A = tvm.runtime.tensor(A_np, device=dev)
         B = tvm.runtime.tensor(B_np, device=dev)
         mod(A, B)
         assert np.allclose(A.numpy().astype("float32"), B.numpy().astype("float32"))
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -628,7 +628,7 @@ def test_cp_async_bulk_tensor_global_to_shared_swizzle(swizzle, dtype):
         per_element=int(math.log2(128 // dtype.bits)), swizzle_len=swizzle, atom_len=3
     )
 
-    def run():
+    def run_and_check():
         dev = tvm.cuda(0)
         A = tvm.runtime.tensor(A_np, device=dev)
         B = tvm.runtime.tensor(B_np, device=dev)
@@ -638,7 +638,7 @@ def test_cp_async_bulk_tensor_global_to_shared_swizzle(swizzle, dtype):
         B_swizzle = np.array(B_swizzle).astype(str(dtype))
         assert np.allclose(A.numpy(), B_swizzle)
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.parametrize(
@@ -716,13 +716,13 @@ def test_cp_async_bulk_tensor_global_to_shared_multicast1(inputs):
     A_np = np.array(A_np, dtype="float32").reshape(shape)
     B_np = np.zeros(shape, dtype="float32")
 
-    def run():
+    def run_and_check():
         dev = tvm.cuda(0)
         A = tvm.runtime.tensor(A_np, device=dev)
         B = tvm.runtime.tensor(B_np, device=dev)
         mod(A, B)
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.parametrize(
@@ -810,14 +810,14 @@ def test_cp_async_bulk_tensor_global_to_shared_multicast2(inputs):
     A_np = np.array(A_np, dtype="float32").reshape(shape)
     B_np = np.zeros(shape, dtype="float32")
 
-    def run():
+    def run_and_check():
         dev = tvm.cuda(0)
         A = tvm.runtime.tensor(A_np, device=dev)
         B = tvm.runtime.tensor(B_np, device=dev)
         mod(A, B)
         assert np.allclose(A.numpy(), B.numpy())
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.parametrize(
@@ -875,12 +875,12 @@ def test_cp_async_bulk_tensor_shared_to_global(inputs):
     A_ref = [i for i in range(math.prod(shape))]
     A_ref = np.array(A_ref, dtype="float32").reshape(shape)
 
-    def run():
+    def run_and_check():
         A = tvm.runtime.tensor(A_np, device=tvm.cuda(0))
         mod(A)
         np.testing.assert_allclose(A.numpy(), A_ref)
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -1029,7 +1029,7 @@ def test_wgmma_ss_nt():
     B_np = np.random.randn(*shapeB).astype(in_dtype)
     C_np = np.zeros(shapeC).astype(out_dtype)
 
-    def run():
+    def run_and_check():
         dev = tvm.cuda(0)
         A_tvm = tvm.runtime.tensor(A_np, device=dev)
         B_tvm = tvm.runtime.tensor(B_np, device=dev)
@@ -1038,7 +1038,7 @@ def test_wgmma_ss_nt():
         C_ref = np.dot(A_np.T, B_np).astype(out_dtype)
         tvm.testing.assert_allclose(C_tvm.numpy(), C_ref, rtol=1e-3, atol=1e-3)
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -1190,7 +1190,7 @@ def test_wgmma_rs_nt():
 
     C_ref = np.dot(A_np, B_np).astype(out_dtype)
 
-    def run():
+    def run_and_check():
         dev = tvm.cuda(0)
         A_tvm = tvm.runtime.tensor(A_np, device=dev)
         B_tvm = tvm.runtime.tensor(B_np, device=dev)
@@ -1198,7 +1198,7 @@ def test_wgmma_rs_nt():
         mod(A_tvm, B_tvm, C_tvm)
         tvm.testing.assert_allclose(C_tvm.numpy(), C_ref, rtol=1e-3, atol=1e-3)
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu

--- a/tests/python/tirx/codegen/test_codegen_hopper.py
+++ b/tests/python/tirx/codegen/test_codegen_hopper.py
@@ -53,8 +53,11 @@ def _run_tensormap_encode(shape, dtype, encode_args):
     target = tvm.target.Target("cuda")
     mod = tvm.IRModule({"main": main})
     mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
-    A = tvm.runtime.tensor(np.zeros(shape, dtype=dtype), device=tvm.cuda(0))
-    mod(A)
+    def run():
+        A = tvm.runtime.tensor(np.zeros(shape, dtype=dtype), device=tvm.cuda(0))
+        mod(A)
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 @pytest.mark.parametrize("inc", [False, True])
@@ -102,7 +105,6 @@ def test_stmatrix_sync_aligned(trans):
                 A[i, j] = A_smem[i, j]
         # fmt: on
 
-    DEV = tvm.cuda(0)
     target = tvm.target.Target("cuda")
     mod = tvm.IRModule({"main": func})
     with target:
@@ -112,8 +114,10 @@ def test_stmatrix_sync_aligned(trans):
             assert "stmatrix.sync.aligned.m8n8.x4.shared.b16" in src
         else:
             assert "stmatrix.sync.aligned.m8n8.x4.trans.shared.b16" in src
+    def run():
+        dev = tvm.cuda(0)
         A_np = np.zeros((16, 16), dtype="float16")
-        A = tvm.runtime.tensor(A_np, device=DEV)
+        A = tvm.runtime.tensor(A_np, device=dev)
         mod(A)
         A_ref = np.zeros((16, 16), dtype="float16")
         for tx in range(32):
@@ -138,6 +142,8 @@ def test_stmatrix_sync_aligned(trans):
                 A_ref[col + 8, row + 8] = tx * 8 + 6
                 A_ref[col + 9, row + 8] = tx * 8 + 7
         np.testing.assert_allclose(A.numpy(), A_ref)
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 @pytest.mark.parametrize("trans", [False, True])
@@ -168,7 +174,6 @@ def test_ptx_stmatrix(trans, num):
                 A[i, j] = A_shared[i, j]
         # fmt: on
 
-    DEV = tvm.cuda(0)
     target = tvm.target.Target("cuda")
     mod = tvm.IRModule({"main": main})
     with target:
@@ -181,9 +186,6 @@ def test_ptx_stmatrix(trans, num):
     A_full[8:16, 0:8] = np.arange(8 * 8, 16 * 8, dtype="float16").reshape((8, 8))
     A_full[0:8, 8:16] = np.arange(16 * 8, 24 * 8, dtype="float16").reshape((8, 8))
     A_full[8:16, 8:16] = np.arange(24 * 8, 32 * 8, dtype="float16").reshape((8, 8))
-    A = tvm.runtime.tensor(A_np, device=DEV)
-
-    mod(A)
     print(src)
 
     if num == 1:
@@ -197,7 +199,12 @@ def test_ptx_stmatrix(trans, num):
         A_ref[8:16, 0:8] = A_full[8:16, 0:8] if not trans else A_full[8:16, 0:8].T
         A_ref[8:16, 8:16] = A_full[8:16, 8:16] if not trans else A_full[8:16, 8:16].T
 
-    np.testing.assert_allclose(A.numpy(), A_ref)
+    def run():
+        A = tvm.runtime.tensor(A_np, device=tvm.cuda(0))
+        mod(A)
+        np.testing.assert_allclose(A.numpy(), A_ref)
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 @pytest.mark.parametrize("trans", [False, True])
@@ -240,7 +247,6 @@ def test_ptx_stmatrix_noncontiguous(trans, num):
                 A[i, j] = A_shared[i, j]
     # fmt: on
 
-    DEV = tvm.cuda(0)
     target = tvm.target.Target("cuda")
     mod = tvm.IRModule({"main": main})
     with target:
@@ -253,8 +259,6 @@ def test_ptx_stmatrix_noncontiguous(trans, num):
             assert f"*(uint32_t*)src{i}" in src
 
     A_np = np.zeros((16, 16), dtype="float16")
-    A = tvm.runtime.tensor(A_np, device=DEV)
-    mod(A)
     A_ref = np.zeros((16, 16), dtype="float16")
     A_full = np.zeros((16, 16), dtype="float16")
     A_full[0:8, 0:8] = np.arange(8 * 8, dtype="float16").reshape((8, 8))
@@ -268,7 +272,13 @@ def test_ptx_stmatrix_noncontiguous(trans, num):
     if num >= 4:
         A_ref[0:8, 8:16] = A_full[0:8, 8:16] if not trans else A_full[0:8, 8:16].T
         A_ref[8:16, 8:16] = A_full[8:16, 8:16] if not trans else A_full[8:16, 8:16].T
-    np.testing.assert_allclose(A.numpy(), A_ref)
+
+    def run():
+        A = tvm.runtime.tensor(A_np, device=tvm.cuda(0))
+        mod(A)
+        np.testing.assert_allclose(A.numpy(), A_ref)
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 @pytest.mark.gpu
@@ -435,7 +445,6 @@ def test_cp_async_bulk_tensor_global_to_shared_unicast(dtype, inputs):
 
         return main
 
-    DEV = tvm.cuda(0)
     target = tvm.target.Target("cuda")
     shape, tma_args = inputs
     mod = tvm.IRModule({"main": get_ir(shape, tma_args)})
@@ -454,10 +463,15 @@ def test_cp_async_bulk_tensor_global_to_shared_unicast(dtype, inputs):
 
     A_np = np.array(A_np).reshape(shape).astype(get_np_dtype(dtype))
     B_np = np.zeros(shape).astype(get_np_dtype(dtype))
-    A = tvm.runtime.tensor(A_np, device=DEV)
-    B = tvm.runtime.tensor(B_np, device=DEV)
-    mod(A, B)
-    assert np.allclose(A.numpy().astype("float32"), B.numpy().astype("float32"))
+
+    def run():
+        dev = tvm.cuda(0)
+        A = tvm.runtime.tensor(A_np, device=dev)
+        B = tvm.runtime.tensor(B_np, device=dev)
+        mod(A, B)
+        assert np.allclose(A.numpy().astype("float32"), B.numpy().astype("float32"))
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 @pytest.mark.gpu
@@ -598,7 +612,6 @@ def test_cp_async_bulk_tensor_global_to_shared_swizzle(swizzle, dtype):
 
         return main, shape
 
-    DEV = tvm.cuda(0)
     target = tvm.target.Target("cuda")
     func, shape = get_ir(swizzle, dtype)
     mod = tvm.IRModule({"main": func})
@@ -610,17 +623,22 @@ def test_cp_async_bulk_tensor_global_to_shared_swizzle(swizzle, dtype):
     A_np = [i for i in range(total_elems)]
     A_np = np.array(A_np).astype(dtype)
     B_np = np.zeros((total_elems,)).astype(dtype)
-    A = tvm.runtime.tensor(A_np, device=DEV)
-    B = tvm.runtime.tensor(B_np, device=DEV)
-    mod(A, B)
     dtype = tvm.DataType(dtype)
     layout = T.SwizzleLayout(
         per_element=int(math.log2(128 // dtype.bits)), swizzle_len=swizzle, atom_len=3
     )
-    B_np = B.numpy()
-    B_swizzle = [B_np[int(layout.apply(i)["m"])] for i in range(total_elems)]
-    B_swizzle = np.array(B_swizzle).astype(str(dtype))
-    assert np.allclose(A.numpy(), B_swizzle)
+
+    def run():
+        dev = tvm.cuda(0)
+        A = tvm.runtime.tensor(A_np, device=dev)
+        B = tvm.runtime.tensor(B_np, device=dev)
+        mod(A, B)
+        B_result = B.numpy()
+        B_swizzle = [B_result[int(layout.apply(i)["m"])] for i in range(total_elems)]
+        B_swizzle = np.array(B_swizzle).astype(str(dtype))
+        assert np.allclose(A.numpy(), B_swizzle)
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 @pytest.mark.parametrize(
@@ -687,7 +705,6 @@ def test_cp_async_bulk_tensor_global_to_shared_multicast1(inputs):
 
         return main
 
-    DEV = tvm.cuda(0)
     target = tvm.target.Target("cuda")
     shape, tma_args = inputs
     mod = tvm.IRModule({"main": get_ir(shape, tma_args)})
@@ -698,9 +715,14 @@ def test_cp_async_bulk_tensor_global_to_shared_multicast1(inputs):
     A_np = [i for i in range(math.prod(shape))]
     A_np = np.array(A_np, dtype="float32").reshape(shape)
     B_np = np.zeros(shape, dtype="float32")
-    A = tvm.runtime.tensor(A_np, device=DEV)
-    B = tvm.runtime.tensor(B_np, device=DEV)
-    mod(A, B)
+
+    def run():
+        dev = tvm.cuda(0)
+        A = tvm.runtime.tensor(A_np, device=dev)
+        B = tvm.runtime.tensor(B_np, device=dev)
+        mod(A, B)
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 @pytest.mark.parametrize(
@@ -777,7 +799,6 @@ def test_cp_async_bulk_tensor_global_to_shared_multicast2(inputs):
 
         return main
 
-    DEV = tvm.cuda(0)
     target = tvm.target.Target("cuda")
     shape, tma_args = inputs
     mod = tvm.IRModule({"main": get_ir(shape, tma_args)})
@@ -788,10 +809,15 @@ def test_cp_async_bulk_tensor_global_to_shared_multicast2(inputs):
     A_np = [i for i in range(math.prod(shape))]
     A_np = np.array(A_np, dtype="float32").reshape(shape)
     B_np = np.zeros(shape, dtype="float32")
-    A = tvm.runtime.tensor(A_np, device=DEV)
-    B = tvm.runtime.tensor(B_np, device=DEV)
-    mod(A, B)
-    assert np.allclose(A.numpy(), B.numpy())
+
+    def run():
+        dev = tvm.cuda(0)
+        A = tvm.runtime.tensor(A_np, device=dev)
+        B = tvm.runtime.tensor(B_np, device=dev)
+        mod(A, B)
+        assert np.allclose(A.numpy(), B.numpy())
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 @pytest.mark.parametrize(
@@ -838,7 +864,6 @@ def test_cp_async_bulk_tensor_shared_to_global(inputs):
 
         return main
 
-    DEV = tvm.cuda(0)
     target = tvm.target.Target("cuda")
     shape, tma_args = inputs
     mod = tvm.IRModule({"main": get_ir(shape, tma_args)})
@@ -847,12 +872,15 @@ def test_cp_async_bulk_tensor_shared_to_global(inputs):
     assert "const __grid_constant__ CUtensorMap" in src
 
     A_np = np.zeros(shape, dtype="float32")
-    A = tvm.runtime.tensor(A_np, device=DEV)
-    mod(A)
-
     A_ref = [i for i in range(math.prod(shape))]
     A_ref = np.array(A_ref, dtype="float32").reshape(shape)
-    np.testing.assert_allclose(A.numpy(), A_ref)
+
+    def run():
+        A = tvm.runtime.tensor(A_np, device=tvm.cuda(0))
+        mod(A)
+        np.testing.assert_allclose(A.numpy(), A_ref)
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 @pytest.mark.gpu
@@ -964,7 +992,6 @@ def test_wgmma_ss_nt():
     t_in_dtype = tvm.DataType(in_dtype)
     elem_bytes = t_in_dtype.bits // 8
 
-    DEV = tvm.cuda(0)
     target = tvm.target.Target("cuda")
     M = 64
     N = 64
@@ -1002,13 +1029,16 @@ def test_wgmma_ss_nt():
     B_np = np.random.randn(*shapeB).astype(in_dtype)
     C_np = np.zeros(shapeC).astype(out_dtype)
 
-    A_tvm = tvm.runtime.tensor(A_np, device=DEV)
-    B_tvm = tvm.runtime.tensor(B_np, device=DEV)
-    C_tvm = tvm.runtime.tensor(C_np, device=DEV)
-    mod(A_tvm, B_tvm, C_tvm)
+    def run():
+        dev = tvm.cuda(0)
+        A_tvm = tvm.runtime.tensor(A_np, device=dev)
+        B_tvm = tvm.runtime.tensor(B_np, device=dev)
+        C_tvm = tvm.runtime.tensor(C_np, device=dev)
+        mod(A_tvm, B_tvm, C_tvm)
+        C_ref = np.dot(A_np.T, B_np).astype(out_dtype)
+        tvm.testing.assert_allclose(C_tvm.numpy(), C_ref, rtol=1e-3, atol=1e-3)
 
-    C_ref = np.dot(A_np.T, B_np).astype(out_dtype)
-    tvm.testing.assert_allclose(C_tvm.numpy(), C_ref, rtol=1e-3, atol=1e-3)
+    tvm.testing.run_with_gpu_lock(run)
 
 
 @pytest.mark.gpu
@@ -1129,7 +1159,6 @@ def test_wgmma_rs_nt():
     t_in_dtype = tvm.DataType(in_dtype)
     elem_bytes = t_in_dtype.bits // 8
 
-    DEV = tvm.cuda(0)
     target = tvm.target.Target("cuda")
     M = 64
     N = 64
@@ -1155,17 +1184,21 @@ def test_wgmma_rs_nt():
     B_np = np.random.randn(*shapeB).astype(in_dtype)
     C_np = np.zeros(shapeC).astype(out_dtype)
 
-    A_tvm = tvm.runtime.tensor(A_np, device=DEV)
-    B_tvm = tvm.runtime.tensor(B_np, device=DEV)
-    C_tvm = tvm.runtime.tensor(C_np, device=DEV)
-    mod(A_tvm, B_tvm, C_tvm)
-
     np.printoptions(threshold=np.inf)
     np.printoptions(linewidth=np.inf)
     np.printoptions(precision=2)
 
     C_ref = np.dot(A_np, B_np).astype(out_dtype)
-    tvm.testing.assert_allclose(C_tvm.numpy(), C_ref, rtol=1e-3, atol=1e-3)
+
+    def run():
+        dev = tvm.cuda(0)
+        A_tvm = tvm.runtime.tensor(A_np, device=dev)
+        B_tvm = tvm.runtime.tensor(B_np, device=dev)
+        C_tvm = tvm.runtime.tensor(C_np, device=dev)
+        mod(A_tvm, B_tvm, C_tvm)
+        tvm.testing.assert_allclose(C_tvm.numpy(), C_ref, rtol=1e-3, atol=1e-3)
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 @pytest.mark.gpu

--- a/tests/python/tirx/codegen/test_codegen_nvshmem.py
+++ b/tests/python/tirx/codegen/test_codegen_nvshmem.py
@@ -294,12 +294,19 @@ def test_codegen_nvshmem():
         finalize_dfunc = sess.get_global_func("runtime.disco.nvshmem.finalize_nvshmem")
         finalize_dfunc()
         sess.sync_worker_0()
+        sess.shutdown()
         return True
 
-    p = PopenWorker()
-    p.send(_test_func)
-    assert p.recv()
+    def run():
+        worker = PopenWorker()
+        try:
+            worker.send(_test_func)
+            assert worker.recv()
+        finally:
+            worker.kill()
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 if __name__ == "__main__":
-    test_codegen_nvshmem()
+    tvm.testing.main()

--- a/tests/python/tirx/codegen/test_codegen_nvshmem.py
+++ b/tests/python/tirx/codegen/test_codegen_nvshmem.py
@@ -297,7 +297,7 @@ def test_codegen_nvshmem():
         sess.shutdown()
         return True
 
-    def run():
+    def run_and_check():
         worker = PopenWorker()
         try:
             worker.send(_test_func)
@@ -305,7 +305,7 @@ def test_codegen_nvshmem():
         finally:
             worker.kill()
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 if __name__ == "__main__":

--- a/tests/python/tirx/codegen/test_cuda_cta_reduce.py
+++ b/tests/python/tirx/codegen/test_cuda_cta_reduce.py
@@ -23,7 +23,6 @@ import tvm
 from tvm.script import tirx as T
 from tvm.testing import env
 
-DEV = tvm.cuda(0)
 TARGET = tvm.target.Target("cuda")
 
 
@@ -31,9 +30,15 @@ def _build_and_run(func, n):
     mod = tvm.IRModule({"main": func})
     mod = tvm.compile(mod, target=TARGET, tir_pipeline="tirx")
     out_np = np.zeros(n, dtype="float32")
-    out = tvm.runtime.tensor(out_np, device=DEV)
-    mod(out)
-    return out.numpy(), mod
+
+    def run():
+        dev = tvm.cuda(0)
+        out = tvm.runtime.tensor(out_np, device=dev)
+        mod(out)
+        dev.sync()
+        return out.numpy()
+
+    return tvm.testing.run_with_gpu_lock(run), mod
 
 
 @pytest.mark.gpu

--- a/tests/python/tirx/codegen/test_cuda_cta_reduce.py
+++ b/tests/python/tirx/codegen/test_cuda_cta_reduce.py
@@ -31,14 +31,13 @@ def _build_and_run(func, n):
     mod = tvm.compile(mod, target=TARGET, tir_pipeline="tirx")
     out_np = np.zeros(n, dtype="float32")
 
-    def run():
+    def run_and_check():
         dev = tvm.cuda(0)
         out = tvm.runtime.tensor(out_np, device=dev)
         mod(out)
-        dev.sync()
         return out.numpy()
 
-    return tvm.testing.run_with_gpu_lock(run), mod
+    return tvm.testing.run_with_gpu_lock(run_and_check), mod
 
 
 @pytest.mark.gpu

--- a/tests/python/tirx/codegen/test_cuda_warp_reduce.py
+++ b/tests/python/tirx/codegen/test_cuda_warp_reduce.py
@@ -23,7 +23,6 @@ import tvm
 from tvm.script import tirx as T
 from tvm.testing import env
 
-DEV = tvm.cuda(0)
 TARGET = tvm.target.Target("cuda")
 
 
@@ -31,9 +30,15 @@ def _build_and_run(func, n=32):
     mod = tvm.IRModule({"main": func})
     mod = tvm.compile(mod, target=TARGET, tir_pipeline="tirx")
     out_np = np.zeros(n, dtype="float32")
-    out = tvm.runtime.tensor(out_np, device=DEV)
-    mod(out)
-    return out.numpy(), mod
+
+    def run():
+        dev = tvm.cuda(0)
+        out = tvm.runtime.tensor(out_np, device=dev)
+        mod(out)
+        dev.sync()
+        return out.numpy()
+
+    return tvm.testing.run_with_gpu_lock(run), mod
 
 
 @pytest.mark.gpu

--- a/tests/python/tirx/codegen/test_cuda_warp_reduce.py
+++ b/tests/python/tirx/codegen/test_cuda_warp_reduce.py
@@ -31,14 +31,13 @@ def _build_and_run(func, n=32):
     mod = tvm.compile(mod, target=TARGET, tir_pipeline="tirx")
     out_np = np.zeros(n, dtype="float32")
 
-    def run():
+    def run_and_check():
         dev = tvm.cuda(0)
         out = tvm.runtime.tensor(out_np, device=dev)
         mod(out)
-        dev.sync()
         return out.numpy()
 
-    return tvm.testing.run_with_gpu_lock(run), mod
+    return tvm.testing.run_with_gpu_lock(run_and_check), mod
 
 
 @pytest.mark.gpu

--- a/tests/python/tirx/codegen/test_ptx_ld_st_ops.py
+++ b/tests/python/tirx/codegen/test_ptx_ld_st_ops.py
@@ -29,7 +29,6 @@ from tvm.tirx.cuda.operator.tile_primitive.copy._common import (
     copy_ptx_ld_return_type,
 )
 
-DEV = tvm.cuda(0)
 TARGET = tvm.target.Target("cuda")
 
 # num_bytes → kernel layout. ``fill_offset`` fills lane i with ``i + fill_offset``.
@@ -44,9 +43,15 @@ _SHARED_COPY_CASES = {
 
 def _build_and_run(func, *np_args):
     mod = tvm.compile(tvm.IRModule({"main": func}), target=TARGET, tir_pipeline="tirx")
-    rt_args = [tvm.runtime.tensor(a, device=DEV) for a in np_args]
-    mod(*rt_args)
-    return (*tuple(a.numpy() for a in rt_args), mod)
+
+    def run():
+        dev = tvm.cuda(0)
+        rt_args = [tvm.runtime.tensor(a, device=dev) for a in np_args]
+        mod(*rt_args)
+        dev.sync()
+        return tuple(a.numpy() for a in rt_args)
+
+    return (*tvm.testing.run_with_gpu_lock(run), mod)
 
 
 def _expected_values(num_bytes: int) -> np.ndarray:

--- a/tests/python/tirx/codegen/test_ptx_ld_st_ops.py
+++ b/tests/python/tirx/codegen/test_ptx_ld_st_ops.py
@@ -44,14 +44,13 @@ _SHARED_COPY_CASES = {
 def _build_and_run(func, *np_args):
     mod = tvm.compile(tvm.IRModule({"main": func}), target=TARGET, tir_pipeline="tirx")
 
-    def run():
+    def run_and_check():
         dev = tvm.cuda(0)
         rt_args = [tvm.runtime.tensor(a, device=dev) for a in np_args]
         mod(*rt_args)
-        dev.sync()
         return tuple(a.numpy() for a in rt_args)
 
-    return (*tvm.testing.run_with_gpu_lock(run), mod)
+    return (*tvm.testing.run_with_gpu_lock(run_and_check), mod)
 
 
 def _expected_values(num_bytes: int) -> np.ndarray:

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy/test_fallback.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy/test_fallback.py
@@ -146,7 +146,6 @@ def test_fallback_round_trip(scope, n_threads, shape, why):
     dtype = "float32"
     kernel = _build_round_trip_kernel(scope, n_threads, shape, dtype)
 
-    dev = tvm.cuda(0)
     target = tvm.target.Target("cuda")
     with target, pytest.warns(UserWarning, match="copy/fallback"):
         mod = tvm.IRModule({"main": kernel})
@@ -155,10 +154,16 @@ def test_fallback_round_trip(scope, n_threads, shape, why):
     np_dtype = tvm.testing.np_dtype_from_str(dtype)
     A_np = tvm.testing.generate_random_array(dtype, shape)
     B_np = np.zeros(shape, dtype=np_dtype)
-    A = tvm.runtime.tensor(A_np, dev)
-    B = tvm.runtime.tensor(B_np, dev)
-    compiled(A, B)
-    np.testing.assert_array_equal(B.numpy(), A_np)
+
+    def run_test():
+        dev = tvm.cuda(0)
+        A = tvm.runtime.tensor(A_np, dev)
+        B = tvm.runtime.tensor(B_np, dev)
+        compiled(A, B)
+        dev.sync()
+        np.testing.assert_array_equal(B.numpy(), A_np)
+
+    tvm.testing.run_with_gpu_lock(run_test)
 
 
 @pytest.mark.gpu
@@ -185,7 +190,6 @@ def test_fallback_thread_scope():
         T.cuda.cta_sync()
         Tx.copy(B[full], A_smem[full])
 
-    dev = tvm.cuda(0)
     target = tvm.target.Target("cuda")
     with target:
         mod = tvm.IRModule({"main": kernel})
@@ -194,10 +198,16 @@ def test_fallback_thread_scope():
     np_dtype = tvm.testing.np_dtype_from_str(dtype)
     A_np = tvm.testing.generate_random_array(dtype, shape)
     B_np = np.zeros(shape, dtype=np_dtype)
-    A = tvm.runtime.tensor(A_np, dev)
-    B = tvm.runtime.tensor(B_np, dev)
-    compiled(A, B)
-    np.testing.assert_array_equal(B.numpy(), A_np)
+
+    def run_test():
+        dev = tvm.cuda(0)
+        A = tvm.runtime.tensor(A_np, dev)
+        B = tvm.runtime.tensor(B_np, dev)
+        compiled(A, B)
+        dev.sync()
+        np.testing.assert_array_equal(B.numpy(), A_np)
+
+    tvm.testing.run_with_gpu_lock(run_test)
 
 
 def test_fallback_emits_gate():

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy/test_fallback.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy/test_fallback.py
@@ -155,15 +155,14 @@ def test_fallback_round_trip(scope, n_threads, shape, why):
     A_np = tvm.testing.generate_random_array(dtype, shape)
     B_np = np.zeros(shape, dtype=np_dtype)
 
-    def run_test():
+    def run_and_check():
         dev = tvm.cuda(0)
         A = tvm.runtime.tensor(A_np, dev)
         B = tvm.runtime.tensor(B_np, dev)
         compiled(A, B)
-        dev.sync()
         np.testing.assert_array_equal(B.numpy(), A_np)
 
-    tvm.testing.run_with_gpu_lock(run_test)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -199,15 +198,14 @@ def test_fallback_thread_scope():
     A_np = tvm.testing.generate_random_array(dtype, shape)
     B_np = np.zeros(shape, dtype=np_dtype)
 
-    def run_test():
+    def run_and_check():
         dev = tvm.cuda(0)
         A = tvm.runtime.tensor(A_np, dev)
         B = tvm.runtime.tensor(B_np, dev)
         compiled(A, B)
-        dev.sync()
         np.testing.assert_array_equal(B.numpy(), A_np)
 
-    tvm.testing.run_with_gpu_lock(run_test)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 def test_fallback_emits_gate():

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy/test_gmem_smem.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy/test_gmem_smem.py
@@ -113,7 +113,6 @@ TASKS = [
 def test_gmem_smem_roundtrip(scope, n_threads, shape, dtype):
     kernel = _build_kernel(scope, n_threads, shape, dtype)
 
-    dev = tvm.cuda(0)
     target = tvm.target.Target("cuda")
     with target:
         mod = tvm.IRModule({"main": kernel})
@@ -122,10 +121,16 @@ def test_gmem_smem_roundtrip(scope, n_threads, shape, dtype):
     np_dtype = tvm.testing.np_dtype_from_str(dtype)
     A_np = tvm.testing.generate_random_array(dtype, shape)
     B_np = np.zeros(shape, dtype=np_dtype)
-    A = tvm.runtime.tensor(A_np, dev)
-    B = tvm.runtime.tensor(B_np, dev)
-    compiled(A, B)
-    np.testing.assert_array_equal(B.numpy(), A_np)
+
+    def run_test():
+        dev = tvm.cuda(0)
+        A = tvm.runtime.tensor(A_np, dev)
+        B = tvm.runtime.tensor(B_np, dev)
+        compiled(A, B)
+        dev.sync()
+        np.testing.assert_array_equal(B.numpy(), A_np)
+
+    tvm.testing.run_with_gpu_lock(run_test)
 
 
 # ----------------------------------------------------------------------------
@@ -146,7 +151,6 @@ def test_gmem_smem_roundtrip(scope, n_threads, shape, dtype):
             TileLayout(S[128, 32]),
             TileLayout(S[128, 32]),
             TileLayout(S[128, 32]),
-            tvm.cuda(0),
         ),
         # A[32:64, 32:64] -> A_smem[0:32, 0:32] -> B[32:64, 32:64]
         (
@@ -157,7 +161,6 @@ def test_gmem_smem_roundtrip(scope, n_threads, shape, dtype):
             TileLayout(S[64, 64]),
             TileLayout(S[64, 64]),
             TileLayout(S[32, 32]),
-            tvm.cuda(0),
         ),
         # A[0:1, 0:32, 0:32] -> A_smem[0:32, 0:32] -> B[0:1, 0:32, 0:32]
         (
@@ -168,7 +171,6 @@ def test_gmem_smem_roundtrip(scope, n_threads, shape, dtype):
             TileLayout(S[4, 32, 32]),
             TileLayout(S[4, 32, 32]),
             TileLayout(S[32, 32]),
-            tvm.cuda(0),
         ),
         # A[0:8, 0:8] -> A_smem[0:8, 0:8] -> B[0:8, 0:8]
         (
@@ -179,7 +181,6 @@ def test_gmem_smem_roundtrip(scope, n_threads, shape, dtype):
             TileLayout(S[16, 16]),
             TileLayout(S[16, 16]),
             TileLayout(S[8, 8]),
-            tvm.cuda(0),
         ),
         # A[32:96, 256:512] -> A_smem[0:32, 0:256] -> B[32:96, 256:512] (swizzled)
         (
@@ -192,7 +193,6 @@ def test_gmem_smem_roundtrip(scope, n_threads, shape, dtype):
             ComposeLayout(SwizzleLayout(3, 3, 3), TileLayout(S[8, 64]))
             .tile_to((16, 128), (8, 64))
             .tile_to((32, 256), (16, 128)),
-            tvm.cuda(0),
         ),
     ],
 )
@@ -203,7 +203,7 @@ def test_gmem_smem_roundtrip(scope, n_threads, shape, dtype):
 )
 @pytest.mark.parametrize("scope", ["cta", "thread"])
 def test_copy_g2s_s2g(task, dtype, scope):
-    g_shape, s_shape, g_region, thread_cnt, layoutA, layoutB, layoutS, dev = task
+    g_shape, s_shape, g_region, thread_cnt, layoutA, layoutB, layoutS = task
 
     r_smem = tuple(slice(None) for _ in range(len(s_shape)))
     r_gmem = tuple(slice(g_region[i][0], g_region[i][1]) for i in range(len(g_shape)))
@@ -237,13 +237,18 @@ def test_copy_g2s_s2g(task, dtype, scope):
         A_np = tvm.testing.generate_random_array(dtype, g_shape)
         B_np = np.zeros(g_shape, dtype=np_dtype)
 
-        A = tvm.runtime.tensor(A_np, dev)
-        B = tvm.runtime.tensor(B_np, dev)
-        mod(A, B)
-
         B_ref = B_np.copy()
         B_ref[r_gmem] = A_np[r_gmem]
-        np.testing.assert_allclose(B_ref, B.numpy())
+
+        def run_test():
+            dev = tvm.cuda(0)
+            A = tvm.runtime.tensor(A_np, dev)
+            B = tvm.runtime.tensor(B_np, dev)
+            mod(A, B)
+            dev.sync()
+            np.testing.assert_allclose(B_ref, B.numpy())
+
+        tvm.testing.run_with_gpu_lock(run_test)
 
 
 # ----------------------------------------------------------------------------
@@ -558,13 +563,18 @@ def test_gmem_smem_swizzle_fast_path_fires_with_var_bounds():
     )
 
     # Round-trip correctness.
-    dev = tvm.cuda(0)
     A_np = np.arange(32 * 64, dtype="float16").reshape(shape)
     B_np = np.zeros(shape, dtype="float16")
-    A = tvm.runtime.tensor(A_np, device=dev)
-    B = tvm.runtime.tensor(B_np, device=dev)
-    ex(A, B)
-    np.testing.assert_allclose(B.numpy(), A_np)
+
+    def run_test():
+        dev = tvm.cuda(0)
+        A = tvm.runtime.tensor(A_np, device=dev)
+        B = tvm.runtime.tensor(B_np, device=dev)
+        ex(A, B)
+        dev.sync()
+        np.testing.assert_allclose(B.numpy(), A_np)
+
+    tvm.testing.run_with_gpu_lock(run_test)
 
 
 if __name__ == "__main__":

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy/test_gmem_smem.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy/test_gmem_smem.py
@@ -122,15 +122,14 @@ def test_gmem_smem_roundtrip(scope, n_threads, shape, dtype):
     A_np = tvm.testing.generate_random_array(dtype, shape)
     B_np = np.zeros(shape, dtype=np_dtype)
 
-    def run_test():
+    def run_and_check():
         dev = tvm.cuda(0)
         A = tvm.runtime.tensor(A_np, dev)
         B = tvm.runtime.tensor(B_np, dev)
         compiled(A, B)
-        dev.sync()
         np.testing.assert_array_equal(B.numpy(), A_np)
 
-    tvm.testing.run_with_gpu_lock(run_test)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 # ----------------------------------------------------------------------------
@@ -240,15 +239,14 @@ def test_copy_g2s_s2g(task, dtype, scope):
         B_ref = B_np.copy()
         B_ref[r_gmem] = A_np[r_gmem]
 
-        def run_test():
+        def run_and_check():
             dev = tvm.cuda(0)
             A = tvm.runtime.tensor(A_np, dev)
             B = tvm.runtime.tensor(B_np, dev)
             mod(A, B)
-            dev.sync()
             np.testing.assert_allclose(B_ref, B.numpy())
 
-        tvm.testing.run_with_gpu_lock(run_test)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 # ----------------------------------------------------------------------------
@@ -566,15 +564,14 @@ def test_gmem_smem_swizzle_fast_path_fires_with_var_bounds():
     A_np = np.arange(32 * 64, dtype="float16").reshape(shape)
     B_np = np.zeros(shape, dtype="float16")
 
-    def run_test():
+    def run_and_check():
         dev = tvm.cuda(0)
         A = tvm.runtime.tensor(A_np, device=dev)
         B = tvm.runtime.tensor(B_np, device=dev)
         ex(A, B)
-        dev.sync()
         np.testing.assert_allclose(B.numpy(), A_np)
 
-    tvm.testing.run_with_gpu_lock(run_test)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 if __name__ == "__main__":

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy/test_ld_stmatrix.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy/test_ld_stmatrix.py
@@ -331,13 +331,18 @@ def test_ldstmatrix(scope, trans, direction, num):
     expected = f"{inst}.sync.aligned.m8n8.x{num}{trans_inst}.shared.b16"
     assert expected in src, f"{expected} not emitted; src=\n{src}"
 
-    DEV = tvm.cuda(0)
     A_np = np.arange(M * N, dtype="float16").reshape(M, N)
     B_np = np.zeros((M, N), dtype="float16")
-    A = tvm.runtime.tensor(A_np, device=DEV)
-    B = tvm.runtime.tensor(B_np, device=DEV)
-    compiled(A, B)
-    np.testing.assert_allclose(B.numpy(), A_np)
+
+    def run_test():
+        dev = tvm.cuda(0)
+        A = tvm.runtime.tensor(A_np, device=dev)
+        B = tvm.runtime.tensor(B_np, device=dev)
+        compiled(A, B)
+        dev.sync()
+        np.testing.assert_allclose(B.numpy(), A_np)
+
+    tvm.testing.run_with_gpu_lock(run_test)
 
 
 # ---------------------------------------------------------------------------
@@ -362,13 +367,18 @@ def test_ldstmatrix_swizzle(scope, trans, direction, num):
     expected = f"{inst}.sync.aligned.m8n8.x{num}{trans_inst}.shared.b16"
     assert expected in src, f"{expected} not emitted; src=\n{src}"
 
-    DEV = tvm.cuda(0)
     A_np = np.arange(M * N, dtype="float16").reshape(M, N)
     B_np = np.zeros((M, N), dtype="float16")
-    A = tvm.runtime.tensor(A_np, device=DEV)
-    B = tvm.runtime.tensor(B_np, device=DEV)
-    compiled(A, B)
-    np.testing.assert_allclose(B.numpy(), A_np)
+
+    def run_test():
+        dev = tvm.cuda(0)
+        A = tvm.runtime.tensor(A_np, device=dev)
+        B = tvm.runtime.tensor(B_np, device=dev)
+        compiled(A, B)
+        dev.sync()
+        np.testing.assert_allclose(B.numpy(), A_np)
+
+    tvm.testing.run_with_gpu_lock(run_test)
 
 
 # ---------------------------------------------------------------------------
@@ -445,16 +455,21 @@ def test_ldstmatrix_swizzle_multi_iter_pow2():
     bitsel = re.findall(r"& 1\) \* v_\d+\[", src)
     assert bitsel, "fast-path bit-select pattern '& 1) * v_<n>[' missing"
 
-    DEV = tvm.cuda(0)
     n_elem = 1
     for e in shape:
         n_elem *= e
     A_np = np.arange(n_elem, dtype="float16").reshape(shape)
     B_np = np.zeros(shape, dtype="float16")
-    A = tvm.runtime.tensor(A_np, device=DEV)
-    B = tvm.runtime.tensor(B_np, device=DEV)
-    compiled(A, B)
-    np.testing.assert_allclose(B.numpy(), A_np)
+
+    def run_test():
+        dev = tvm.cuda(0)
+        A = tvm.runtime.tensor(A_np, device=dev)
+        B = tvm.runtime.tensor(B_np, device=dev)
+        compiled(A, B)
+        dev.sync()
+        np.testing.assert_allclose(B.numpy(), A_np)
+
+    tvm.testing.run_with_gpu_lock(run_test)
 
 
 def test_ldstmatrix_tcgen05_warpgroup_atom_emits_ldmatrix():
@@ -516,13 +531,18 @@ def test_ldstmatrix_swizzle_multi_iter_linear():
     bitsel = re.findall(r"& 1\) \* v_\d+\[", src)
     assert bitsel, "fast-path bit-select pattern missing"
 
-    DEV = tvm.cuda(0)
     n_elem = 1
     for e in shape:
         n_elem *= e
     A_np = np.arange(n_elem, dtype="float16").reshape(shape)
     B_np = np.zeros(shape, dtype="float16")
-    A = tvm.runtime.tensor(A_np, device=DEV)
-    B = tvm.runtime.tensor(B_np, device=DEV)
-    compiled(A, B)
-    np.testing.assert_allclose(B.numpy(), A_np)
+
+    def run_test():
+        dev = tvm.cuda(0)
+        A = tvm.runtime.tensor(A_np, device=dev)
+        B = tvm.runtime.tensor(B_np, device=dev)
+        compiled(A, B)
+        dev.sync()
+        np.testing.assert_allclose(B.numpy(), A_np)
+
+    tvm.testing.run_with_gpu_lock(run_test)

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy/test_ld_stmatrix.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy/test_ld_stmatrix.py
@@ -334,15 +334,14 @@ def test_ldstmatrix(scope, trans, direction, num):
     A_np = np.arange(M * N, dtype="float16").reshape(M, N)
     B_np = np.zeros((M, N), dtype="float16")
 
-    def run_test():
+    def run_and_check():
         dev = tvm.cuda(0)
         A = tvm.runtime.tensor(A_np, device=dev)
         B = tvm.runtime.tensor(B_np, device=dev)
         compiled(A, B)
-        dev.sync()
         np.testing.assert_allclose(B.numpy(), A_np)
 
-    tvm.testing.run_with_gpu_lock(run_test)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 # ---------------------------------------------------------------------------
@@ -370,15 +369,14 @@ def test_ldstmatrix_swizzle(scope, trans, direction, num):
     A_np = np.arange(M * N, dtype="float16").reshape(M, N)
     B_np = np.zeros((M, N), dtype="float16")
 
-    def run_test():
+    def run_and_check():
         dev = tvm.cuda(0)
         A = tvm.runtime.tensor(A_np, device=dev)
         B = tvm.runtime.tensor(B_np, device=dev)
         compiled(A, B)
-        dev.sync()
         np.testing.assert_allclose(B.numpy(), A_np)
 
-    tvm.testing.run_with_gpu_lock(run_test)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 # ---------------------------------------------------------------------------
@@ -461,15 +459,14 @@ def test_ldstmatrix_swizzle_multi_iter_pow2():
     A_np = np.arange(n_elem, dtype="float16").reshape(shape)
     B_np = np.zeros(shape, dtype="float16")
 
-    def run_test():
+    def run_and_check():
         dev = tvm.cuda(0)
         A = tvm.runtime.tensor(A_np, device=dev)
         B = tvm.runtime.tensor(B_np, device=dev)
         compiled(A, B)
-        dev.sync()
         np.testing.assert_allclose(B.numpy(), A_np)
 
-    tvm.testing.run_with_gpu_lock(run_test)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 def test_ldstmatrix_tcgen05_warpgroup_atom_emits_ldmatrix():
@@ -537,12 +534,11 @@ def test_ldstmatrix_swizzle_multi_iter_linear():
     A_np = np.arange(n_elem, dtype="float16").reshape(shape)
     B_np = np.zeros(shape, dtype="float16")
 
-    def run_test():
+    def run_and_check():
         dev = tvm.cuda(0)
         A = tvm.runtime.tensor(A_np, device=dev)
         B = tvm.runtime.tensor(B_np, device=dev)
         compiled(A, B)
-        dev.sync()
         np.testing.assert_allclose(B.numpy(), A_np)
 
-    tvm.testing.run_with_gpu_lock(run_test)
+    tvm.testing.run_with_gpu_lock(run_and_check)

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy/test_reg.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy/test_reg.py
@@ -249,7 +249,6 @@ def test_reg_roundtrip(scope, n_threads, k, dtype, non_r_scope):
     shape = (n_threads, k)
     kernel = _build_roundtrip_kernel(scope, n_threads, k, dtype, non_r_scope)
 
-    dev = tvm.cuda(0)
     target = tvm.target.Target("cuda")
     with target:
         mod = tvm.IRModule({"main": kernel})
@@ -257,15 +256,21 @@ def test_reg_roundtrip(scope, n_threads, k, dtype, non_r_scope):
 
     np_dtype = tvm.testing.np_dtype_from_str(dtype)
     B_np = np.zeros(shape, dtype=np_dtype)
-    B = tvm.runtime.tensor(B_np, dev)
     expected = _expected(shape, dtype)
-    if non_r_scope == "shared":
-        compiled(B)
-    else:
-        A_np = np.zeros(shape, dtype=np_dtype)
-        A = tvm.runtime.tensor(A_np, dev)
-        compiled(A, B)
-    np.testing.assert_array_equal(B.numpy(), expected)
+
+    def run_test():
+        dev = tvm.cuda(0)
+        B = tvm.runtime.tensor(B_np, dev)
+        if non_r_scope == "shared":
+            compiled(B)
+        else:
+            A_np = np.zeros(shape, dtype=np_dtype)
+            A = tvm.runtime.tensor(A_np, dev)
+            compiled(A, B)
+        dev.sync()
+        np.testing.assert_array_equal(B.numpy(), expected)
+
+    tvm.testing.run_with_gpu_lock(run_test)
 
 
 # ----------------------------------------------------------------------------
@@ -286,7 +291,6 @@ def test_reg_roundtrip(scope, n_threads, k, dtype, non_r_scope):
             TileLayout(S[4, 16, 16]),  # layoutA
             TileLayout(S[4, 16, 16]),  # layoutB
             TileLayout(S[8, 8]),  # layoutLocal
-            tvm.cuda(0),
         ),
     ],
 )
@@ -296,7 +300,7 @@ def test_reg_roundtrip(scope, n_threads, k, dtype, non_r_scope):
     "dtype", ["int8", "float8_e4m3fn", "float8_e5m2", "float16", "bfloat16", "float32"]
 )
 def test_copy_g2l_l2g_vec_load(task, dtype):
-    g_shape, l_shape, g_region, thread_cnt, layoutA, layoutB, layoutLocal, dev = task
+    g_shape, l_shape, g_region, thread_cnt, layoutA, layoutB, layoutLocal = task
 
     r_lmem = tuple(slice(None) for _ in range(len(l_shape)))
     r_gmem = tuple(slice(g_region[i][0], g_region[i][1]) for i in range(len(g_shape)))
@@ -322,13 +326,18 @@ def test_copy_g2l_l2g_vec_load(task, dtype):
         A_np = tvm.testing.generate_random_array(dtype, g_shape)
         B_np = np.zeros(g_shape, dtype=np_dtype)
 
-        A = tvm.runtime.tensor(A_np, dev)
-        B = tvm.runtime.tensor(B_np, dev)
-        mod(A, B)
-
         B_ref = B_np.copy()
         B_ref[r_gmem] = A_np[r_gmem]
-        np.testing.assert_allclose(B_ref, B.numpy())
+
+        def run_test():
+            dev = tvm.cuda(0)
+            A = tvm.runtime.tensor(A_np, dev)
+            B = tvm.runtime.tensor(B_np, dev)
+            mod(A, B)
+            dev.sync()
+            np.testing.assert_allclose(B_ref, B.numpy())
+
+        tvm.testing.run_with_gpu_lock(run_test)
 
 
 def test_reg_copy_wg_local_to_swizzled_shared_uses_swizzle_fastpath():
@@ -603,15 +612,20 @@ def test_reg_copy_tcgen05_d_epilogue_deposit_gpu():
             tir_pipeline="tirx",
         )
 
-    dev = tvm.cuda(0)
     rows = np.arange(m, dtype=np.int32)[:, None]
     cols = np.arange(n, dtype=np.int32)[None, :]
     a_np = (rows * 100 + cols).astype(np.float32)
     b_np = np.zeros((m, n), dtype=np.float32)
-    a = tvm.runtime.tensor(a_np, dev)
-    b = tvm.runtime.tensor(b_np, dev)
-    mod(a, b)
-    np.testing.assert_allclose(b.numpy(), a_np, rtol=0, atol=0)
+
+    def run_test():
+        dev = tvm.cuda(0)
+        a = tvm.runtime.tensor(a_np, dev)
+        b = tvm.runtime.tensor(b_np, dev)
+        mod(a, b)
+        dev.sync()
+        np.testing.assert_allclose(b.numpy(), a_np, rtol=0, atol=0)
+
+    tvm.testing.run_with_gpu_lock(run_test)
 
 
 if __name__ == "__main__":

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy/test_reg.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy/test_reg.py
@@ -258,7 +258,7 @@ def test_reg_roundtrip(scope, n_threads, k, dtype, non_r_scope):
     B_np = np.zeros(shape, dtype=np_dtype)
     expected = _expected(shape, dtype)
 
-    def run_test():
+    def run_and_check():
         dev = tvm.cuda(0)
         B = tvm.runtime.tensor(B_np, dev)
         if non_r_scope == "shared":
@@ -267,10 +267,9 @@ def test_reg_roundtrip(scope, n_threads, k, dtype, non_r_scope):
             A_np = np.zeros(shape, dtype=np_dtype)
             A = tvm.runtime.tensor(A_np, dev)
             compiled(A, B)
-        dev.sync()
         np.testing.assert_array_equal(B.numpy(), expected)
 
-    tvm.testing.run_with_gpu_lock(run_test)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 # ----------------------------------------------------------------------------
@@ -329,15 +328,14 @@ def test_copy_g2l_l2g_vec_load(task, dtype):
         B_ref = B_np.copy()
         B_ref[r_gmem] = A_np[r_gmem]
 
-        def run_test():
+        def run_and_check():
             dev = tvm.cuda(0)
             A = tvm.runtime.tensor(A_np, dev)
             B = tvm.runtime.tensor(B_np, dev)
             mod(A, B)
-            dev.sync()
             np.testing.assert_allclose(B_ref, B.numpy())
 
-        tvm.testing.run_with_gpu_lock(run_test)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 def test_reg_copy_wg_local_to_swizzled_shared_uses_swizzle_fastpath():
@@ -617,15 +615,14 @@ def test_reg_copy_tcgen05_d_epilogue_deposit_gpu():
     a_np = (rows * 100 + cols).astype(np.float32)
     b_np = np.zeros((m, n), dtype=np.float32)
 
-    def run_test():
+    def run_and_check():
         dev = tvm.cuda(0)
         a = tvm.runtime.tensor(a_np, dev)
         b = tvm.runtime.tensor(b_np, dev)
         mod(a, b)
-        dev.sync()
         np.testing.assert_allclose(b.numpy(), a_np, rtol=0, atol=0)
 
-    tvm.testing.run_with_gpu_lock(run_test)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 if __name__ == "__main__":

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_dsmem.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_dsmem.py
@@ -220,15 +220,14 @@ def test_dsmem(shape, dtype, src_spec, dst_spec, expected):
         A_np = tvm.testing.generate_random_array(dtype, shape)
         B_np = np.zeros(shape, dtype=np_dtype)
 
-    def run_test():
+    def run_and_check():
         dev = tvm.cuda(0)
         A_tvm = tvm.runtime.tensor(A_np, dev)
         B_tvm = tvm.runtime.tensor(B_np, dev)
         mod(A_tvm, B_tvm)
-        dev.sync()
         np.testing.assert_allclose(A_np, B_tvm.numpy())
 
-    tvm.testing.run_with_gpu_lock(run_test)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 def test_dsmem_dispatch_missing_config():

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_dsmem.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_dsmem.py
@@ -208,7 +208,6 @@ def test_dsmem(shape, dtype, src_spec, dst_spec, expected):
         # fmt: on
 
     np_dtype = tvm.testing.np_dtype_from_str(dtype)
-    dev = tvm.cuda(0)
     target = tvm.target.Target("cuda")
     with target:
         mod = tvm.IRModule({"main": dsmem_copy})
@@ -221,10 +220,15 @@ def test_dsmem(shape, dtype, src_spec, dst_spec, expected):
         A_np = tvm.testing.generate_random_array(dtype, shape)
         B_np = np.zeros(shape, dtype=np_dtype)
 
+    def run_test():
+        dev = tvm.cuda(0)
         A_tvm = tvm.runtime.tensor(A_np, dev)
         B_tvm = tvm.runtime.tensor(B_np, dev)
         mod(A_tvm, B_tvm)
+        dev.sync()
         np.testing.assert_allclose(A_np, B_tvm.numpy())
+
+    tvm.testing.run_with_gpu_lock(run_test)
 
 
 def test_dsmem_dispatch_missing_config():

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_ldgsts.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_ldgsts.py
@@ -109,15 +109,14 @@ def test_copy_g2s_s2g_cta_vec_load(task, dtype):
         B_ref = B_np.copy()
         B_ref[tuple(r_gmem)] = A_np[tuple(r_gmem)]
 
-        def run_test():
+        def run_and_check():
             dev = tvm.cuda(0)
             A = tvm.runtime.tensor(A_np, dev)
             B = tvm.runtime.tensor(B_np, dev)
             mod(A, B)
-            dev.sync()
             np.testing.assert_allclose(B_ref, B.numpy())
 
-        tvm.testing.run_with_gpu_lock(run_test)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 if __name__ == "__main__":

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_ldgsts.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_ldgsts.py
@@ -73,7 +73,6 @@ from tvm.tirx.layout import S, TileLayout
 )
 def test_copy_g2s_s2g_cta_vec_load(task, dtype):
     g_shape, s_shape, g_st, g_extent, thread_cnt, layoutA, layoutB, layoutS = task
-    dev = tvm.cuda(0)
 
     r_smem = list(slice(None) for i in range(len(s_shape)))
     r_gmem = list(slice(g_st[i], g_st[i] + g_extent[i]) for i in range(len(g_shape)))
@@ -107,13 +106,18 @@ def test_copy_g2s_s2g_cta_vec_load(task, dtype):
         A_np = np.random.rand(*g_shape).astype(np_dtype)
         B_np = np.zeros(g_shape, dtype=np_dtype)
 
-        A = tvm.runtime.tensor(A_np, dev)
-        B = tvm.runtime.tensor(B_np, dev)
-        mod(A, B)
-
         B_ref = B_np.copy()
         B_ref[tuple(r_gmem)] = A_np[tuple(r_gmem)]
-        np.testing.assert_allclose(B_ref, B.numpy())
+
+        def run_test():
+            dev = tvm.cuda(0)
+            A = tvm.runtime.tensor(A_np, dev)
+            B = tvm.runtime.tensor(B_np, dev)
+            mod(A, B)
+            dev.sync()
+            np.testing.assert_allclose(B_ref, B.numpy())
+
+        tvm.testing.run_with_gpu_lock(run_test)
 
 
 if __name__ == "__main__":

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_smem_tmem.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_smem_tmem.py
@@ -209,15 +209,21 @@ def _execute(kernel, A_init, expected):
     target = tvm.target.Target("cuda")
     with target:
         mod = tvm.compile(tvm.IRModule({"main": kernel}), target=target, tir_pipeline="tirx")
-    dev = tvm.cuda(0)
-    A = tvm.runtime.tensor(A_init, dev)
     B_np = np.zeros((32, 16), dtype=A_init.dtype)
-    B = tvm.runtime.tensor(B_np, dev)
-    mod(A, B)
-    B_out = B.numpy()
-    assert np.array_equal(B_out, expected), (
-        f"mismatch:\nlane 0 expected={expected[0].tolist()}\n        got     ={B_out[0].tolist()}"
-    )
+
+    def run_test():
+        dev = tvm.cuda(0)
+        A = tvm.runtime.tensor(A_init, dev)
+        B = tvm.runtime.tensor(B_np, dev)
+        mod(A, B)
+        dev.sync()
+        B_out = B.numpy()
+        assert np.array_equal(B_out, expected), (
+            f"mismatch:\nlane 0 expected={expected[0].tolist()}\n"
+            f"        got     ={B_out[0].tolist()}"
+        )
+
+    tvm.testing.run_with_gpu_lock(run_test)
 
 
 @pytest.mark.gpu

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_smem_tmem.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_smem_tmem.py
@@ -211,19 +211,18 @@ def _execute(kernel, A_init, expected):
         mod = tvm.compile(tvm.IRModule({"main": kernel}), target=target, tir_pipeline="tirx")
     B_np = np.zeros((32, 16), dtype=A_init.dtype)
 
-    def run_test():
+    def run_and_check():
         dev = tvm.cuda(0)
         A = tvm.runtime.tensor(A_init, dev)
         B = tvm.runtime.tensor(B_np, dev)
         mod(A, B)
-        dev.sync()
         B_out = B.numpy()
         assert np.array_equal(B_out, expected), (
             f"mismatch:\nlane 0 expected={expected[0].tolist()}\n"
             f"        got     ={B_out[0].tolist()}"
         )
 
-    tvm.testing.run_with_gpu_lock(run_test)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_tma.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_tma.py
@@ -1139,15 +1139,14 @@ def test_copy_tma_symbolic_dimension(dtype, swizzle_len):
         for ks in range(SMEM_PIPE_DEPTH):
             B_ref[ks, :, :] = A_np[0:BLK_M, ks * BLK_K : (ks + 1) * BLK_K]
 
-        def run_test():
+        def run_and_check():
             dev = tvm.cuda(0)
             A = tvm.runtime.tensor(A_np, dev)
             B = tvm.runtime.tensor(B_np, dev)
             mod(A, B)
-            dev.sync()
             np.testing.assert_allclose(B_ref, B.numpy())
 
-        tvm.testing.run_with_gpu_lock(run_test)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -1244,15 +1243,14 @@ def test_copy_tma_3d_with_view(dtype, swizzle_len):
         B_ref = np.zeros((32, 4, 64), dtype=np_dtype)
         B_ref[:, :, :] = Q_np[0, 0:32, 0:4, 0:64]
 
-        def run_test():
+        def run_and_check():
             dev = tvm.cuda(0)
             Q = tvm.runtime.tensor(Q_np, dev)
             B = tvm.runtime.tensor(B_np, dev)
             mod(Q, B)
-            dev.sync()
             np.testing.assert_allclose(B_ref, B.numpy())
 
-        tvm.testing.run_with_gpu_lock(run_test)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 # ===========================================================================
@@ -1425,15 +1423,14 @@ def test_copy_tma_gpu_smoke_g2s(task, dtype):
             B_ref = np.zeros(g_shape, dtype=np_dtype)
             B_ref[tuple(r_gmem)] = A_np[tuple(r_gmem)]
 
-    def run_test():
+    def run_and_check():
         dev = tvm.cuda(0)
         A = tvm.runtime.tensor(A_np, dev)
         B = tvm.runtime.tensor(B_np, dev)
         mod(A, B)
-        dev.sync()
         np.testing.assert_allclose(B_ref, B.numpy())
 
-    tvm.testing.run_with_gpu_lock(run_test)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -1493,15 +1490,14 @@ def test_copy_tma_gpu_smoke_s2g(dtype):
         A_np = tvm.testing.generate_random_array(dtype, g_shape)
         B_np = np.zeros(g_shape, dtype=np_dtype)
 
-        def run_test():
+        def run_and_check():
             dev = tvm.cuda(0)
             A = tvm.runtime.tensor(A_np, dev)
             B = tvm.runtime.tensor(B_np, dev)
             mod(A, B)
-            dev.sync()
             np.testing.assert_allclose(A_np, B.numpy())
 
-        tvm.testing.run_with_gpu_lock(run_test)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_tma.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_tma.py
@@ -1069,8 +1069,6 @@ def test_copy_tma_symbolic_dimension(dtype, swizzle_len):
     M_CONCRETE = 128  # Concrete value for testing
     thread_cnt = 128
 
-    dev = tvm.cuda(0)
-
     # Shared memory layout with swizzle
     shared_layout = T.ComposeLayout(
         T.SwizzleLayout(3, swizzle_len, 3, swizzle_inner=True),
@@ -1136,15 +1134,20 @@ def test_copy_tma_symbolic_dimension(dtype, swizzle_len):
         A_np = tvm.testing.generate_random_array(dtype, (M_CONCRETE, K))
         B_np = np.zeros((SMEM_PIPE_DEPTH, BLK_M, BLK_K), dtype=np_dtype)
 
-        A = tvm.runtime.tensor(A_np, dev)
-        B = tvm.runtime.tensor(B_np, dev)
-        mod(A, B)
-
         # Verify: B[ks, :, :] should equal A[0:BLK_M, ks*BLK_K:(ks+1)*BLK_K]
         B_ref = np.zeros((SMEM_PIPE_DEPTH, BLK_M, BLK_K), dtype=np_dtype)
         for ks in range(SMEM_PIPE_DEPTH):
             B_ref[ks, :, :] = A_np[0:BLK_M, ks * BLK_K : (ks + 1) * BLK_K]
-        np.testing.assert_allclose(B_ref, B.numpy())
+
+        def run_test():
+            dev = tvm.cuda(0)
+            A = tvm.runtime.tensor(A_np, dev)
+            B = tvm.runtime.tensor(B_np, dev)
+            mod(A, B)
+            dev.sync()
+            np.testing.assert_allclose(B_ref, B.numpy())
+
+        tvm.testing.run_with_gpu_lock(run_test)
 
 
 @pytest.mark.gpu
@@ -1160,7 +1163,6 @@ def test_copy_tma_3d_with_view(dtype, swizzle_len):
         Tx.copy_async(Q_smem_3d[pipe_idx, blk_k_idx, :, :, :],
                       Q[batch, seq_start:seq_end, head_start:head_end, k_start:k_end], ...)
     """
-    dev = tvm.cuda(0)
     smem_bytes = 2 * 2 * 128 * 64 * tvm.DataType(dtype).bits // 8
     copy_bytes_per_blk = 32 * 4 * 64 * tvm.DataType(dtype).bits // 8
 
@@ -1239,13 +1241,18 @@ def test_copy_tma_3d_with_view(dtype, swizzle_len):
         Q_np = tvm.testing.generate_random_array(dtype, (2, 128, 8, 128))
         B_np = np.zeros((32, 4, 64), dtype=np_dtype)
 
-        Q = tvm.runtime.tensor(Q_np, dev)
-        B = tvm.runtime.tensor(B_np, dev)
-        mod(Q, B)
-
         B_ref = np.zeros((32, 4, 64), dtype=np_dtype)
         B_ref[:, :, :] = Q_np[0, 0:32, 0:4, 0:64]
-        np.testing.assert_allclose(B_ref, B.numpy())
+
+        def run_test():
+            dev = tvm.cuda(0)
+            Q = tvm.runtime.tensor(Q_np, dev)
+            B = tvm.runtime.tensor(B_np, dev)
+            mod(Q, B)
+            dev.sync()
+            np.testing.assert_allclose(B_ref, B.numpy())
+
+        tvm.testing.run_with_gpu_lock(run_test)
 
 
 # ===========================================================================
@@ -1306,8 +1313,6 @@ def test_copy_tma_3d_with_view(dtype, swizzle_len):
 def test_copy_tma_gpu_smoke_g2s(task, dtype):
     """Smoke test: compile and run TMA G2S copy on GPU to verify end-to-end correctness."""
     g_shape, g_region, s_shape, s_region, thread_cnt, layoutA, layoutB, layoutS_fn = task
-    dev = tvm.cuda(0)
-
     shared_layout = layoutS_fn(dtype)
     is_pipeline = g_region is None
 
@@ -1367,10 +1372,7 @@ def test_copy_tma_gpu_smoke_g2s(task, dtype):
             A_np = tvm.testing.generate_random_array(dtype, g_shape)
             B_np = np.zeros(g_shape, dtype=np_dtype)
 
-            A = tvm.runtime.tensor(A_np, dev)
-            B = tvm.runtime.tensor(B_np, dev)
-            mod(A, B)
-            np.testing.assert_allclose(A_np, B.numpy())
+            B_ref = A_np
     else:
         total_bytes = functools.reduce(
             lambda acc, region: acc * (region[1] - region[0]), s_region, 1
@@ -1420,13 +1422,18 @@ def test_copy_tma_gpu_smoke_g2s(task, dtype):
             A_np = tvm.testing.generate_random_array(dtype, g_shape)
             B_np = np.zeros(g_shape, dtype=np_dtype)
 
-            A = tvm.runtime.tensor(A_np, dev)
-            B = tvm.runtime.tensor(B_np, dev)
-            mod(A, B)
-
             B_ref = np.zeros(g_shape, dtype=np_dtype)
             B_ref[tuple(r_gmem)] = A_np[tuple(r_gmem)]
-            np.testing.assert_allclose(B_ref, B.numpy())
+
+    def run_test():
+        dev = tvm.cuda(0)
+        A = tvm.runtime.tensor(A_np, dev)
+        B = tvm.runtime.tensor(B_np, dev)
+        mod(A, B)
+        dev.sync()
+        np.testing.assert_allclose(B_ref, B.numpy())
+
+    tvm.testing.run_with_gpu_lock(run_test)
 
 
 @pytest.mark.gpu
@@ -1477,7 +1484,6 @@ def test_copy_tma_gpu_smoke_s2g(dtype):
 
     np_dtype = tvm.testing.np_dtype_from_str(dtype)
     target = tvm.target.Target("cuda")
-    dev = tvm.cuda(0)
 
     with target:
         mod = tvm.IRModule({"main": copy_async})
@@ -1487,11 +1493,15 @@ def test_copy_tma_gpu_smoke_s2g(dtype):
         A_np = tvm.testing.generate_random_array(dtype, g_shape)
         B_np = np.zeros(g_shape, dtype=np_dtype)
 
-        A = tvm.runtime.tensor(A_np, dev)
-        B = tvm.runtime.tensor(B_np, dev)
-        mod(A, B)
+        def run_test():
+            dev = tvm.cuda(0)
+            A = tvm.runtime.tensor(A_np, dev)
+            B = tvm.runtime.tensor(B_np, dev)
+            mod(A, B)
+            dev.sync()
+            np.testing.assert_allclose(A_np, B.numpy())
 
-        np.testing.assert_allclose(A_np, B.numpy())
+        tvm.testing.run_with_gpu_lock(run_test)
 
 
 @pytest.mark.gpu

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_tmem.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_tmem.py
@@ -121,11 +121,16 @@ def test_copy_tmem2reg_async(dtype, width_32b):
         mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
         A_np = tvm.testing.generate_random_array(dtype, (128, WIDTH))
         B_np = np.zeros((128, WIDTH), dtype=dtype)
-        DEV = tvm.cuda(0)
-        A = tvm.runtime.tensor(A_np, DEV)
-        B = tvm.runtime.tensor(B_np, DEV)
-        mod(A, B)
-        np.testing.assert_allclose(B.numpy(), A_np)
+
+        def run_test():
+            dev = tvm.cuda(0)
+            A = tvm.runtime.tensor(A_np, dev)
+            B = tvm.runtime.tensor(B_np, dev)
+            mod(A, B)
+            dev.sync()
+            np.testing.assert_allclose(B.numpy(), A_np)
+
+        tvm.testing.run_with_gpu_lock(run_test)
 
 
 # ----------------------------------------------------------------------------
@@ -222,11 +227,16 @@ def test_copy_tmem2reg(dtype, width_32b, offset_32b):
         mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
         A_np = tvm.testing.generate_random_array(dtype, (128, WIDTH))
         B_np = np.zeros((128, WIDTH), dtype=dtype)
-        DEV = tvm.cuda(0)
-        A = tvm.runtime.tensor(A_np, DEV)
-        B = tvm.runtime.tensor(B_np, DEV)
-        mod(A, B)
-        np.testing.assert_allclose(B.numpy(), A_np)
+
+        def run_test():
+            dev = tvm.cuda(0)
+            A = tvm.runtime.tensor(A_np, dev)
+            B = tvm.runtime.tensor(B_np, dev)
+            mod(A, B)
+            dev.sync()
+            np.testing.assert_allclose(B.numpy(), A_np)
+
+        tvm.testing.run_with_gpu_lock(run_test)
 
 
 @pytest.mark.gpu
@@ -321,11 +331,16 @@ def test_copy_tmem2reg_sliced_local(dtype, width_32b, local_offset_32b):
         mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
         A_np = tvm.testing.generate_random_array(dtype, (128, WIDTH))
         B_np = np.zeros((128, WIDTH), dtype=dtype)
-        DEV = tvm.cuda(0)
-        A = tvm.runtime.tensor(A_np, DEV)
-        B = tvm.runtime.tensor(B_np, DEV)
-        mod(A, B)
-        np.testing.assert_allclose(B.numpy(), A_np)
+
+        def run_test():
+            dev = tvm.cuda(0)
+            A = tvm.runtime.tensor(A_np, dev)
+            B = tvm.runtime.tensor(B_np, dev)
+            mod(A, B)
+            dev.sync()
+            np.testing.assert_allclose(B.numpy(), A_np)
+
+        tvm.testing.run_with_gpu_lock(run_test)
 
 
 if __name__ == "__main__":

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_tmem.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_tmem.py
@@ -122,15 +122,14 @@ def test_copy_tmem2reg_async(dtype, width_32b):
         A_np = tvm.testing.generate_random_array(dtype, (128, WIDTH))
         B_np = np.zeros((128, WIDTH), dtype=dtype)
 
-        def run_test():
+        def run_and_check():
             dev = tvm.cuda(0)
             A = tvm.runtime.tensor(A_np, dev)
             B = tvm.runtime.tensor(B_np, dev)
             mod(A, B)
-            dev.sync()
             np.testing.assert_allclose(B.numpy(), A_np)
 
-        tvm.testing.run_with_gpu_lock(run_test)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 # ----------------------------------------------------------------------------
@@ -228,15 +227,14 @@ def test_copy_tmem2reg(dtype, width_32b, offset_32b):
         A_np = tvm.testing.generate_random_array(dtype, (128, WIDTH))
         B_np = np.zeros((128, WIDTH), dtype=dtype)
 
-        def run_test():
+        def run_and_check():
             dev = tvm.cuda(0)
             A = tvm.runtime.tensor(A_np, dev)
             B = tvm.runtime.tensor(B_np, dev)
             mod(A, B)
-            dev.sync()
             np.testing.assert_allclose(B.numpy(), A_np)
 
-        tvm.testing.run_with_gpu_lock(run_test)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -332,15 +330,14 @@ def test_copy_tmem2reg_sliced_local(dtype, width_32b, local_offset_32b):
         A_np = tvm.testing.generate_random_array(dtype, (128, WIDTH))
         B_np = np.zeros((128, WIDTH), dtype=dtype)
 
-        def run_test():
+        def run_and_check():
             dev = tvm.cuda(0)
             A = tvm.runtime.tensor(A_np, dev)
             B = tvm.runtime.tensor(B_np, dev)
             mod(A, B)
-            dev.sync()
             np.testing.assert_allclose(B.numpy(), A_np)
 
-        tvm.testing.run_with_gpu_lock(run_test)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 if __name__ == "__main__":

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_tmem_16xnb.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_tmem_16xnb.py
@@ -335,14 +335,19 @@ def _run_roundtrip_16b(
         mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
         A_np = tvm.testing.generate_random_array(dtype, (128, per_thread_elems))
         B_np = np.zeros((128, per_thread_elems), dtype=dtype)
-        DEV = tvm.cuda(0)
-        A = tvm.runtime.tensor(A_np, DEV)
-        B = tvm.runtime.tensor(B_np, DEV)
-        mod(A, B)
-        # Round-trip should preserve every per-thread bit pattern.
-        A_view = A.numpy().view(np.uint16)
-        B_view = B.numpy().view(np.uint16)
-        np.testing.assert_array_equal(B_view, A_view)
+
+        def run_test():
+            dev = tvm.cuda(0)
+            A = tvm.runtime.tensor(A_np, dev)
+            B = tvm.runtime.tensor(B_np, dev)
+            mod(A, B)
+            dev.sync()
+            # Round-trip should preserve every per-thread bit pattern.
+            A_view = A.numpy().view(np.uint16)
+            B_view = B.numpy().view(np.uint16)
+            np.testing.assert_array_equal(B_view, A_view)
+
+        tvm.testing.run_with_gpu_lock(run_test)
 
 
 def _next_pow2(x: int) -> int:
@@ -610,21 +615,14 @@ def _run_load_test(shape: str, rep: int, dtype: str):
         mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
         A_np = tvm.testing.generate_random_array(dtype, (128, stage_width_elem))
         B_np = np.zeros((128, per_thread_elems), dtype=dtype)
-        DEV = tvm.cuda(0)
-        A = tvm.runtime.tensor(A_np, DEV)
-        B = tvm.runtime.tensor(B_np, DEV)
-        mod(A, B)
-        B_out = B.numpy()
 
-    # Build expected B_out from the layout.
+    # Build the expected register dump from the layout before acquiring the GPU.
     if bits == 32:
         # Each register slot in B[t, r] holds a single fp32; compare bit-exactly.
         B_expected = np.zeros((128, per_thread_elems), dtype=np.uint32)
         for t in range(128):
             for r in range(regs_per_thread):
                 B_expected[t, r] = _expected_reg_value_fp32(A_np, shape, rep, 0, t, r)
-        B_view = B_out.view(np.uint32)
-        np.testing.assert_array_equal(B_view, B_expected)
     else:
         # B[t, :] holds per_thread_elems 16-bit values; each fp32 register packs
         # two of them in (low, high) order. Compare bit-exactly via uint32 view.
@@ -637,12 +635,23 @@ def _run_load_test(shape: str, rep: int, dtype: str):
                 dtype_np = _bf16
             except ImportError:
                 pytest.skip("bfloat16 verification needs ml_dtypes")
-        B_view = B_out.view(np.uint32).reshape(128, regs_per_thread)
         B_expected = np.zeros((128, regs_per_thread), dtype=np.uint32)
         for t in range(128):
             for r in range(regs_per_thread):
                 B_expected[t, r] = _expected_reg_value_16b(A_np, shape, rep, 0, t, r, dtype_np)
+
+    def run_test():
+        dev = tvm.cuda(0)
+        A = tvm.runtime.tensor(A_np, dev)
+        B = tvm.runtime.tensor(B_np, dev)
+        mod(A, B)
+        dev.sync()
+        B_view = B.numpy().view(np.uint32)
+        if bits != 32:
+            B_view = B_view.reshape(128, regs_per_thread)
         np.testing.assert_array_equal(B_view, B_expected)
+
+    tvm.testing.run_with_gpu_lock(run_test)
 
 
 # --------------------------------------------------------------------------
@@ -762,47 +771,47 @@ def test_tcgen05_st_16xnb_store(shape, rep, dtype):
         mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
         A_np = tvm.testing.generate_random_array(dtype, (128, per_thread_elems))
         B_np = np.zeros((128, stage_width_elem), dtype=dtype)
-        DEV = tvm.cuda(0)
-        A = tvm.runtime.tensor(A_np, DEV)
-        B = tvm.runtime.tensor(B_np, DEV)
-        mod(A, B)
-        B_out = B.numpy()
 
     # Build expected TMEM staging: only rows that the M=64 fragment writes to
     # should match A's per-thread data; other rows are untouched (we set B_np to
     # zero and the .32x32b.ld reads whatever the TMEM allocator left, which may
     # be arbitrary, so only check the fragment positions).
+    expected_values = []
     if bits == 32:
-        view = B_out.view(np.uint32)
         for t in range(128):
             for r in range(regs_per_thread):
                 row, col = _decompose_fp32(shape, t, r)
                 tmem_lane = _frag_row_to_tmem_lane(shape, row)
                 expected = np.float32(A_np[t, r]).view(np.uint32)
-                assert view[tmem_lane, col] == expected, (
-                    f"{shape}.x{rep} {dtype}: thread {t} reg {r} → "
-                    f"(row={row}, col={col}) tmem_lane={tmem_lane} got "
-                    f"{view[tmem_lane, col]:#x} want {expected:#x}"
-                )
+                expected_values.append((tmem_lane, col, expected, t, r, row))
     else:
         # 16-bit: each fp32 reg packs two 16-bit elements at adjacent TMEM cols.
-        view = B_out.view(np.uint16)
+        if dtype != "float16":
+            pytest.skip("16b store check restricted to float16")
         for t in range(128):
             for r in range(regs_per_thread):
                 row, col_fp32 = _decompose_fp32(shape, t, r)
                 tmem_lane = _frag_row_to_tmem_lane(shape, row)
-                lo = np.float16(A_np[t, 2 * r]).view(np.uint16) if dtype == "float16" else None
-                # bfloat16 (numpy) lacks a clean .view(uint16); skip in store mode
-                # for now to keep this test path bit-exact only for float16.
-                if dtype != "float16":
-                    pytest.skip("16b store check restricted to float16")
+                lo = np.float16(A_np[t, 2 * r]).view(np.uint16)
                 hi = np.float16(A_np[t, 2 * r + 1]).view(np.uint16)
-                assert view[tmem_lane, 2 * col_fp32] == lo, (
-                    f"{shape}.x{rep} {dtype}: t={t} r={r} lo "
-                    f"({tmem_lane=}, {col_fp32=}) got {view[tmem_lane, 2 * col_fp32]:#x} "
-                    f"want {lo:#x}"
-                )
-                assert view[tmem_lane, 2 * col_fp32 + 1] == hi
+                expected_values.append((tmem_lane, 2 * col_fp32, lo, t, r, row))
+                expected_values.append((tmem_lane, 2 * col_fp32 + 1, hi, t, r, row))
+
+    def run_test():
+        dev = tvm.cuda(0)
+        A = tvm.runtime.tensor(A_np, dev)
+        B = tvm.runtime.tensor(B_np, dev)
+        mod(A, B)
+        dev.sync()
+        view = B.numpy().view(np.uint32 if bits == 32 else np.uint16)
+        for tmem_lane, col, expected, t, r, row in expected_values:
+            assert view[tmem_lane, col] == expected, (
+                f"{shape}.x{rep} {dtype}: thread {t} reg {r} → "
+                f"(row={row}, col={col}) tmem_lane={tmem_lane} got "
+                f"{view[tmem_lane, col]:#x} want {expected:#x}"
+            )
+
+    tvm.testing.run_with_gpu_lock(run_test)
 
 
 # --------------------------------------------------------------------------
@@ -971,13 +980,18 @@ def _run_sliced_vs_full_load(shape, full_rep, n_chunks):
         A_np = tvm.testing.generate_random_array(dtype, (128, stage_width_elem))
         Bf_np = np.zeros((128, per_thread_elems), dtype=dtype)
         Bs_np = np.zeros((128, per_thread_elems), dtype=dtype)
-        DEV = tvm.cuda(0)
-        A = tvm.runtime.tensor(A_np, DEV)
-        Bf = tvm.runtime.tensor(Bf_np, DEV)
-        Bs = tvm.runtime.tensor(Bs_np, DEV)
-        mod(A, Bf, Bs)
-        # Sliced load must reproduce the full-width load bit-for-bit.
-        np.testing.assert_array_equal(Bs.numpy().view(np.uint32), Bf.numpy().view(np.uint32))
+
+        def run_test():
+            dev = tvm.cuda(0)
+            A = tvm.runtime.tensor(A_np, dev)
+            Bf = tvm.runtime.tensor(Bf_np, dev)
+            Bs = tvm.runtime.tensor(Bs_np, dev)
+            mod(A, Bf, Bs)
+            dev.sync()
+            # Sliced load must reproduce the full-width load bit-for-bit.
+            np.testing.assert_array_equal(Bs.numpy().view(np.uint32), Bf.numpy().view(np.uint32))
+
+        tvm.testing.run_with_gpu_lock(run_test)
 
 
 @pytest.mark.gpu

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_tmem_16xnb.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_tmem_16xnb.py
@@ -336,18 +336,17 @@ def _run_roundtrip_16b(
         A_np = tvm.testing.generate_random_array(dtype, (128, per_thread_elems))
         B_np = np.zeros((128, per_thread_elems), dtype=dtype)
 
-        def run_test():
+        def run_and_check():
             dev = tvm.cuda(0)
             A = tvm.runtime.tensor(A_np, dev)
             B = tvm.runtime.tensor(B_np, dev)
             mod(A, B)
-            dev.sync()
             # Round-trip should preserve every per-thread bit pattern.
             A_view = A.numpy().view(np.uint16)
             B_view = B.numpy().view(np.uint16)
             np.testing.assert_array_equal(B_view, A_view)
 
-        tvm.testing.run_with_gpu_lock(run_test)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 def _next_pow2(x: int) -> int:
@@ -640,18 +639,17 @@ def _run_load_test(shape: str, rep: int, dtype: str):
             for r in range(regs_per_thread):
                 B_expected[t, r] = _expected_reg_value_16b(A_np, shape, rep, 0, t, r, dtype_np)
 
-    def run_test():
+    def run_and_check():
         dev = tvm.cuda(0)
         A = tvm.runtime.tensor(A_np, dev)
         B = tvm.runtime.tensor(B_np, dev)
         mod(A, B)
-        dev.sync()
         B_view = B.numpy().view(np.uint32)
         if bits != 32:
             B_view = B_view.reshape(128, regs_per_thread)
         np.testing.assert_array_equal(B_view, B_expected)
 
-    tvm.testing.run_with_gpu_lock(run_test)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 # --------------------------------------------------------------------------
@@ -797,12 +795,11 @@ def test_tcgen05_st_16xnb_store(shape, rep, dtype):
                 expected_values.append((tmem_lane, 2 * col_fp32, lo, t, r, row))
                 expected_values.append((tmem_lane, 2 * col_fp32 + 1, hi, t, r, row))
 
-    def run_test():
+    def run_and_check():
         dev = tvm.cuda(0)
         A = tvm.runtime.tensor(A_np, dev)
         B = tvm.runtime.tensor(B_np, dev)
         mod(A, B)
-        dev.sync()
         view = B.numpy().view(np.uint32 if bits == 32 else np.uint16)
         for tmem_lane, col, expected, t, r, row in expected_values:
             assert view[tmem_lane, col] == expected, (
@@ -811,7 +808,7 @@ def test_tcgen05_st_16xnb_store(shape, rep, dtype):
                 f"{view[tmem_lane, col]:#x} want {expected:#x}"
             )
 
-    tvm.testing.run_with_gpu_lock(run_test)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 # --------------------------------------------------------------------------
@@ -981,17 +978,16 @@ def _run_sliced_vs_full_load(shape, full_rep, n_chunks):
         Bf_np = np.zeros((128, per_thread_elems), dtype=dtype)
         Bs_np = np.zeros((128, per_thread_elems), dtype=dtype)
 
-        def run_test():
+        def run_and_check():
             dev = tvm.cuda(0)
             A = tvm.runtime.tensor(A_np, dev)
             Bf = tvm.runtime.tensor(Bf_np, dev)
             Bs = tvm.runtime.tensor(Bs_np, dev)
             mod(A, Bf, Bs)
-            dev.sync()
             # Sliced load must reproduce the full-width load bit-for-bit.
             np.testing.assert_array_equal(Bs.numpy().view(np.uint32), Bf.numpy().view(np.uint32))
 
-        tvm.testing.run_with_gpu_lock(run_test)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu

--- a/tests/python/tirx/operator/tile_primitive/cuda/elementwise/test_binary.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/elementwise/test_binary.py
@@ -40,7 +40,7 @@ from tvm.tirx.layout import S, TileLayout, wg_local_layout
             (32, 32),  # extent_b
             (32, 32),  # extent_res
             64,  # thread_cnt
-            tvm.cuda(0),  # dev
+            0,  # device_id
         ),
         ######### offset test #########
         (
@@ -52,7 +52,7 @@ from tvm.tirx.layout import S, TileLayout, wg_local_layout
             (5, 6, 7),  # extent_b
             (5, 6, 7),  # extent_res
             64,  # thread_cnt
-            tvm.cuda(0),  # dev
+            0,  # device_id
         ),
         ######### broadcast test #########
         (
@@ -64,7 +64,7 @@ from tvm.tirx.layout import S, TileLayout, wg_local_layout
             (1, 6, 1),  # extent_b
             (5, 6, 7),  # extent_res
             64,  # thread_cnt
-            tvm.cuda(0),  # dev
+            0,  # device_id
         ),
     ],
 )
@@ -78,7 +78,7 @@ def test_binary_op_shared(input, op_type, operands_type, dtype):
     if op_type in ["sub", "fdiv"] and operands_type == "const_region":
         return
 
-    g_shape, st_a, st_b, st_res, ext_a, ext_b, ext_res, thread_cnt, dev = input
+    g_shape, st_a, st_b, st_res, ext_a, ext_b, ext_res, thread_cnt, device_id = input
     g_layout = s_layout = TileLayout(S[g_shape])
 
     copy_slice = list(slice(None) for i in range(len(g_shape)))
@@ -187,17 +187,20 @@ def test_binary_op_shared(input, op_type, operands_type, dtype):
         np.random.seed(0)
         A_np = np.random.rand(*g_shape).astype(dtype)
         B_np = np.random.rand(*g_shape).astype(dtype)
-        A = tvm.runtime.tensor(A_np, dev)
-        B = tvm.runtime.tensor(B_np, dev)
-
         mod = tvm.IRModule({"main": get_prim_func(operands_type)})
         mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
         print(f"compiled source code: {mod.mod.imports[0].inspect_source()}")
-        mod(A, B)
-
         A_ref = get_ref(A_np, B_np)
         atol = 1e-3
-        tvm.testing.assert_allclose(A_ref, A.numpy(), atol=atol)
+
+        def run_and_check():
+            dev = tvm.cuda(device_id)
+            A = tvm.runtime.tensor(A_np, dev)
+            B = tvm.runtime.tensor(B_np, dev)
+            mod(A, B)
+            tvm.testing.assert_allclose(A_ref, A.numpy(), atol=atol)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.parametrize("op_type", ["sub", "fdiv"])
@@ -235,7 +238,6 @@ def test_binary_op_shared_subcta_scope(exec_scope, op_type):
     dtype = "float16"
     n_warps = 4 if exec_scope == "warpgroup" else 1
     g_shape = (n_warps * 32, 8)
-    dev = tvm.cuda(0)
     tx_op = {
         ("warp", "add"): Tx.warp.add,
         ("warp", "mul"): Tx.warp.mul,
@@ -271,14 +273,19 @@ def test_binary_op_shared_subcta_scope(exec_scope, op_type):
         np.random.seed(0)
         A_np = np.random.rand(*g_shape).astype(dtype)
         B_np = np.random.rand(*g_shape).astype(dtype)
-        A = tvm.runtime.tensor(A_np, dev)
-        B = tvm.runtime.tensor(B_np, dev)
         mod = tvm.IRModule({"main": kernel})
         mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
-        mod(A, B)
         np_op = {"add": np.add, "mul": np.multiply}[op_type]
         A_ref = np_op(A_np, B_np).astype(dtype)
-        tvm.testing.assert_allclose(A_ref, A.numpy(), atol=1e-3)
+
+        def run_and_check():
+            dev = tvm.cuda(0)
+            A = tvm.runtime.tensor(A_np, dev)
+            B = tvm.runtime.tensor(B_np, dev)
+            mod(A, B)
+            tvm.testing.assert_allclose(A_ref, A.numpy(), atol=1e-3)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -296,7 +303,6 @@ def test_binary_op_local_subcta_trivial(exec_scope, rhs_kind, op_type):
     b_shape = (n_threads, m, n if rhs_kind == "region" else 1)
     c_shape = a_shape
     const = T.float16(1.25)
-    dev = tvm.cuda(0)
     tx_op = {"add": Tx.add, "sub": Tx.sub, "mul": Tx.mul, "fdiv": Tx.fdiv}[op_type]
     tid_in_scope_fn = {"cta": T.thread_id, "warpgroup": T.thread_id_in_wg, "warp": T.lane_id}[
         exec_scope
@@ -358,15 +364,9 @@ def test_binary_op_local_subcta_trivial(exec_scope, rhs_kind, op_type):
         A_np = np.random.rand(*a_shape).astype(dtype)
         B_np = np.random.rand(*b_shape).astype(dtype)
         C_np = np.zeros(c_shape, dtype=dtype)
-        A = tvm.runtime.tensor(A_np, dev)
-        B = tvm.runtime.tensor(B_np, dev)
-        C = tvm.runtime.tensor(C_np, dev)
-
         mod = tvm.IRModule({"main": kernel})
         mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
         print(f"compiled source code: {mod.mod.imports[0].inspect_source()}")
-        mod(A, B, C)
-
         np_op = {"add": np.add, "sub": np.subtract, "mul": np.multiply, "fdiv": np.divide}[op_type]
         if rhs_kind == "region":
             C_ref = np_op(A_np, B_np)
@@ -375,7 +375,16 @@ def test_binary_op_local_subcta_trivial(exec_scope, rhs_kind, op_type):
         else:
             C_ref = np_op(A_np, const.value)
         atol = 1e-2 if op_type == "fdiv" else 1e-3
-        tvm.testing.assert_allclose(C_ref, C.numpy(), atol=atol)
+
+        def run_and_check():
+            dev = tvm.cuda(0)
+            A = tvm.runtime.tensor(A_np, dev)
+            B = tvm.runtime.tensor(B_np, dev)
+            C = tvm.runtime.tensor(C_np, dev)
+            mod(A, B, C)
+            tvm.testing.assert_allclose(C_ref, C.numpy(), atol=atol)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.parametrize(
@@ -387,7 +396,7 @@ def test_binary_op_local_subcta_trivial(exec_scope, rhs_kind, op_type):
             (64, 32),  # b_shape
             (64, 32),  # res_shape
             64,  # thread_cnt
-            tvm.cuda(0),  # dev
+            0,  # device_id
         ),
         ######### broadcast test #########
         (
@@ -395,7 +404,7 @@ def test_binary_op_local_subcta_trivial(exec_scope, rhs_kind, op_type):
             (32, 1, 4),  # b_shape
             (32, 5, 4),  # res_shape
             32,  # thread_cnt (≥ warp size so sctx.intra at cta scope models cleanly)
-            tvm.cuda(0),  # dev
+            0,  # device_id
         ),
     ],
 )
@@ -406,7 +415,7 @@ def test_binary_op_local_subcta_trivial(exec_scope, rhs_kind, op_type):
 @pytest.mark.parametrize("op_type", ["add", "sub", "mul", "fdiv"])
 @pytest.mark.parametrize("dtype", ["float16"])
 def test_binary_op_vectorized(input, storage_scope, exec_scope, op_type, dtype):
-    a_shape, b_shape, res_shape, thread_cnt, dev = input
+    a_shape, b_shape, res_shape, thread_cnt, device_id = input
     tx_op = {"add": Tx.add, "sub": Tx.sub, "mul": Tx.mul, "fdiv": Tx.fdiv}[op_type]
 
     # fmt: off
@@ -490,18 +499,21 @@ def test_binary_op_vectorized(input, storage_scope, exec_scope, op_type, dtype):
         np.random.seed(0)
         A_np = np.random.rand(*a_shape).astype(dtype)
         B_np = np.random.rand(*b_shape).astype(dtype)
-        A = tvm.runtime.tensor(A_np, dev)
-        B = tvm.runtime.tensor(B_np, dev)
-
         mod = tvm.IRModule({"main": get_prim_func()})
         mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
         print(f"compiled source code: {mod.mod.imports[0].inspect_source()}")
-        mod(A, B)
-
         np_op = {"add": np.add, "sub": np.subtract, "mul": np.multiply, "fdiv": np.divide}[op_type]
         A_ref = np_op(A_np, B_np)
         atol = 1e-2 if op_type == "fdiv" else 1e-3
-        tvm.testing.assert_allclose(A_ref, A.numpy(), atol=atol)
+
+        def run_and_check():
+            dev = tvm.cuda(device_id)
+            A = tvm.runtime.tensor(A_np, dev)
+            B = tvm.runtime.tensor(B_np, dev)
+            mod(A, B)
+            tvm.testing.assert_allclose(A_ref, A.numpy(), atol=atol)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -521,7 +533,6 @@ def test_binary_op_packed_f32x2_auto_dispatch(op_type):
 
     a_shape, b_shape = (64, 32), (64, 32)
     dtype = "float32"
-    dev = tvm.cuda(0)
 
     @T.prim_func
     def test_func(A_ptr: T.handle, B_ptr: T.handle) -> None:
@@ -551,9 +562,6 @@ def test_binary_op_packed_f32x2_auto_dispatch(op_type):
         np.random.seed(0)
         A_np = np.random.rand(*a_shape).astype(dtype)
         B_np = np.random.rand(*b_shape).astype(dtype)
-        A = tvm.runtime.tensor(A_np, dev)
-        B = tvm.runtime.tensor(B_np, dev)
-
         mod = tvm.IRModule({"main": test_func})
         mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
         src = mod.mod.imports[0].inspect_source()
@@ -568,15 +576,21 @@ def test_binary_op_packed_f32x2_auto_dispatch(op_type):
             "mul": r"tvm_builtin_ptx_mul_packed_",
         }[op_type]
         assert re.search(ptx_pat, src) or re.search(builtin_pat, src), src
-        mod(A, B)
-
         if op_type == "add":
             A_ref = A_np + B_np
         elif op_type == "sub":
             A_ref = A_np - B_np
         elif op_type == "mul":
             A_ref = A_np * B_np
-        tvm.testing.assert_allclose(A_ref, A.numpy(), atol=1e-3)
+
+        def run_and_check():
+            dev = tvm.cuda(0)
+            A = tvm.runtime.tensor(A_np, dev)
+            B = tvm.runtime.tensor(B_np, dev)
+            mod(A, B)
+            tvm.testing.assert_allclose(A_ref, A.numpy(), atol=1e-3)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -585,7 +599,6 @@ def test_binary_op_packed_f32x2_auto_dispatch(op_type):
 def test_binary_op_warpgroup_wg_local_layout(op_name):
     dtype = "float32"
     rows, cols = 128, 16
-    dev = tvm.cuda(0)
     target = tvm.target.Target("cuda")
 
     @T.prim_func
@@ -625,21 +638,24 @@ def test_binary_op_warpgroup_wg_local_layout(op_name):
         B_np = np.random.rand(rows, cols).astype(dtype)
         C_np = np.zeros((rows, cols), dtype=dtype)
 
-        A = tvm.runtime.tensor(A_np, dev)
-        B = tvm.runtime.tensor(B_np, dev)
-        C = tvm.runtime.tensor(C_np, dev)
-
         mod = tvm.IRModule({"main": test_func})
         mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
-        mod(A, B, C)
-
         if op_name == "add":
             C_ref = A_np + B_np
         elif op_name == "sub":
             C_ref = A_np - B_np
         else:
             C_ref = A_np * B_np
-        tvm.testing.assert_allclose(C_ref, C.numpy(), atol=1e-5)
+
+        def run_and_check():
+            dev = tvm.cuda(0)
+            A = tvm.runtime.tensor(A_np, dev)
+            B = tvm.runtime.tensor(B_np, dev)
+            C = tvm.runtime.tensor(C_np, dev)
+            mod(A, B, C)
+            tvm.testing.assert_allclose(C_ref, C.numpy(), atol=1e-5)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.parametrize("op_name,ptx_op", [("add", "add"), ("sub", "sub"), ("mul", "mul")])
@@ -803,7 +819,6 @@ def test_binary_maximum_reg():
         Tx.maximum(a_reg[:], a_reg[:], b_reg[:])
         Tx.copy(C[tid : tid + 1], a_reg[:])
 
-    dev = tvm.cuda(0)
     target = tvm.target.Target("cuda")
     with target:
         mod = tvm.compile(tvm.IRModule({"main": relu_max}), target=target, tir_pipeline="tirx")
@@ -811,9 +826,14 @@ def test_binary_maximum_reg():
     a = np.random.randn(N).astype("float32")
     b = np.random.randn(N).astype("float32")
     c = np.zeros(N, dtype="float32")
-    a_t, b_t, c_t = (tvm.runtime.tensor(x, dev) for x in (a, b, c))
-    mod["main"](a_t, b_t, c_t)
-    np.testing.assert_allclose(c_t.numpy(), np.maximum(a, b), atol=0, rtol=0)
+
+    def run_and_check():
+        dev = tvm.cuda(0)
+        a_t, b_t, c_t = (tvm.runtime.tensor(x, dev) for x in (a, b, c))
+        mod["main"](a_t, b_t, c_t)
+        np.testing.assert_allclose(c_t.numpy(), np.maximum(a, b), atol=0, rtol=0)
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 def test_binary_add_f16_scalar_fallback_dispatch():

--- a/tests/python/tirx/operator/tile_primitive/cuda/elementwise/test_fma.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/elementwise/test_fma.py
@@ -51,7 +51,6 @@ def test_fma_scalar_scalar():
 
     N = 128
     dtype = "float32"
-    dev = tvm.cuda(0)
     target = tvm.target.Target("cuda")
 
     scale_val = 0.5
@@ -70,12 +69,17 @@ def test_fma_scalar_scalar():
 
     with target:
         A_np = np.random.rand(N).astype(dtype)
-        A = tvm.runtime.tensor(A_np, dev)
         mod = tvm.IRModule({"main": test_func})
         mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
-        mod(A)
-        expected = A_np * scale_val + bias_val
-        tvm.testing.assert_allclose(expected, A.numpy(), atol=1e-3)
+
+        def run_and_check():
+            dev = tvm.cuda(0)
+            A = tvm.runtime.tensor(A_np, dev)
+            mod(A)
+            expected = A_np * scale_val + bias_val
+            tvm.testing.assert_allclose(expected, A.numpy(), atol=1e-3)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 # ---------------------------------------------------------------------------
@@ -90,7 +94,6 @@ def test_fma_buffer_scale_scalar_bias():
 
     N = 2
     dtype = "float32"
-    dev = tvm.cuda(0)
     target = tvm.target.Target("cuda")
 
     coeff = 0.695
@@ -112,13 +115,18 @@ def test_fma_buffer_scale_scalar_bias():
     with target:
         A_np = np.random.rand(N).astype(dtype)
         B_np = np.random.rand(N).astype(dtype)
-        A = tvm.runtime.tensor(A_np, dev)
-        B = tvm.runtime.tensor(B_np, dev)
         mod = tvm.IRModule({"main": test_func})
         mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
-        mod(A, B)
-        expected = A_np * B_np + coeff
-        tvm.testing.assert_allclose(expected, A.numpy(), atol=1e-3)
+
+        def run_and_check():
+            dev = tvm.cuda(0)
+            A = tvm.runtime.tensor(A_np, dev)
+            B = tvm.runtime.tensor(B_np, dev)
+            mod(A, B)
+            expected = A_np * B_np + coeff
+            tvm.testing.assert_allclose(expected, A.numpy(), atol=1e-3)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 # ---------------------------------------------------------------------------
@@ -133,7 +141,6 @@ def test_mul_scalar_broadcast():
 
     N = 16
     dtype = "float32"
-    dev = tvm.cuda(0)
     target = tvm.target.Target("cuda")
 
     @T.prim_func
@@ -153,13 +160,18 @@ def test_mul_scalar_broadcast():
     with target:
         A_np = np.random.rand(N).astype(dtype)
         S_np = np.array([2.5], dtype=dtype)
-        A_dev = tvm.runtime.tensor(A_np, dev)
-        S_dev = tvm.runtime.tensor(S_np, dev)
         mod = tvm.IRModule({"main": test_func})
         mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
-        mod(A_dev, S_dev)
-        expected = A_np * S_np[0]
-        tvm.testing.assert_allclose(expected, A_dev.numpy(), atol=1e-3)
+
+        def run_and_check():
+            dev = tvm.cuda(0)
+            A_dev = tvm.runtime.tensor(A_np, dev)
+            S_dev = tvm.runtime.tensor(S_np, dev)
+            mod(A_dev, S_dev)
+            expected = A_np * S_np[0]
+            tvm.testing.assert_allclose(expected, A_dev.numpy(), atol=1e-3)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 # ---------------------------------------------------------------------------
@@ -174,7 +186,6 @@ def test_add_rounding_mode():
 
     N = 2
     dtype = "float32"
-    dev = tvm.cuda(0)
     target = tvm.target.Target("cuda")
 
     round_const = float(2**23 + 2**22)
@@ -192,7 +203,6 @@ def test_add_rounding_mode():
 
     with target:
         A_np = np.array([1.3, 2.7], dtype=dtype)
-        A_dev = tvm.runtime.tensor(A_np, dev)
         mod = tvm.IRModule({"main": test_func})
         mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
         # Check that the PTX uses the rounding mode
@@ -200,9 +210,15 @@ def test_add_rounding_mode():
         assert re.search(r"add\.rm\.ftz\.f32x2", src) or re.search(
             r"tvm_builtin_ptx_add_packed_", src
         ), f"Expected packed add with rm rounding in PTX:\n{src}"
-        mod(A_dev)
-        expected = A_np + round_const
-        tvm.testing.assert_allclose(expected, A_dev.numpy(), atol=1.0)
+
+        def run_and_check():
+            dev = tvm.cuda(0)
+            A_dev = tvm.runtime.tensor(A_np, dev)
+            mod(A_dev)
+            expected = A_np + round_const
+            tvm.testing.assert_allclose(expected, A_dev.numpy(), atol=1.0)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 # ---------------------------------------------------------------------------
@@ -217,7 +233,6 @@ def test_fma_no_layout():
 
     N = 4
     dtype = "float32"
-    dev = tvm.cuda(0)
     target = tvm.target.Target("cuda")
 
     scale_val = 2.0
@@ -238,12 +253,17 @@ def test_fma_no_layout():
 
     with target:
         A_np = np.array([1.0, 2.0, 3.0, 4.0], dtype=dtype)
-        A_dev = tvm.runtime.tensor(A_np, dev)
         mod = tvm.IRModule({"main": test_func})
         mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
-        mod(A_dev)
-        expected = A_np * scale_val + bias_val
-        tvm.testing.assert_allclose(expected, A_dev.numpy(), atol=1e-3)
+
+        def run_and_check():
+            dev = tvm.cuda(0)
+            A_dev = tvm.runtime.tensor(A_np, dev)
+            mod(A_dev)
+            expected = A_np * scale_val + bias_val
+            tvm.testing.assert_allclose(expected, A_dev.numpy(), atol=1e-3)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 # ---------------------------------------------------------------------------
@@ -258,7 +278,6 @@ def test_sub_buffer_buffer_rounding():
 
     N = 2
     dtype = "float32"
-    dev = tvm.cuda(0)
     target = tvm.target.Target("cuda")
 
     @T.prim_func
@@ -278,17 +297,22 @@ def test_sub_buffer_buffer_rounding():
     with target:
         A_np = np.array([3.14, 2.71], dtype=dtype)
         B_np = np.array([1.41, 0.57], dtype=dtype)
-        A_dev = tvm.runtime.tensor(A_np, dev)
-        B_dev = tvm.runtime.tensor(B_np, dev)
         mod = tvm.IRModule({"main": test_func})
         mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
         src = mod.mod.imports[0].inspect_source()
         assert re.search(r"sub\.rn\.ftz\.f32x2", src) or re.search(
             r"tvm_builtin_ptx_sub_packed_", src
         ), f"Expected packed sub with rn rounding in PTX:\n{src}"
-        mod(A_dev, B_dev)
-        expected = A_np - B_np
-        tvm.testing.assert_allclose(expected, A_dev.numpy(), atol=1e-6)
+
+        def run_and_check():
+            dev = tvm.cuda(0)
+            A_dev = tvm.runtime.tensor(A_np, dev)
+            B_dev = tvm.runtime.tensor(B_np, dev)
+            mod(A_dev, B_dev)
+            expected = A_np - B_np
+            tvm.testing.assert_allclose(expected, A_dev.numpy(), atol=1e-6)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -298,7 +322,6 @@ def test_fma_warpgroup_wg_local_layout():
     dtype = "float32"
     scale_val = 1.5
     bias_val = -0.25
-    dev = tvm.cuda(0)
     target = tvm.target.Target("cuda")
 
     @T.prim_func
@@ -323,13 +346,18 @@ def test_fma_warpgroup_wg_local_layout():
         np.random.seed(0)
         A_np = np.random.rand(rows, cols).astype(dtype)
         B_np = np.zeros((rows, cols), dtype=dtype)
-        A_dev = tvm.runtime.tensor(A_np, dev)
-        B_dev = tvm.runtime.tensor(B_np, dev)
         mod = tvm.IRModule({"main": test_func})
         mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
-        mod(A_dev, B_dev)
-        expected = A_np * scale_val + bias_val
-        tvm.testing.assert_allclose(expected, B_dev.numpy(), atol=1e-5)
+
+        def run_and_check():
+            dev = tvm.cuda(0)
+            A_dev = tvm.runtime.tensor(A_np, dev)
+            B_dev = tvm.runtime.tensor(B_np, dev)
+            mod(A_dev, B_dev)
+            expected = A_np * scale_val + bias_val
+            tvm.testing.assert_allclose(expected, B_dev.numpy(), atol=1e-5)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 # -----------------------------------------------------------------------------

--- a/tests/python/tirx/operator/tile_primitive/cuda/elementwise/test_unary.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/elementwise/test_unary.py
@@ -41,7 +41,7 @@ from tvm.tirx.layout import S, TileLayout, laneid, tid_in_wg, tx, warpid
             (32, 32),  # extent_a
             (32, 32),  # extent_res
             64,  # thread_cnt
-            tvm.cuda(0),  # dev
+            0,  # device_id
         ),
         ######### offset test #########
         (
@@ -51,7 +51,7 @@ from tvm.tirx.layout import S, TileLayout, laneid, tid_in_wg, tx, warpid
             (5, 6, 7),  # extent_a
             (5, 6, 7),  # extent_res
             64,  # thread_cnt
-            tvm.cuda(0),  # dev
+            0,  # device_id
         ),
     ],
 )
@@ -62,7 +62,7 @@ from tvm.tirx.layout import S, TileLayout, laneid, tid_in_wg, tx, warpid
     "src_dtype,dst_dtype", [("float16", "float16"), ("float32", "float16"), ("float32", "bfloat16")]
 )
 def test_unary_op_shared(input, op_type, src_dtype, dst_dtype):
-    g_shape, st_a, st_res, ext_a, ext_res, thread_cnt, dev = input
+    g_shape, st_a, st_res, ext_a, ext_res, thread_cnt, device_id = input
     s_shape = g_shape
     g_layout = s_layout = TileLayout(S[g_shape])
     in_place = src_dtype == dst_dtype
@@ -132,20 +132,23 @@ def test_unary_op_shared(input, op_type, src_dtype, dst_dtype):
     with target:
         np.random.seed(0)
         A_np = np.abs(np.random.rand(*g_shape).astype(src_dtype)) + 0.1
-        A = tvm.runtime.tensor(A_np, dev)
-
         mod = tvm.IRModule({"main": unary_op})
         mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
 
-        if in_place:
-            mod(A)
-            A_ref = get_ref(A_np)
-            tvm.testing.assert_allclose(A_ref, A.numpy(), atol=1e-3)
-        else:
-            B = tvm.runtime.tensor(np.zeros(g_shape, dtype=dst_dtype), dev)
-            mod(A, B)
-            B_ref = get_ref(A_np)
-            tvm.testing.assert_allclose(B_ref, B.numpy(), atol=1e-2, rtol=1e-2)
+        def run_and_check():
+            dev = tvm.cuda(device_id)
+            A = tvm.runtime.tensor(A_np, dev)
+            if in_place:
+                mod(A)
+                A_ref = get_ref(A_np)
+                tvm.testing.assert_allclose(A_ref, A.numpy(), atol=1e-3)
+            else:
+                B = tvm.runtime.tensor(np.zeros(g_shape, dtype=dst_dtype), dev)
+                mod(A, B)
+                B_ref = get_ref(A_np)
+                tvm.testing.assert_allclose(B_ref, B.numpy(), atol=1e-2, rtol=1e-2)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -155,7 +158,6 @@ def test_unary_op_shared_subcta_scope(exec_scope):
     dtype = "float16"
     n_warps = 4 if exec_scope == "warpgroup" else 1
     g_shape = (n_warps * 32, 8)
-    dev = tvm.cuda(0)
 
     @T.prim_func
     def unary_op_subcta(A_ptr: T.handle) -> None:
@@ -182,11 +184,16 @@ def test_unary_op_shared_subcta_scope(exec_scope):
     with target:
         np.random.seed(0)
         A_np = np.random.rand(*g_shape).astype(dtype)
-        A = tvm.runtime.tensor(A_np, dev)
         mod = tvm.IRModule({"main": unary_op_subcta})
         mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
-        mod(A)
-        tvm.testing.assert_allclose(A.numpy(), np.zeros_like(A_np), atol=1e-3)
+
+        def run_and_check():
+            dev = tvm.cuda(0)
+            A = tvm.runtime.tensor(A_np, dev)
+            mod(A)
+            tvm.testing.assert_allclose(A.numpy(), np.zeros_like(A_np), atol=1e-3)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.parametrize(
@@ -200,7 +207,7 @@ def test_unary_op_shared_subcta_scope(exec_scope):
             (32, 32),  # extent_a
             (32, 32),  # extent_res
             64,  # thread_cnt
-            tvm.cuda(0),  # dev
+            0,  # device_id
         ),
         ######### offset test #########
         (
@@ -210,7 +217,7 @@ def test_unary_op_shared_subcta_scope(exec_scope):
             (5, 6, 7),  # extent_a
             (5, 6, 7),  # extent_res
             64,  # thread_cnt
-            tvm.cuda(0),  # dev
+            0,  # device_id
         ),
     ],
 )
@@ -228,7 +235,7 @@ def test_unary_op_shared_subcta_scope(exec_scope):
     ],
 )
 def test_unary_op_shared_with_bias_scale(input, op_type, bias_type, src_dtype, dst_dtype):
-    g_shape, st_a, st_res, ext_a, ext_res, thread_cnt, dev = input
+    g_shape, st_a, st_res, ext_a, ext_res, thread_cnt, device_id = input
     s_shape = g_shape
     g_layout = s_layout = TileLayout(S[g_shape])
     in_place = src_dtype == dst_dtype
@@ -391,26 +398,29 @@ def test_unary_op_shared_with_bias_scale(input, op_type, bias_type, src_dtype, d
         np.random.seed(0)
         A_np = np.abs(np.random.rand(*g_shape).astype(src_dtype)) + 0.1
         bias_np = np.random.rand(*g_shape).astype(src_dtype)
-        A = tvm.runtime.tensor(A_np, dev)
-        bias = tvm.runtime.tensor(bias_np, dev)
-
         mod = tvm.IRModule({"main": unary_op_with_bias})
         mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
+        atol = (
+            1e-1
+            if src_dtype == "float16" and op_type == "exp"
+            else (1e-2 if src_dtype == "float16" else 1e-3)
+        )
 
-        if in_place:
-            mod(A, bias)
-            A_ref = get_ref(A_np, bias_np)
-            atol = (
-                1e-1
-                if src_dtype == "float16" and op_type == "exp"
-                else (1e-2 if src_dtype == "float16" else 1e-3)
-            )
-            tvm.testing.assert_allclose(A_ref, A.numpy(), atol=atol)
-        else:
-            B = tvm.runtime.tensor(np.zeros(g_shape, dtype=dst_dtype), dev)
-            mod(A, B, bias)
-            B_ref = get_ref(A_np, bias_np)
-            tvm.testing.assert_allclose(B_ref, B.numpy(), atol=1e-1, rtol=1e-2)
+        def run_and_check():
+            dev = tvm.cuda(device_id)
+            A = tvm.runtime.tensor(A_np, dev)
+            bias = tvm.runtime.tensor(bias_np, dev)
+            if in_place:
+                mod(A, bias)
+                A_ref = get_ref(A_np, bias_np)
+                tvm.testing.assert_allclose(A_ref, A.numpy(), atol=atol)
+            else:
+                B = tvm.runtime.tensor(np.zeros(g_shape, dtype=dst_dtype), dev)
+                mod(A, B, bias)
+                B_ref = get_ref(A_np, bias_np)
+                tvm.testing.assert_allclose(B_ref, B.numpy(), atol=1e-1, rtol=1e-2)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.parametrize(
@@ -421,21 +431,21 @@ def test_unary_op_shared_with_bias_scale(input, op_type, bias_type, src_dtype, d
             1,  # N_GROUPS
             1,  # N_WARPS
             32,  # thread_cnt
-            tvm.cuda(0),  # dev
+            0,  # device_id
         ),
         (
             "wgmma",  # layout
             1,  # N_GROUPS
             4,  # N_WARPS
             32,  # thread_cnt
-            tvm.cuda(0),  # dev
+            0,  # device_id
         ),
         (
             "wgmma",  # layout
             2,  # N_GROUPS
             8,  # N_WARPS
             32,  # thread_cnt
-            tvm.cuda(0),  # dev
+            0,  # device_id
         ),
     ],
 )
@@ -446,7 +456,7 @@ def test_unary_op_shared_with_bias_scale(input, op_type, bias_type, src_dtype, d
     "src_dtype,dst_dtype", [("float16", "float16"), ("float32", "float16"), ("float32", "bfloat16")]
 )
 def test_unary_op_local(input, op_type, src_dtype, dst_dtype):
-    layout, N_GROUPS, N_WARPS, thread_cnt, dev = input
+    layout, N_GROUPS, N_WARPS, thread_cnt, device_id = input
     assert layout == "wgmma", "logical tensor which is not WGMMA layout is not supported"
 
     # get shape info
@@ -520,10 +530,7 @@ def test_unary_op_local(input, op_type, src_dtype, dst_dtype):
         np.random.seed(0)
         A_np = np.abs(np.random.rand(*g_shape_a).astype(src_dtype)) + 0.1
         B_np = np.zeros(g_shape_b, dtype=dst_dtype)
-        A = tvm.runtime.tensor(A_np, dev)
-        B = tvm.runtime.tensor(B_np, dev)
         print(f"compiled source code: {mod.mod.imports[0].inspect_source()}")
-        mod(A, B)
 
         # find ref result
         if op_type == "reciprocal":
@@ -534,7 +541,15 @@ def test_unary_op_local(input, op_type, src_dtype, dst_dtype):
             B_ref = np.exp2(A_np).astype(dst_dtype)
         else:
             raise ValueError(f"op_type={op_type} is not supported")
-        tvm.testing.assert_allclose(B_ref, B.numpy(), atol=1e-2, rtol=1e-2)
+
+        def run_and_check():
+            dev = tvm.cuda(device_id)
+            A = tvm.runtime.tensor(A_np, dev)
+            B = tvm.runtime.tensor(B_np, dev)
+            mod(A, B)
+            tvm.testing.assert_allclose(B_ref, B.numpy(), atol=1e-2, rtol=1e-2)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.parametrize(
@@ -545,21 +560,21 @@ def test_unary_op_local(input, op_type, src_dtype, dst_dtype):
             1,  # N_GROUPS
             1,  # N_WARPS
             32,  # thread_cnt
-            tvm.cuda(0),  # dev
+            0,  # device_id
         ),
         (
             "wgmma",  # layout
             1,  # N_GROUPS
             4,  # N_WARPS
             32,  # thread_cnt
-            tvm.cuda(0),  # dev
+            0,  # device_id
         ),
         (
             "wgmma",  # layout
             2,  # N_GROUPS
             8,  # N_WARPS
             32,  # thread_cnt
-            tvm.cuda(0),  # dev
+            0,  # device_id
         ),
     ],
 )
@@ -571,7 +586,7 @@ def test_unary_op_local(input, op_type, src_dtype, dst_dtype):
     "src_dtype,dst_dtype", [("float32", "float32"), ("float32", "float16"), ("float32", "bfloat16")]
 )
 def test_unary_op_local_with_bias_scale(input, op_type, bias_type, src_dtype, dst_dtype):
-    layout, N_GROUPS, N_WARPS, thread_cnt, dev = input
+    layout, N_GROUPS, N_WARPS, thread_cnt, device_id = input
     assert layout == "wgmma", "logical tensor which is not WGMMA layout is not supported"
 
     # get shape info
@@ -680,17 +695,20 @@ def test_unary_op_local_with_bias_scale(input, op_type, bias_type, src_dtype, ds
         A_np = np.random.rand(*g_shape_a).astype(src_dtype)
         bias_np = np.random.rand(*g_shape_bias).astype(src_dtype)
         B_np = np.zeros(g_shape_b, dtype=dst_dtype)
-        A = tvm.runtime.tensor(A_np, dev)
-        bias = tvm.runtime.tensor(bias_np, dev)
-        B = tvm.runtime.tensor(B_np, dev)
-
         mod = tvm.IRModule({"main": test_unary_with_bias})
         mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
-        mod(A, B, bias)
-
         B_ref = get_ref(A_np, bias_np)
         atol = 1e-3 if src_dtype == dst_dtype else 2e-2
-        tvm.testing.assert_allclose(B_ref, B.numpy(), atol=atol)
+
+        def run_and_check():
+            dev = tvm.cuda(device_id)
+            A = tvm.runtime.tensor(A_np, dev)
+            bias = tvm.runtime.tensor(bias_np, dev)
+            B = tvm.runtime.tensor(B_np, dev)
+            mod(A, B, bias)
+            tvm.testing.assert_allclose(B_ref, B.numpy(), atol=atol)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -702,10 +720,8 @@ def test_unary_op_local_with_bias_scale(input, op_type, bias_type, src_dtype, ds
 def test_unary_op_vectorized(shape, op_type, exec_scope, storage_scope):
     if storage_scope == "local" and exec_scope == "cta":
         return  # skip unsupported case
-    dev = tvm.cuda(0)
     dtype = "float16"
     A_ref = np.random.rand(*shape).astype(dtype)
-    A = tvm.runtime.tensor(A_ref, dev)
     value = T.float16(7.89) if dtype == "float16" else T.float32(7.89)
 
     # fmt: off
@@ -748,9 +764,14 @@ def test_unary_op_vectorized(shape, op_type, exec_scope, storage_scope):
             {"main": test_unary_thread if exec_scope == "thread" else test_unary_cta}
         )
         mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
-        mod(A)
         print(mod.mod.imports[0].inspect_source())
-        tvm.testing.assert_allclose(A.numpy(), np.full(shape, value.value), atol=1e-2)
+        def run_and_check():
+            dev = tvm.cuda(0)
+            A = tvm.runtime.tensor(A_ref, dev)
+            mod(A)
+            tvm.testing.assert_allclose(A.numpy(), np.full(shape, value.value), atol=1e-2)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -761,7 +782,6 @@ def test_unary_op_local_thread_wise(op_type, dtype):
     """Test unary ops in thread scope with local buffers (trivial layout)."""
     shape = (64, 32)
     local_shape = shape[1:]
-    dev = tvm.cuda(0)
 
     @T.prim_func
     def kernel(A_ptr: T.handle) -> None:
@@ -789,10 +809,8 @@ def test_unary_op_local_thread_wise(op_type, dtype):
     with target:
         np.random.seed(0)
         A_np = np.abs(np.random.rand(*shape).astype(dtype)) + 0.1
-        A = tvm.runtime.tensor(A_np, dev)
         mod = tvm.IRModule({"main": kernel})
         mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
-        mod(A)
         if op_type == "zero":
             A_ref = np.zeros_like(A_np)
         elif op_type == "sqrt":
@@ -803,7 +821,14 @@ def test_unary_op_local_thread_wise(op_type, dtype):
             A_ref = np.exp(A_np)
         elif op_type == "silu":
             A_ref = (A_np / (1.0 + np.exp(-A_np.astype("float32")))).astype(dtype)
-        tvm.testing.assert_allclose(A_ref, A.numpy(), atol=1e-2, rtol=1e-2)
+
+        def run_and_check():
+            dev = tvm.cuda(0)
+            A = tvm.runtime.tensor(A_np, dev)
+            mod(A)
+            tvm.testing.assert_allclose(A_ref, A.numpy(), atol=1e-2, rtol=1e-2)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -815,12 +840,8 @@ def test_cast_thread_local(shape, A_dtype, B_dtype):
     if A_dtype == B_dtype:
         return
 
-    dev = tvm.cuda(0)
     A_ref = np.random.rand(*shape).astype(A_dtype)
     B_ref = np.random.rand(*shape).astype(B_dtype)
-    A = tvm.runtime.tensor(A_ref, dev)
-    B = tvm.runtime.tensor(B_ref, dev)
-
     B_ref = A_ref.astype(B_dtype)
 
     # fmt: off
@@ -843,9 +864,16 @@ def test_cast_thread_local(shape, A_dtype, B_dtype):
     with target:
         mod = tvm.IRModule({"main": test_cast})
         mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
-        mod(A, B)
         print(mod.mod.imports[0].inspect_source())
-        tvm.testing.assert_allclose(B.numpy(), B_ref, atol=1e-2)
+
+        def run_and_check():
+            dev = tvm.cuda(0)
+            A = tvm.runtime.tensor(A_ref, dev)
+            B = tvm.runtime.tensor(np.zeros(shape, dtype=B_dtype), dev)
+            mod(A, B)
+            tvm.testing.assert_allclose(B.numpy(), B_ref, atol=1e-2)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -866,11 +894,8 @@ def test_cast_warpgroup_local_view(A_dtype, B_dtype):
     else:
         cast_layout = TileLayout(S[(N_THREADS, LOCAL_LEN) : (1 @ tid_in_wg, 1)])
 
-    dev = tvm.cuda(0)
     A_ref = np.random.rand(*g_shape).astype(A_dtype)
     B_ref = np.zeros(g_shape, dtype=B_dtype)
-    A = tvm.runtime.tensor(A_ref, dev)
-    B = tvm.runtime.tensor(B_ref, dev)
     B_ref = A_ref.astype(B_dtype)
 
     # fmt: off
@@ -898,9 +923,16 @@ def test_cast_warpgroup_local_view(A_dtype, B_dtype):
     with target:
         mod = tvm.IRModule({"main": test_cast})
         mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
-        mod(A, B)
         print(mod.mod.imports[0].inspect_source())
-        tvm.testing.assert_allclose(B.numpy(), B_ref, atol=1e-2)
+
+        def run_and_check():
+            dev = tvm.cuda(0)
+            A = tvm.runtime.tensor(A_ref, dev)
+            B = tvm.runtime.tensor(np.zeros(g_shape, dtype=B_dtype), dev)
+            mod(A, B)
+            tvm.testing.assert_allclose(B.numpy(), B_ref, atol=1e-2)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -919,11 +951,8 @@ def test_cast_warpgroup_src_layout_to_flat_uses_vec2_intrinsic(A_dtype, B_dtype)
     g_shape = (N_THREADS, LOCAL_LEN * N_CHUNKS)
     g_layout = TileLayout(S[g_shape])
 
-    dev = tvm.cuda(0)
     A_ref = np.random.rand(*g_shape).astype(A_dtype)
     B_ref = np.zeros(g_shape, dtype=B_dtype)
-    A = tvm.runtime.tensor(A_ref, dev)
-    B = tvm.runtime.tensor(B_ref, dev)
     B_ref = A_ref.astype(B_dtype)
 
     # fmt: off
@@ -961,8 +990,15 @@ def test_cast_warpgroup_src_layout_to_flat_uses_vec2_intrinsic(A_dtype, B_dtype)
         # falling back to scalar T.cast inside T.vectorized.
         helper = f"tvm_builtin_cast_{A_dtype}x2_{B_dtype}x2"
         assert helper in src, f"expected {helper!r} in generated CUDA, fell back to scalar cast"
-        mod(A, B)
-        tvm.testing.assert_allclose(B.numpy(), B_ref, atol=1e-2)
+
+        def run_and_check():
+            dev = tvm.cuda(0)
+            A = tvm.runtime.tensor(A_ref, dev)
+            B = tvm.runtime.tensor(np.zeros(g_shape, dtype=B_dtype), dev)
+            mod(A, B)
+            tvm.testing.assert_allclose(B.numpy(), B_ref, atol=1e-2)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -975,11 +1011,8 @@ def test_cast_cta_local_view(A_dtype, B_dtype):
     g_layout = TileLayout(S[g_shape])
     cast_layout = TileLayout(S[(N_THREADS, LOCAL_LEN) : (1 @ tx, 1)])
 
-    dev = tvm.cuda(0)
     A_ref = np.random.rand(*g_shape).astype(A_dtype)
     B_ref = np.zeros(g_shape, dtype=B_dtype)
-    A = tvm.runtime.tensor(A_ref, dev)
-    B = tvm.runtime.tensor(B_ref, dev)
     B_ref = A_ref.astype(B_dtype)
 
     # fmt: off
@@ -1006,9 +1039,16 @@ def test_cast_cta_local_view(A_dtype, B_dtype):
     with target:
         mod = tvm.IRModule({"main": test_cast})
         mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
-        mod(A, B)
         print(mod.mod.imports[0].inspect_source())
-        tvm.testing.assert_allclose(B.numpy(), B_ref, atol=1e-2)
+
+        def run_and_check():
+            dev = tvm.cuda(0)
+            A = tvm.runtime.tensor(A_ref, dev)
+            B = tvm.runtime.tensor(np.zeros(g_shape, dtype=B_dtype), dev)
+            mod(A, B)
+            tvm.testing.assert_allclose(B.numpy(), B_ref, atol=1e-2)
+
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -1022,11 +1062,8 @@ def test_cast_local_view_sliced(A_dtype, B_dtype, slice_start, slice_end):
     g_layout = TileLayout(S[g_shape])
     cast_layout = TileLayout(S[(N_THREADS, LOCAL_LEN) : (1 @ tx, 1)])
 
-    dev = tvm.cuda(0)
     A_ref = np.random.rand(*g_shape).astype(A_dtype)
     B_ref = np.zeros(g_shape, dtype=B_dtype)
-    A = tvm.runtime.tensor(A_ref, dev)
-    B = tvm.runtime.tensor(np.zeros(g_shape, dtype=B_dtype), dev)
     B_ref[:, slice_start:slice_end] = A_ref[:, slice_start:slice_end].astype(B_dtype)
 
     # fmt: off
@@ -1055,10 +1092,17 @@ def test_cast_local_view_sliced(A_dtype, B_dtype, slice_start, slice_end):
     with target:
         mod = tvm.IRModule({"main": kernel})
         mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
+
+    def run_and_check():
+        dev = tvm.cuda(0)
+        A = tvm.runtime.tensor(A_ref, dev)
+        B = tvm.runtime.tensor(np.zeros(g_shape, dtype=B_dtype), dev)
         mod(A, B)
-    tvm.testing.assert_allclose(
-        B.numpy()[:, slice_start:slice_end], B_ref[:, slice_start:slice_end], atol=1e-2
-    )
+        tvm.testing.assert_allclose(
+            B.numpy()[:, slice_start:slice_end], B_ref[:, slice_start:slice_end], atol=1e-2
+        )
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 def test_cast_layout_partition_and_validation():
@@ -1133,10 +1177,6 @@ def test_cast_mixed_axes_and_subregion(slice_start, slice_end):
     B_ref = np.zeros(full_shape, dtype="float16")
     B_ref[:, :, :, slice_start:slice_end] = A_ref[:, :, :, slice_start:slice_end].astype("float16")
 
-    dev = tvm.cuda(0)
-    A = tvm.runtime.tensor(A_ref, dev)
-    B = tvm.runtime.tensor(np.zeros(full_shape, dtype="float16"), dev)
-
     @T.prim_func
     def kernel(A_ptr: T.handle, B_ptr: T.handle) -> None:
         A = T.match_buffer(A_ptr, full_shape, "float32", layout=g_layout)
@@ -1164,13 +1204,20 @@ def test_cast_mixed_axes_and_subregion(slice_start, slice_end):
     with target:
         mod = tvm.IRModule({"main": kernel})
         mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
+
+    def run_and_check():
+        dev = tvm.cuda(0)
+        A = tvm.runtime.tensor(A_ref, dev)
+        B = tvm.runtime.tensor(np.zeros(full_shape, dtype="float16"), dev)
         mod(A, B)
-    tvm.testing.assert_allclose(
-        B.numpy()[:, :, :, slice_start:slice_end],
-        B_ref[:, :, :, slice_start:slice_end],
-        atol=1e-2,
-        rtol=0,
-    )
+        tvm.testing.assert_allclose(
+            B.numpy()[:, :, :, slice_start:slice_end],
+            B_ref[:, :, :, slice_start:slice_end],
+            atol=1e-2,
+            rtol=0,
+        )
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 def test_cast_joint_decomposition_extents_order():
@@ -1579,14 +1626,18 @@ def test_cast_tcgen05_atom_warpgroup_gpu():
             tir_pipeline="tirx",
         )
 
-    dev = tvm.cuda(0)
     np.random.seed(0)
     a_np = (np.random.randn(m, k).astype("float32") * 4.0).astype("bfloat16")
     b_ref = a_np.astype("float32")
-    a = tvm.runtime.tensor(a_np, dev)
-    b = tvm.runtime.tensor(np.zeros((m, k), dtype="float32"), dev)
-    mod(a, b)
-    tvm.testing.assert_allclose(b.numpy(), b_ref, rtol=0, atol=1e-2)
+
+    def run_and_check():
+        dev = tvm.cuda(0)
+        a = tvm.runtime.tensor(a_np, dev)
+        b = tvm.runtime.tensor(np.zeros((m, k), dtype="float32"), dev)
+        mod(a, b)
+        tvm.testing.assert_allclose(b.numpy(), b_ref, rtol=0, atol=1e-2)
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 if __name__ == "__main__":

--- a/tests/python/tirx/operator/tile_primitive/cuda/gemm/test_gemm_mma_m16n8k_.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/gemm/test_gemm_mma_m16n8k_.py
@@ -466,20 +466,24 @@ def test_cuda_gemm_mma_numerical(dtype):
             rM = s // 2
             D_g[lane // 4 + 8 * rM, 2 * (lane % 4) + rN] = D_reg[s]
 
-    dev = tvm.cuda(0)
     with tvm.target.Target("cuda"):
         mod = tvm.compile(tvm.IRModule({"main": gemm}), target="cuda", tir_pipeline="tirx")
 
     np.random.seed(0)
     A_np = np.random.uniform(-1, 1, (16, 16)).astype(np.float32)
     B_np = np.random.uniform(-1, 1, (16, 8)).astype(np.float32)
-    A_dev = tvm.runtime.tensor(A_np.astype(np_dtype), dev)
-    B_dev = tvm.runtime.tensor(B_np.astype(np_dtype), dev)
-    D_dev = tvm.runtime.tensor(np.zeros((16, 8), np.float32), dev)
-    mod(A_dev, B_dev, D_dev)
-
     golden = A_np @ B_np
-    tvm.testing.assert_allclose(golden, D_dev.numpy(), atol=1e-2, rtol=1e-2)
+
+    def run_test():
+        dev = tvm.cuda(0)
+        A_dev = tvm.runtime.tensor(A_np.astype(np_dtype), dev)
+        B_dev = tvm.runtime.tensor(B_np.astype(np_dtype), dev)
+        D_dev = tvm.runtime.tensor(np.zeros((16, 8), np.float32), dev)
+        mod(A_dev, B_dev, D_dev)
+        dev.sync()
+        tvm.testing.assert_allclose(golden, D_dev.numpy(), atol=1e-2, rtol=1e-2)
+
+    tvm.testing.run_with_gpu_lock(run_test)
 
 
 # (Mt, Nt, Kt, kinst) tilings: single tile, each dim multi-tiled, fully tiled,
@@ -522,7 +526,6 @@ def test_cuda_gemm_mma_numerical_tiled(dtype, beta, Mt, Nt, Kt, kinst):
         np_dtype = np.float16
 
     func, M, N, K = _build_tiled_numeric(Mt, Nt, Kt, kinst, beta, dtype)
-    dev = tvm.cuda(0)
     with tvm.target.Target("cuda"):
         mod = tvm.compile(tvm.IRModule({"main": func}), target="cuda", tir_pipeline="tirx")
 
@@ -530,14 +533,19 @@ def test_cuda_gemm_mma_numerical_tiled(dtype, beta, Mt, Nt, Kt, kinst):
     A_np = np.random.uniform(-1, 1, (M, K)).astype(np.float32)
     B_np = np.random.uniform(-1, 1, (K, N)).astype(np.float32)
     C_np = np.random.uniform(-1, 1, (M, N)).astype(np.float32)
-    A_dev = tvm.runtime.tensor(A_np.astype(np_dtype), dev)
-    B_dev = tvm.runtime.tensor(B_np.astype(np_dtype), dev)
-    C_dev = tvm.runtime.tensor(C_np, dev)
-    D_dev = tvm.runtime.tensor(np.zeros((M, N), np.float32), dev)
-    mod(A_dev, B_dev, C_dev, D_dev)
-
     golden = A_np @ B_np + (C_np if beta == 1.0 else 0.0)
-    tvm.testing.assert_allclose(golden, D_dev.numpy(), atol=2e-2, rtol=2e-2)
+
+    def run_test():
+        dev = tvm.cuda(0)
+        A_dev = tvm.runtime.tensor(A_np.astype(np_dtype), dev)
+        B_dev = tvm.runtime.tensor(B_np.astype(np_dtype), dev)
+        C_dev = tvm.runtime.tensor(C_np, dev)
+        D_dev = tvm.runtime.tensor(np.zeros((M, N), np.float32), dev)
+        mod(A_dev, B_dev, C_dev, D_dev)
+        dev.sync()
+        tvm.testing.assert_allclose(golden, D_dev.numpy(), atol=2e-2, rtol=2e-2)
+
+    tvm.testing.run_with_gpu_lock(run_test)
 
 
 @pytest.mark.gpu
@@ -559,7 +567,6 @@ def test_cuda_gemm_mma_numerical_transpose(transpose_A, transpose_B, dtype):
         np_dtype = np.float16
 
     func = _build_transpose_numeric(transpose_A, transpose_B, dtype)
-    dev = tvm.cuda(0)
     with tvm.target.Target("cuda"):
         mod = tvm.compile(tvm.IRModule({"main": func}), target="cuda", tir_pipeline="tirx")
 
@@ -568,12 +575,18 @@ def test_cuda_gemm_mma_numerical_transpose(transpose_A, transpose_B, dtype):
     B_log = np.random.uniform(-1, 1, (16, 8)).astype(np.float32)  # logical B[K, N]
     A_buf = (A_log.T if transpose_A else A_log).astype(np_dtype)
     B_buf = (B_log.T if transpose_B else B_log).astype(np_dtype)
-    A_dev = tvm.runtime.tensor(A_buf, dev)
-    B_dev = tvm.runtime.tensor(B_buf, dev)
-    D_dev = tvm.runtime.tensor(np.zeros((16, 8), np.float32), dev)
-    mod(A_dev, B_dev, D_dev)
+    golden = A_log @ B_log
 
-    tvm.testing.assert_allclose(A_log @ B_log, D_dev.numpy(), atol=2e-2, rtol=2e-2)
+    def run_test():
+        dev = tvm.cuda(0)
+        A_dev = tvm.runtime.tensor(A_buf, dev)
+        B_dev = tvm.runtime.tensor(B_buf, dev)
+        D_dev = tvm.runtime.tensor(np.zeros((16, 8), np.float32), dev)
+        mod(A_dev, B_dev, D_dev)
+        dev.sync()
+        tvm.testing.assert_allclose(golden, D_dev.numpy(), atol=2e-2, rtol=2e-2)
+
+    tvm.testing.run_with_gpu_lock(run_test)
 
 
 @pytest.mark.parametrize(

--- a/tests/python/tirx/operator/tile_primitive/cuda/gemm/test_gemm_mma_m16n8k_.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/gemm/test_gemm_mma_m16n8k_.py
@@ -474,16 +474,15 @@ def test_cuda_gemm_mma_numerical(dtype):
     B_np = np.random.uniform(-1, 1, (16, 8)).astype(np.float32)
     golden = A_np @ B_np
 
-    def run_test():
+    def run_and_check():
         dev = tvm.cuda(0)
         A_dev = tvm.runtime.tensor(A_np.astype(np_dtype), dev)
         B_dev = tvm.runtime.tensor(B_np.astype(np_dtype), dev)
         D_dev = tvm.runtime.tensor(np.zeros((16, 8), np.float32), dev)
         mod(A_dev, B_dev, D_dev)
-        dev.sync()
         tvm.testing.assert_allclose(golden, D_dev.numpy(), atol=1e-2, rtol=1e-2)
 
-    tvm.testing.run_with_gpu_lock(run_test)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 # (Mt, Nt, Kt, kinst) tilings: single tile, each dim multi-tiled, fully tiled,
@@ -535,17 +534,16 @@ def test_cuda_gemm_mma_numerical_tiled(dtype, beta, Mt, Nt, Kt, kinst):
     C_np = np.random.uniform(-1, 1, (M, N)).astype(np.float32)
     golden = A_np @ B_np + (C_np if beta == 1.0 else 0.0)
 
-    def run_test():
+    def run_and_check():
         dev = tvm.cuda(0)
         A_dev = tvm.runtime.tensor(A_np.astype(np_dtype), dev)
         B_dev = tvm.runtime.tensor(B_np.astype(np_dtype), dev)
         C_dev = tvm.runtime.tensor(C_np, dev)
         D_dev = tvm.runtime.tensor(np.zeros((M, N), np.float32), dev)
         mod(A_dev, B_dev, C_dev, D_dev)
-        dev.sync()
         tvm.testing.assert_allclose(golden, D_dev.numpy(), atol=2e-2, rtol=2e-2)
 
-    tvm.testing.run_with_gpu_lock(run_test)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -577,16 +575,15 @@ def test_cuda_gemm_mma_numerical_transpose(transpose_A, transpose_B, dtype):
     B_buf = (B_log.T if transpose_B else B_log).astype(np_dtype)
     golden = A_log @ B_log
 
-    def run_test():
+    def run_and_check():
         dev = tvm.cuda(0)
         A_dev = tvm.runtime.tensor(A_buf, dev)
         B_dev = tvm.runtime.tensor(B_buf, dev)
         D_dev = tvm.runtime.tensor(np.zeros((16, 8), np.float32), dev)
         mod(A_dev, B_dev, D_dev)
-        dev.sync()
         tvm.testing.assert_allclose(golden, D_dev.numpy(), atol=2e-2, rtol=2e-2)
 
-    tvm.testing.run_with_gpu_lock(run_test)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.parametrize(

--- a/tests/python/tirx/operator/tile_primitive/cuda/gemm_async/test_gemm_async.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/gemm_async/test_gemm_async.py
@@ -271,7 +271,6 @@ def test_gemm_tcgen05_cta_group_1(task):
             T.ptx.tcgen05.dealloc(tmem_addr[0], n_cols=cols_alloc, cta_group=1)
         # fmt: on
 
-    dev = tvm.cuda(0)
     np.random.seed(0)
 
     target = tvm.target.Target("cuda")
@@ -284,16 +283,20 @@ def test_gemm_tcgen05_cta_group_1(task):
         A_np = np.random.randn(*A_shape).astype(A_dtype)
         B_np = np.random.randn(*B_shape).astype(B_dtype)
         C_np = np.zeros(C_shape, dtype=C_dtype)
-        A_tvm = tvm.runtime.tensor(A_np, dev)
-        B_tvm = tvm.runtime.tensor(B_np, dev)
-        C_tvm = tvm.runtime.tensor(C_np, dev)
-        mod["main"](A_tvm, B_tvm, C_tvm)
-
         C_ref = np.zeros(C_shape, dtype=C_dtype)
         A_ref = np.squeeze(A_np[tuple(r_smem_A)] if not transA else A_np[tuple(r_smem_A)].T)
         B_ref = np.squeeze(B_np[tuple(r_smem_B)] if transB else B_np[tuple(r_smem_B)].T)
         C_ref[tuple(r_tmem_C)] = A_ref @ B_ref
-        np.testing.assert_allclose(C_tvm.numpy(), C_ref, atol=1e-3, rtol=1e-3)
+        def run_test():
+            dev = tvm.cuda(0)
+            A_tvm = tvm.runtime.tensor(A_np, dev)
+            B_tvm = tvm.runtime.tensor(B_np, dev)
+            C_tvm = tvm.runtime.tensor(C_np, dev)
+            mod["main"](A_tvm, B_tvm, C_tvm)
+            dev.sync()
+            np.testing.assert_allclose(C_tvm.numpy(), C_ref, atol=1e-3, rtol=1e-3)
+
+        tvm.testing.run_with_gpu_lock(run_test)
 
 
 @pytest.mark.gpu
@@ -392,7 +395,6 @@ def test_gemm_tcgen05_cta_group_1_layout_f_m64():
             T.ptx.tcgen05.dealloc(tmem_addr[0], n_cols=64, cta_group=1)
     # fmt: on
 
-    dev = tvm.cuda(0)
     np.random.seed(0)
     target = tvm.target.Target("cuda")
     with target:
@@ -401,13 +403,18 @@ def test_gemm_tcgen05_cta_group_1_layout_f_m64():
     A_np = np.random.randn(*A_shape).astype(A_dtype)
     B_np = np.random.randn(*B_shape).astype(B_dtype)
     C_np = np.zeros(C_shape, dtype=C_dtype)
-    A_tvm = tvm.runtime.tensor(A_np, dev)
-    B_tvm = tvm.runtime.tensor(B_np, dev)
-    C_tvm = tvm.runtime.tensor(C_np, dev)
-    mod["main"](A_tvm, B_tvm, C_tvm)
-
     C_ref = A_np.astype(np.float32) @ B_np.astype(np.float32).T
-    np.testing.assert_allclose(C_tvm.numpy(), C_ref, atol=1e-2, rtol=1e-2)
+
+    def run_test():
+        dev = tvm.cuda(0)
+        A_tvm = tvm.runtime.tensor(A_np, dev)
+        B_tvm = tvm.runtime.tensor(B_np, dev)
+        C_tvm = tvm.runtime.tensor(C_np, dev)
+        mod["main"](A_tvm, B_tvm, C_tvm)
+        dev.sync()
+        np.testing.assert_allclose(C_tvm.numpy(), C_ref, atol=1e-2, rtol=1e-2)
+
+    tvm.testing.run_with_gpu_lock(run_test)
 
 
 @pytest.mark.gpu
@@ -525,7 +532,6 @@ def test_gemm_tcgen05_cta_group_2(task):
             T.ptx.tcgen05.dealloc(tmem_addr[0], n_cols=cols_alloc, cta_group=2)
         # fmt: on
 
-    dev = tvm.cuda(0)
     np.random.seed(0)
 
     target = tvm.target.Target("cuda")
@@ -538,18 +544,22 @@ def test_gemm_tcgen05_cta_group_2(task):
         A_np = np.random.randn(*A_shape).astype(A_dtype)
         B_np = np.random.randn(*B_shape).astype(B_dtype)
         C_np = np.zeros(C_shape, dtype=C_dtype)
-        A_tvm = tvm.runtime.tensor(A_np, dev)
-        B_tvm = tvm.runtime.tensor(B_np, dev)
-        C_tvm = tvm.runtime.tensor(C_np, dev)
-        mod["main"](A_tvm, B_tvm, C_tvm)
-
         C_ref = np.zeros(C_shape, dtype=C_dtype)
         A_ref = np.squeeze(
             A_np[tuple(r_smem_A[:-2])] if not transA else A_np[tuple(r_smem_A[:-2])].T
         )
         B_ref = np.squeeze(B_np[tuple(r_smem_B[:-2])] if transB else B_np[tuple(r_smem_B[:-2])].T)
         C_ref[:, C_region[1][0] : C_region[1][0] + width] = A_ref @ B_ref
-        np.testing.assert_allclose(C_tvm.numpy(), C_ref, atol=1e-3, rtol=1e-3)
+        def run_test():
+            dev = tvm.cuda(0)
+            A_tvm = tvm.runtime.tensor(A_np, dev)
+            B_tvm = tvm.runtime.tensor(B_np, dev)
+            C_tvm = tvm.runtime.tensor(C_np, dev)
+            mod["main"](A_tvm, B_tvm, C_tvm)
+            dev.sync()
+            np.testing.assert_allclose(C_tvm.numpy(), C_ref, atol=1e-3, rtol=1e-3)
+
+        tvm.testing.run_with_gpu_lock(run_test)
 
 
 @pytest.mark.gpu
@@ -662,7 +672,6 @@ def test_gemm_tcgen05_cta_group_2_layout_b():
             T.ptx.tcgen05.dealloc(tmem_addr[0], n_cols=cols_alloc, cta_group=2)
         # fmt: on
 
-    dev = tvm.cuda(0)
     np.random.seed(0)
 
     target = tvm.target.Target("cuda")
@@ -674,14 +683,19 @@ def test_gemm_tcgen05_cta_group_2_layout_b():
         A_np = np.random.randn(M_per_cta * 2, K).astype(A_dtype)
         B_np = np.random.randn(N_logical, K).astype(B_dtype)
         C_np = np.zeros(C_shape, dtype=C_dtype)
-        A_tvm = tvm.runtime.tensor(A_np, dev)
-        B_tvm = tvm.runtime.tensor(B_np, dev)
-        C_tvm = tvm.runtime.tensor(C_np, dev)
-        mod["main"](A_tvm, B_tvm, C_tvm)
-
         # Reference: C = A @ B.T
         C_ref = A_np.astype(np.float32) @ B_np.astype(np.float32).T
-        np.testing.assert_allclose(C_tvm.numpy(), C_ref, atol=1e-3, rtol=1e-3)
+
+        def run_test():
+            dev = tvm.cuda(0)
+            A_tvm = tvm.runtime.tensor(A_np, dev)
+            B_tvm = tvm.runtime.tensor(B_np, dev)
+            C_tvm = tvm.runtime.tensor(C_np, dev)
+            mod["main"](A_tvm, B_tvm, C_tvm)
+            dev.sync()
+            np.testing.assert_allclose(C_tvm.numpy(), C_ref, atol=1e-3, rtol=1e-3)
+
+        tvm.testing.run_with_gpu_lock(run_test)
 
 
 @pytest.mark.gpu
@@ -842,7 +856,6 @@ def test_gemm_block_scaled_fp8_cta_group_1(task):
             T.ptx.tcgen05.dealloc(tmem_addr[0], n_cols=cols_alloc, cta_group=1)
         # fmt: on
 
-    dev = tvm.cuda(0)
     np.random.seed(0)
 
     target = tvm.target.Target("cuda")
@@ -860,19 +873,23 @@ def test_gemm_block_scaled_fp8_cta_group_1(task):
         sfb_packed = pack_scale_uint32(sfb_exp.ravel(), 128)
 
         C_np = np.zeros(C_shape, dtype=C_dtype)
-        A_tvm = tvm.runtime.tensor(A_fp8, dev)
-        B_tvm = tvm.runtime.tensor(B_fp8, dev)
-        C_tvm = tvm.runtime.tensor(C_np, dev)
-        sfa_tvm = tvm.runtime.tensor(sfa_packed, dev)
-        sfb_tvm = tvm.runtime.tensor(sfb_packed, dev)
-        mod["main"](A_tvm, B_tvm, C_tvm, sfa_tvm, sfb_tvm)
-
         # Reference: C = dequant(A) @ dequant(B).T
         A_dq = A_fp8[tuple(r_smem_A)].astype(np.float32) * sfa_scale[..., None]
         B_dq = B_fp8[tuple(r_smem_B)].astype(np.float32) * sfb_scale[..., None]
         C_ref = np.zeros(C_shape, dtype=C_dtype)
         C_ref[tuple(r_tmem_C)] = A_dq @ B_dq.T
-        np.testing.assert_allclose(C_tvm.numpy(), C_ref, atol=1.0, rtol=0.15)
+        def run_test():
+            dev = tvm.cuda(0)
+            A_tvm = tvm.runtime.tensor(A_fp8, dev)
+            B_tvm = tvm.runtime.tensor(B_fp8, dev)
+            C_tvm = tvm.runtime.tensor(C_np, dev)
+            sfa_tvm = tvm.runtime.tensor(sfa_packed, dev)
+            sfb_tvm = tvm.runtime.tensor(sfb_packed, dev)
+            mod["main"](A_tvm, B_tvm, C_tvm, sfa_tvm, sfb_tvm)
+            dev.sync()
+            np.testing.assert_allclose(C_tvm.numpy(), C_ref, atol=1.0, rtol=0.15)
+
+        tvm.testing.run_with_gpu_lock(run_test)
 
 
 @pytest.mark.gpu
@@ -1052,7 +1069,6 @@ def test_gemm_block_scaled_fp8_cta_group_2(task):
             T.ptx.tcgen05.dealloc(tmem_addr[0], n_cols=cols_alloc, cta_group=2)
         # fmt: on
 
-    dev = tvm.cuda(0)
     np.random.seed(0)
 
     target = tvm.target.Target("cuda")
@@ -1087,19 +1103,23 @@ def test_gemm_block_scaled_fp8_cta_group_2(task):
         sfb_packed = pack_scale_uint32(np.full(128, sfb_exp_val, dtype=np.uint8), 128)
 
         C_np = np.zeros(C_shape, dtype=C_dtype)
-        A_tvm = tvm.runtime.tensor(A_fp8, dev)
-        B_tvm = tvm.runtime.tensor(B_fp8, dev)
-        C_tvm = tvm.runtime.tensor(C_np, dev)
-        sfa_tvm = tvm.runtime.tensor(sfa_packed, dev)
-        sfb_tvm = tvm.runtime.tensor(sfb_packed, dev)
-        mod["main"](A_tvm, B_tvm, C_tvm, sfa_tvm, sfb_tvm)
-
         # Reference: C = dequant(A) @ dequant(B).T
         A_dq = A_fp8_active.astype(np.float32) * sfa_scale[:, None]
         B_dq = B_fp8_active.astype(np.float32) * b_scale
         C_ref = np.zeros(C_shape, dtype=C_dtype)
         C_ref[:, C_region[1][0] : C_region[1][0] + width] = A_dq @ B_dq.T
-        np.testing.assert_allclose(C_tvm.numpy(), C_ref, atol=1.0, rtol=0.15)
+        def run_test():
+            dev = tvm.cuda(0)
+            A_tvm = tvm.runtime.tensor(A_fp8, dev)
+            B_tvm = tvm.runtime.tensor(B_fp8, dev)
+            C_tvm = tvm.runtime.tensor(C_np, dev)
+            sfa_tvm = tvm.runtime.tensor(sfa_packed, dev)
+            sfb_tvm = tvm.runtime.tensor(sfb_packed, dev)
+            mod["main"](A_tvm, B_tvm, C_tvm, sfa_tvm, sfb_tvm)
+            dev.sync()
+            np.testing.assert_allclose(C_tvm.numpy(), C_ref, atol=1.0, rtol=0.15)
+
+        tvm.testing.run_with_gpu_lock(run_test)
 
 
 @pytest.mark.gpu
@@ -1236,7 +1256,6 @@ def test_gemm_block_scaled_nvfp4_cta_group_1():
             T.ptx.tcgen05.dealloc(tmem_addr[0], n_cols=cols_alloc, cta_group=1)
         # fmt: on
 
-    dev = tvm.cuda(0)
     np.random.seed(0)
 
     target = tvm.target.Target("cuda")
@@ -1258,19 +1277,23 @@ def test_gemm_block_scaled_nvfp4_cta_group_1():
         sfb_packed = pack_sf_fp8_uint32(sfb_fp8.view(np.uint8).ravel(), 128)
 
         C_np = np.zeros(C_shape, dtype=C_dtype)
-        A_tvm = tvm.runtime.tensor(A_packed, dev)
-        B_tvm = tvm.runtime.tensor(B_packed, dev)
-        C_tvm = tvm.runtime.tensor(C_np, dev)
-        sfa_tvm = tvm.runtime.tensor(sfa_packed, dev)
-        sfb_tvm = tvm.runtime.tensor(sfb_packed, dev)
-        mod["main"](A_tvm, B_tvm, C_tvm, sfa_tvm, sfb_tvm)
-
         # Reference: C = dequant(A) @ dequant(B).T
         A_dq = A_fp4.astype(np.float32) * sfa_f32[..., None]
         B_dq = B_fp4.astype(np.float32) * sfb_f32[..., None]
         C_ref = np.zeros(C_shape, dtype=C_dtype)
         C_ref[0:128, 0:N] = A_dq @ B_dq.T
-        np.testing.assert_allclose(C_tvm.numpy(), C_ref, atol=1.0, rtol=0.15)
+        def run_test():
+            dev = tvm.cuda(0)
+            A_tvm = tvm.runtime.tensor(A_packed, dev)
+            B_tvm = tvm.runtime.tensor(B_packed, dev)
+            C_tvm = tvm.runtime.tensor(C_np, dev)
+            sfa_tvm = tvm.runtime.tensor(sfa_packed, dev)
+            sfb_tvm = tvm.runtime.tensor(sfb_packed, dev)
+            mod["main"](A_tvm, B_tvm, C_tvm, sfa_tvm, sfb_tvm)
+            dev.sync()
+            np.testing.assert_allclose(C_tvm.numpy(), C_ref, atol=1.0, rtol=0.15)
+
+        tvm.testing.run_with_gpu_lock(run_test)
 
 
 @pytest.mark.gpu
@@ -1430,7 +1453,6 @@ def test_gemm_block_scaled_nvfp4_cta_group_2():
             T.ptx.tcgen05.dealloc(tmem_addr[0], n_cols=cols_alloc, cta_group=2)
         # fmt: on
 
-    dev = tvm.cuda(0)
     np.random.seed(0)
 
     target = tvm.target.Target("cuda")
@@ -1464,19 +1486,23 @@ def test_gemm_block_scaled_nvfp4_cta_group_2():
         sfb_packed = pack_sf_fp8_uint32(np.full(128, sfb_exp, dtype=np.uint8), 128)
 
         C_np = np.zeros(C_shape, dtype=C_dtype)
-        A_tvm = tvm.runtime.tensor(A_packed, dev)
-        B_tvm = tvm.runtime.tensor(B_packed, dev)
-        C_tvm = tvm.runtime.tensor(C_np, dev)
-        sfa_tvm = tvm.runtime.tensor(sfa_packed, dev)
-        sfb_tvm = tvm.runtime.tensor(sfb_packed, dev)
-        mod["main"](A_tvm, B_tvm, C_tvm, sfa_tvm, sfb_tvm)
-
         # Reference: C = dequant(A) @ dequant(B).T
         A_dq = A_fp4.astype(np.float32) * sfa_f32[..., None]
         B_dq = B_fp4.astype(np.float32) * b_scale_f32
         C_ref = np.zeros(C_shape, dtype=C_dtype)
         C_ref[0:M_total, 0:N_total] = A_dq @ B_dq.T
-        np.testing.assert_allclose(C_tvm.numpy(), C_ref, atol=1.0, rtol=0.15)
+        def run_test():
+            dev = tvm.cuda(0)
+            A_tvm = tvm.runtime.tensor(A_packed, dev)
+            B_tvm = tvm.runtime.tensor(B_packed, dev)
+            C_tvm = tvm.runtime.tensor(C_np, dev)
+            sfa_tvm = tvm.runtime.tensor(sfa_packed, dev)
+            sfb_tvm = tvm.runtime.tensor(sfb_packed, dev)
+            mod["main"](A_tvm, B_tvm, C_tvm, sfa_tvm, sfb_tvm)
+            dev.sync()
+            np.testing.assert_allclose(C_tvm.numpy(), C_ref, atol=1.0, rtol=0.15)
+
+        tvm.testing.run_with_gpu_lock(run_test)
 
 
 @pytest.mark.gpu
@@ -1638,7 +1664,6 @@ def test_gemm_block_scaled_fp8_sf_id():
         exp_uint8 = (log_scale.astype(np.int32) + 127).astype(np.uint8)  # (rows, n_blocks)
         return mat_fp8, scale, exp_uint8
 
-    dev = tvm.cuda(0)
     np.random.seed(42)
 
     target = tvm.target.Target("cuda")
@@ -1674,13 +1699,6 @@ def test_gemm_block_scaled_fp8_sf_id():
         sfb_packed[:N] = sfb_base
 
         C_np = np.zeros(C_shape, dtype=C_dtype)
-        A_tvm = tvm.runtime.tensor(A_fp8, dev)
-        B_tvm = tvm.runtime.tensor(B_fp8, dev)
-        C_tvm = tvm.runtime.tensor(C_np, dev)
-        sfa_tvm = tvm.runtime.tensor(sfa_packed, dev)
-        sfb_tvm = tvm.runtime.tensor(sfb_packed, dev)
-        mod["main"](A_tvm, B_tvm, C_tvm, sfa_tvm, sfb_tvm)
-
         # Reference: per-block dequantize and accumulate
         C_ref = np.zeros(C_shape, dtype=C_dtype)
         for i in range(num_blocks):
@@ -1691,7 +1709,18 @@ def test_gemm_block_scaled_fp8_sf_id():
                 B_fp8[:, i * MMA_K : (i + 1) * MMA_K].astype(np.float32) * B_scale[:, i : i + 1]
             )
             C_ref[:M, :N] += A_block @ B_block.T
-        np.testing.assert_allclose(C_tvm.numpy(), C_ref, atol=1.0, rtol=0.15)
+        def run_test():
+            dev = tvm.cuda(0)
+            A_tvm = tvm.runtime.tensor(A_fp8, dev)
+            B_tvm = tvm.runtime.tensor(B_fp8, dev)
+            C_tvm = tvm.runtime.tensor(C_np, dev)
+            sfa_tvm = tvm.runtime.tensor(sfa_packed, dev)
+            sfb_tvm = tvm.runtime.tensor(sfb_packed, dev)
+            mod["main"](A_tvm, B_tvm, C_tvm, sfa_tvm, sfb_tvm)
+            dev.sync()
+            np.testing.assert_allclose(C_tvm.numpy(), C_ref, atol=1.0, rtol=0.15)
+
+        tvm.testing.run_with_gpu_lock(run_test)
 
         # Sanity: blocks must have different scales (test is meaningless if uniform)
         for i in range(1, num_blocks):
@@ -1941,7 +1970,6 @@ def test_gemm_tcgen05_arbitrary_tiles(task):
             T.ptx.tcgen05.dealloc(tmem_addr[0], n_cols=cols_alloc, cta_group=cta_group)
         # fmt: on
 
-    dev = tvm.cuda(0)
     np.random.seed(0)
 
     target = tvm.target.Target("cuda")
@@ -1952,11 +1980,6 @@ def test_gemm_tcgen05_arbitrary_tiles(task):
         A_np = np.random.randn(*A_shape).astype(A_dtype)
         B_np = np.random.randn(*B_shape).astype(B_dtype)
         C_np = np.zeros(C_shape, dtype=C_dtype)
-        A_tvm = tvm.runtime.tensor(A_np, dev)
-        B_tvm = tvm.runtime.tensor(B_np, dev)
-        C_tvm = tvm.runtime.tensor(C_np, dev)
-        mod["main"](A_tvm, B_tvm, C_tvm)
-
         C_ref = np.zeros(C_shape, dtype=C_dtype)
         # Apply ref_perm: when global layout differs from row-major, the kernel
         # reinterprets the flat bytes, so the reference must transpose accordingly.
@@ -1978,7 +2001,16 @@ def test_gemm_tcgen05_arbitrary_tiles(task):
             B_np_ref[tuple(r_smem_B_ref)] if transB else B_np_ref[tuple(r_smem_B_ref)].T
         )
         C_ref[tuple(r_tmem_C)] = A_ref @ B_ref
-        np.testing.assert_allclose(C_tvm.numpy(), C_ref, atol=1e-3, rtol=1e-3)
+        def run_test():
+            dev = tvm.cuda(0)
+            A_tvm = tvm.runtime.tensor(A_np, dev)
+            B_tvm = tvm.runtime.tensor(B_np, dev)
+            C_tvm = tvm.runtime.tensor(C_np, dev)
+            mod["main"](A_tvm, B_tvm, C_tvm)
+            dev.sync()
+            np.testing.assert_allclose(C_tvm.numpy(), C_ref, atol=1e-3, rtol=1e-3)
+
+        tvm.testing.run_with_gpu_lock(run_test)
 
 
 @pytest.mark.gpu
@@ -2053,18 +2085,23 @@ def test_gemm_tcgen05_contiguous_kslice_partial_k(k_lo, k_hi):
             T.ptx.tcgen05.dealloc(tmem_addr[0], n_cols=128, cta_group=1)
     # fmt: on
 
-    dev = tvm.cuda(0)
     np.random.seed(0)
     with tvm.target.Target("cuda"):
         mod = tvm.compile(tvm.IRModule({"main": gemm_async}), target="cuda", tir_pipeline="tirx")
     A_np = np.random.randn(*A_shape).astype(dtype)
     B_np = np.random.randn(*B_shape).astype(dtype)
     C_np = np.zeros(C_shape, "float32")
-    A_t, B_t, C_t = (tvm.runtime.tensor(x, dev) for x in (A_np, B_np, C_np))
-    mod["main"](A_t, B_t, C_t)
     # Reference: accumulate only k in [k_lo, k_hi).
     C_ref = A_np[:, k_lo:k_hi].astype("float32") @ B_np[:, k_lo:k_hi].astype("float32").T
-    np.testing.assert_allclose(C_t.numpy(), C_ref, atol=1e-2, rtol=1e-2)
+
+    def run_test():
+        dev = tvm.cuda(0)
+        A_t, B_t, C_t = (tvm.runtime.tensor(x, dev) for x in (A_np, B_np, C_np))
+        mod["main"](A_t, B_t, C_t)
+        dev.sync()
+        np.testing.assert_allclose(C_t.numpy(), C_ref, atol=1e-2, rtol=1e-2)
+
+    tvm.testing.run_with_gpu_lock(run_test)
 
 
 def _run_dense_gemm(
@@ -2142,7 +2179,6 @@ def _run_dense_gemm(
             T.ptx.tcgen05.relinquish_alloc_permit(cta_group=1)
             T.ptx.tcgen05.dealloc(tmem_addr[0], n_cols=cols_alloc, cta_group=1)
 
-    dev = tvm.cuda(0)
     np.random.seed(0)
     target = tvm.target.Target("cuda")
     with target:
@@ -2155,10 +2191,16 @@ def _run_dense_gemm(
     A_np = _rand(A_shape, A_dtype)
     B_np = _rand(B_shape, B_dtype)
     C_np = np.zeros(C_shape, dtype=C_dtype)
-    A_t, B_t, C_t = (tvm.runtime.tensor(x, dev) for x in (A_np, B_np, C_np))
-    mod["main"](A_t, B_t, C_t)
     C_ref = A_np.astype("float32") @ B_np.astype("float32").T
-    np.testing.assert_allclose(C_t.numpy().astype("float32"), C_ref, atol=atol, rtol=rtol)
+
+    def run_test():
+        dev = tvm.cuda(0)
+        A_t, B_t, C_t = (tvm.runtime.tensor(x, dev) for x in (A_np, B_np, C_np))
+        mod["main"](A_t, B_t, C_t)
+        dev.sync()
+        np.testing.assert_allclose(C_t.numpy().astype("float32"), C_ref, atol=atol, rtol=rtol)
+
+    tvm.testing.run_with_gpu_lock(run_test)
 
 
 @pytest.mark.gpu

--- a/tests/python/tirx/operator/tile_primitive/cuda/gemm_async/test_gemm_async.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/gemm_async/test_gemm_async.py
@@ -287,16 +287,15 @@ def test_gemm_tcgen05_cta_group_1(task):
         A_ref = np.squeeze(A_np[tuple(r_smem_A)] if not transA else A_np[tuple(r_smem_A)].T)
         B_ref = np.squeeze(B_np[tuple(r_smem_B)] if transB else B_np[tuple(r_smem_B)].T)
         C_ref[tuple(r_tmem_C)] = A_ref @ B_ref
-        def run_test():
+        def run_and_check():
             dev = tvm.cuda(0)
             A_tvm = tvm.runtime.tensor(A_np, dev)
             B_tvm = tvm.runtime.tensor(B_np, dev)
             C_tvm = tvm.runtime.tensor(C_np, dev)
             mod["main"](A_tvm, B_tvm, C_tvm)
-            dev.sync()
             np.testing.assert_allclose(C_tvm.numpy(), C_ref, atol=1e-3, rtol=1e-3)
 
-        tvm.testing.run_with_gpu_lock(run_test)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -405,16 +404,15 @@ def test_gemm_tcgen05_cta_group_1_layout_f_m64():
     C_np = np.zeros(C_shape, dtype=C_dtype)
     C_ref = A_np.astype(np.float32) @ B_np.astype(np.float32).T
 
-    def run_test():
+    def run_and_check():
         dev = tvm.cuda(0)
         A_tvm = tvm.runtime.tensor(A_np, dev)
         B_tvm = tvm.runtime.tensor(B_np, dev)
         C_tvm = tvm.runtime.tensor(C_np, dev)
         mod["main"](A_tvm, B_tvm, C_tvm)
-        dev.sync()
         np.testing.assert_allclose(C_tvm.numpy(), C_ref, atol=1e-2, rtol=1e-2)
 
-    tvm.testing.run_with_gpu_lock(run_test)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -550,16 +548,15 @@ def test_gemm_tcgen05_cta_group_2(task):
         )
         B_ref = np.squeeze(B_np[tuple(r_smem_B[:-2])] if transB else B_np[tuple(r_smem_B[:-2])].T)
         C_ref[:, C_region[1][0] : C_region[1][0] + width] = A_ref @ B_ref
-        def run_test():
+        def run_and_check():
             dev = tvm.cuda(0)
             A_tvm = tvm.runtime.tensor(A_np, dev)
             B_tvm = tvm.runtime.tensor(B_np, dev)
             C_tvm = tvm.runtime.tensor(C_np, dev)
             mod["main"](A_tvm, B_tvm, C_tvm)
-            dev.sync()
             np.testing.assert_allclose(C_tvm.numpy(), C_ref, atol=1e-3, rtol=1e-3)
 
-        tvm.testing.run_with_gpu_lock(run_test)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -686,16 +683,15 @@ def test_gemm_tcgen05_cta_group_2_layout_b():
         # Reference: C = A @ B.T
         C_ref = A_np.astype(np.float32) @ B_np.astype(np.float32).T
 
-        def run_test():
+        def run_and_check():
             dev = tvm.cuda(0)
             A_tvm = tvm.runtime.tensor(A_np, dev)
             B_tvm = tvm.runtime.tensor(B_np, dev)
             C_tvm = tvm.runtime.tensor(C_np, dev)
             mod["main"](A_tvm, B_tvm, C_tvm)
-            dev.sync()
             np.testing.assert_allclose(C_tvm.numpy(), C_ref, atol=1e-3, rtol=1e-3)
 
-        tvm.testing.run_with_gpu_lock(run_test)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -878,7 +874,7 @@ def test_gemm_block_scaled_fp8_cta_group_1(task):
         B_dq = B_fp8[tuple(r_smem_B)].astype(np.float32) * sfb_scale[..., None]
         C_ref = np.zeros(C_shape, dtype=C_dtype)
         C_ref[tuple(r_tmem_C)] = A_dq @ B_dq.T
-        def run_test():
+        def run_and_check():
             dev = tvm.cuda(0)
             A_tvm = tvm.runtime.tensor(A_fp8, dev)
             B_tvm = tvm.runtime.tensor(B_fp8, dev)
@@ -886,10 +882,9 @@ def test_gemm_block_scaled_fp8_cta_group_1(task):
             sfa_tvm = tvm.runtime.tensor(sfa_packed, dev)
             sfb_tvm = tvm.runtime.tensor(sfb_packed, dev)
             mod["main"](A_tvm, B_tvm, C_tvm, sfa_tvm, sfb_tvm)
-            dev.sync()
             np.testing.assert_allclose(C_tvm.numpy(), C_ref, atol=1.0, rtol=0.15)
 
-        tvm.testing.run_with_gpu_lock(run_test)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -1108,7 +1103,7 @@ def test_gemm_block_scaled_fp8_cta_group_2(task):
         B_dq = B_fp8_active.astype(np.float32) * b_scale
         C_ref = np.zeros(C_shape, dtype=C_dtype)
         C_ref[:, C_region[1][0] : C_region[1][0] + width] = A_dq @ B_dq.T
-        def run_test():
+        def run_and_check():
             dev = tvm.cuda(0)
             A_tvm = tvm.runtime.tensor(A_fp8, dev)
             B_tvm = tvm.runtime.tensor(B_fp8, dev)
@@ -1116,10 +1111,9 @@ def test_gemm_block_scaled_fp8_cta_group_2(task):
             sfa_tvm = tvm.runtime.tensor(sfa_packed, dev)
             sfb_tvm = tvm.runtime.tensor(sfb_packed, dev)
             mod["main"](A_tvm, B_tvm, C_tvm, sfa_tvm, sfb_tvm)
-            dev.sync()
             np.testing.assert_allclose(C_tvm.numpy(), C_ref, atol=1.0, rtol=0.15)
 
-        tvm.testing.run_with_gpu_lock(run_test)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -1282,7 +1276,7 @@ def test_gemm_block_scaled_nvfp4_cta_group_1():
         B_dq = B_fp4.astype(np.float32) * sfb_f32[..., None]
         C_ref = np.zeros(C_shape, dtype=C_dtype)
         C_ref[0:128, 0:N] = A_dq @ B_dq.T
-        def run_test():
+        def run_and_check():
             dev = tvm.cuda(0)
             A_tvm = tvm.runtime.tensor(A_packed, dev)
             B_tvm = tvm.runtime.tensor(B_packed, dev)
@@ -1290,10 +1284,9 @@ def test_gemm_block_scaled_nvfp4_cta_group_1():
             sfa_tvm = tvm.runtime.tensor(sfa_packed, dev)
             sfb_tvm = tvm.runtime.tensor(sfb_packed, dev)
             mod["main"](A_tvm, B_tvm, C_tvm, sfa_tvm, sfb_tvm)
-            dev.sync()
             np.testing.assert_allclose(C_tvm.numpy(), C_ref, atol=1.0, rtol=0.15)
 
-        tvm.testing.run_with_gpu_lock(run_test)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -1491,7 +1484,7 @@ def test_gemm_block_scaled_nvfp4_cta_group_2():
         B_dq = B_fp4.astype(np.float32) * b_scale_f32
         C_ref = np.zeros(C_shape, dtype=C_dtype)
         C_ref[0:M_total, 0:N_total] = A_dq @ B_dq.T
-        def run_test():
+        def run_and_check():
             dev = tvm.cuda(0)
             A_tvm = tvm.runtime.tensor(A_packed, dev)
             B_tvm = tvm.runtime.tensor(B_packed, dev)
@@ -1499,10 +1492,9 @@ def test_gemm_block_scaled_nvfp4_cta_group_2():
             sfa_tvm = tvm.runtime.tensor(sfa_packed, dev)
             sfb_tvm = tvm.runtime.tensor(sfb_packed, dev)
             mod["main"](A_tvm, B_tvm, C_tvm, sfa_tvm, sfb_tvm)
-            dev.sync()
             np.testing.assert_allclose(C_tvm.numpy(), C_ref, atol=1.0, rtol=0.15)
 
-        tvm.testing.run_with_gpu_lock(run_test)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -1709,7 +1701,7 @@ def test_gemm_block_scaled_fp8_sf_id():
                 B_fp8[:, i * MMA_K : (i + 1) * MMA_K].astype(np.float32) * B_scale[:, i : i + 1]
             )
             C_ref[:M, :N] += A_block @ B_block.T
-        def run_test():
+        def run_and_check():
             dev = tvm.cuda(0)
             A_tvm = tvm.runtime.tensor(A_fp8, dev)
             B_tvm = tvm.runtime.tensor(B_fp8, dev)
@@ -1717,10 +1709,9 @@ def test_gemm_block_scaled_fp8_sf_id():
             sfa_tvm = tvm.runtime.tensor(sfa_packed, dev)
             sfb_tvm = tvm.runtime.tensor(sfb_packed, dev)
             mod["main"](A_tvm, B_tvm, C_tvm, sfa_tvm, sfb_tvm)
-            dev.sync()
             np.testing.assert_allclose(C_tvm.numpy(), C_ref, atol=1.0, rtol=0.15)
 
-        tvm.testing.run_with_gpu_lock(run_test)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
         # Sanity: blocks must have different scales (test is meaningless if uniform)
         for i in range(1, num_blocks):
@@ -2001,16 +1992,15 @@ def test_gemm_tcgen05_arbitrary_tiles(task):
             B_np_ref[tuple(r_smem_B_ref)] if transB else B_np_ref[tuple(r_smem_B_ref)].T
         )
         C_ref[tuple(r_tmem_C)] = A_ref @ B_ref
-        def run_test():
+        def run_and_check():
             dev = tvm.cuda(0)
             A_tvm = tvm.runtime.tensor(A_np, dev)
             B_tvm = tvm.runtime.tensor(B_np, dev)
             C_tvm = tvm.runtime.tensor(C_np, dev)
             mod["main"](A_tvm, B_tvm, C_tvm)
-            dev.sync()
             np.testing.assert_allclose(C_tvm.numpy(), C_ref, atol=1e-3, rtol=1e-3)
 
-        tvm.testing.run_with_gpu_lock(run_test)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -2094,14 +2084,13 @@ def test_gemm_tcgen05_contiguous_kslice_partial_k(k_lo, k_hi):
     # Reference: accumulate only k in [k_lo, k_hi).
     C_ref = A_np[:, k_lo:k_hi].astype("float32") @ B_np[:, k_lo:k_hi].astype("float32").T
 
-    def run_test():
+    def run_and_check():
         dev = tvm.cuda(0)
         A_t, B_t, C_t = (tvm.runtime.tensor(x, dev) for x in (A_np, B_np, C_np))
         mod["main"](A_t, B_t, C_t)
-        dev.sync()
         np.testing.assert_allclose(C_t.numpy(), C_ref, atol=1e-2, rtol=1e-2)
 
-    tvm.testing.run_with_gpu_lock(run_test)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 def _run_dense_gemm(
@@ -2193,14 +2182,13 @@ def _run_dense_gemm(
     C_np = np.zeros(C_shape, dtype=C_dtype)
     C_ref = A_np.astype("float32") @ B_np.astype("float32").T
 
-    def run_test():
+    def run_and_check():
         dev = tvm.cuda(0)
         A_t, B_t, C_t = (tvm.runtime.tensor(x, dev) for x in (A_np, B_np, C_np))
         mod["main"](A_t, B_t, C_t)
-        dev.sync()
         np.testing.assert_allclose(C_t.numpy().astype("float32"), C_ref, atol=atol, rtol=rtol)
 
-    tvm.testing.run_with_gpu_lock(run_test)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu

--- a/tests/python/tirx/operator/tile_primitive/cuda/permute_layout/test_permute_layout.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/permute_layout/test_permute_layout.py
@@ -162,10 +162,15 @@ def _compile_and_run(prim_func, np_inputs):
     with target:
         mod = tvm.IRModule({"main": prim_func})
         mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
-    dev = tvm.cuda(0)
-    tensors = [tvm.runtime.tensor(a, dev) for a in np_inputs]
-    mod(*tensors)
-    return [t.numpy() for t in tensors], mod.mod.imports[0].inspect_source()
+
+    def run_test():
+        dev = tvm.cuda(0)
+        tensors = [tvm.runtime.tensor(a, dev) for a in np_inputs]
+        mod(*tensors)
+        return [tensor.numpy() for tensor in tensors]
+
+    outputs = tvm.testing.run_with_gpu_lock(run_test)
+    return outputs, mod.mod.imports[0].inspect_source()
 
 
 @pytest.mark.gpu
@@ -256,6 +261,7 @@ def test_identity_passes_through_as_copy():
     np.random.seed(0)
     A_np = tvm.testing.generate_random_array("uint32", shape)
     B_np = np.zeros_like(A_np)
+
     [_, B_out], _ = _compile_and_run(f, [A_np, B_np])
     np.testing.assert_array_equal(B_out, A_np)
 

--- a/tests/python/tirx/operator/tile_primitive/cuda/permute_layout/test_permute_layout.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/permute_layout/test_permute_layout.py
@@ -163,13 +163,13 @@ def _compile_and_run(prim_func, np_inputs):
         mod = tvm.IRModule({"main": prim_func})
         mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
 
-    def run_test():
+    def run_and_check():
         dev = tvm.cuda(0)
         tensors = [tvm.runtime.tensor(a, dev) for a in np_inputs]
         mod(*tensors)
         return [tensor.numpy() for tensor in tensors]
 
-    outputs = tvm.testing.run_with_gpu_lock(run_test)
+    outputs = tvm.testing.run_with_gpu_lock(run_and_check)
     return outputs, mod.mod.imports[0].inspect_source()
 
 

--- a/tests/python/tirx/operator/tile_primitive/cuda/reduction/test_reduction.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/reduction/test_reduction.py
@@ -125,15 +125,14 @@ def test_reduction_shared(
 
         atol = 1e-5 if dtype == "float32" else 1e-1
 
-        def run_test():
+        def run_and_check():
             dev = tvm.cuda(0)
             A = tvm.runtime.tensor(A_np, dev)
             B = tvm.runtime.tensor(B_np.copy(), dev)
             mod(A, B)
-            dev.sync()
             tvm.testing.assert_allclose(ref, B.numpy()[tuple(reduce_slice_dst)], atol=atol)
 
-        tvm.testing.run_with_gpu_lock(run_test)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -250,15 +249,14 @@ def test_reduction_shared_subscope(exec_scope, op_type, accum):
             if accum:
                 ref = np.minimum(ref, B_np)
 
-        def run_test():
+        def run_and_check():
             dev = tvm.cuda(0)
             A = tvm.runtime.tensor(A_np, dev)
             B = tvm.runtime.tensor(B_np.copy(), dev)
             mod(A, B)
-            dev.sync()
             tvm.testing.assert_allclose(ref, B.numpy(), atol=1e-5)
 
-        tvm.testing.run_with_gpu_lock(run_test)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.parametrize(
@@ -357,15 +355,14 @@ def test_reduction_local_thread_wise(src_shape, dst_shape, axes, op_type, accum)
             if accum:
                 ref = np.minimum(ref, B_np)
 
-        def run_test():
+        def run_and_check():
             dev = tvm.cuda(0)
             A = tvm.runtime.tensor(A_np, dev)
             B = tvm.runtime.tensor(B_np.copy(), dev)
             mod(A, B)
-            dev.sync()
             tvm.testing.assert_allclose(ref.reshape(B_np.shape), B.numpy(), atol=1e-5)
 
-        tvm.testing.run_with_gpu_lock(run_test)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.parametrize(
@@ -495,15 +492,14 @@ def test_reduction_local_view_basic(inner_dims, dst_dims, axes, accum, slice_end
             if accum:
                 ref = np.minimum(ref, B_np)
 
-        def run_test():
+        def run_and_check():
             dev = tvm.cuda(0)
             A = tvm.runtime.tensor(A_np, dev)
             B = tvm.runtime.tensor(B_np.copy(), dev)
             mod(A, B)
-            dev.sync()
             tvm.testing.assert_allclose(ref, B.numpy(), atol=1e-5)
 
-        tvm.testing.run_with_gpu_lock(run_test)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -633,15 +629,14 @@ def test_reduction_local_view_complex(n_groups, n_warps, op_type, dtype, shuffle
 
         atol = 1e-5 if dtype == "float32" else 2e-1
 
-        def run_test():
+        def run_and_check():
             dev = tvm.cuda(0)
             A = tvm.runtime.tensor(A_np, dev)
             B = tvm.runtime.tensor(B_np.copy(), dev)
             mod(A, B)
-            dev.sync()
             tvm.testing.assert_allclose(B_ref, B.numpy(), atol=atol)
 
-        tvm.testing.run_with_gpu_lock(run_test)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -707,15 +702,14 @@ def test_reduction_local_optimized_3input_maxmin(reduction_len, op_type, accum):
             else:
                 B_ref = A_np.min()
 
-        def run_test():
+        def run_and_check():
             dev = tvm.cuda(0)
             A = tvm.runtime.tensor(A_np, dev)
             B = tvm.runtime.tensor(B_np, dev)
             mod(A, B)
-            dev.sync()
             tvm.testing.assert_allclose(B_ref, B.numpy()[0], atol=1e-5)
 
-        tvm.testing.run_with_gpu_lock(run_test)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -773,15 +767,14 @@ def test_reduction_local_optimized_packed_add_sum(reduction_len, accum):
             B_ref = A_np.sum()
 
         # Use larger tolerance due to rounding differences from packed add (add.rz.ftz.f32x2)
-        def run_test():
+        def run_and_check():
             dev = tvm.cuda(0)
             A = tvm.runtime.tensor(A_np, dev)
             B = tvm.runtime.tensor(B_np, dev)
             mod(A, B)
-            dev.sync()
             tvm.testing.assert_allclose(B_ref, B.numpy()[0], atol=1e-4)
 
-        tvm.testing.run_with_gpu_lock(run_test)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -840,15 +833,14 @@ def test_reduction_op_warp_shuffle(op_type, dtype):
         B_ref = np.full(N, ref_val, dtype=dtype)
         atol = 1e-4 if dtype == "float32" else 1e-1
 
-        def run_test():
+        def run_and_check():
             dev = tvm.cuda(0)
             A = tvm.runtime.tensor(A_np, dev)
             B = tvm.runtime.tensor(B_np, dev)
             mod(A, B)
-            dev.sync()
             tvm.testing.assert_allclose(B_ref, B.numpy(), atol=atol)
 
-        tvm.testing.run_with_gpu_lock(run_test)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -914,15 +906,14 @@ def test_reduction_op_warp_shuffle_multi_elem(op_type, dtype):
 
         atol = 1e-4 if dtype == "float32" else 1e-1
 
-        def run_test():
+        def run_and_check():
             dev = tvm.cuda(0)
             A = tvm.runtime.tensor(A_np, dev)
             B = tvm.runtime.tensor(B_np, dev)
             mod(A, B)
-            dev.sync()
             tvm.testing.assert_allclose(B_ref, B.numpy(), atol=atol)
 
-        tvm.testing.run_with_gpu_lock(run_test)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -996,15 +987,14 @@ def test_reduction_warp_shuffle_multi_warp_loop():
         # Each iteration: sum across all N threads
         B_ref = A_np.astype("float64").sum(axis=1).astype("float32")
 
-        def run_test():
+        def run_and_check():
             dev = tvm.cuda(0)
             A_dev = tvm.runtime.tensor(A_np, dev)
             B_dev = tvm.runtime.tensor(B_np, dev)
             mod(A_dev, B_dev)
-            dev.sync()
             tvm.testing.assert_allclose(B_ref, B_dev.numpy(), atol=1e-3)
 
-        tvm.testing.run_with_gpu_lock(run_test)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -1050,15 +1040,14 @@ def test_reduction_warpgroup_wg_local_layout(op_name):
         else:
             B_ref = A_np.max(axis=1, keepdims=True)
 
-        def run_test():
+        def run_and_check():
             dev = tvm.cuda(0)
             A_dev = tvm.runtime.tensor(A_np, dev)
             B_dev = tvm.runtime.tensor(B_np, dev)
             mod(A_dev, B_dev)
-            dev.sync()
             tvm.testing.assert_allclose(B_ref, B_dev.numpy(), atol=1e-5)
 
-        tvm.testing.run_with_gpu_lock(run_test)
+        tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 if __name__ == "__main__":

--- a/tests/python/tirx/operator/tile_primitive/cuda/reduction/test_reduction.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/reduction/test_reduction.py
@@ -50,7 +50,6 @@ from tvm.tirx.layout import R, S, TileLayout, laneid, wg_local_layout
 def test_reduction_shared(
     src_shape, dst_shape, axes, st_src, st_dst, extent_src, extent_dst, op_type, dtype, accum
 ):
-    dev = tvm.cuda(0)
     ndim_src = len(src_shape)
 
     thread_cnt = 32
@@ -105,10 +104,6 @@ def test_reduction_shared(
             B_np = np.random.rand(*dst_shape).astype(dtype) * 0.5
         else:
             B_np = np.zeros(dst_shape, dtype=dtype)
-        A = tvm.runtime.tensor(A_np, dev)
-        B = tvm.runtime.tensor(B_np.copy(), dev)
-        mod(A, B)
-
         A_slice = A_np[tuple(reduce_slice_src)]
         if op_type == "sum":
             ref = A_slice.sum(axis=axes)
@@ -129,7 +124,16 @@ def test_reduction_shared(
                 ref = np.minimum(ref, B_old_slice)
 
         atol = 1e-5 if dtype == "float32" else 1e-1
-        tvm.testing.assert_allclose(ref, B.numpy()[tuple(reduce_slice_dst)], atol=atol)
+
+        def run_test():
+            dev = tvm.cuda(0)
+            A = tvm.runtime.tensor(A_np, dev)
+            B = tvm.runtime.tensor(B_np.copy(), dev)
+            mod(A, B)
+            dev.sync()
+            tvm.testing.assert_allclose(ref, B.numpy()[tuple(reduce_slice_dst)], atol=atol)
+
+        tvm.testing.run_with_gpu_lock(run_test)
 
 
 @pytest.mark.gpu
@@ -139,7 +143,6 @@ def test_reduction_shared(
 @pytest.mark.parametrize("accum", [False, True])
 def test_reduction_shared_subscope(exec_scope, op_type, accum):
     """Test shared reduction at warp/warpgroup/thread exec scope."""
-    dev = tvm.cuda(0)
     dtype = "float32"
     src_shape = (4, 8)
     dst_shape = (4,)
@@ -234,10 +237,6 @@ def test_reduction_shared_subscope(exec_scope, op_type, accum):
         else:
             B_np = np.zeros(dst_shape, dtype=dtype)
 
-        A = tvm.runtime.tensor(A_np, dev)
-        B = tvm.runtime.tensor(B_np.copy(), dev)
-        mod(A, B)
-
         if op_type == "sum":
             ref = A_np.sum(axis=-1)
             if accum:
@@ -251,7 +250,15 @@ def test_reduction_shared_subscope(exec_scope, op_type, accum):
             if accum:
                 ref = np.minimum(ref, B_np)
 
-        tvm.testing.assert_allclose(ref, B.numpy(), atol=1e-5)
+        def run_test():
+            dev = tvm.cuda(0)
+            A = tvm.runtime.tensor(A_np, dev)
+            B = tvm.runtime.tensor(B_np.copy(), dev)
+            mod(A, B)
+            dev.sync()
+            tvm.testing.assert_allclose(ref, B.numpy(), atol=1e-5)
+
+        tvm.testing.run_with_gpu_lock(run_test)
 
 
 @pytest.mark.parametrize(
@@ -275,7 +282,6 @@ def test_reduction_shared_subscope(exec_scope, op_type, accum):
 @pytest.mark.parametrize("accum", [False, True])
 def test_reduction_local_thread_wise(src_shape, dst_shape, axes, op_type, accum):
     """Test thread-wise local reduction with various shapes and axes."""
-    dev = tvm.cuda(0)
     dtype = "float32"
     src_total = 1
     for s in src_shape:
@@ -338,10 +344,6 @@ def test_reduction_local_thread_wise(src_shape, dst_shape, axes, op_type, accum)
         else:
             B_np = np.zeros(dst_shape, dtype=dtype)
 
-        A = tvm.runtime.tensor(A_np, dev)
-        B = tvm.runtime.tensor(B_np.copy(), dev)
-        mod(A, B)
-
         if op_type == "sum":
             ref = A_np.sum(axis=axes)
             if accum:
@@ -355,7 +357,15 @@ def test_reduction_local_thread_wise(src_shape, dst_shape, axes, op_type, accum)
             if accum:
                 ref = np.minimum(ref, B_np)
 
-        tvm.testing.assert_allclose(ref.reshape(B_np.shape), B.numpy(), atol=1e-5)
+        def run_test():
+            dev = tvm.cuda(0)
+            A = tvm.runtime.tensor(A_np, dev)
+            B = tvm.runtime.tensor(B_np.copy(), dev)
+            mod(A, B)
+            dev.sync()
+            tvm.testing.assert_allclose(ref.reshape(B_np.shape), B.numpy(), atol=1e-5)
+
+        tvm.testing.run_with_gpu_lock(run_test)
 
 
 @pytest.mark.parametrize(
@@ -379,7 +389,6 @@ def test_reduction_local_thread_wise(src_shape, dst_shape, axes, op_type, accum)
 @pytest.mark.parametrize("op_type", ["sum", "max", "min"])
 def test_reduction_local_view_basic(inner_dims, dst_dims, axes, accum, slice_end, op_type):
     """Test view-based local reduction with simple purely-local layouts."""
-    dev = tvm.cuda(0)
     dtype = "float32"
     thread_cnt = 32
 
@@ -472,10 +481,6 @@ def test_reduction_local_view_basic(inner_dims, dst_dims, axes, accum, slice_end
         else:
             B_np = np.zeros(dst_shape, dtype=dtype)
 
-        A = tvm.runtime.tensor(A_np, dev)
-        B = tvm.runtime.tensor(B_np.copy(), dev)
-        mod(A, B)
-
         A_data = A_np[:, slice_end // 2 : slice_end] if slice_end is not None else A_np
         if op_type == "sum":
             ref = A_data.sum(axis=axes, keepdims=True)
@@ -490,7 +495,15 @@ def test_reduction_local_view_basic(inner_dims, dst_dims, axes, accum, slice_end
             if accum:
                 ref = np.minimum(ref, B_np)
 
-        tvm.testing.assert_allclose(ref, B.numpy(), atol=1e-5)
+        def run_test():
+            dev = tvm.cuda(0)
+            A = tvm.runtime.tensor(A_np, dev)
+            B = tvm.runtime.tensor(B_np.copy(), dev)
+            mod(A, B)
+            dev.sync()
+            tvm.testing.assert_allclose(ref, B.numpy(), atol=1e-5)
+
+        tvm.testing.run_with_gpu_lock(run_test)
 
 
 @pytest.mark.gpu
@@ -504,7 +517,6 @@ def test_reduction_local_view_complex(n_groups, n_warps, op_type, dtype, shuffle
     """Test view-based local reduction with wgmma layouts and optional shuffle."""
     if not shuffle and accum:
         pytest.skip("accum without shuffle is not supported in current implementation")
-    dev = tvm.cuda(0)
     thread_cnt = 32
     NUM_COL = 128
     g_shape_a = (16 * n_warps, NUM_COL)
@@ -598,10 +610,6 @@ def test_reduction_local_view_complex(n_groups, n_warps, op_type, dtype, shuffle
             B_np = np.random.rand(*g_shape_b).astype(dtype) * 0.5
         else:
             B_np = np.zeros(g_shape_b, dtype=dtype)
-        A = tvm.runtime.tensor(A_np, dev)
-        B = tvm.runtime.tensor(B_np.copy(), dev)
-        mod(A, B)
-
         if op_type == "sum":
             row_reduce = A_np.sum(axis=-1)
             if accum:
@@ -624,7 +632,16 @@ def test_reduction_local_view_complex(n_groups, n_warps, op_type, dtype, shuffle
             raise ValueError(f"Unsupported op_type: {op_type}")
 
         atol = 1e-5 if dtype == "float32" else 2e-1
-        tvm.testing.assert_allclose(B_ref, B.numpy(), atol=atol)
+
+        def run_test():
+            dev = tvm.cuda(0)
+            A = tvm.runtime.tensor(A_np, dev)
+            B = tvm.runtime.tensor(B_np.copy(), dev)
+            mod(A, B)
+            dev.sync()
+            tvm.testing.assert_allclose(B_ref, B.numpy(), atol=atol)
+
+        tvm.testing.run_with_gpu_lock(run_test)
 
 
 @pytest.mark.gpu
@@ -634,7 +651,6 @@ def test_reduction_local_view_complex(n_groups, n_warps, op_type, dtype, shuffle
 @pytest.mark.parametrize("accum", [False, True])
 def test_reduction_local_optimized_3input_maxmin(reduction_len, op_type, accum):
     """Test thread-level local buffer reduction with 3-input max/min PTX intrinsics."""
-    dev = tvm.cuda(0)
     dtype = "float32"
 
     # fmt: off
@@ -680,10 +696,6 @@ def test_reduction_local_optimized_3input_maxmin(reduction_len, op_type, accum):
         else:
             B_np = np.zeros(1, dtype=dtype)
 
-        A = tvm.runtime.tensor(A_np, dev)
-        B = tvm.runtime.tensor(B_np, dev)
-        mod(A, B)
-
         if op_type == "max":
             if accum:
                 B_ref = max(A_np.max(), 0.5)
@@ -695,7 +707,15 @@ def test_reduction_local_optimized_3input_maxmin(reduction_len, op_type, accum):
             else:
                 B_ref = A_np.min()
 
-        tvm.testing.assert_allclose(B_ref, B.numpy()[0], atol=1e-5)
+        def run_test():
+            dev = tvm.cuda(0)
+            A = tvm.runtime.tensor(A_np, dev)
+            B = tvm.runtime.tensor(B_np, dev)
+            mod(A, B)
+            dev.sync()
+            tvm.testing.assert_allclose(B_ref, B.numpy()[0], atol=1e-5)
+
+        tvm.testing.run_with_gpu_lock(run_test)
 
 
 @pytest.mark.gpu
@@ -704,7 +724,6 @@ def test_reduction_local_optimized_3input_maxmin(reduction_len, op_type, accum):
 @pytest.mark.parametrize("accum", [False, True])
 def test_reduction_local_optimized_packed_add_sum(reduction_len, accum):
     """Test thread-level sum reduction using packed add with add.f32x2 PTX instruction."""
-    dev = tvm.cuda(0)
     dtype = "float32"
 
     # fmt: off
@@ -748,17 +767,21 @@ def test_reduction_local_optimized_packed_add_sum(reduction_len, accum):
         else:
             B_np = np.zeros(1, dtype=dtype)
 
-        A = tvm.runtime.tensor(A_np, dev)
-        B = tvm.runtime.tensor(B_np, dev)
-        mod(A, B)
-
         if accum:
             B_ref = A_np.sum() + 0.5
         else:
             B_ref = A_np.sum()
 
         # Use larger tolerance due to rounding differences from packed add (add.rz.ftz.f32x2)
-        tvm.testing.assert_allclose(B_ref, B.numpy()[0], atol=1e-4)
+        def run_test():
+            dev = tvm.cuda(0)
+            A = tvm.runtime.tensor(A_np, dev)
+            B = tvm.runtime.tensor(B_np, dev)
+            mod(A, B)
+            dev.sync()
+            tvm.testing.assert_allclose(B_ref, B.numpy()[0], atol=1e-4)
+
+        tvm.testing.run_with_gpu_lock(run_test)
 
 
 @pytest.mark.gpu
@@ -770,7 +793,6 @@ def test_reduction_op_warp_shuffle(op_type, dtype):
 
     Case A: full warp reduce (32 lanes → 1 value, replicated to all lanes).
     """
-    dev = tvm.cuda(0)
     N = 32
     g_shape = (N,)
     g_layout = TileLayout(S[N])
@@ -810,10 +832,6 @@ def test_reduction_op_warp_shuffle(op_type, dtype):
         np.random.seed(0)
         A_np = np.random.rand(N).astype(dtype)
         B_np = np.zeros(N, dtype=dtype)
-        A = tvm.runtime.tensor(A_np, dev)
-        B = tvm.runtime.tensor(B_np, dev)
-        mod(A, B)
-
         if op_type == "sum":
             ref_val = A_np.astype("float64").sum()
         elif op_type == "max":
@@ -821,7 +839,16 @@ def test_reduction_op_warp_shuffle(op_type, dtype):
 
         B_ref = np.full(N, ref_val, dtype=dtype)
         atol = 1e-4 if dtype == "float32" else 1e-1
-        tvm.testing.assert_allclose(B_ref, B.numpy(), atol=atol)
+
+        def run_test():
+            dev = tvm.cuda(0)
+            A = tvm.runtime.tensor(A_np, dev)
+            B = tvm.runtime.tensor(B_np, dev)
+            mod(A, B)
+            dev.sync()
+            tvm.testing.assert_allclose(B_ref, B.numpy(), atol=atol)
+
+        tvm.testing.run_with_gpu_lock(run_test)
 
 
 @pytest.mark.gpu
@@ -833,7 +860,6 @@ def test_reduction_op_warp_shuffle_multi_elem(op_type, dtype):
 
     Each thread holds 4 elements, reduce across 32 lanes for each element group.
     """
-    dev = tvm.cuda(0)
     ELEMS_PER_THREAD = 4
     N_LANES = 32
     TOTAL = ELEMS_PER_THREAD * N_LANES  # 128
@@ -879,10 +905,6 @@ def test_reduction_op_warp_shuffle_multi_elem(op_type, dtype):
         np.random.seed(0)
         A_np = np.random.rand(TOTAL).astype(dtype)
         B_np = np.zeros(ELEMS_PER_THREAD, dtype=dtype)
-        A = tvm.runtime.tensor(A_np, dev)
-        B = tvm.runtime.tensor(B_np, dev)
-        mod(A, B)
-
         # Each group of 4 elements: element j is sum/max of A[j], A[j+4], A[j+8], ..., A[j+124]
         A_reshaped = A_np.reshape(N_LANES, ELEMS_PER_THREAD)
         if op_type == "sum":
@@ -891,7 +913,16 @@ def test_reduction_op_warp_shuffle_multi_elem(op_type, dtype):
             B_ref = A_reshaped.max(axis=0)
 
         atol = 1e-4 if dtype == "float32" else 1e-1
-        tvm.testing.assert_allclose(B_ref, B.numpy(), atol=atol)
+
+        def run_test():
+            dev = tvm.cuda(0)
+            A = tvm.runtime.tensor(A_np, dev)
+            B = tvm.runtime.tensor(B_np, dev)
+            mod(A, B)
+            dev.sync()
+            tvm.testing.assert_allclose(B_ref, B.numpy(), atol=atol)
+
+        tvm.testing.run_with_gpu_lock(run_test)
 
 
 @pytest.mark.gpu
@@ -902,7 +933,6 @@ def test_reduction_warp_shuffle_multi_warp_loop():
     Validates the scope alternation pattern (thread → warp → thread) inside a loop,
     which is needed for replacing manual warp shuffle reductions in tirx-kernels.
     """
-    dev = tvm.cuda(0)
     BDX = 32
     BDY = 4
     N = BDX * BDY  # 128
@@ -963,13 +993,18 @@ def test_reduction_warp_shuffle_multi_warp_loop():
         np.random.seed(42)
         A_np = np.random.rand(N_ITER, N).astype("float32")
         B_np = np.zeros(N_ITER, dtype="float32")
-        A_dev = tvm.runtime.tensor(A_np, dev)
-        B_dev = tvm.runtime.tensor(B_np, dev)
-        mod(A_dev, B_dev)
-
         # Each iteration: sum across all N threads
         B_ref = A_np.astype("float64").sum(axis=1).astype("float32")
-        tvm.testing.assert_allclose(B_ref, B_dev.numpy(), atol=1e-3)
+
+        def run_test():
+            dev = tvm.cuda(0)
+            A_dev = tvm.runtime.tensor(A_np, dev)
+            B_dev = tvm.runtime.tensor(B_np, dev)
+            mod(A_dev, B_dev)
+            dev.sync()
+            tvm.testing.assert_allclose(B_ref, B_dev.numpy(), atol=1e-3)
+
+        tvm.testing.run_with_gpu_lock(run_test)
 
 
 @pytest.mark.gpu
@@ -978,7 +1013,6 @@ def test_reduction_warp_shuffle_multi_warp_loop():
 def test_reduction_warpgroup_wg_local_layout(op_name):
     rows, cols = 128, 16
     dtype = "float32"
-    dev = tvm.cuda(0)
     target = tvm.target.Target("cuda")
 
     @T.prim_func
@@ -1004,21 +1038,27 @@ def test_reduction_warpgroup_wg_local_layout(op_name):
         B[tid, 0] = dst_local[0]
 
     with target:
+        mod = tvm.IRModule({"main": test_func})
+        mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
+
         np.random.seed(0)
         A_np = np.random.rand(rows, cols).astype(dtype)
         B_np = np.zeros((rows, 1), dtype=dtype)
-        A_dev = tvm.runtime.tensor(A_np, dev)
-        B_dev = tvm.runtime.tensor(B_np, dev)
-
-        mod = tvm.IRModule({"main": test_func})
-        mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
-        mod(A_dev, B_dev)
 
         if op_name == "sum":
             B_ref = A_np.sum(axis=1, keepdims=True)
         else:
             B_ref = A_np.max(axis=1, keepdims=True)
-        tvm.testing.assert_allclose(B_ref, B_dev.numpy(), atol=1e-5)
+
+        def run_test():
+            dev = tvm.cuda(0)
+            A_dev = tvm.runtime.tensor(A_np, dev)
+            B_dev = tvm.runtime.tensor(B_np, dev)
+            mod(A_dev, B_dev)
+            dev.sync()
+            tvm.testing.assert_allclose(B_ref, B_dev.numpy(), atol=1e-5)
+
+        tvm.testing.run_with_gpu_lock(run_test)
 
 
 if __name__ == "__main__":

--- a/tests/python/tirx/test_bench_utils.py
+++ b/tests/python/tirx/test_bench_utils.py
@@ -19,6 +19,8 @@
 import pytest
 import torch
 
+import tvm.testing
+
 pytest.importorskip("triton")  # tvm.tirx.bench imports triton.profiler
 
 from tvm.testing import env
@@ -104,9 +106,12 @@ def test_bench_basic():
         B = torch.randn(M, N, device="cuda", dtype=torch.float16)
         return (A, B), tensor_bytes(A, B)
 
-    results = bench(funcs, make_input, warmup=5, repeat=10, cooldown_s=0.0, timer="event")
-    assert "matmul" in results["impls"]
-    assert results["impls"]["matmul"] > 0
+    def run_and_check():
+        results = bench(funcs, make_input, warmup=5, repeat=10, cooldown_s=0.0, timer="event")
+        assert "matmul" in results["impls"]
+        assert results["impls"]["matmul"] > 0
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -126,9 +131,12 @@ def test_bench_multiple_impls():
         B = torch.randn(M, N, device="cuda", dtype=torch.float16)
         return (A, B), tensor_bytes(A, B)
 
-    results = bench(funcs, make_input, warmup=5, repeat=10, cooldown_s=0.0, timer="event")
-    assert set(results["impls"].keys()) == {"mm", "addmm"}
-    assert all(v > 0 for v in results["impls"].values())
+    def run_and_check():
+        results = bench(funcs, make_input, warmup=5, repeat=10, cooldown_s=0.0, timer="event")
+        assert set(results["impls"].keys()) == {"mm", "addmm"}
+        assert all(v > 0 for v in results["impls"].values())
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -145,11 +153,21 @@ def test_bench_multiple_input_groups():
         return (A, B), tensor_bytes(A, B)
 
     funcs = {"mm": lambda case: torch.mm(case[0], case[1])}
-    results = bench(
-        funcs, make_input, warmup=5, repeat=20, cooldown_s=0.0, timer="event", l2_bytes=64 * 1024
-    )
-    assert results["impls"]["mm"] > 0
-    assert call_count[0] > 1
+
+    def run_and_check():
+        results = bench(
+            funcs,
+            make_input,
+            warmup=5,
+            repeat=20,
+            cooldown_s=0.0,
+            timer="event",
+            l2_bytes=64 * 1024,
+        )
+        assert results["impls"]["mm"] > 0
+        assert call_count[0] > 1
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 # ── _compute_group_count ───────────────────────────────────────────────────
@@ -184,13 +202,16 @@ def test_compute_groups_moderate_tensors():
 def test_bench_legacy_callable_api():
     """bench still accepts the existing single-callable API used by TIRx tests."""
     M, N = 128, 128
-    A = torch.randn(M, N, device="cuda", dtype=torch.float16)
-    B = torch.randn(M, N, device="cuda", dtype=torch.float16)
 
-    result = bench(
-        lambda: torch.mm(A, B), warmup=1, repeat=2, proton_name="legacy", flush_l2_size=1
-    )
-    assert result > 0
+    def run_and_check():
+        A = torch.randn(M, N, device="cuda", dtype=torch.float16)
+        B = torch.randn(M, N, device="cuda", dtype=torch.float16)
+        result = bench(
+            lambda: torch.mm(A, B), warmup=1, repeat=2, proton_name="legacy", flush_l2_size=1
+        )
+        assert result > 0
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu
@@ -210,10 +231,14 @@ def test_bench_callable_inputs():
         return case, tensor_bytes(*case)
 
     funcs = {"mm": lambda case: torch.mm(case[0], case[1])}
-    results = bench(funcs, make_input, warmup=5, repeat=10, cooldown_s=0.0, timer="event")
-    assert "mm" in results["impls"]
-    assert results["impls"]["mm"] > 0
-    assert call_count[0] >= 2  # at least 2 groups created
+
+    def run_and_check():
+        results = bench(funcs, make_input, warmup=5, repeat=10, cooldown_s=0.0, timer="event")
+        assert "mm" in results["impls"]
+        assert results["impls"]["mm"] > 0
+        assert call_count[0] >= 2  # at least 2 groups created
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 if __name__ == "__main__":

--- a/tests/python/tirx/test_buffer_print.py
+++ b/tests/python/tirx/test_buffer_print.py
@@ -384,12 +384,12 @@ def test_print():
         test_const_scalar(np.int32, "int32"),
     ]
 
-    def run():
+    def run_and_check():
         device = tvm.cuda()
         for runner in runners:
             runner(device)
 
-    tvm.testing.run_with_gpu_lock(run)
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 if __name__ == "__main__":

--- a/tests/python/tirx/test_buffer_print.py
+++ b/tests/python/tirx/test_buffer_print.py
@@ -35,10 +35,13 @@ def create_tvm_arrays(data_np, device):
     return [tvm.runtime.tensor(data, device=device) for data in data_np]
 
 
-def build_and_run_tvm_func(sch, target, *args):
-    func = tvm.compile(sch.mod, target=target)
-    func(*args)
-    return func, args[-1]
+def make_tvm_runner(func, input_data, initial_output, expected_output):
+    def run(device):
+        args = create_tvm_arrays([*input_data, initial_output], device)
+        func(*args)
+        verify_result(args[-1], expected_output)
+
+    return run
 
 
 def from_source(code):
@@ -186,7 +189,6 @@ def verify_cuda_code_string(func, expected_var_name, expected_string_literal):
 @pytest.mark.gpu
 @pytest.mark.skipif(not env.has_cuda(), reason="need cuda")
 def test_print():
-    DEV = tvm.cuda()
     target = tvm.target.Target("cuda")
 
     def test_vector_add_1D(dtype, dtype_str):
@@ -195,7 +197,6 @@ def test_print():
         dim_num = 1
         A_np, B_np = generate_random_data((M,), dtype), generate_random_data((M,), dtype)
         C_np = A_np + B_np
-        A_tvm, B_tvm = create_tvm_arrays([A_np, B_np], DEV)
 
         @T.prim_func(s_tir=True)
         def add_func(A_ptr: T.handle, B_ptr: T.handle, C_ptr: T.handle) -> None:
@@ -219,11 +220,10 @@ def test_print():
         sch.bind(i1, "threadIdx.x")
 
         C_np_tmp = np.zeros((M,), dtype=dtype)
-        C_tvm = tvm.runtime.tensor(C_np_tmp, device=DEV)
-        func, C_tvm = build_and_run_tvm_func(sch, target, A_tvm, B_tvm, C_tvm)
-        verify_result(C_tvm, C_np)
+        func = tvm.compile(sch.mod, target=target)
         verify_tir_code(add_func.script())
         verify_cuda_code_array(func, dim_num, dtype_str, M)
+        return make_tvm_runner(func, [A_np, B_np], C_np_tmp, C_np)
 
     def test_vector_add_2D(dtype, dtype_str):
         M, N = 6, 6
@@ -231,7 +231,6 @@ def test_print():
         dim_num = 2
         A_np, B_np = generate_random_data((M, N), dtype), generate_random_data((M, N), dtype)
         C_np = A_np + B_np
-        A_tvm, B_tvm = create_tvm_arrays([A_np, B_np], DEV)
 
         @T.prim_func(s_tir=True)
         def add_func(A_ptr: T.handle, B_ptr: T.handle, C_ptr: T.handle) -> None:
@@ -259,11 +258,10 @@ def test_print():
         sch.bind(j1, "threadIdx.y")
 
         C_np_tmp = np.zeros((M, N), dtype=dtype)
-        C_tvm = tvm.runtime.tensor(C_np_tmp, device=DEV)
-        func, C_tvm = build_and_run_tvm_func(sch, target, A_tvm, B_tvm, C_tvm)
-        verify_result(C_tvm, C_np)
+        func = tvm.compile(sch.mod, target=target)
         verify_tir_code(add_func.script())
         verify_cuda_code_array(func, dim_num, dtype_str, M, N)
+        return make_tvm_runner(func, [A_np, B_np], C_np_tmp, C_np)
 
     def test_vector_add_3D(dtype, dtype_str):
         M, N, K = 6, 6, 6
@@ -271,8 +269,6 @@ def test_print():
         dim_num = 3
         A_np, B_np = generate_random_data((M, N, K), dtype), generate_random_data((M, N, K), dtype)
         C_np = A_np + B_np
-
-        A_tvm, B_tvm = create_tvm_arrays([A_np, B_np], DEV)
 
         @T.prim_func(s_tir=True)
         def add_func(A_ptr: T.handle, B_ptr: T.handle, C_ptr: T.handle) -> None:
@@ -304,11 +300,10 @@ def test_print():
         sch.bind(k1, "threadIdx.z")
 
         C_np_tmp = np.zeros((M, N, K), dtype=dtype)
-        C_tvm = tvm.runtime.tensor(C_np_tmp, device=DEV)
-        func, C_tvm = build_and_run_tvm_func(sch, target, A_tvm, B_tvm, C_tvm)
-        verify_result(C_tvm, C_np)
+        func = tvm.compile(sch.mod, target=target)
         verify_tir_code(add_func.script())
         verify_cuda_code_array(func, dim_num, dtype_str, M, N, K)
+        return make_tvm_runner(func, [A_np, B_np], C_np_tmp, C_np)
 
     def test_const_scalar(dtype, dtype_str):
         M = 6
@@ -316,7 +311,6 @@ def test_print():
         dim_num = 1
         A_np, B_np = generate_random_data((M,), dtype), generate_random_data((M,), dtype)
         C_np = A_np + B_np
-        A_tvm, B_tvm = create_tvm_arrays([A_np, B_np], DEV)
 
         @T.prim_func(s_tir=True)
         def add_func(A_ptr: T.handle, B_ptr: T.handle, C_ptr: T.handle) -> None:
@@ -341,11 +335,10 @@ def test_print():
         sch.bind(i1, "threadIdx.x")
 
         C_np_tmp = np.zeros((M,), dtype=dtype)
-        C_tvm = tvm.runtime.tensor(C_np_tmp, device=DEV)
-        func, C_tvm = build_and_run_tvm_func(sch, target, A_tvm, B_tvm, C_tvm)
-        verify_result(C_tvm, C_np)
+        func = tvm.compile(sch.mod, target=target)
         verify_tir_code(add_func.script())
         verify_cuda_code_scalar(func, dtype_str, 10)
+        return make_tvm_runner(func, [A_np, B_np], C_np_tmp, C_np)
 
     def test_string(dtype, dtype_str, test_string):
         M = 6
@@ -353,7 +346,6 @@ def test_print():
         dim_num = 1
         A_np, B_np = generate_random_data((M,), dtype), generate_random_data((M,), dtype)
         C_np = A_np + B_np
-        A_tvm, B_tvm = create_tvm_arrays([A_np, B_np], DEV)
 
         @T.prim_func(s_tir=True)
         def add_func(A_ptr: T.handle, B_ptr: T.handle, C_ptr: T.handle) -> None:
@@ -378,19 +370,27 @@ def test_print():
         sch.bind(i1, "threadIdx.x")
 
         C_np_tmp = np.zeros((M,), dtype=dtype)
-        C_tvm = tvm.runtime.tensor(C_np_tmp, device=DEV)
-        func, C_tvm = build_and_run_tvm_func(sch, target, A_tvm, B_tvm, C_tvm)
-        verify_result(C_tvm, C_np)
+        func = tvm.compile(sch.mod, target=target)
         verify_tir_code(add_func.script())
         verify_cuda_code_string(func, "string_var", test_string)
+        return make_tvm_runner(func, [A_np, B_np], C_np_tmp, C_np)
 
-    test_vector_add_1D(np.float32, "float32")
-    test_vector_add_2D(np.int32, "int32")
-    test_vector_add_2D(np.float16, "float16")
-    test_vector_add_3D(np.uint32, "uint32")
-    test_string(np.float32, "float32", "hello tirx!")
-    test_const_scalar(np.int32, "int32")
+    runners = [
+        test_vector_add_1D(np.float32, "float32"),
+        test_vector_add_2D(np.int32, "int32"),
+        test_vector_add_2D(np.float16, "float16"),
+        test_vector_add_3D(np.uint32, "uint32"),
+        test_string(np.float32, "float32", "hello tirx!"),
+        test_const_scalar(np.int32, "int32"),
+    ]
+
+    def run():
+        device = tvm.cuda()
+        for runner in runners:
+            runner(device)
+
+    tvm.testing.run_with_gpu_lock(run)
 
 
 if __name__ == "__main__":
-    test_print()
+    tvm.testing.main()

--- a/tests/python/tirx/test_control_flow.py
+++ b/tests/python/tirx/test_control_flow.py
@@ -23,15 +23,20 @@ from tvm.testing import env
 
 
 def run_test_break_continue(func, shape, expected):
-    dev = tvm.cuda(0)
     target = tvm.target.Target("cuda")
     mod = tvm.IRModule({"main": func})
     with target:
         mod = tvm.compile(mod, target=target, tir_pipeline="tirx")
     arr_np = np.zeros(shape, dtype="int32")
-    arr = tvm.runtime.tensor(arr_np, device=dev)
-    mod(arr)
-    np.testing.assert_allclose(arr.numpy(), expected)
+
+    def run_and_check():
+        dev = tvm.cuda(0)
+        arr = tvm.runtime.tensor(arr_np, device=dev)
+        mod(arr)
+        dev.sync()
+        np.testing.assert_allclose(arr.numpy(), expected)
+
+    tvm.testing.run_with_gpu_lock(run_and_check)
 
 
 @pytest.mark.gpu

--- a/tests/python/tirx/test_control_flow.py
+++ b/tests/python/tirx/test_control_flow.py
@@ -33,7 +33,6 @@ def run_test_break_continue(func, shape, expected):
         dev = tvm.cuda(0)
         arr = tvm.runtime.tensor(arr_np, device=dev)
         mod(arr)
-        dev.sync()
         np.testing.assert_allclose(arr.numpy(), expected)
 
     tvm.testing.run_with_gpu_lock(run_and_check)


### PR DESCRIPTION
Add tvm.testing.run_with_gpu_lock backed by the existing tvm_ffi.utils.FileLock. Migrate live local GPU tests to acquire the machine-local lock around device execution, synchronization, host transfer, and checks while leaving target construction and compilation outside the critical section.

Replace the custom xdist scheduler with standard xdist_group placement for the order-dependent test family. RPC tests retain dynamic port allocation and per-test process isolation rather than gaining a broad category lock.

