### PR TITLE
[TVMSCRIPT][TIRx] Preserve parser source spans in IR

### DIFF
--- a/include/tvm/script/ir_builder/base.h
+++ b/include/tvm/script/ir_builder/base.h
@@ -161,6 +161,8 @@ class IRBuilderNode : public ffi::Object {
   ffi::Array<IRBuilderFrame> frames;
   /*! \brief The outcome of IR construction */
   ffi::Optional<ffi::ObjectRef> result;
+  /*! \brief Active frontend source spans, from outermost to innermost. */
+  std::vector<Span> source_spans;
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
@@ -195,6 +197,14 @@ class IRBuilderNode : public ffi::Object {
    */
   template <typename TObjectRef>
   inline TObjectRef Get() const;
+  /*! \brief Push a frontend source span for IR constructed in the nested scope. */
+  void PushSourceSpan(Span span);
+  /*! \brief Pop the innermost frontend source span. */
+  void PopSourceSpan();
+  /*! \brief Return the normalized active source span, including expansion history. */
+  Span GetCurrentSourceSpan() const;
+  /*! \brief Attach the active source span to an expression that has no span yet. */
+  ffi::ObjectRef SetCurrentSourceSpan(ffi::ObjectRef obj) const;
 };
 
 /*!

--- a/python/tvm/script/ir_builder/base.py
+++ b/python/tvm/script/ir_builder/base.py
@@ -17,6 +17,7 @@
 """A generic IRBuilder across the TVM stack"""
 
 from collections.abc import Callable
+from contextlib import contextmanager
 from typing import Any
 
 from tvm_ffi import register_object as _register_object
@@ -160,6 +161,34 @@ class IRBuilder(_Object):
     def get(self) -> _Object:
         """Get the constructed IR."""
         return _ffi_api.IRBuilderGet(self)  # type: ignore[attr-defined] # pylint: disable=no-member
+
+    @contextmanager
+    def with_source_span(self, span):
+        """Attach ``span`` to IR nodes constructed in the nested scope.
+
+        Nested scopes are retained as a ``SequentialSpan`` when they describe
+        distinct source ranges, such as a TVMScript inline expansion.
+
+        Parameters
+        ----------
+        span : tvm.ir.Span
+            The frontend source range active in the nested scope.
+        """
+        _ffi_api.IRBuilderPushSourceSpan(  # type: ignore[attr-defined] # pylint: disable=no-member
+            self, span
+        )
+        try:
+            yield
+        finally:
+            _ffi_api.IRBuilderPopSourceSpan(  # type: ignore[attr-defined] # pylint: disable=no-member
+                self
+            )
+
+    def _set_current_source_span(self, value):
+        """Attach the active source span to an expression without one."""
+        return _ffi_api.IRBuilderSetCurrentSourceSpan(  # type: ignore[attr-defined] # pylint: disable=no-member
+            self, value
+        )
 
     @staticmethod
     def name(s: str, v: Any) -> Any:

--- a/python/tvm/script/parser/core/diagnostics.py
+++ b/python/tvm/script/parser/core/diagnostics.py
@@ -21,6 +21,7 @@ import inspect
 import sys
 
 from tvm.error import DiagnosticError
+from tvm.ir import SourceName, Span
 
 from . import doc
 
@@ -98,6 +99,31 @@ class Source:
             The AST of source code.
         """
         return doc.parse(self.source)
+
+    def location(self, node: doc.AST) -> tuple[int, int, int, int]:
+        """Return the absolute 1-based source range of an AST node."""
+        lineno = getattr(node, "lineno", 1) or 1
+        col_offset = getattr(node, "col_offset", self.start_column)
+        col_offset = self.start_column if col_offset is None else col_offset
+        end_lineno = getattr(node, "end_lineno", lineno) or lineno
+        end_col_offset = getattr(node, "end_col_offset", col_offset)
+        end_col_offset = col_offset if end_col_offset is None else end_col_offset
+        lineno += self.start_line - 1
+        end_lineno += self.start_line - 1
+        col_offset += self.start_column + 1
+        end_col_offset += self.start_column + 1
+        return lineno, col_offset, end_lineno, end_col_offset
+
+    def to_span(self, node: doc.AST) -> Span:
+        """Convert an AST node to the canonical IR source span."""
+        lineno, col_offset, end_lineno, end_col_offset = self.location(node)
+        return Span(
+            SourceName(self.source_name or "<unknown>"),
+            lineno,
+            end_lineno,
+            col_offset,
+            end_col_offset,
+        )
 
 
 _getfile = inspect.getfile  # pylint: disable=invalid-name
@@ -286,14 +312,7 @@ class Diagnostics:
         message : str
             The diagnostic message.
         """
-        lineno = getattr(node, "lineno", 1)
-        col_offset = getattr(node, "col_offset", self.source.start_column)
-        end_lineno = getattr(node, "end_lineno", lineno)
-        end_col_offset = getattr(node, "end_col_offset", col_offset)
-        lineno += self.source.start_line - 1
-        end_lineno += self.source.start_line - 1
-        col_offset += self.source.start_column + 1
-        end_col_offset += self.source.start_column + 1
+        lineno, col_offset, end_lineno, end_col_offset = self.source.location(node)
 
         source_lines = self.source.full_source.splitlines(keepends=True)
         snippet = _format_source_snippet(

--- a/python/tvm/script/parser/core/evaluator.py
+++ b/python/tvm/script/parser/core/evaluator.py
@@ -144,6 +144,8 @@ class ExprEvaluator:
         name : doc.Name
             The doc AST name node with intermediate name for intermediate result.
         """
+        if self.parser is not None:
+            value = self.parser.annotate_current_source_span(value)
         name = f"__tvm_tmp_value_{self.new_value_count}"
         self.new_value_count += 1
         self.value_table[name] = value
@@ -171,6 +173,18 @@ class ExprEvaluator:
         res : Any
             The evaluation result.
         """
+        if isinstance(node, list):
+            return [self._visit(n) for n in node]
+        if isinstance(node, tuple):
+            return tuple(self._visit(n) for n in node)
+        assert isinstance(node, doc.AST)
+        if self.parser is None:
+            return self._visit_node(node)
+        with self.parser.with_source_span(node):
+            return self._visit_node(node)
+
+    def _visit_node(self, node: doc.AST) -> Any:
+        """Evaluate one AST node while its source span is active."""
         args = []
         if (
             isinstance(node, doc.Call)
@@ -208,11 +222,6 @@ class ExprEvaluator:
                             s.upper.lineno,
                             s.upper.end_col_offset + 2,
                         )
-        if isinstance(node, list):
-            return [self._visit(n) for n in node]
-        if isinstance(node, tuple):
-            return tuple(self._visit(n) for n in node)
-        assert isinstance(node, doc.AST)
         if isinstance(node, doc.Name):
             if node.id not in self.value_table and not _get_builtin_or_none(node.id):
                 raise ParserError(node, f"Undefined variable: {node.id}")

--- a/python/tvm/script/parser/core/parser.py
+++ b/python/tvm/script/parser/core/parser.py
@@ -29,6 +29,7 @@ from tvm.error import DiagnosticError
 from tvm.ir import GlobalVar
 from tvm.runtime import Object
 
+from ...ir_builder import IRBuilder
 from . import dispatch, doc
 from .diagnostics import Diagnostics, Source
 from .evaluator import eval_assign, eval_expr
@@ -503,6 +504,25 @@ class Parser(doc.NodeVisitor):
 
         return _deferred(pop_source)
 
+    @contextmanager
+    def with_source_span(self, node: doc.AST):
+        """Make ``node``'s source range active while constructing its IR."""
+        if (
+            not IRBuilder.is_in_scope()
+            or getattr(node, "lineno", None) is None
+            or getattr(node, "col_offset", None) is None
+        ):
+            yield
+            return
+        with IRBuilder.current().with_source_span(self.diag.source.to_span(node)):
+            yield
+
+    def annotate_current_source_span(self, value: Any) -> Any:
+        """Attach the active parser span to an expression result, when applicable."""
+        if isinstance(value, Object) and IRBuilder.is_in_scope():
+            return IRBuilder.current()._set_current_source_span(value)  # pylint: disable=protected-access
+        return value
+
     def eval_expr(
         self,
         node: doc.Expression | doc.expr,
@@ -667,7 +687,8 @@ class Parser(doc.NodeVisitor):
         if func is None:
             raise NotImplementedError(f"Visitor of AST node is not implemented: {name}")
         try:
-            func(node)
+            with self.with_source_span(node):
+                func(node)
         except Exception as err:  # pylint: disable=broad-except
             self.report_error(node, err)
 

--- a/src/script/ir_builder/base.cc
+++ b/src/script/ir_builder/base.cc
@@ -22,9 +22,45 @@
 #include <tvm/ir/module.h>
 #include <tvm/script/ir_builder/base.h>
 
+#include <utility>
+
 namespace tvm {
 namespace script {
 namespace ir_builder {
+
+namespace {
+
+bool PositionLessEqual(int lhs_line, int lhs_column, int rhs_line, int rhs_column) {
+  return lhs_line < rhs_line || (lhs_line == rhs_line && lhs_column <= rhs_column);
+}
+
+bool Contains(const Span& outer, const Span& inner) {
+  if (!outer.defined() || !inner.defined() || outer.as<SequentialSpanNode>() ||
+      inner.as<SequentialSpanNode>() || !outer->source_name.same_as(inner->source_name)) {
+    return false;
+  }
+  return PositionLessEqual(outer->line, outer->column, inner->line, inner->column) &&
+         PositionLessEqual(inner->end_line, inner->end_column, outer->end_line, outer->end_column);
+}
+
+void AppendNormalizedSpan(const Span& span, std::vector<Span>* normalized) {
+  if (!span.defined()) {
+    return;
+  }
+  if (const auto* sequential = span.as<SequentialSpanNode>()) {
+    for (const Span& nested : sequential->spans) {
+      AppendNormalizedSpan(nested, normalized);
+    }
+    return;
+  }
+  if (!normalized->empty() && Contains(normalized->back(), span)) {
+    normalized->back() = span;
+  } else {
+    normalized->push_back(span);
+  }
+}
+
+}  // namespace
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   IRBuilderFrameNode::RegisterReflection();
@@ -54,7 +90,49 @@ IRBuilder::IRBuilder() {
   ffi::ObjectPtr<IRBuilderNode> n = ffi::make_object<IRBuilderNode>();
   n->frames.clear();
   n->result = std::nullopt;
+  n->source_spans.clear();
   data_ = n;
+}
+
+void IRBuilderNode::PushSourceSpan(Span span) {
+  TVM_FFI_CHECK(span.defined(), ValueError) << "ValueError: Cannot push an undefined source span";
+  source_spans.push_back(std::move(span));
+}
+
+void IRBuilderNode::PopSourceSpan() {
+  TVM_FFI_CHECK(!source_spans.empty(), ValueError)
+      << "ValueError: No source span exists in the builder scope";
+  source_spans.pop_back();
+}
+
+Span IRBuilderNode::GetCurrentSourceSpan() const {
+  std::vector<Span> normalized;
+  normalized.reserve(source_spans.size());
+  for (const Span& span : source_spans) {
+    AppendNormalizedSpan(span, &normalized);
+  }
+  if (normalized.empty()) {
+    return Span();
+  }
+  if (normalized.size() == 1) {
+    return normalized[0];
+  }
+  ffi::Array<Span> spans;
+  spans.reserve(normalized.size());
+  for (const Span& span : normalized) {
+    spans.push_back(span);
+  }
+  return SequentialSpan(std::move(spans));
+}
+
+ffi::ObjectRef IRBuilderNode::SetCurrentSourceSpan(ffi::ObjectRef obj) const {
+  Span span = GetCurrentSourceSpan();
+  if (span.defined()) {
+    if (const auto* expr = obj.as<ExprNode>(); expr != nullptr && !expr->span.defined()) {
+      expr->span = std::move(span);
+    }
+  }
+  return obj;
 }
 
 std::vector<IRBuilder>* ThreadLocalBuilderStack() {
@@ -66,6 +144,9 @@ void IRBuilder::EnterWithScope() {
   IRBuilderNode* n = this->get();
   TVM_FFI_CHECK(n->frames.empty(), ValueError)
       << "ValueError: There are frame(s) left in the builder: " << n->frames.size()
+      << ". Please use a fresh new builder every time building IRs";
+  TVM_FFI_CHECK(n->source_spans.empty(), ValueError)
+      << "ValueError: There are source span(s) left in the builder: " << n->source_spans.size()
       << ". Please use a fresh new builder every time building IRs";
   n->result = std::nullopt;
   std::vector<IRBuilder>* stack = ThreadLocalBuilderStack();
@@ -118,6 +199,10 @@ TVM_FFI_STATIC_INIT_BLOCK() {
       .def("script.ir_builder.IRBuilderCurrent", IRBuilder::Current)
       .def("script.ir_builder.IRBuilderIsInScope", IRBuilder::IsInScope)
       .def_method("script.ir_builder.IRBuilderGet", &IRBuilderNode::Get<ffi::ObjectRef>)
+      .def_method("script.ir_builder.IRBuilderPushSourceSpan", &IRBuilderNode::PushSourceSpan)
+      .def_method("script.ir_builder.IRBuilderPopSourceSpan", &IRBuilderNode::PopSourceSpan)
+      .def_method("script.ir_builder.IRBuilderSetCurrentSourceSpan",
+                  &IRBuilderNode::SetCurrentSourceSpan)
       .def("script.ir_builder.IRBuilderName", IRBuilder::Name<ffi::ObjectRef>);
 }
 

--- a/src/tirx/script/builder/utils.h
+++ b/src/tirx/script/builder/utils.h
@@ -37,6 +37,10 @@ namespace tirx {
  */
 inline void AddToParent(tvm::tirx::Stmt stmt) {
   IRBuilder builder = IRBuilder::Current();
+  // Some builder paths use an undefined statement as an omitted branch.
+  if (stmt.defined() && !stmt->span.defined()) {
+    stmt->span = builder->GetCurrentSourceSpan();
+  }
   if (builder->frames.empty()) {
     TVM_FFI_CHECK(!builder->result.has_value(), ValueError)
         << "Builder.result has already been set";

--- a/tests/python/tvmscript/test_tvmscript_ir_builder_tir.py
+++ b/tests/python/tvmscript/test_tvmscript_ir_builder_tir.py
@@ -25,7 +25,7 @@ import tvm
 import tvm.runtime
 import tvm.testing
 from tvm import tirx
-from tvm.ir.base import assert_structural_equal
+from tvm.ir.base import SourceName, Span, assert_structural_equal
 from tvm.script.ir_builder import IRBuilder
 from tvm.script.ir_builder import tirx as T
 
@@ -49,6 +49,18 @@ def test_ir_builder_tir_primfunc_base():
 
     # Check if the generated ir is expected
     assert_structural_equal(prim_func_actual, prim_func_expected, map_free_vars=True)
+
+
+def test_ir_builder_source_span_applies_to_emitted_stmt():
+    span = Span(SourceName("builder_test.py"), 7, 7, 5, 18)
+    with IRBuilder() as ib:
+        with T.prim_func(s_tir=True):
+            with ib.with_source_span(span):
+                T.evaluate(1)
+
+    actual = ib.get().body.span
+    assert actual.source_name.name == "builder_test.py"
+    assert (actual.line, actual.column, actual.end_line, actual.end_column) == (7, 5, 7, 18)
 
 
 def test_ir_builder_tir_primfunc_complete():

--- a/tests/python/tvmscript/test_tvmscript_parser_source.py
+++ b/tests/python/tvmscript/test_tvmscript_parser_source.py
@@ -20,11 +20,25 @@
 import inspect
 
 import pytest
+import tvm_ffi
 
+import tvm
 import tvm.testing
+from tvm.ir import Call, SequentialSpan, assert_structural_equal
 from tvm.script import tirx as T
 from tvm.script.parser.core import doc_core as doc
 from tvm.script.parser.core.diagnostics import Source
+from tvm.script.tirx import tile as Tx
+from tvm.tirx.stmt import TilePrimitiveCall
+from tvm.tirx.stmt_functor import post_order_visit
+
+
+def _tirx_source(func):
+    """Leave a function intact while marking its source as TIRx."""
+    return func
+
+
+_tirx_source.dispatch_token = "tirx"
 
 
 def matmul(a: T.handle, b: T.handle, c: T.handle) -> None:
@@ -84,6 +98,118 @@ def test_source_ast():
     assert len(for_body) == 1
     for_block = for_body[0]
     assert isinstance(for_block, doc.With) and len(for_block.body) == 2
+
+
+def _span_range(span):
+    return (
+        span.source_name.name,
+        span.line,
+        span.column,
+        span.end_line,
+        span.end_column,
+    )
+
+
+def _find_ir_node(func, predicate):
+    nodes = []
+    post_order_visit(func.body, nodes.append)
+    matches = [node for node in nodes if predicate(node)]
+    assert len(matches) == 1
+    return matches[0]
+
+
+def test_source_to_span_matches_parser_diagnostic_coordinates():
+    source = Source(matmul)
+    assign = source.as_ast().body[0].body[0]
+    span = source.to_span(assign)
+    expected_location = (
+        source.start_line + 1,
+        5,
+        source.start_line + 1,
+        38,
+    )
+
+    assert source.location(assign) == expected_location
+    assert _span_range(span) == (source.source_name, *expected_location)
+
+
+def test_parser_attaches_span_to_direct_call():
+    @_tirx_source
+    def direct_call():
+        T.device_entry()
+        barriers = T.alloc_buffer((1,), "uint64", scope="shared")
+        T.ptx.mbarrier.try_wait(
+            T.address_of(barriers[0]),
+            0,
+        )
+
+    source = Source(direct_call)
+    call_ast = source.as_ast().body[0].body[-1].value
+    func = T.prim_func(direct_call)
+    call = _find_ir_node(
+        func,
+        lambda node: isinstance(node, Call)
+        and getattr(node.op, "name", None) == "tirx.ptx.mbarrier_try_wait",
+    )
+
+    assert _span_range(call.span) == _span_range(source.to_span(call_ast))
+
+
+def test_parser_retains_inline_call_site_and_definition_spans():
+    def wait_impl(barrier):
+        T.ptx.mbarrier.try_wait(barrier, 0)
+
+    wait_source = Source(wait_impl)
+    wait_call_ast = wait_source.as_ast().body[0].body[0].value
+    wait = T.inline(wait_impl)
+
+    @_tirx_source
+    def inline_call():
+        T.device_entry()
+        barriers = T.alloc_buffer((1,), "uint64", scope="shared")
+        wait(T.address_of(barriers[0]))
+
+    caller_source = Source(inline_call)
+    caller_call_ast = caller_source.as_ast().body[0].body[-1].value
+    func = T.prim_func(inline_call)
+    call = _find_ir_node(
+        func,
+        lambda node: isinstance(node, Call)
+        and getattr(node.op, "name", None) == "tirx.ptx.mbarrier_try_wait",
+    )
+
+    assert isinstance(call.span, SequentialSpan)
+    assert [_span_range(span) for span in call.span.spans] == [
+        _span_range(caller_source.to_span(caller_call_ast)),
+        _span_range(wait_source.to_span(wait_call_ast)),
+    ]
+
+
+def test_parser_attaches_span_to_tile_primitive_call():
+    @_tirx_source
+    def tile_call():
+        A = T.alloc_buffer((16,), "float32")
+        Tx.memset(A[0:16], T.float32(0))
+
+    source = Source(tile_call)
+    call_ast = source.as_ast().body[0].body[-1].value
+    func = T.prim_func(tile_call)
+    call = _find_ir_node(func, lambda node: isinstance(node, TilePrimitiveCall))
+
+    assert _span_range(call.span) == _span_range(source.to_span(call_ast))
+
+
+def test_parser_spans_do_not_affect_structural_identity():
+    source_a = """@T.prim_func\ndef f():\n    T.evaluate(1)\n"""
+    source_b = """\n\n@T.prim_func\ndef f():\n    T.evaluate(1)\n"""
+
+    func_a = tvm.script.from_source(source_a)
+    func_b = tvm.script.from_source(source_b)
+
+    assert _span_range(func_a.body.span) == ("<str>", 3, 5, 3, 18)
+    assert _span_range(func_b.body.span) == ("<str>", 5, 5, 5, 18)
+    assert tvm_ffi.structural_hash(func_a) == tvm_ffi.structural_hash(func_b)
+    assert_structural_equal(func_a, func_b)
 
 
 def test_nesting_parsing():


### PR DESCRIPTION
## Motivation and context

The TVMScript parser already tracks Python AST locations for diagnostics, but TIRx statements and expression results emitted through `IRBuilder` did not retain those locations.  After parsing, a direct intrinsic call, an inlined helper body, or a `TilePrimitiveCall` therefore could not be traced back to the source range that produced it.

Inline expansion also needs more than a single flat location.  The generated IR should retain both the caller location and the helper-definition location, while ordinary nested AST evaluation within one source should not accumulate redundant enclosing spans.

## Changes

- Add an active source-span stack to `IRBuilder`, with scoped push/pop support.
- Make the parser activate the current AST source range while visiting statements and evaluating expressions.
- Attach the active span to emitted TIRx statements and to expression results that do not already carry an explicit span.
- Normalize nested spans from the same source to the innermost relevant range.
- Preserve cross-source inline expansion history as a `SequentialSpan`, ordered from the call site to the expanded definition.
- Reuse the same source-coordinate calculation for diagnostics and IR spans so their line and column conventions remain consistent.

Source spans remain diagnostic metadata: functions parsed from different source locations keep the same structural hash and remain structurally equal.

## Testing

- Verify exact parser source coordinates against diagnostic coordinates.
- Verify spans on direct intrinsic calls and `TilePrimitiveCall` nodes.
- Verify that inline expansion produces a `SequentialSpan` containing caller and callee ranges.
- Verify direct `IRBuilder.with_source_span` behavior.
- Verify that source spans do not affect structural identity.
- Run changed-files pre-commit checks, including clang-format.

Focused result: 9 tests passed.
