### PR TITLE
[Fix][TIRx] Ignore statement spans in structural identity

### DIFF
--- a/include/tvm/tirx/stmt.h
+++ b/include/tvm/tirx/stmt.h
@@ -51,7 +51,8 @@ class StmtNode : public ffi::Object {
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
-    refl::ObjectDef<StmtNode>().def_ro("span", &StmtNode::span);
+    refl::ObjectDef<StmtNode>().def_ro("span", &StmtNode::span,
+                                       refl::AttachFieldFlag::SEqHashIgnore());
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;

--- a/tests/python/tirx-base/test_tir_base.py
+++ b/tests/python/tirx-base/test_tir_base.py
@@ -118,6 +118,16 @@ def test_return_accepts_expr_and_roundtrips():
         tirx.Return(None)
 
 
+def test_stmt_span_not_structural():
+    span_a = tvm.ir.Span(tvm.ir.SourceName("a.py"), 1, 1, 1, 2)
+    span_b = tvm.ir.Span(tvm.ir.SourceName("b.py"), 10, 10, 3, 4)
+    stmt_a = tirx.Evaluate(tirx.IntImm("int32", 0), span_a)
+    stmt_b = tirx.Evaluate(tirx.IntImm("int32", 0), span_b)
+
+    assert tvm_ffi.structural_equal(stmt_a, stmt_b)
+    assert tvm_ffi.structural_hash(stmt_a) == tvm_ffi.structural_hash(stmt_b)
+
+
 def test_return_stmt_functor_traversal_and_mutation():
     x = tirx.Var("x", "int32")
     span = tvm.ir.Span(tvm.ir.SourceName("return_test"), 1, 1, 1, 9)


### PR DESCRIPTION
This PR excludes `tirx::StmtNode::span` from structural equality and structural hash calculations.

Source locations are diagnostic metadata and should not affect the structural identity of a TIRx statement. Other TIRx nodes with spans already follow this behavior, but `StmtNode::span` was missing the `SEqHashIgnore` field flag.

A regression test is added to verify that two otherwise identical statements with different spans are structurally equal and produce the same structural hash.