### PR TITLE
[CI] Enable parallel GitHub Actions wheel builds

### DIFF
--- a/.github/actions/detect-env-vars/action.yml
+++ b/.github/actions/detect-env-vars/action.yml
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Detect Environment Variables
+description: Detects environment variables such as CPU count and sets them as outputs.
+runs:
+  using: "composite"
+  steps:
+    - name: Run Python to detect environment variables
+      shell: python
+      id: detect
+      run: |
+        import multiprocessing, os
+
+        output_file = open(os.environ.get("GITHUB_OUTPUT"), "a")
+
+        def write_env_var(name, value):
+            output_file.write(f"{name}={value}\n")
+            print(f"Detected environment variable: {name}={value}")
+
+        write_env_var("cpu_count", multiprocessing.cpu_count())
+
+outputs:
+  cpu_count:
+    description: "The number of CPU cores"
+    value: ${{ steps.detect.outputs.cpu_count }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,8 +47,13 @@ jobs:
           submodules: 'recursive'
       - name: Set up environment
         uses: ./.github/actions/setup
+      - name: Detect environment variables
+        uses: ./.github/actions/detect-env-vars
+        id: env_vars
       - name: Build TVM wheel
         shell: bash -l {0}
+        env:
+          CMAKE_BUILD_PARALLEL_LEVEL: ${{ steps.env_vars.outputs.cpu_count }}
         run: |
           pip install scikit-build-core
           export CMAKE_ARGS="-DUSE_LLVM=ON -DBUILD_TESTING=OFF"
@@ -93,8 +98,13 @@ jobs:
           submodules: 'recursive'
       - name: Set up environment
         uses: ./.github/actions/setup
+      - name: Detect environment variables
+        uses: ./.github/actions/detect-env-vars
+        id: env_vars
       - name: Install TVM
         shell: cmd /C call {0}
+        env:
+          CMAKE_BUILD_PARALLEL_LEVEL: ${{ steps.env_vars.outputs.cpu_count }}
         run: |
           pip install scikit-build-core
           set CMAKE_ARGS=-DUSE_LLVM=ON -DBUILD_TESTING=OFF


### PR DESCRIPTION
This PR enables parallel TVM wheel builds on macOS and Windows GitHub Actions by detecting the available CPU count and passing it to CMake through CMAKE_BUILD_PARALLEL_LEVEL.