### PR TITLE
fix: preserve LLVM vector value dominance across control flow

### DIFF
--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -1454,13 +1454,43 @@ llvm::Value* CodeGenLLVM::CreateIntrinsic(const CallNode* op) {
     builder_->CreateCondBr(MakeValue(args[0]), then_block, else_block);
     builder_->SetInsertPoint(then_block);
     llvm::Value* then_value = MakeValue(args[1]);
+    std::vector<llvm::Value*> then_elements;
+    // Merge fixed-width vectors lane-by-lane so branch-local vector assembly does not escape
+    // its defining block.  Some LLVM optimization pipelines otherwise form uses of the
+    // branch-local shuffles that are not dominated by their definitions.
+    if (auto* vector_type = llvm::dyn_cast<llvm::FixedVectorType>(then_value->getType())) {
+      for (unsigned i = 0; i < vector_type->getNumElements(); ++i) {
+        then_elements.push_back(builder_->CreateExtractElement(then_value, ConstInt32(i)));
+      }
+    }
     llvm::BasicBlock* then_value_block = builder_->GetInsertBlock();
     builder_->CreateBr(end_block);
     builder_->SetInsertPoint(else_block);
     llvm::Value* else_value = MakeValue(args[2]);
+    std::vector<llvm::Value*> else_elements;
+    if (!then_elements.empty()) {
+      TVM_FFI_ICHECK_EQ(then_value->getType(), else_value->getType());
+      for (size_t i = 0; i < then_elements.size(); ++i) {
+        else_elements.push_back(builder_->CreateExtractElement(else_value, ConstInt32(i)));
+      }
+    }
     llvm::BasicBlock* else_value_block = builder_->GetInsertBlock();
     builder_->CreateBr(end_block);
     builder_->SetInsertPoint(end_block);
+    if (!then_elements.empty()) {
+      std::vector<llvm::PHINode*> elements;
+      for (size_t i = 0; i < then_elements.size(); ++i) {
+        llvm::PHINode* element = builder_->CreatePHI(then_elements[i]->getType(), 2);
+        element->addIncoming(then_elements[i], then_value_block);
+        element->addIncoming(else_elements[i], else_value_block);
+        elements.push_back(element);
+      }
+      llvm::Value* result = llvm::UndefValue::get(then_value->getType());
+      for (size_t i = 0; i < elements.size(); ++i) {
+        result = builder_->CreateInsertElement(result, elements[i], ConstInt32(i));
+      }
+      return result;
+    }
     llvm::PHINode* value = builder_->CreatePHI(then_value->getType(), 2);
     value->addIncoming(then_value, then_value_block);
     value->addIncoming(else_value, else_value_block);

--- a/tests/python/codegen/test_target_codegen_llvm.py
+++ b/tests/python/codegen/test_target_codegen_llvm.py
@@ -1015,6 +1015,74 @@ def test_llvm_scalar_concat():
 
 
 @pytest.mark.skipif(not env.has_llvm(), reason="need llvm")
+def test_llvm_vector_concat_across_conditional():
+    @I.ir_module(s_tir=True)
+    class Module:
+        @T.prim_func(s_tir=True)
+        def uneven_lanes(
+            A: T.Buffer((16,), "float32"), B: T.Buffer((4,), "float32"), condition: T.int32
+        ):
+            first = T.Shuffle([A[T.Ramp(0, 1, 4)], A[T.Ramp(4, 1, 4)]], [2, 6])
+            second = T.if_then_else(
+                condition != 0,
+                T.Shuffle([A[T.Ramp(8, 1, 4)], A[T.Ramp(12, 1, 4)]], [0, 5]),
+                T.Shuffle([A[T.Ramp(8, 1, 4)], A[T.Ramp(12, 1, 4)]], [2, 7]),
+            )
+            B[T.Ramp(0, 1, 4)] = T.Shuffle([first, second], [0, 1, 2, 3])
+
+        @T.prim_func(s_tir=True)
+        def alternate_shape(
+            A: T.Buffer((16,), "float32"), B: T.Buffer((4,), "float32"), condition: T.int32
+        ):
+            first = T.if_then_else(
+                condition != 0,
+                T.Shuffle([A[T.Ramp(0, 1, 8)], A[T.Ramp(8, 1, 8)]], [1, 5, 9]),
+                T.Shuffle([A[T.Ramp(0, 1, 8)], A[T.Ramp(8, 1, 8)]], [2, 6, 10]),
+            )
+            B[T.Ramp(0, 1, 4)] = T.Shuffle([first, A[15]], [0, 1, 2, 3])
+
+    built = tvm.compile(Module, target="llvm")
+    dev = tvm.cpu(0)
+
+    a = tvm.runtime.tensor(np.arange(16, dtype="float32"), dev)
+    b = tvm.runtime.empty((4,), dtype="float32", device=dev)
+    built["uneven_lanes"](a, b, 1)
+    tvm.testing.assert_allclose(b.numpy(), np.array([2, 6, 8, 13], dtype="float32"))
+    built["uneven_lanes"](a, b, 0)
+    tvm.testing.assert_allclose(b.numpy(), np.array([2, 6, 10, 15], dtype="float32"))
+
+    a = tvm.runtime.tensor(np.arange(16, dtype="float32"), dev)
+    b = tvm.runtime.empty((4,), dtype="float32", device=dev)
+    built["alternate_shape"](a, b, 1)
+    tvm.testing.assert_allclose(b.numpy(), np.array([1, 5, 9, 15], dtype="float32"))
+    built["alternate_shape"](a, b, 0)
+    tvm.testing.assert_allclose(b.numpy(), np.array([2, 6, 10, 15], dtype="float32"))
+
+
+@pytest.mark.skipif(not env.has_llvm(), reason="need llvm")
+def test_llvm_vector_conditional_remains_lazy():
+    @I.ir_module(s_tir=True)
+    class Module:
+        @T.prim_func(s_tir=True)
+        def main(
+            A: T.Buffer((4,), "float32"), B: T.Buffer((4,), "float32"), condition: T.int32
+        ):
+            B[T.Ramp(0, 1, 4)] = T.if_then_else(
+                condition != 0,
+                A[T.Ramp(0, 1, 4)],
+                A[T.Ramp(1024, 1, 4)],
+            )
+
+    built = tvm.compile(Module, target="llvm")
+    dev = tvm.cpu(0)
+    a_np = np.arange(4, dtype="float32")
+    a = tvm.runtime.tensor(a_np, dev)
+    b = tvm.runtime.empty((4,), dtype="float32", device=dev)
+    built(a, b, 1)
+    tvm.testing.assert_allclose(b.numpy(), a_np)
+
+
+@pytest.mark.skipif(not env.has_llvm(), reason="need llvm")
 def test_raise_exception_during_codegen():
     @I.ir_module(s_tir=True)
     class Module:


### PR DESCRIPTION
LLVM code generation rejects valid vectorized TIR produced by Relax `avg_pool2d` for shapes such as `[1, 4, 6, 3]`, reporting that one `shufflevector` instruction does not dominate a later use. The reporter supplied a second `silu` reproducer with a different shape, showing that the defect is in the shared TIR-to-LLVM path rather than pooling legalization. Both failures involve vector values assembled around conditional control flow, while the Relax IR and generated TIR remain valid. The issue is open and unassigned, but two earlier cross-referenced pull requests (#20024 and #20025) closed without landing.

## Testing

- Compile the reduced vectorized TIR reproducer for LLVM and confirm module verification succeeds instead of reporting a non-dominating `shufflevector`.
- Exercise the same control-flow/vector assembly pattern with the uneven lane grouping exposed by the `avg_pool2d` case and verify the generated function executes with the expected numeric output.
- Exercise the alternate vector shape derived from the reporter's `silu` variant so the regression is not coupled to pooling legalization or a single tensor layout.
- Retain a lazy conditional case whose unselected branch contains a potentially unsafe load, proving the dominance fix does not replace `tirx.if_then_else` with eager evaluation.

## What changed

Reduce the two Relax examples to the smallest vectorized TIR expression that reproduces the invalid SSA graph, then add it to the LLVM codegen suite so the regression is owned at the failing backend boundary. Adjust `CodeGenLLVM`'s lowering of branch-bearing vector expressions so every value consumed after a control-flow merge is produced in a dominating block (or represented by the merge value), and branch-local shuffle/concat values cannot escape into a sibling or successor path. Preserve lazy `tirx.if_then_else` behavior for unsafe operands and the existing vector concatenation semantics; do not special-case `avg_pool2d`, `silu`, or the reported dimensions.

Fixes #20015
