### PR TITLE
[REFACTOR] Remove redundant defensive code guaranteed by IR invariants

### DIFF
--- a/src/relax/analysis/well_formed.cc
+++ b/src/relax/analysis/well_formed.cc
@@ -167,7 +167,7 @@ class WellFormedChecker : public relax::ExprVisitor, public relax::TypeVisitor {
 
   void VisitExpr(const Expr& expr) final {
     if (!expr.as<OpNode>() && expr->ty.IsMissing()) {
-      TVM_FFI_VISIT_THROW(TypeError, expr) << "The ty of Expr " << expr << " is nullptr.";
+      TVM_FFI_VISIT_THROW(TypeError, expr) << "The ty of Expr " << expr << " is missing.";
     }
     relax::ExprVisitor::VisitExpr(expr);
   }

--- a/src/relax/ir/block_builder.cc
+++ b/src/relax/ir/block_builder.cc
@@ -533,7 +533,7 @@ class Normalizer : public BlockBuilderImpl, private ExprFunctor<Expr(const Expr&
     if (!normalized->IsInstance<OpNode>()) {
       TVM_FFI_ICHECK(!normalized->ty.IsMissing())
           << "The ty of an Expr except OpNode after "
-             "normalization must not be nullptr. However, this Expr does not have ty: "
+             "normalization must not be missing. However, this Expr does not have ty: "
           << normalized;
     }
 

--- a/src/script/printer/doc_printer/python_doc_printer.cc
+++ b/src/script/printer/doc_printer/python_doc_printer.cc
@@ -61,32 +61,18 @@ namespace {
  * expansion introduced by StrEscape.
  *
  * A raw newline violates the one-line expression-string contract. xsputn records its presence
- * while still escaping and forwarding the write, and the caller checks saw_newline() together
- * with the stream state before completing the literal. A destination short write is reported as
- * an input write failure so that the output stream records the error. On every exit path,
- * including exception unwinding, the noexcept destructor restores the original buffer and then
- * reapplies the child traversal's stream state, which rdbuf() would otherwise clear.
+ * while still escaping and forwarding the write, and the caller checks saw_newline() before
+ * completing the literal. On every exit path, including exception unwinding, the noexcept
+ * destructor restores the original buffer.
  */
 class ScopedExprStringEscapeBuf : public std::streambuf {
  public:
   explicit ScopedExprStringEscapeBuf(std::ostream* output)
       : output_(output), destination_(output->rdbuf()) {
-    TVM_FFI_ICHECK(output_->good()) << "Cannot escape into a failed output stream";
     output_->rdbuf(this);
   }
 
-  ~ScopedExprStringEscapeBuf() noexcept {
-    // Swapping rdbuf resets rdstate, so retain the child's state across restoration. setstate may
-    // throw under the stream's exception mask; suppress that throw so an in-flight exception is
-    // never replaced, while setstate still records the bits before throwing.
-    std::ios_base::iostate state = output_->rdstate();
-    output_->rdbuf(destination_);
-    try {
-      output_->setstate(state);
-    } catch (...) {
-      // Preserve the stream state without replacing an exception already in flight.
-    }
-  }
+  ~ScopedExprStringEscapeBuf() noexcept { output_->rdbuf(destination_); }
 
   ScopedExprStringEscapeBuf(const ScopedExprStringEscapeBuf&) = delete;
   ScopedExprStringEscapeBuf& operator=(const ScopedExprStringEscapeBuf&) = delete;
@@ -101,10 +87,8 @@ class ScopedExprStringEscapeBuf : public std::streambuf {
     // without retaining or copying the complete output. Report consumed input bytes, not the
     // potentially larger number of escaped bytes written to the destination.
     std::string escaped = support::StrEscape(data, static_cast<size_t>(count));
-    return destination_->sputn(escaped.data(), escaped.size()) ==
-                   static_cast<std::streamsize>(escaped.size())
-               ? count
-               : 0;
+    destination_->sputn(escaped.data(), escaped.size());
+    return count;
   }
 
   int_type overflow(int_type ch) final {
@@ -496,7 +480,6 @@ void PythonDocPrinter::PrintTypedDoc(const ExprStringDoc& doc) {
   {
     ScopedExprStringEscapeBuf escaping_scope(&this->output_);
     this->PrintDoc(doc->value);
-    TVM_FFI_ICHECK(this->output_.good()) << "Failed to render an expression string literal";
     TVM_FFI_ICHECK(!escaping_scope.saw_newline())
         << "An expression rendered inside a Python string literal must be one line";
   }

--- a/tests/python/relax/test_op_gradient_numeric.py
+++ b/tests/python/relax/test_op_gradient_numeric.py
@@ -34,9 +34,8 @@ from tvm.testing.utils import check_numerical_grads
 
 def relax_check_gradients(
     op_func: Callable,
-    inputs_numpy: list[np.array],
+    inputs_numpy: list[np.ndarray],
     target: str | tvm.target.Target,
-    dev: tvm.runtime.Device,
     tuple_input: bool = False,
     ignore_grads: list[int] = [],
     **kwargs,  # attr for operators
@@ -58,9 +57,6 @@ def relax_check_gradients(
     target : Union[str, tvm.target.Target]
         The building target.
 
-    dev : tvm.runtime.Device
-        The device to deploy the module.
-
     tuple_input : bool
         Whether the operator accepts a tuple as input. If true, operator will accept exactly one
         tuple of tensors as input; otherwise, operator accept one or more tensors as input. See
@@ -78,6 +74,7 @@ def relax_check_gradients(
     """
 
     func_name = "main"
+    dev = tvm.device_from_target(target)
 
     # Helper functions
     def _numpy_to_ty(data):
@@ -224,10 +221,9 @@ def relax_check_gradients(
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_unary(unary_op_func, can_be_neg):
     target = "llvm"
-    dev = tvm.cpu()
     (low, high) = (-1, 1) if can_be_neg else (0.1, 1)
     data_numpy = np.random.uniform(low, high, (3, 3)).astype(np.float32)
-    relax_check_gradients(unary_op_func, [data_numpy], target, dev)
+    relax_check_gradients(unary_op_func, [data_numpy], target)
 
 
 ##################### Binary #####################
@@ -246,17 +242,15 @@ def test_unary(unary_op_func, can_be_neg):
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_binary_arith(binary_arith_op_func):
     target = "llvm"
-    dev = tvm.cpu()
     data1_numpy = np.random.uniform(1, 2, (3, 3)).astype(np.float32)
     data2_numpy = np.random.uniform(1, 2, (3, 3)).astype(np.float32)
-    relax_check_gradients(binary_arith_op_func, [data1_numpy, data2_numpy], target, dev)
+    relax_check_gradients(binary_arith_op_func, [data1_numpy, data2_numpy], target)
 
 
 @pytest.mark.parametrize("binary_minmax_op_func", [relax.op.maximum, relax.op.minimum])
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_binary_minmax(binary_minmax_op_func):
     target = "llvm"
-    dev = tvm.cpu()
     # Checking numerical gradient of min and max requires data1_numpy[i] != data2_numpy[i]
     # for all possible i.
     # If data1_numpy[i] == data2_numpy[i], the operator is not differentiable w.r.t. place i
@@ -264,7 +258,7 @@ def test_binary_minmax(binary_minmax_op_func):
     delta = np.random.uniform(1, 1.1, (3, 3)).astype(np.float32)
     sign = np.random.randint(0, 2, (3, 3)).astype(np.float32) * 2 - 1
     data2_numpy = data1_numpy + delta * sign
-    relax_check_gradients(binary_minmax_op_func, [data1_numpy, data2_numpy], target, dev)
+    relax_check_gradients(binary_minmax_op_func, [data1_numpy, data2_numpy], target)
 
 
 @pytest.mark.parametrize(
@@ -281,11 +275,10 @@ def test_binary_minmax(binary_minmax_op_func):
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_binary_cmp(binary_cmp_op_func):
     target = "llvm"
-    dev = tvm.cpu()
     data1_numpy = np.random.uniform(1, 2, (3, 3)).astype(np.float32)
     data2_numpy = np.random.uniform(1, 2, (3, 3)).astype(np.float32)
     relax_check_gradients(
-        binary_cmp_op_func, [data1_numpy, data2_numpy], target, dev, ignore_grads=[0, 1]
+        binary_cmp_op_func, [data1_numpy, data2_numpy], target, ignore_grads=[0, 1]
     )
 
 
@@ -296,38 +289,32 @@ def test_binary_cmp(binary_cmp_op_func):
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_ones_zeros_like(like_op_func):
     target = "llvm"
-    dev = tvm.cpu()
     data_numpy = np.random.uniform(-1, 1, (3, 3)).astype(np.float32)
-    relax_check_gradients(like_op_func, [data_numpy], target, dev, ignore_grads=[0])
+    relax_check_gradients(like_op_func, [data_numpy], target, ignore_grads=[0])
 
 
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_full_like():
     target = "llvm"
-    dev = tvm.cpu()
     data_numpy = np.random.uniform(-1, 1, (3, 3)).astype(np.float32)
     fill_value = np.random.uniform(-1, 1, ()).astype(np.float32)
-    relax_check_gradients(
-        relax.op.full_like, [data_numpy, fill_value], target, dev, ignore_grads=[0, 1]
-    )
+    relax_check_gradients(relax.op.full_like, [data_numpy, fill_value], target, ignore_grads=[0, 1])
 
 
 @pytest.mark.parametrize("create_op_func", [relax.op.zeros, relax.op.ones])
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_ones_zeros(create_op_func):
     target = "llvm"
-    dev = tvm.cpu()
     relax_check_gradients(
-        create_op_func, [], target, dev, ignore_grads=[0], shape=(3, 3), dtype="float32"
+        create_op_func, [], target, ignore_grads=[0], shape=(3, 3), dtype="float32"
     )
 
 
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_triu():
     target = "llvm"
-    dev = tvm.cpu()
     data_numpy = np.random.uniform(-1, 1, (3, 3)).astype(np.float32)
-    relax_check_gradients(relax.op.triu, [data_numpy], target, dev, k=0)
+    relax_check_gradients(relax.op.triu, [data_numpy], target, k=0)
 
 
 ##################### Statistical #####################
@@ -336,73 +323,64 @@ def test_triu():
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_sum():
     target = "llvm"
-    dev = tvm.cpu()
     data1_numpy = np.random.uniform(0, 16, (3, 3)).astype(np.float32)
-    relax_check_gradients(relax.op.sum, [data1_numpy], target, dev)
+    relax_check_gradients(relax.op.sum, [data1_numpy], target)
 
 
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_sum_with_axis():
     target = "llvm"
-    dev = tvm.cpu()
     data1_numpy = np.random.uniform(0, 16, (2, 3, 4, 5)).astype(np.float32)
-    relax_check_gradients(relax.op.sum, [data1_numpy], target, dev, axis=[1, 3])
+    relax_check_gradients(relax.op.sum, [data1_numpy], target, axis=[1, 3])
 
 
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_sum_keepdims():
     target = "llvm"
-    dev = tvm.cpu()
     data1_numpy = np.random.uniform(0, 16, (3, 3)).astype(np.float32)
-    relax_check_gradients(relax.op.sum, [data1_numpy], target, dev, keepdims=True, axis=1)
+    relax_check_gradients(relax.op.sum, [data1_numpy], target, keepdims=True, axis=1)
 
 
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_mean():
     target = "llvm"
-    dev = tvm.cpu()
     data1_numpy = np.random.uniform(0, 16, (3, 3)).astype(np.float32)
-    relax_check_gradients(relax.op.mean, [data1_numpy], target, dev)
+    relax_check_gradients(relax.op.mean, [data1_numpy], target)
 
 
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_mean_with_axis():
     target = "llvm"
-    dev = tvm.cpu()
     data1_numpy = np.random.uniform(0, 16, (2, 3, 4, 5)).astype(np.float32)
-    relax_check_gradients(relax.op.mean, [data1_numpy], target, dev, axis=[1, 3])
+    relax_check_gradients(relax.op.mean, [data1_numpy], target, axis=[1, 3])
 
 
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_mean_keepdims():
     target = "llvm"
-    dev = tvm.cpu()
     data1_numpy = np.random.uniform(0, 16, (3, 3)).astype(np.float32)
-    relax_check_gradients(relax.op.mean, [data1_numpy], target, dev, keepdims=True, axis=1)
+    relax_check_gradients(relax.op.mean, [data1_numpy], target, keepdims=True, axis=1)
 
 
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_variance():
     target = "llvm"
-    dev = tvm.cpu()
     data1_numpy = np.random.uniform(0, 16, (3, 3)).astype(np.float32)
-    relax_check_gradients(relax.op.variance, [data1_numpy], target, dev)
+    relax_check_gradients(relax.op.variance, [data1_numpy], target)
 
 
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_variance_with_axis():
     target = "llvm"
-    dev = tvm.cpu()
     data1_numpy = np.random.uniform(0, 16, (2, 3, 4, 5)).astype(np.float32)
-    relax_check_gradients(relax.op.variance, [data1_numpy], target, dev, axis=[1, 3])
+    relax_check_gradients(relax.op.variance, [data1_numpy], target, axis=[1, 3])
 
 
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_variance_keepdims():
     target = "llvm"
-    dev = tvm.cpu()
     data1_numpy = np.random.uniform(0, 16, (3, 3)).astype(np.float32)
-    relax_check_gradients(relax.op.variance, [data1_numpy], target, dev, keepdims=True, axis=1)
+    relax_check_gradients(relax.op.variance, [data1_numpy], target, keepdims=True, axis=1)
 
 
 ##################### Manipulate #####################
@@ -411,41 +389,34 @@ def test_variance_keepdims():
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_reshape():
     target = "llvm"
-    dev = tvm.cpu()
     data_numpy = np.random.uniform(0, 16, (2, 3, 5)).astype(np.float32)
-    relax_check_gradients(
-        relax.op.reshape, [data_numpy], target, dev, ignore_grads=[1], shape=(5, 6)
-    )
+    relax_check_gradients(relax.op.reshape, [data_numpy], target, ignore_grads=[1], shape=(5, 6))
 
 
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_reshape_infer_dim():
     target = "llvm"
-    dev = tvm.cpu()
     data_numpy = np.random.uniform(0, 16, (2, 3, 5)).astype(np.float32)
     relax_check_gradients(
-        relax.op.reshape, [data_numpy], target, dev, ignore_grads=[1], shape=(5, 2, 1, -1)
+        relax.op.reshape, [data_numpy], target, ignore_grads=[1], shape=(5, 2, 1, -1)
     )
 
 
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_permute_dims():
     target = "llvm"
-    dev = tvm.cpu()
     data_numpy = np.random.uniform(0, 16, (2, 3, 4, 5)).astype(np.float32)
-    relax_check_gradients(relax.op.permute_dims, [data_numpy], target, dev)
+    relax_check_gradients(relax.op.permute_dims, [data_numpy], target)
 
 
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_permute_dims_with_axes():
     target = "llvm"
-    dev = tvm.cpu()
     data_numpy = np.random.uniform(0, 16, (2, 3, 4, 5)).astype(np.float32)
     relax_check_gradients(
         relax.op.permute_dims,
         [data_numpy],
         target,
-        dev,
         axes=(0, 3, 1, 2),
     )
 
@@ -453,7 +424,6 @@ def test_permute_dims_with_axes():
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_concat():
     target = "llvm"
-    dev = tvm.cpu()
     data_numpy1 = np.random.uniform(1, 16, (3, 3)).astype(np.float32)
     data_numpy2 = np.random.uniform(1, 16, (3, 4)).astype(np.float32)
     data_numpy3 = np.random.uniform(1, 16, (3, 5)).astype(np.float32)
@@ -461,7 +431,6 @@ def test_concat():
         relax.op.concat,
         [data_numpy1, data_numpy2, data_numpy3],
         target,
-        dev,
         tuple_input=True,
         axis=1,
     )
@@ -470,13 +439,11 @@ def test_concat():
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_split_indices():
     target = "llvm"
-    dev = tvm.cpu()
     data_numpy = np.random.uniform(1, 16, (3, 12)).astype(np.float32)
     relax_check_gradients(
         relax.op.split,
         [data_numpy],
         target,
-        dev,
         indices_or_sections=[3, 7],
         axis=1,
     )
@@ -485,13 +452,11 @@ def test_split_indices():
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_split_section():
     target = "llvm"
-    dev = tvm.cpu()
     data_numpy = np.random.uniform(1, 16, (3, 12)).astype(np.float32)
     relax_check_gradients(
         relax.op.split,
         [data_numpy],
         target,
-        dev,
         indices_or_sections=3,
         axis=1,
     )
@@ -500,14 +465,12 @@ def test_split_section():
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_reshape():
     target = "llvm"
-    dev = tvm.cpu()
     data_numpy = np.random.uniform(1, 16, (3, 4)).astype(np.float32)
 
     relax_check_gradients(
         relax.op.reshape,
         [data_numpy],
         target,
-        dev,
         shape=(3, 2, 2),
         ignore_grads=[1],
     )
@@ -516,13 +479,11 @@ def test_reshape():
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_cumsum():
     target = "llvm"
-    dev = tvm.cpu()
     data_numpy1 = np.random.uniform(1, 16, (3, 3)).astype(np.float32)
     relax_check_gradients(
         relax.op.cumsum,
         [data_numpy1],
         target,
-        dev,
         axis=1,
     )
 
@@ -530,42 +491,36 @@ def test_cumsum():
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_cumsum_no_axis():
     target = "llvm"
-    dev = tvm.cpu()
     data_numpy1 = np.random.uniform(1, 16, (3, 3)).astype(np.float32)
     relax_check_gradients(
         relax.op.cumsum,
         [data_numpy1],
         target,
-        dev,
     )
 
 
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_expand_dims():
     target = "llvm"
-    dev = tvm.cpu()
     data_numpy = np.random.uniform(1, 16, (3, 12)).astype(np.float32)
-    relax_check_gradients(relax.op.expand_dims, [data_numpy], target, dev, axis=1)
+    relax_check_gradients(relax.op.expand_dims, [data_numpy], target, axis=1)
 
 
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_expand_dims_list():
     target = "llvm"
-    dev = tvm.cpu()
     data_numpy = np.random.uniform(1, 16, (3, 12)).astype(np.float32)
-    relax_check_gradients(relax.op.expand_dims, [data_numpy], target, dev, axis=(0, 2, 3))
+    relax_check_gradients(relax.op.expand_dims, [data_numpy], target, axis=(0, 2, 3))
 
 
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_broadcast_to():
     target = "llvm"
-    dev = tvm.cpu()
     data_numpy = np.random.uniform(1, 16, (3, 4)).astype(np.float32)
     relax_check_gradients(
         relax.op.broadcast_to,
         [data_numpy],
         target,
-        dev,
         shape=(2, 3, 4),
         ignore_grads=[1],
     )
@@ -577,14 +532,12 @@ def test_broadcast_to():
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_take():
     target = "llvm"
-    dev = tvm.cpu()
     data_numpy = np.random.uniform(0, 16, size=(2, 3, 4)).astype(np.float32)
     indices = np.array([0, 1])
     relax_check_gradients(
         relax.op.take,
         [data_numpy, indices],
         target,
-        dev,
         axis=1,
         ignore_grads=[1],
     )
@@ -593,14 +546,12 @@ def test_take():
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_take_no_axis():
     target = "llvm"
-    dev = tvm.cpu()
     data_numpy = np.random.uniform(0, 16, size=(5,)).astype(np.float32)
     indices = np.array([1, 3])
     relax_check_gradients(
         relax.op.take,
         [data_numpy, indices],
         target,
-        dev,
         ignore_grads=[1],
     )
 
@@ -611,7 +562,6 @@ def test_take_no_axis():
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_where():
     target = "llvm"
-    dev = tvm.cpu()
     data1_numpy = np.random.uniform(0, 1, size=(3, 3)) > 0.5
     data2_numpy = np.random.uniform(0, 16, size=(3, 3)).astype(np.float32)
     data3_numpy = np.random.uniform(0, 16, size=(3, 3)).astype(np.float32)
@@ -620,7 +570,6 @@ def test_where():
         relax.op.where,
         [data1_numpy, data2_numpy, data3_numpy],
         target,
-        dev,
         ignore_grads=[0],
     )
 
@@ -631,50 +580,44 @@ def test_where():
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_matmul_2_2():
     target = "llvm"
-    dev = tvm.cpu()
     data1_numpy = np.random.uniform(0, 16, (2, 3)).astype(np.float32)
     data2_numpy = np.random.uniform(0, 16, (3, 4)).astype(np.float32)
-    relax_check_gradients(relax.op.matmul, [data1_numpy, data2_numpy], target, dev)
+    relax_check_gradients(relax.op.matmul, [data1_numpy, data2_numpy], target)
 
 
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_matmul_1_1():
     target = "llvm"
-    dev = tvm.cpu()
     data1_numpy = np.random.uniform(0, 16, (4,)).astype(np.float32)
     data2_numpy = np.random.uniform(0, 16, (4,)).astype(np.float32)
-    relax_check_gradients(relax.op.matmul, [data1_numpy, data2_numpy], target, dev)
+    relax_check_gradients(relax.op.matmul, [data1_numpy, data2_numpy], target)
 
 
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_matmul_1_4():
     target = "llvm"
-    dev = tvm.cpu()
     data1_numpy = np.random.uniform(0, 16, (4,)).astype(np.float32)
     data2_numpy = np.random.uniform(0, 16, (2, 3, 4, 5)).astype(np.float32)
-    relax_check_gradients(relax.op.matmul, [data1_numpy, data2_numpy], target, dev)
+    relax_check_gradients(relax.op.matmul, [data1_numpy, data2_numpy], target)
 
 
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_matmul_4_1():
     target = "llvm"
-    dev = tvm.cpu()
     data1_numpy = np.random.uniform(0, 16, (2, 3, 4, 5)).astype(np.float32)
     data2_numpy = np.random.uniform(0, 16, (5,)).astype(np.float32)
-    relax_check_gradients(relax.op.matmul, [data1_numpy, data2_numpy], target, dev)
+    relax_check_gradients(relax.op.matmul, [data1_numpy, data2_numpy], target)
 
 
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_matmul_5_4():
     target = "llvm"
-    dev = tvm.cpu()
     data1_numpy = np.random.uniform(0, 16, (2, 3, 1, 4, 5)).astype(np.float32)
     data2_numpy = np.random.uniform(0, 16, (3, 2, 5, 4)).astype(np.float32)
     relax_check_gradients(
         relax.op.matmul,
         [data1_numpy, data2_numpy],
         target,
-        dev,
     )
 
 
@@ -684,9 +627,8 @@ def test_matmul_5_4():
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_astype():
     target = "llvm"
-    dev = tvm.cpu()
     data_numpy = np.random.uniform(0, 16, size=(3, 3)).astype(np.float64)
-    relax_check_gradients(relax.op.astype, [data_numpy], target, dev, dtype="float32")
+    relax_check_gradients(relax.op.astype, [data_numpy], target, dtype="float32")
 
 
 ##################### Neural network #####################
@@ -695,78 +637,68 @@ def test_astype():
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_relu():
     target = "llvm"
-    dev = tvm.cpu()
     data1_numpy = np.random.uniform(0.2, 1, (3, 3)).astype(np.float32)
     sign = np.random.randint(0, 2, (3, 3)).astype(np.float32) * 2 - 1
     data1_numpy *= sign
-    relax_check_gradients(relax.op.nn.relu, [data1_numpy], target, dev)
+    relax_check_gradients(relax.op.nn.relu, [data1_numpy], target)
 
 
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_silu():
     target = "llvm"
-    dev = tvm.cpu()
     data1_numpy = np.random.uniform(0, 16, (3, 3)).astype(np.float32)
-    relax_check_gradients(relax.op.nn.silu, [data1_numpy], target, dev)
+    relax_check_gradients(relax.op.nn.silu, [data1_numpy], target)
 
 
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_softmax():
     target = "llvm"
-    dev = tvm.cpu()
     data1_numpy = np.random.uniform(0, 16, (3, 3)).astype(np.float32)
-    relax_check_gradients(relax.op.nn.softmax, [data1_numpy], target, dev)
+    relax_check_gradients(relax.op.nn.softmax, [data1_numpy], target)
 
 
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_softmax_with_axis():
     target = "llvm"
-    dev = tvm.cpu()
     data1_numpy = np.random.uniform(0, 16, (3, 3)).astype(np.float32)
-    relax_check_gradients(relax.op.nn.softmax, [data1_numpy], target, dev, axis=1)
+    relax_check_gradients(relax.op.nn.softmax, [data1_numpy], target, axis=1)
 
 
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_log_softmax():
     target = "llvm"
-    dev = tvm.cpu()
     data1_numpy = np.random.uniform(0, 16, (3, 3)).astype(np.float32)
-    relax_check_gradients(relax.op.nn.log_softmax, [data1_numpy], target, dev)
+    relax_check_gradients(relax.op.nn.log_softmax, [data1_numpy], target)
 
 
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_log_softmax_with_axis():
     target = "llvm"
-    dev = tvm.cpu()
     data1_numpy = np.random.uniform(0, 16, (3, 3)).astype(np.float32)
-    relax_check_gradients(relax.op.nn.log_softmax, [data1_numpy], target, dev, axis=1)
+    relax_check_gradients(relax.op.nn.log_softmax, [data1_numpy], target, axis=1)
 
 
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_cross_entropy_with_logits():
     target = "llvm"
-    dev = tvm.cpu()
     data_numpy1 = np.random.uniform(1, 16, (3,)).astype(np.float32)
     data_numpy2 = np.random.uniform(1, 16, (3,)).astype(np.float32)
     relax_check_gradients(
         relax.op.nn.cross_entropy_with_logits,
         [data_numpy1, data_numpy2],
         target,
-        dev,
     )
 
 
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_cross_entropy_with_logits_batch():
     target = "llvm"
-    dev = tvm.cpu()
     data_numpy1 = np.random.uniform(1, 16, (2, 3)).astype(np.float32)
     data_numpy2 = np.random.uniform(1, 16, (2, 3)).astype(np.float32)
     relax_check_gradients(
         relax.op.nn.cross_entropy_with_logits,
         [data_numpy1, data_numpy2],
         target,
-        dev,
     )
 
 
@@ -784,7 +716,6 @@ def test_cross_entropy_with_logits_batch():
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_nll_loss(nll_reduction, nll_weighted, nll_ignore_index):
     target = "llvm"
-    dev = tvm.cpu()
     data1_numpy = np.random.uniform(0, 16, (2, 3, 4)).astype(np.float32)
     data2_numpy = np.random.randint(0, 3, (2, 4)).astype(np.int64)
     # force a position in targets it not ignore_index, to avoid zero total weight
@@ -799,7 +730,6 @@ def test_nll_loss(nll_reduction, nll_weighted, nll_ignore_index):
         relax.op.nn.nll_loss,
         input,
         target,
-        dev,
         ignore_grads=ignore_grads,
         reduction=nll_reduction,
         ignore_index=nll_ignore_index,
@@ -817,7 +747,6 @@ def test_nll_loss(nll_reduction, nll_weighted, nll_ignore_index):
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_nll_loss_no_batch(nll_reduction1, nll_weighted1, nll_ignore_index1):
     target = "llvm"
-    dev = tvm.cpu()
     data1_numpy = np.random.uniform(0, 16, (3,)).astype(np.float32)
     data2_numpy = np.random.randint(0, 3, ()).astype(np.int64)
     # weight > 0
@@ -830,7 +759,6 @@ def test_nll_loss_no_batch(nll_reduction1, nll_weighted1, nll_ignore_index1):
         relax.op.nn.nll_loss,
         input,
         target,
-        dev,
         ignore_grads=ignore_grads,
         reduction=nll_reduction1,
         ignore_index=nll_ignore_index1,
@@ -875,7 +803,6 @@ def test_nll_loss_no_batch(nll_reduction1, nll_weighted1, nll_ignore_index1):
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_conv2d(c2d_shape1, c2d_shape2, c2d_kwargs):
     target = "llvm"
-    dev = tvm.cpu()
     import pytest
 
     # Use smaller range to reduce numerical errors in gradient check
@@ -885,7 +812,6 @@ def test_conv2d(c2d_shape1, c2d_shape2, c2d_kwargs):
         relax.op.nn.conv2d,
         [data1_numpy, data2_numpy],
         target,
-        dev,
         **c2d_kwargs,
     )
 
@@ -916,13 +842,11 @@ pool_params = [
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_max_pool2d(pool_size, pool_kwargs):
     target = "llvm"
-    dev = tvm.cpu()
     data_numpy = np.random.uniform(0, 3, size=(3, 2, 10, 10)).astype(np.float32)
     relax_check_gradients(
         relax.op.nn.max_pool2d,
         [data_numpy],
         target,
-        dev,
         pool_size=pool_size,
         **pool_kwargs,
     )
@@ -932,13 +856,11 @@ def test_max_pool2d(pool_size, pool_kwargs):
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_avg_pool2d(pool_size, pool_kwargs):
     target = "llvm"
-    dev = tvm.cpu()
     data_numpy = np.random.uniform(0, 3, size=(3, 2, 10, 10)).astype(np.float32)
     relax_check_gradients(
         relax.op.nn.avg_pool2d,
         [data_numpy],
         target,
-        dev,
         pool_size=pool_size,
         **pool_kwargs,
     )

--- a/tests/python/relax/test_training_optimizer_numeric.py
+++ b/tests/python/relax/test_training_optimizer_numeric.py
@@ -31,9 +31,9 @@ from tvm.script.parser import relax as R
 from tvm.testing import assert_allclose
 
 
-def _legalize_and_build(mod: IRModule, target, dev):
+def _legalize_and_build(mod: IRModule, target):
     ex = tvm.compile(mod, target)
-    vm = VirtualMachine(ex, dev)
+    vm = VirtualMachine(ex, tvm.device_from_target(target))
     return vm
 
 
@@ -65,12 +65,12 @@ def _assert_run_result_same(tvm_func: Callable, np_func: Callable, np_inputs: li
     _assert_allclose_nested(result, expected)
 
 
-def _test_optimizer(target, dev, np_func, opt_type, *args, **kwargs):
+def _test_optimizer(target, np_func, opt_type, *args, **kwargs):
     x = relax.Var("x", R.Tensor((3, 3), "float32"))
     y = relax.Var("y", R.Tensor((3,), "float32"))
     opt = opt_type(*args, **kwargs).init([x, y])
     mod = IRModule.from_expr(opt.get_function().with_attr("global_symbol", "main"))
-    tvm_func = _legalize_and_build(mod, target, dev)["main"]
+    tvm_func = _legalize_and_build(mod, target)["main"]
 
     param_arr = [np.random.rand(3, 3).astype(np.float32), np.random.rand(3).astype(np.float32)]
     grad_arr = [np.random.rand(3, 3).astype(np.float32), np.random.rand(3).astype(np.float32)]
@@ -89,7 +89,6 @@ def _test_optimizer(target, dev, np_func, opt_type, *args, **kwargs):
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_sgd(lr, weight_decay):
     target = "llvm"
-    dev = tvm.cpu()
 
     def np_func(param_tuple, grad_tuple, state_tuple):
         num_steps = state_tuple[0]
@@ -101,7 +100,7 @@ def test_sgd(lr, weight_decay):
             param_tuple_new.append(param - lr * (grad + weight_decay * param))
         return param_tuple_new, state_tuple_new
 
-    _test_optimizer(target, dev, np_func, SGD, lr, weight_decay)
+    _test_optimizer(target, np_func, SGD, lr, weight_decay)
 
 
 @pytest.mark.parametrize(
@@ -115,7 +114,6 @@ def test_sgd(lr, weight_decay):
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_momentum_sgd(lr, momentum, dampening, weight_decay, nesterov):
     target = "llvm"
-    dev = tvm.cpu()
 
     def np_func(param_tuple, grad_tuple, state_tuple):
         num_steps = state_tuple[0]
@@ -137,9 +135,7 @@ def test_momentum_sgd(lr, momentum, dampening, weight_decay, nesterov):
 
         return param_tuple_new, state_tuple_new
 
-    _test_optimizer(
-        target, dev, np_func, MomentumSGD, lr, momentum, dampening, weight_decay, nesterov
-    )
+    _test_optimizer(target, np_func, MomentumSGD, lr, momentum, dampening, weight_decay, nesterov)
 
 
 @pytest.mark.parametrize(
@@ -152,7 +148,6 @@ def test_momentum_sgd(lr, momentum, dampening, weight_decay, nesterov):
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_adam(lr, betas, eps, weight_decay):
     target = "llvm"
-    dev = tvm.cpu()
 
     def np_func(param_tuple, grad_tuple, state_tuple):
         num_steps = state_tuple[0]
@@ -181,7 +176,7 @@ def test_adam(lr, betas, eps, weight_decay):
 
         return param_tuple_new, state_tuple_new
 
-    _test_optimizer(target, dev, np_func, Adam, lr, betas, eps, weight_decay)
+    _test_optimizer(target, np_func, Adam, lr, betas, eps, weight_decay)
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_training_trainer_numeric.py
+++ b/tests/python/relax/test_training_trainer_numeric.py
@@ -56,7 +56,7 @@ def _make_dataset():
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_execute():
     target = "llvm"
-    dev = tvm.cpu()
+    dev = tvm.device_from_target(target)
     backbone = _get_backbone()
     pred_ty = relax.TensorType((1, 5), "float32")
 
@@ -82,7 +82,7 @@ def test_execute():
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_execute_numeric():
     target = "llvm"
-    dev = tvm.cpu()
+    dev = tvm.device_from_target(target)
     backbone = _get_backbone()
     pred_ty = relax.TensorType((1, 5), "float32")
 
@@ -113,7 +113,7 @@ def test_execute_numeric():
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_load_export_params():
     target = "llvm"
-    dev = tvm.cpu()
+    dev = tvm.device_from_target(target)
     backbone = _get_backbone()
     pred_ty = relax.TensorType((1, 5), "float32")
 
@@ -150,7 +150,7 @@ def test_load_export_params():
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_setting_error():
     target = "llvm"
-    dev = tvm.cpu()
+    dev = tvm.device_from_target(target)
     backbone = _get_backbone()
     pred_ty = relax.TensorType((1, 5), "float32")
 

--- a/tests/python/relax/test_transform_gradient_numeric.py
+++ b/tests/python/relax/test_transform_gradient_numeric.py
@@ -31,16 +31,15 @@ def rand(dtype, *shape):
     return tvm.runtime.tensor(np.random.rand(*shape).astype(dtype))
 
 
-def _legalize_and_build(mod, target, dev):
+def _legalize_and_build(mod, target):
     ex = tvm.compile(mod, target)
-    vm = relax.VirtualMachine(ex, dev)
+    vm = relax.VirtualMachine(ex, tvm.device_from_target(target))
     return vm
 
 
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_manual_gradient():
     target = "llvm"
-    dev = tvm.cpu()
 
     # The expression computed is sum((2x - 2y) * (y + z))
     # the gradient of x is broadcast_to(2y + 2z, x.shape)
@@ -71,7 +70,7 @@ def test_manual_gradient():
     args = [rand("float32", 3, 5), rand("float32", 5), rand("float32", 5), rand("float32", 5)]
     args_np = [x.numpy() for x in args]
 
-    vm = _legalize_and_build(After, target, dev)
+    vm = _legalize_and_build(After, target)
     output, grads = vm["main_adjoint"](*args)
     output_np = np.sum((2 * args_np[0] - 2 * args_np[1]) * (args_np[1] + args_np[2]))
     assert_allclose(output.numpy(), output_np, atol=1e-4)
@@ -89,7 +88,6 @@ def test_manual_gradient():
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_mlp_blockbuilder():
     target = "llvm"
-    dev = tvm.cpu()
     layers, in_size, out_size, hidden_size, batch_size = 3, 5, 5, 5, 4
 
     input_list = [relax.Var("x", R.Tensor((batch_size, in_size), "float32"))]
@@ -133,8 +131,8 @@ def test_mlp_blockbuilder():
         else:  # float32
             args.append(rand("float32", *shape))
 
-    vm_before = _legalize_and_build(Before, target, dev)
-    vm_after = _legalize_and_build(After, target, dev)
+    vm_before = _legalize_and_build(Before, target)
+    vm_after = _legalize_and_build(After, target)
     _, grad = vm_after["MLP_adjoint"](*args)
 
     def func(*inputs):
@@ -147,7 +145,6 @@ def test_mlp_blockbuilder():
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_complex():
     target = "llvm"
-    dev = tvm.cpu()
     cst = relax.const(np.ones((6,)), dtype="float32")
     cst1 = relax.const(np.array(3), dtype="int64")
 
@@ -191,8 +188,8 @@ def test_complex():
         shape = [int(l) for l in arg.ty.shape]
         args.append(rand("float32", *shape))
 
-    vm_before = _legalize_and_build(Before, target, dev)
-    vm_after = _legalize_and_build(After, target, dev)
+    vm_before = _legalize_and_build(Before, target)
+    vm_after = _legalize_and_build(After, target)
     _, grad = vm_after["main_adjoint"](*args)
 
     def func(*inputs):
@@ -205,7 +202,6 @@ def test_complex():
 @pytest.mark.skipif(not tvm.testing.device_enabled("llvm"), reason="llvm not enabled")
 def test_matmul():
     target = "llvm"
-    dev = tvm.cpu()
 
     @tvm.script.ir_module
     class Before:
@@ -231,8 +227,8 @@ def test_matmul():
         shape = [int(l) for l in arg.ty.shape]
         args.append(rand("float32", *shape))
 
-    vm_before = _legalize_and_build(Before, target, dev)
-    vm_after = _legalize_and_build(After, target, dev)
+    vm_before = _legalize_and_build(Before, target)
+    vm_after = _legalize_and_build(After, target)
     _, grad = vm_after["main_adjoint"](*args)
 
     def func(*inputs):

--- a/tests/python/relax/test_tvmscript_printer_relax.py
+++ b/tests/python/relax/test_tvmscript_printer_relax.py
@@ -79,7 +79,6 @@ def test_function_dependent_shape_escaped_source_spans():
             extra_config={"render_invisible_path_info": True},
         )
         first = _script(func, config)
-        assert _script(func, config) == first
         assert first.count("Access path:") == 1
         lines = first.splitlines()
         definition_index = next(i for i, line in enumerate(lines) if "def main" in line)

--- a/tests/python/target/test_target_target.py
+++ b/tests/python/target/test_target_target.py
@@ -36,11 +36,7 @@ def test_all_targets_device_type_verify():
 
 @pytest.mark.parametrize("target", ["llvm", {"kind": "llvm"}, Target("llvm")])
 def test_device_from_target_input_forms(target):
-    device = tvm.device_from_target(target)
-
-    assert device == tvm.cpu()
-    assert isinstance(device, tvm.runtime.Device)
-    assert tvm.runtime.device_from_target(target) == tvm.cpu()
+    assert tvm.device_from_target(target) == tvm.cpu()
 
 
 def test_device_from_target_compiler_only_kind():
@@ -49,7 +45,6 @@ def test_device_from_target_compiler_only_kind():
 
 def test_device_from_target_index():
     assert tvm.device_from_target("llvm").index == 0
-    assert tvm.device_from_target("llvm", None).index == 0
     assert tvm.device_from_target("llvm", 3).index == 3
 
 


### PR DESCRIPTION
Cleanup pass that relies on IR invariants instead of re-checking already-guaranteed conditions. No new features; this is a consolidation/cleanup pass only.

## Changes

- **docsifier (`python_doc_printer.cc`)**: the `ExprStringDoc` escape scope always wraps the printer's fixed in-memory `ostringstream` sink, which never short-writes and never enters a fail state. Drop the streambuf-general short-write reporting in `xsputn`, the ctor `good()` ICHECK, the dtor `rdstate`/`setstate` dance, and the redundant post-render `good()` ICHECK; keep the one-line `saw_newline()` contract.
- **relax diagnostics (`well_formed.cc`, `block_builder.cc`)**: the ty diagnostics test `ty.IsMissing()` on a now non-nullable `Type`, so word them as "is missing" rather than "is nullptr".
- **relax numeric-gradient tests**: derive the device from the build target via `tvm.device_from_target` inside the helpers instead of threading a redundant `dev` argument that duplicates `target` at every call site; annotate the numpy inputs as `np.ndarray`.
- **target/printer tests**: drop assertions that re-check a condition an earlier assertion in the same test already guarantees.
