### PR TITLE
[Fix][Relax][PyTorch] Compare Dynamo output against PyTorch reference

### DIFF
--- a/tests/python/relax/test_frontend_dynamo.py
+++ b/tests/python/relax/test_frontend_dynamo.py
@@ -177,7 +177,7 @@ def test_relax_dynamo_dynamic():
         x = torch.randn(s, 100)
         y = torch.randn(s, 100)
         with torch.no_grad():
-            tvm.testing.assert_allclose(opt_func(x, y), opt_func(x, y))
+            tvm.testing.assert_allclose(Func1(x, y), opt_func(x, y))
 
 
 def test_relax_dynamo_dynamic_sym_input_reference():


### PR DESCRIPTION
Fix a self-comparison in test_relax_dynamo_dynamic.