### PR TITLE
[Fix][Relax] Return frontend tensor dtype value

### DIFF
--- a/python/tvm/relax/frontend/nn/core.py
+++ b/python/tvm/relax/frontend/nn/core.py
@@ -226,7 +226,7 @@ class Tensor(_TensorOp):
         dtype : str
             The data type of the tensor
         """
-        return self._expr.ty.dtype
+        return self._expr.ty.dtype.dtype
 
     def __repr__(self) -> str:
         return f'Tensor({self.shape}, "{self.dtype}")'

--- a/tests/python/relax/test_frontend_nn_tensor.py
+++ b/tests/python/relax/test_frontend_nn_tensor.py
@@ -30,6 +30,7 @@ def test_tensor_from_numpy():
     tensor_x = Tensor.from_const(x)
     assert tensor_x.shape == [1, 10]
     assert tensor_x.ndim == 2
+    assert isinstance(tensor_x.dtype, str)
     assert tensor_x.dtype == "float32"
     assert repr(tensor_x) == 'Tensor([1, 10], "float32")'
 


### PR DESCRIPTION
Following the recent PrimType refactor, `nn.Tensor.dtype` returns a `PrimType` object instead of the documented string dtype value. This breaks consumers such as NumPy's astype. This PR returns the underlying dtype value and adds an assertion verifying that `Tensor.dtype` remains string-compatible.