### PR TITLE
[Web] Bump tvmjs version to 0.27.0-dev0 on main

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tvmjs",
-  "version": "0.26.0-dev0",
+  "version": "0.27.0-dev0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tvmjs",
-      "version": "0.26.0-dev0",
+      "version": "0.27.0-dev0",
       "license": "Apache-2.0",
       "dependencies": {
         "audit": "^0.0.6",

--- a/web/package.json
+++ b/web/package.json
@@ -3,7 +3,7 @@
   "description": "TVM WASM/WebGPU runtime for JS/TS",
   "license": "Apache-2.0",
   "homepage": "https://github.com/apache/tvm/tree/main/web",
-  "version": "0.26.0-dev0",
+  "version": "0.27.0-dev0",
   "files": [
     "lib"
   ],


### PR DESCRIPTION
The `v0.26.0` release branch has been cut and `main` now carries the `v0.27.dev0` tag, so this opens the matching npm dev cycle.

`web/package.json` is the only version that `setuptools_scm` does not derive from git tags — npm is a separate ecosystem — so it is bumped by hand once per cycle. The release branch keeps `0.26.0` for the v0.26.0 release (#20093).

Note for the release timeline: while v0.26.0 is still in flight, any cherry-pick from `main` to the release branch that touches `web/package*` will conflict with this bump, so it may be preferable to hold the merge until v0.26.0 has shipped.