### PR TITLE
[TIRx] Handle None AttrStmt nodes

### DIFF
--- a/src/tirx/ir/stmt.cc
+++ b/src/tirx/ir/stmt.cc
@@ -92,8 +92,9 @@ TVM_FFI_STATIC_INIT_BLOCK() {
   refl::GlobalDef().def("tirx.AttrStmt",
                         [](Any node, ffi::String attr_key, PrimExpr value, Stmt body, Span span) {
                           // when node is a POD data type like int or bool, first convert to
-                          // primexpr.
-                          if (node.type_index() < ffi::TypeIndex::kTVMFFISmallStr) {
+                          // primexpr. Preserve None, which is a valid AttrStmt node value.
+                          if (node.type_index() > ffi::TypeIndex::kTVMFFINone &&
+                              node.type_index() < ffi::TypeIndex::kTVMFFISmallStr) {
                             return AttrStmt(node.cast<PrimExpr>(), attr_key, value, body, span);
                           }
                           return AttrStmt(node, attr_key, value, body, span);

--- a/src/tirx/ir/tir_visitor_with_path.cc
+++ b/src/tirx/ir/tir_visitor_with_path.cc
@@ -190,7 +190,7 @@ void TIRVisitorWithPath::VisitStmt_(const AttrStmtNode* op, AccessPath path) {
     // tirx::Var they annotate.
     context.push_back(WithDef(iter_var.value(), path->Attr("node")));
 
-  } else if (auto expr = op->node.as<PrimExpr>()) {
+  } else if (auto expr = op->node.as<PrimExpr>(); expr && expr.value().defined()) {
     Visit(expr.value(), path->Attr("node"));
   }
   bind_scope_.WithNewScope([&]() { Visit(op->body, path->Attr("body")); });

--- a/tests/python/tirx-base/test_tir_constructor.py
+++ b/tests/python/tirx-base/test_tir_constructor.py
@@ -249,6 +249,15 @@ def test_stmt_constructor():
     assert x.else_case == nop
 
 
+def test_attr_stmt_none_preserves_none_for_purity_analysis():
+    body = tvm.tirx.AttrStmt(None, "threadblock_swizzle_pattern", 0, tvm.tirx.Evaluate(0))
+    assert body.node is None
+    func = tvm.tirx.PrimFunc([], body)
+    from tvm.s_tir.analysis import is_pure_function
+
+    assert is_pure_function(func)
+
+
 def test_float_constructor_requires_float_dtype():
     # FloatImm dtype validation raises a builtin ValueError.
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary

- Preserve `None` when constructing a TIRx `AttrStmt` instead of treating it as a POD value to cast to `PrimExpr`.
- Avoid visiting an undefined `PrimExpr` when an `AttrStmt` node is `None`.
- Add an end-to-end regression covering construction and S-TIR purity analysis.

## Root cause

`ffi::TypeIndex::kTVMFFINone` is below `kTVMFFISmallStr`, so the previous POD conversion condition also attempted to cast `None` to `PrimExpr`. In the path-aware TIR visitor, `Any::as<PrimExpr>()` can then yield an optional containing an undefined `PrimExpr`; visiting that value caused a segmentation fault. The reported baseline process exited with status 139.

## Upstream application

The original proven fix commit (`c8c8c6f14f316cdef4e63591238efdf644b97576`) did not cherry-pick cleanly onto current `apache/main` because its visitor hunk was based on a fork-only iterative `AttrStmt` visitor. This PR reconstructs only the null-node fix directly on Apache commit `d02a68e403eb1b473844bd1b36302f44ac66dc32`. It does not include the iterative visitor or any Triton/TileLang changes.

## Validation

- CPU-only macOS arm64 CMake build: passed (`cmake --build build --parallel 8`)
- Focused regression: `1 passed, 6 deselected`
- `tests/python/tirx-base/test_tir_constructor.py` plus `tests/python/s_tir/analysis/test_s_tir_analysis_is_pure_function.py`: `25 passed`
- `clang-format --dry-run --Werror --style=file` on both changed C++ files: passed
- Ruff 0.12.3 check and format check on the changed Python test: passed
- `clang-tidy` `clang-analyzer-*` checks on both changed C++ files: passed
- ASF header check, file-type check, and `git diff --check`: passed

## Residual risk

Local runtime validation used a CPU-only build with LLVM, Z3, GPU backends, RPC, and optional libbacktrace disabled. The change is confined to TIRx construction and traversal; Apache CI should provide the broader build matrix.
