### PR TITLE
[FIX][TIRx] Use typed buffer parameter in pointer config test

### DIFF
--- a/tests/python/tirx/transform/test_stmt_functor.py
+++ b/tests/python/tirx/transform/test_stmt_functor.py
@@ -1196,7 +1196,7 @@ def test_op_call_pointer_config_visited_and_mutated():
 
     op_call = copy_async.body
     assert isinstance(op_call, tir.TilePrimitiveCall)
-    mbar_buffer = copy_async.buffer_map[copy_async.params[2]]
+    mbar_buffer = copy_async.params[2]
 
     class LoadCollector(StmtExprVisitor):
         def __init__(self):


### PR DESCRIPTION
This updates the pointer-config statement-functor regression to use the typed buffer parameter after PrimFunc.buffer_map removal. It preserves the visitor and mutator assertions while matching the current PrimFunc representation.
