### PR TITLE
[Target][LLVM] Fall back to unoptimized module on invalid post-opt IR

### DIFF
--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -77,6 +77,7 @@
 #include <llvm/Support/TypeSize.h>
 #include <llvm/Target/TargetMachine.h>
 #include <llvm/Transforms/IPO.h>
+#include <llvm/Transforms/Utils/Cloning.h>
 #include <llvm/Transforms/Utils/ModuleUtils.h>
 #include <tvm/runtime/base.h>
 #include <tvm/runtime/device_api.h>
@@ -376,9 +377,38 @@ std::unique_ptr<llvm::Module> CodeGenLLVM::Finish() {
         << "Failed to link modules";
   }
   link_modules_.clear();
+
+  // Verify the freshly generated (pre-optimization) module. This is TVM's own
+  // codegen output; if it fails to verify that is a genuine TVM bug, so keep
+  // throwing here.
   this->Verify();
+
+  // LLVM's optimizer has been observed to miscompile perfectly valid IR into a
+  // structurally-invalid module for certain shapes -- e.g. avg_pool2d with
+  // C == 4 and W == 3 sends LLVM's vectorizer down a buggy path that emits a
+  // shufflevector whose definition does not dominate its use (TVM issue #20015;
+  // reproducible with stock `opt -passes='default<O2>'`, an upstream LLVM bug).
+  // To avoid hard-crashing the whole build on such backend-optimizer bugs, keep
+  // a verified copy of the pre-optimization module and fall back to it if
+  // optimization produces an invalid module. The result is correct (just
+  // unoptimized for the affected module) rather than a crash, and we never emit
+  // the broken module.
+  std::unique_ptr<llvm::Module> pre_opt_module = llvm::CloneModule(*module_);
+
   this->Optimize();
-  this->Verify();
+
+  std::string verify_errors_storage;
+  llvm::raw_string_ostream verify_errors(verify_errors_storage);
+  if (llvm::verifyModule(*module_, &verify_errors)) {
+    LOG(WARNING) << "LLVM " << (TVM_LLVM_VERSION / 10) << "." << (TVM_LLVM_VERSION % 10)
+                 << " optimization produced an invalid module; this is a known LLVM "
+                    "optimizer bug on valid IR (see TVM issue #20015). Falling back to the "
+                    "unoptimized module so the build can proceed with correct results.\n"
+                 << "Verifier errors:\n"
+                 << verify_errors.str();
+    module_ = std::move(pre_opt_module);
+  }
+
   return std::move(module_);
 }
 

--- a/tests/python/relax/test_vm_build.py
+++ b/tests/python/relax/test_vm_build.py
@@ -1238,5 +1238,43 @@ def test_relax_module_with_multiple_targets(exec_mode):
     tvm.testing.run_with_gpu_lock(run_and_check)
 
 
+@pytest.mark.parametrize("shape", [[1, 4, 6, 3], [1, 4, 8, 3], [1, 4, 6, 2], [1, 3, 6, 3]])
+def test_avg_pool2d_llvm_codegen_regression(shape):
+    """Regression for issue #20015.
+
+    ``avg_pool2d`` with shape ``[N, C=4, H(even>=6), W=3]`` used to hard-crash in
+    LLVM codegen verification ("Instruction does not dominate all uses") because
+    LLVM's own O2 vectorizer miscompiles the (valid) IR TVM emits. The backend
+    now falls back to the verified unoptimized module instead of crashing, so the
+    build must succeed and produce numerically correct results.
+    """
+    bb = relax.BlockBuilder()
+    x = relax.Var("x", R.Tensor(shape, "float32"))
+    with bb.function("main", [x]):
+        out = bb.emit(
+            relax.op.nn.avg_pool2d(x, pool_size=[2, 2], strides=[1, 1], padding=[0, 0])
+        )
+        bb.emit_func_output(out)
+    mod = bb.get()
+
+    # Default llvm target uses an aggressive opt-level, which is what triggers
+    # the LLVM optimizer bug for the affected shapes.
+    ex = relax.build(mod, target="llvm")
+    vm = relax.VirtualMachine(ex, tvm.cpu())
+
+    np_x = np.random.rand(*shape).astype("float32")
+    out = vm["main"](tvm.runtime.tensor(np_x)).numpy()
+
+    # NumPy reference: 2x2 average pool, stride 1, no padding (NCHW).
+    n, c, h, w = shape
+    oh, ow = h - 1, w - 1
+    ref = np.empty((n, c, oh, ow), dtype="float32")
+    for i in range(oh):
+        for j in range(ow):
+            ref[:, :, i, j] = np_x[:, :, i : i + 2, j : j + 2].mean(axis=(2, 3))
+
+    tvm.testing.assert_allclose(out, ref, rtol=1e-5, atol=1e-5)
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
relax.build(target="llvm") hard-crashed during LLVM codegen verification for avg_pool2d with input shape [N, C=4, H(even>=6), W=3], e.g. [1,4,6,3]:

    InternalError: LLVM module verification failed:
    Instruction does not dominate all uses!
      %314 = shufflevector <4 x float> %287, <4 x float> %311, <2 x i32> <i32 2, i32 6>
      %90  = shufflevector <2 x float> %314, <2 x float> %89,  <4 x i32> <i32 0, 1, 2, 3>

Root cause is an LLVM optimizer bug, not TVM codegen. The TIR TVM lowers is scalar and the IR TVM emits verifies clean (both llvm::verifyModule and llvm-as accept it); the crash only appears at opt-level >= 2. Running stock `opt -passes='default<O2>'` on TVM's valid IR reproduces the identical "does not dominate all uses" abort, so LLVM's own vectorizer turns valid IR into a structurally-invalid module (C=4 fills a 4-wide vector and W=3 misaligns the strided gather, steering the SLP/loop vectorizer into the bug).

Rather than hard-crash on a backend-optimizer bug, CodeGenLLVM::Finish() now keeps a verified clone of the pre-optimization module and, if the optimized module fails verification, warns and falls back to that known-good module. The build then produces correct (unoptimized) code and never emits the broken module. The pre-opt Verify() still throws, so genuine TVM codegen bugs remain surfaced.

Adds a numerical regression test in test_vm_build.py covering the crashing and neighbouring shapes.