### PR TITLE
[Fix][TIRx] Fix MSVC build of IndexDataTypeNormalizer

### DIFF
--- a/src/tirx/ir/data_type_rewriter.cc
+++ b/src/tirx/ir/data_type_rewriter.cc
@@ -693,7 +693,7 @@ Expr IndexDataTypeNormalizer::VisitExpr_(const CastNode* op) {
   // has some other purpose, and we should not unwrap the cast.
   PrimType dtype = op->ty.as_or_throw<PrimType>();
   if (is_enabled_ && CanRewriteDType(dtype)) {
-    PrimExpr value = IndexDataTypeNormalizer::VisitPrimExpr(op->value);
+    PrimExpr value = this->VisitPrimExpr(op->value);
     return value.ty() == target_data_type_ ? value : Cast(target_data_type_, value);
   }
   return IndexDataTypeRewriter::VisitExpr_(op);


### PR DESCRIPTION
The Windows wheel build for `v0.26.0.rc0` fails to compile:

```
src\tirx\ir\data_type_rewriter.cc(696,47): error C2352:
  'tvm::tirx::ExprMutator::VisitPrimExpr': a call of a non-static member function requires an object
```

`StmtExprMutator` derives from both `ExprMutator` and `StmtMutator`, and re-exports the name via `using ExprMutator::VisitPrimExpr;`. MSVC resolves the class-qualified `IndexDataTypeNormalizer::VisitPrimExpr` down to `ExprMutator::VisitPrimExpr` and then fails to form the implicit object conversion. GCC and Clang accept the same expression, so only the Windows leg broke — the macOS and both Linux wheels built fine.

The fix calls it through `this` instead, matching every other `VisitPrimExpr` call site in this file. `VisitPrimExpr` is a non-virtual inline helper, so the qualification was suppressing nothing and behavior is unchanged. The other class-qualified call sites in the tree name `StmtExprMutator` directly — that is where the using-declaration lives, so they resolve fine and are left alone.

The call was introduced in #19931, which changed `IndexDataTypeNormalizer::VisitExpr` to `IndexDataTypeNormalizer::VisitPrimExpr`; the former resolved unambiguously.

Targeting the release branch first to unblock the `v0.26.0.rc0` Windows wheel; it will be ported to `main` separately.

Failing job: https://github.com/apache/tvm/actions/runs/31033249253/job/92400739674