### PR TITLE
[Fix][Python] Use standard scikit-build directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ dev = [{ include-group = "test" }, { include-group = "lint" }]
 [tool.scikit-build]
 cmake.build-type = "Release"
 wheel.py-api = "py3"
-build-dir = "build/{wheel_tag}"
+build-dir = "build"
 
 # Wheel configuration
 wheel.packages = ["python/tvm"]


### PR DESCRIPTION
This PR removes `{wheel_tag}` from the scikit-build build directory, solving the issue #19987 mentioned

Each cibuildwheel matrix job runs in an isolated environment, so separate tagged build directories are unnecessary. Using `build` restores the existing `build/lib` development layout expected by `tvm.libinfo` and fixes editable installs without adding runtime directory globbing. 