### PR TITLE
[CI] Restore dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#about-the-dependabotyml-file
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 0
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
Restore the Dependabot version-update configuration removed during the stale GitHub automation cleanup.\n\nThis re-adds the prior npm and pip monthly update entries with open pull requests limited to 0, preserving the previous rate-control behavior.