### PR TITLE
[Fix] Add `origins` option to `requestFileHandle`

### DIFF
--- a/web/src/artifact_cache.ts
+++ b/web/src/artifact_cache.ts
@@ -189,7 +189,7 @@ class CrossOriginStorage {
     if (!api) {
       throw new Error("Cross-origin storage API unavailable.");
     }
-    const handle = await api.requestFileHandle(hash, { create: true, origins: "*" });
+    const handle = await api.requestFileHandle(hash, { create: true, origins: "*" /* All origins */ });
     if (!handle) {
       throw new Error("Cross-origin storage API returned no handle.");
     }

--- a/web/src/artifact_cache.ts
+++ b/web/src/artifact_cache.ts
@@ -188,7 +188,7 @@ class CrossOriginStorage {
     if (!api) {
       throw new Error("Cross-origin storage API unavailable.");
     }
-    const handle = await api.requestFileHandle(hash, { create: true });
+    const handle = await api.requestFileHandle(hash, { create: true, origins: "*" });
     if (!handle) {
       throw new Error("Cross-origin storage API returned no handle.");
     }

--- a/web/src/artifact_cache.ts
+++ b/web/src/artifact_cache.ts
@@ -111,6 +111,7 @@ interface CrossOriginStorageHandle {
 
 interface CrossOriginStorageRequestFileHandleOptions {
   create?: boolean;
+  origins?: string[] | string | undefined;
 }
 
 interface CrossOriginStorageWritable {


### PR DESCRIPTION
This makes the resources available globally. Initially this wasn't implemented in the extension, but the origins check is implemented now, so we need to update the code to make use of it. (Internally, the extension as a one-off upgrades all resources that were stored already as origins: '*'.)