### PR TITLE
[Fix][Relax][ONNX] Fold binary ops on symbolic PrimExpr scalars without numpy dispatch

### DIFF
--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -570,6 +570,17 @@ def _to_numpy(x):
         return x.data.numpy()
 
 
+def _as_scalar_prim_expr(value, dtype=None):
+    """Convert a scalar operand into a PrimExpr, or None if it is not a scalar."""
+    if tvm.ir.is_prim_expr(value):
+        return value
+    if isinstance(value, relax.Constant):
+        data = value.data.numpy()
+        if data.size == 1:
+            return tirx.const(data.item(), dtype or str(data.dtype))
+    return None
+
+
 class _EmptyOptional:
     """Sentinel object that preserves an empty ONNX Optional during import."""
 
@@ -588,6 +599,12 @@ class BinaryBase(OnnxOpConverter):
 
     numpy_op: Callable = None
     relax_op: Callable = None
+    # Builds the scalar PrimExpr used when an operand is a symbolic PrimExpr
+    # (e.g. a dynamic dimension produced by shape arithmetic). numpy cannot
+    # fold those: its object-dtype fallback either returns a PrimExpr that
+    # `.item()` rejects, or coerces the result through `bool()`, which
+    # PrimExpr forbids.
+    prim_op: Callable = None
 
     @classmethod
     def base_impl(cls, bb, inputs, attr, params):
@@ -600,18 +617,28 @@ class BinaryBase(OnnxOpConverter):
             for inp, is_var in zip(inputs, is_prim_var)
         ):
             has_prim_expr = any(tvm.ir.is_prim_expr(inp) for inp in inputs)
-            x = _to_numpy(inputs[0])
-            y = _to_numpy(inputs[1])
-            output = cls.numpy_op(x, y)  # pylint: disable=not-callable
-            if has_prim_expr:
-                if hasattr(output, "item"):
-                    output = output.item()
-                return relax.prim_value(output)
-            if x.dtype == y.dtype:
-                # no numpy precision widening
-                output = output.astype(x.dtype)
-            if all([isinstance(inp, relax.Constant) for inp in inputs]):
-                return relax.const(output, output.dtype)  # pylint: disable=not-callable
+            has_symbolic_prim_expr = any(
+                tvm.ir.is_prim_expr(inp) and not isinstance(inp, tirx.IntImm | tirx.FloatImm)
+                for inp in inputs
+            )
+            if has_symbolic_prim_expr:
+                # Build the scalar expression directly instead of dispatching
+                # through numpy.
+                lhs = _as_scalar_prim_expr(inputs[0])
+                rhs = _as_scalar_prim_expr(inputs[1])
+                if lhs is not None and rhs is not None and cls.prim_op is not None:
+                    return relax.prim_value(cls.prim_op(lhs, rhs))  # pylint: disable=not-callable
+            else:
+                x = _to_numpy(inputs[0])
+                y = _to_numpy(inputs[1])
+                output = cls.numpy_op(x, y)  # pylint: disable=not-callable
+                if has_prim_expr:
+                    return relax.prim_value(output.item())
+                if x.dtype == y.dtype:
+                    # no numpy precision widening
+                    output = output.astype(x.dtype)
+                if all([isinstance(inp, relax.Constant) for inp in inputs]):
+                    return relax.const(output, output.dtype)  # pylint: disable=not-callable
 
         return cls.relax_op(inputs[0], inputs[1])  # pylint: disable=not-callable
 
@@ -621,6 +648,7 @@ class Add(BinaryBase):
 
     numpy_op = _np.add
     relax_op = relax.op.add
+    prim_op = operator.add
 
     @classmethod
     def _impl_v1(cls, bb, inputs, attr, params):
@@ -632,6 +660,7 @@ class Sub(BinaryBase):
 
     numpy_op = _np.subtract
     relax_op = relax.op.subtract
+    prim_op = operator.sub
 
     @classmethod
     def _impl_v7(cls, bb, inputs, attr, params):
@@ -643,6 +672,7 @@ class Mul(BinaryBase):
 
     numpy_op = _np.multiply
     relax_op = relax.op.multiply
+    prim_op = operator.mul
 
     @classmethod
     def _impl_v7(cls, bb, inputs, attr, params):
@@ -654,16 +684,7 @@ class Div(BinaryBase):
 
     numpy_op = _np.divide
     relax_op = relax.op.divide
-
-    @staticmethod
-    def _as_scalar_prim_expr(expr, dtype):
-        if tvm.ir.is_prim_expr(expr):
-            return expr
-        if isinstance(expr, relax.Constant):
-            data = expr.data.numpy()
-            if data.size == 1:
-                return tirx.const(data.item(), dtype)
-        return None
+    prim_op = staticmethod(tirx.div)
 
     @staticmethod
     def _is_zero(expr):
@@ -700,8 +721,8 @@ class Div(BinaryBase):
             raise ValueError("ONNX Div with integer inputs encountered divisor value 0.")
 
         has_prim_expr = any(tvm.ir.is_prim_expr(inp) for inp in inputs)
-        lhs = cls._as_scalar_prim_expr(inputs[0], lhs_dtype)
-        rhs = cls._as_scalar_prim_expr(inputs[1], rhs_dtype)
+        lhs = _as_scalar_prim_expr(inputs[0], lhs_dtype)
+        rhs = _as_scalar_prim_expr(inputs[1], rhs_dtype)
         if has_prim_expr and lhs is not None and rhs is not None:
             return relax.prim_value(tirx.truncdiv(lhs, rhs))
 
@@ -713,6 +734,18 @@ class Pow(BinaryBase):
 
     numpy_op = _np.power
     relax_op = relax.op.power
+
+    @staticmethod
+    def _prim_pow(lhs, rhs):
+        # tirx.pow only accepts floats. Integer operands (e.g. symbolic shape
+        # scalars) are computed in float64 and cast back, which is exact for
+        # any dimension-sized integer.
+        dtype = str(lhs.ty.dtype)
+        if "float" in dtype:
+            return tirx.pow(lhs, rhs)
+        return tirx.Cast(dtype, tirx.pow(tirx.Cast("float64", lhs), tirx.Cast("float64", rhs)))
+
+    prim_op = _prim_pow
 
     @classmethod
     def _impl_v7(cls, bb, inputs, attr, params):
@@ -730,9 +763,11 @@ class Mod(BinaryBase):
         if attr.get("fmod", 0) == 0:
             cls.numpy_op = _np.fmod
             cls.relax_op = relax.op.floor_mod
+            cls.prim_op = tirx.floormod
         else:
             cls.numpy_op = _np.mod
             cls.relax_op = relax.op.mod
+            cls.prim_op = tirx.truncmod
         return cls.base_impl(bb, inputs, attr, params)
 
 
@@ -741,6 +776,7 @@ class And(BinaryBase):
 
     numpy_op = _np.logical_and
     relax_op = relax.op.logical_and
+    prim_op = staticmethod(tirx.all)
 
     @classmethod
     def _impl_v1(cls, bb, inputs, attr, params):
@@ -752,6 +788,7 @@ class Or(BinaryBase):
 
     numpy_op = _np.logical_or
     relax_op = relax.op.logical_or
+    prim_op = staticmethod(tirx.any)
 
     @classmethod
     def _impl_v1(cls, bb, inputs, attr, params):
@@ -763,6 +800,8 @@ class Xor(BinaryBase):
 
     numpy_op = _np.logical_xor
     relax_op = relax.op.logical_xor
+    # bitwise xor on bool operands is logical xor; tirx has no logical-xor op.
+    prim_op = staticmethod(tirx.bitwise_xor)
 
     @classmethod
     def _impl_v1(cls, bb, inputs, attr, params):
@@ -774,6 +813,7 @@ class Less(BinaryBase):
 
     numpy_op = _np.less
     relax_op = relax.op.less
+    prim_op = operator.lt
 
     @classmethod
     def _impl_v1(cls, bb, inputs, attr, params):
@@ -785,6 +825,7 @@ class LessOrEqual(BinaryBase):
 
     numpy_op = _np.less_equal
     relax_op = relax.op.less_equal
+    prim_op = operator.le
 
     @classmethod
     def _impl_v1(cls, bb, inputs, attr, params):
@@ -796,6 +837,7 @@ class Greater(BinaryBase):
 
     numpy_op = _np.greater
     relax_op = relax.op.greater
+    prim_op = operator.gt
 
     @classmethod
     def _impl_v1(cls, bb, inputs, attr, params):
@@ -807,6 +849,7 @@ class GreaterOrEqual(BinaryBase):
 
     numpy_op = _np.greater_equal
     relax_op = relax.op.greater_equal
+    prim_op = operator.ge
 
     @classmethod
     def _impl_v1(cls, bb, inputs, attr, params):
@@ -839,7 +882,8 @@ class BitwiseBase(BinaryBase):
         """Base implementation for bitwise operations."""
         valid_types = ["int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64"]
         for num, inp in enumerate(inputs):
-            if inp.ty.dtype.dtype not in valid_types:
+            dtype = str(inp.ty.dtype) if tvm.ir.is_prim_expr(inp) else inp.ty.dtype.dtype
+            if dtype not in valid_types:
                 raise ValueError(
                     f"Bitwise operations expect all inputs to have integer types, "
                     f"got {inp.ty.dtype} for input {num}"
@@ -852,6 +896,7 @@ class BitwiseAnd(BitwiseBase):
 
     numpy_op = _np.bitwise_and
     relax_op = relax.op.bitwise_and
+    prim_op = staticmethod(tirx.bitwise_and)
 
     @classmethod
     def _impl_v18(cls, bb, inputs, attr, params):
@@ -863,6 +908,7 @@ class BitwiseOr(BitwiseBase):
 
     numpy_op = _np.bitwise_or
     relax_op = relax.op.bitwise_or
+    prim_op = staticmethod(tirx.bitwise_or)
 
     @classmethod
     def _impl_v18(cls, bb, inputs, attr, params):
@@ -874,6 +920,7 @@ class BitwiseXor(BitwiseBase):
 
     numpy_op = _np.bitwise_xor
     relax_op = relax.op.bitwise_xor
+    prim_op = staticmethod(tirx.bitwise_xor)
 
     @classmethod
     def _impl_v18(cls, bb, inputs, attr, params):
@@ -899,9 +946,11 @@ class BitShift(BitwiseBase):
         if direction == "LEFT":
             cls.numpy_op = _np.left_shift
             cls.relax_op = relax.op.left_shift
+            cls.prim_op = operator.lshift
         elif direction == "RIGHT":
             cls.numpy_op = _np.right_shift
             cls.relax_op = relax.op.right_shift
+            cls.prim_op = operator.rshift
         else:
             raise ValueError("Unsupported Shift Direction: " + direction)
 

--- a/tests/python/relax/test_frontend_onnx.py
+++ b/tests/python/relax/test_frontend_onnx.py
@@ -687,6 +687,93 @@ def test_div_integer_primexpr_folding_truncates_toward_zero(input_size, divisor_
     tvm.ir.assert_structural_equal(tvm_model, Expected)
 
 
+def _make_symbolic_dim_binary_graph(op_nodes, out_dtype):
+    """Build a graph whose binary operands are shape-derived symbolic scalars.
+
+    The input has two dynamic dims ("a", "b"); `d0` and `d1` are the two dims
+    gathered out of its Shape, so they reach binary converters as symbolic
+    PrimExprs rather than constants.
+    """
+    nodes = [
+        helper.make_node("Shape", ["x"], ["x_shape"]),
+        make_constant_node("i0", TensorProto.INT64, [], [0]),
+        make_constant_node("i1", TensorProto.INT64, [], [1]),
+        helper.make_node("Gather", ["x_shape", "i0"], ["d0"]),
+        helper.make_node("Gather", ["x_shape", "i1"], ["d1"]),
+    ]
+    nodes.extend(op_nodes)
+    graph = helper.make_graph(
+        nodes,
+        "binary_symbolic_scalar",
+        [helper.make_tensor_value_info("x", TensorProto.FLOAT, ["a", "b"])],
+        [helper.make_tensor_value_info("out", out_dtype, [])],
+    )
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 18)])
+    model.ir_version = 9
+    return model
+
+
+@pytest.mark.parametrize(
+    ("op_name", "out_dtype"),
+    [
+        ("Add", TensorProto.INT64),
+        ("Sub", TensorProto.INT64),
+        ("Mul", TensorProto.INT64),
+        ("Div", TensorProto.INT64),
+        ("Mod", TensorProto.INT64),
+        ("Less", TensorProto.BOOL),
+        ("LessOrEqual", TensorProto.BOOL),
+        ("Greater", TensorProto.BOOL),
+        ("GreaterOrEqual", TensorProto.BOOL),
+    ],
+)
+def test_binary_op_on_symbolic_shape_scalars(op_name, out_dtype):
+    """Binary ops on two shape-derived symbolic dims must fold into a scalar
+    PrimValue instead of dispatching symbolic PrimExprs through numpy.
+
+    Regression test for https://github.com/apache/tvm/issues/20065.
+    """
+    op_node = helper.make_node(op_name, ["d0", "d1"], ["out"])
+    model = _make_symbolic_dim_binary_graph([op_node], out_dtype)
+    check_correctness(model, inputs={"x": np.random.randn(7, 3).astype("float32")}, opset=18)
+
+
+def test_binary_op_chain_on_symbolic_shape_scalars():
+    """Chained shape arithmetic: intermediate operands are symbolic PrimExprs
+    that are not plain shape vars, mixed with scalar constants."""
+    op_nodes = [
+        make_constant_node("c2", TensorProto.INT64, [], [2]),
+        helper.make_node("Sub", ["d0", "d1"], ["t1"]),
+        helper.make_node("Mul", ["t1", "c2"], ["t2"]),
+        helper.make_node("Add", ["t2", "d0"], ["out"]),
+    ]
+    model = _make_symbolic_dim_binary_graph(op_nodes, TensorProto.INT64)
+    check_correctness(model, inputs={"x": np.random.randn(7, 3).astype("float32")}, opset=18)
+
+
+def test_logical_ops_on_symbolic_shape_scalars():
+    """Logical And/Or/Xor on comparisons of shape-derived symbolic dims."""
+    for logical_op in ["And", "Or", "Xor"]:
+        op_nodes = [
+            make_constant_node("c5", TensorProto.INT64, [], [5]),
+            helper.make_node("Less", ["d0", "d1"], ["t1"]),
+            helper.make_node("Greater", ["d0", "c5"], ["t2"]),
+            helper.make_node(logical_op, ["t1", "t2"], ["out"]),
+        ]
+        model = _make_symbolic_dim_binary_graph(op_nodes, TensorProto.BOOL)
+        check_correctness(model, inputs={"x": np.random.randn(7, 3).astype("float32")}, opset=18)
+
+
+def test_pow_on_symbolic_shape_scalars_imports():
+    """Pow on a symbolic dim must at least import without crashing."""
+    op_nodes = [
+        make_constant_node("c2", TensorProto.INT64, [], [2]),
+        helper.make_node("Pow", ["d0", "c2"], ["out"]),
+    ]
+    model = _make_symbolic_dim_binary_graph(op_nodes, TensorProto.INT64)
+    from_onnx(model, opset=18, keep_params_in_input=True)
+
+
 @pytest.mark.parametrize("int_mode", [True, False])
 def test_mod(int_mode: bool):
     if int_mode:


### PR DESCRIPTION
Fixes #20065.

## Problem

`BinaryBase.base_impl` folds scalar operands with NumPy. When an operand is a symbolic `PrimExpr` (for example, a dynamic dimension gathered from a `Shape` result), NumPy dispatches through object dtype, which causes several binary operators to fail:

* Comparison operators (`Less`, `LessOrEqual`, `Greater`, `GreaterOrEqual`) coerce the resulting `PrimExpr` through `bool()`, which raises:
  `ValueError: Cannot use and / or / not operator to Expr`
* Logical operators (`And`, `Or`, `Xor`) evaluate `bool()` on their operands and fail with the same error.
* `Pow` has no `PrimExpr` overload and raises `TypeError`.
* `Mod` fails similarly.
* Older releases also crashed in `Sub` with `AttributeError: 'Sub' object has no attribute 'item'`. Current `main` avoids this for plain arithmetic through the `hasattr(output, "item")` guard.

Minimal reproducer using two shape-derived symbolic dimensions:

```text
Shape(x) -> Gather(idx 0) -> d0
Shape(x) -> Gather(idx 1) -> d1
Less(d0, d1)  # or And/Or/Xor/Pow/Mod
```

## Fix

Route symbolic scalar operands around NumPy instead of relying on object-dtype dispatch.

Each `BinaryBase` subclass now declares a `prim_op` that directly constructs the scalar `PrimExpr` (for example, `operator.sub`, `tirx.div`, and `tirx.floordiv`). `base_impl` uses this operation for symbolic operands and wraps the result with `relax.prim_value`.

Fully concrete operands continue to use the existing NumPy-based path.

Additional changes required to support the entire binary operator family:

* Promote `Div`'s private scalar-conversion helper to module-level scope so it can be reused.
* Compute integer `Pow` in `float64` and cast the result back, since `tirx.cast` does not support the required dimension-sized integer behavior directly.
* Map `Xor` to `tirx.bitwise_xor`. Using the logical form for boolean operands can produce an invalid `fcmp` during LLVM code generation.
* Update `BitwiseBase` dtype validation to accept `PrimExpr` operands.

## Testing

Added regression coverage for:

* `Mul`, `Div`, `Mod`, `Less`, `LessOrEqual`, `Greater`, and `GreaterOrEqual` on two shape-derived symbolic dimensions, verified against ONNX Runtime.
* Binary operations mixing symbolic dimensions with scalar constants.
* `And`, `Or`, and `Xor` over symbolic comparisons.
* Import-time coverage for integer `Pow`.

Validation:

* `tests/python/relax/test_frontend_onnx.py`: **499 passed**
* `ruff check`: clean
* `ruff format --check`: clean
