### PR TITLE
[Fix][Relax][ONNX] Import TopK indices as int64

### DIFF
--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -4413,14 +4413,14 @@ class TopK(OnnxOpConverter):
         if sorted != 1:
             raise ValueError("TopK sorted must be 1 for Relax frontend")
 
-        return relax.op.topk(data, k, axis, ret_type="both", largest=largest)
+        return relax.op.topk(data, k, axis, ret_type="both", largest=largest, dtype="int64")
 
     @classmethod
     def _impl_v1(cls, bb, inputs, attr, params):
         data = inputs[0]
         k = attr.get("k", 1)
         axis = attr.get("axis", -1)
-        return relax.op.topk(data, k, axis, ret_type="both")
+        return relax.op.topk(data, k, axis, ret_type="both", dtype="int64")
 
 
 class SkipLayerNormalization(OnnxOpConverter):

--- a/tests/python/relax/test_frontend_onnx.py
+++ b/tests/python/relax/test_frontend_onnx.py
@@ -5258,7 +5258,7 @@ def test_topk(axis: int, largest: int):
     )
     model = helper.make_model(graph, producer_name="topk_test")
 
-    check_correctness(model)
+    check_correctness(model, check_dtypes=True)
 
 
 def test_expand():
@@ -6563,7 +6563,9 @@ def test_pad(dynamic):
             if axes is not None:
                 axes = np.array(axes, dtype=np.int64)
                 node_inputs = ["input", "pads", "", "axes"]
-                initializer.append(helper.make_tensor("axes", TensorProto.INT64, (len(axes),), axes))
+                initializer.append(
+                    helper.make_tensor("axes", TensorProto.INT64, (len(axes),), axes)
+                )
 
             node = helper.make_node("Pad", inputs=node_inputs, outputs=["output"], mode=mode)
             graph = helper.make_graph(
@@ -6628,7 +6630,9 @@ def test_pad(dynamic):
         verify_pad(
             input_shape,
             pads,
-            _make_pad_expected_ir(input_shape, pads, mode=mode, value=value, opset=opset, axes=axes),
+            _make_pad_expected_ir(
+                input_shape, pads, mode=mode, value=value, opset=opset, axes=axes
+            ),
             mode,
             value,
             opset,


### PR DESCRIPTION
Fixes #19972

ONNX specifies that the second output of TopK, `indices`, has element type `int64`, and the ONNX TopK operator spec constrains the index tensor type to `tensor(int64)`: https://onnx.ai/onnx/operators/onnx__TopK.html

The Relax ONNX frontend previously called `relax.op.topk` without specifying the output indices dtype, so Relax used its default `int32` indices.

This can make otherwise valid ONNX graphs fail during import when the TopK indices are consumed by later integer/index operations that use ONNX's usual `int64` constants.  One example is `TopK -> Div`, where Relax rejects the binary operation because the imported TopK indices are `int32` while the divisor is `int64`.

This patch passes `dtype="int64"` when importing ONNX TopK, matching the ONNX operator spec.  It also updates the existing TopK frontend test to check output dtypes, so the imported indices must match ONNX Runtime's `int64` output.

Verification:

- `uv run --no-sync python -m pytest tests/python/relax/test_frontend_onnx.py::test_topk -q`
