### PR TITLE
[FIX][Testing] Strip whitespace when parsing testing env flags

### DIFF
--- a/python/tvm/testing/utils.py
+++ b/python/tvm/testing/utils.py
@@ -90,12 +90,20 @@ import tvm.tirx
 from tvm.contrib import cudnn
 from tvm.support import nvcc
 
-SKIP_SLOW_TESTS = os.getenv("SKIP_SLOW_TESTS", "").lower() in {"true", "1", "yes"}
-IS_IN_CI = os.getenv("CI", "") == "true"
+_TRUTHY_ENV_VALUES = frozenset({"true", "1", "yes"})
+
+
+def _env_truthy(name: str, default: str = "") -> bool:
+    """Return whether an environment variable is set to a truthy value."""
+    return os.getenv(name, default).strip().lower() in _TRUTHY_ENV_VALUES
+
+
+SKIP_SLOW_TESTS = _env_truthy("SKIP_SLOW_TESTS")
+IS_IN_CI = os.getenv("CI", "").strip().lower() == "true"
 _REQUEST_HOOK_INITIALIZERS = {}
 
 skip_if_wheel_test = pytest.mark.skipif(
-    os.getenv("WHEEL_TEST", "").lower() in {"true", "1", "yes"},
+    _env_truthy("WHEEL_TEST"),
     reason="Test not supported in wheel.",
 )
 

--- a/tests/python/testing/test_testing_utils_env.py
+++ b/tests/python/testing/test_testing_utils_env.py
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Tests for tvm.testing.utils environment flag parsing."""
+
+import os
+from unittest import mock
+
+import tvm.testing.utils as testing_utils
+
+
+def test_env_truthy_strips_whitespace():
+    with mock.patch.dict(os.environ, {"SKIP_SLOW_TESTS": "  true  "}):
+        assert testing_utils._env_truthy("SKIP_SLOW_TESTS") is True
+    with mock.patch.dict(os.environ, {"SKIP_SLOW_TESTS": "\t1\n"}):
+        assert testing_utils._env_truthy("SKIP_SLOW_TESTS") is True
+    with mock.patch.dict(os.environ, {"SKIP_SLOW_TESTS": "   "}):
+        assert testing_utils._env_truthy("SKIP_SLOW_TESTS") is False


### PR DESCRIPTION
## Summary
- Strip leading/trailing whitespace for `SKIP_SLOW_TESTS`, `WHEEL_TEST`, and `CI` in `tvm.testing.utils`.
- Add `_env_truthy()` helper used by slow-test and wheel-test skips.

## Motivation
CI/K8s env values are often exported with accidental whitespace, which silently disables or mis-parses flags.

## Test plan
- `tests/python/testing/test_testing_utils_env.py`