### PR TITLE
[CI] Bump tvm-ffi with compatible Python wrappers

### DIFF
--- a/include/tvm/runtime/device_api.h
+++ b/include/tvm/runtime/device_api.h
@@ -25,6 +25,7 @@
 #define TVM_RUNTIME_DEVICE_API_H_
 
 #include <tvm/ffi/any.h>
+#include <tvm/ffi/device.h>
 #include <tvm/ffi/error.h>
 #include <tvm/ffi/optional.h>
 #include <tvm/ffi/string.h>

--- a/include/tvm/script/printer/ir_docsifier.h
+++ b/include/tvm/script/printer/ir_docsifier.h
@@ -19,6 +19,7 @@
 #ifndef TVM_SCRIPT_PRINTER_IR_DOCSIFIER_H_
 #define TVM_SCRIPT_PRINTER_IR_DOCSIFIER_H_
 
+#include <tvm/ffi/device.h>
 #include <tvm/ffi/reflection/access_path.h>
 #include <tvm/ffi/reflection/registry.h>
 #include <tvm/ir/module.h>

--- a/python/tvm/ir/__init__.py
+++ b/python/tvm/ir/__init__.py
@@ -30,11 +30,14 @@ from .base import (
     load_json,
     save_json,
 )
+
+# Register Type before Expr.  Expr's reflected ``ty`` field otherwise creates
+# an auto-generated Type wrapper before the concrete Python class is available.
+from .type import FuncType, PointerType, PrimType, TupleType, Type
 from .expr import Call, Expr, GlobalVar, Range, Var, is_prim_expr, is_prim_var
 from .function import BaseFunc, CallingConv
 from .global_info import GlobalInfo, DummyGlobalInfo, VDevice
 from .module import IRModule
 from .op import Op, register_intrin_lowering, register_op_attr
-from .type import FuncType, PointerType, PrimType, TupleType, Type
 
 from tvm_ffi import Array, Map

--- a/python/tvm/ir/function.py
+++ b/python/tvm/ir/function.py
@@ -62,17 +62,24 @@ class BaseFunc(Expr):
         func : BaseFunc
             A new copy of the function
         """
-        # make sure we first copy so that we can safely do copy on write
-        # for multiple updates.
-        res = _ffi_api.BaseFuncCopy(self)
+        # BaseFuncCopy may return the canonical wrapper ``self``.  Keep that
+        # first value as an lvalue so copy-on-write preserves the caller; after
+        # the first update, the private result can be moved on later updates.
+        new_value = _ffi_api.BaseFuncCopy(self)
 
         if isinstance(attr_key_or_dict, dict):
             for key, val in attr_key_or_dict.items():
-                res = _ffi_api.BaseFuncWithAttr(res._move(), key, tvm.runtime.convert(val))
-            return res
+                new_value = _ffi_api.BaseFuncWithAttr(
+                    new_value if new_value is self else new_value._move(),
+                    key,
+                    tvm.runtime.convert(val),
+                )
+            return new_value
 
         return _ffi_api.BaseFuncWithAttr(
-            res._move(), attr_key_or_dict, tvm.runtime.convert(attr_value)
+            new_value if new_value is self else new_value._move(),
+            attr_key_or_dict,
+            tvm.runtime.convert(attr_value),
         )
 
     def with_attrs(self, attr_map: DictAttrs | dict[str, Object]) -> "BaseFunc":

--- a/python/tvm/runtime/_tensor.py
+++ b/python/tvm/runtime/_tensor.py
@@ -75,6 +75,12 @@ class Tensor(tvm_ffi.core.Tensor):
     how can we use TVM in existing project which might have their own array containers.
     """
 
+    # Keep the same instance layout as ``tvm_ffi.core.Tensor``: the FFI runtime
+    # registers ``ffi.Tensor`` to its base wrapper and rejects re-registration
+    # with a larger wrapper (a subclass without ``__slots__`` would add
+    # ``__dict__``/``__weakref__`` and grow ``__basicsize__``).
+    __slots__ = ()
+
     def __setitem__(self, in_slice, value):
         """Set ndarray value"""
         if (

--- a/src/s_tir/meta_schedule/task_scheduler/task_scheduler.cc
+++ b/src/s_tir/meta_schedule/task_scheduler/task_scheduler.cc
@@ -18,6 +18,7 @@
  */
 #include <tvm/ffi/cast.h>
 #include <tvm/ffi/reflection/registry.h>
+#include <tvm/runtime/device_api.h>
 #include <tvm/s_tir/analysis.h>
 
 #include "../utils.h"
@@ -78,9 +79,10 @@ void SendToRunner(TaskRecordNode* self, const Runner& runner) {
       ++n_build_errors;
       continue;
     }
-    inputs.push_back(RunnerInput(/*artifact_path=*/builder_result->artifact_path.value(),
-                                 /*device_type=*/target->kind->name,
-                                 /*args_info=*/candidate->args_info));
+    inputs.push_back(
+        RunnerInput(/*artifact_path=*/builder_result->artifact_path.value(),
+                    /*device_type=*/runtime::DLDeviceType2Str(target->GetTargetDeviceType()),
+                    /*args_info=*/candidate->args_info));
   }
   ffi::Array<RunnerFuture> futures = runner->Run(inputs);
   if (n_build_errors == 0) {

--- a/tests/python/ir/test_ir_type.py
+++ b/tests/python/ir/test_ir_type.py
@@ -29,6 +29,13 @@ def check_json_roundtrip(node):
     tvm.ir.assert_structural_equal(back, node, map_free_vars=True)
 
 
+def test_missing_type():
+    missing = tvm.ir.Type.missing()
+
+    assert isinstance(missing, tvm.ir.Type)
+    assert missing.is_missing()
+
+
 def test_prim_type():
     x = tvm.ir.PrimType("int32")
     assert isinstance(x, tvm.ir.PrimType)

--- a/tests/python/relax/test_expr.py
+++ b/tests/python/relax/test_expr.py
@@ -243,11 +243,16 @@ def test_func():
     seqe = rx.SeqExpr(blocks, x)
     ret_ty = R.Tensor(dtype="float32", ndim=-1)
     func = rx.Function([x], seqe, ret_ty)
-    func = func.with_attr("global_symbol", "func")
-    assert func.params[0] == x
-    assert func.body == seqe
-    assert func.ret_ty == ret_ty
-    assert func.attrs["global_symbol"] == "func"
+    with_attr = func.with_attr("global_symbol", "func")
+    with_attrs = func.with_attr({"global_symbol": "func", "num_input": 1})
+
+    assert "global_symbol" not in func.attrs
+    assert with_attr.params[0] == x
+    assert with_attr.body == seqe
+    assert with_attr.ret_ty == ret_ty
+    assert with_attr.attrs["global_symbol"] == "func"
+    assert with_attrs.attrs["global_symbol"] == "func"
+    assert with_attrs.attrs["num_input"] == 1
 
 
 def test_shape_of():

--- a/tests/python/s_tir/meta_schedule/test_meta_schedule_task_scheduler.py
+++ b/tests/python/s_tir/meta_schedule/test_meta_schedule_task_scheduler.py
@@ -149,6 +149,14 @@ class MyTaskScheduler(ms.task_scheduler.PyTaskScheduler):
 
 
 def test_meta_schedule_task_scheduler_single():
+    device_types: list[str] = []
+
+    @derived_object
+    class RecordingRunner(ms.runner.PyRunner):
+        def run(self, runner_inputs: list[ms.runner.RunnerInput]) -> list[ms.runner.RunnerFuture]:
+            device_types.extend(str(runner_input.device_type) for runner_input in runner_inputs)
+            return DummyRunner().run(runner_inputs)
+
     num_trials_per_iter = 3
     max_trials_per_task = 10
     database = ms.database.MemoryDatabase()
@@ -170,12 +178,13 @@ def test_meta_schedule_task_scheduler_single():
         max_trials_per_task=max_trials_per_task,
         num_trials_per_iter=64,
         builder=DummyBuilder(),
-        runner=DummyRunner(),
+        runner=RecordingRunner(),
         database=database,
         measure_callbacks=[ms.measure_callback.AddToDatabase()],
         cost_model=None,
     )
     assert len(database) == max_trials_per_task
+    assert device_types == ["cpu"] * max_trials_per_task
 
 
 def test_meta_schedule_task_scheduler_multiple():


### PR DESCRIPTION
## Summary

- bump tvm-ffi and include the device definition where its `DLDevice` traits are instantiated
- keep only the required Tensor wrapper layout fix and register `ir.Type` before reflected `Expr` fields can materialize a fallback wrapper
- preserve `BaseFunc.with_attr` callers by moving only method-private results, never the canonical `self` wrapper

## Rationale

The tvm-ffi lifetime update requires a replacement wrapper to fit the layout already registered for the same type index. `runtime.Tensor` replaces the core `ffi.Tensor` wrapper, so it must use empty slots. The ordinary TVM mixins are first-registered with their concrete descendants and may safely retain normal Python dictionaries; the additional mixin and explicit-dictionary slot changes are not required.

Object tying also means `BaseFuncCopy(self)` may return `self`. Passing that wrapper through `_move()` invalidates the caller. The first update now passes the alias as an lvalue, forcing native copy-on-write to create a private result. Only later dictionary updates move a result that is not `self` and has not escaped the method.

## Validation

- built an exact CPython 3.12 wheel from tvm-ffi `21e30c3b1d` and rebuilt TVM against it
- direct Type/function/detach regressions: 3 passed
- complete IR plus focused Relax coverage: 111 passed
- prior Relax failure set: 157 passed, 9 skipped
- runtime probe for `relax.Function`, `relax.ExternFunc`, and `tirx.PrimFunc`: original wrappers preserved; single- and multi-attribute results distinct and valid
- all touched-file pre-commit hooks passed
