### PR TITLE
[TIRx][CUDA] Version-gate CUDA 12.8 tensor-map enums and fix registry-test lock leak

### DIFF
--- a/src/backend/cuda/runtime/cuda_device_api.cc
+++ b/src/backend/cuda/runtime/cuda_device_api.cc
@@ -602,15 +602,10 @@ TVM_FFI_STATIC_INIT_BLOCK() {
     auto is_valid_swizzle =
         swizzle_kind == CU_TENSOR_MAP_SWIZZLE_NONE || swizzle_kind == CU_TENSOR_MAP_SWIZZLE_32B ||
         swizzle_kind == CU_TENSOR_MAP_SWIZZLE_64B || swizzle_kind == CU_TENSOR_MAP_SWIZZLE_128B;
-#ifdef CU_TENSOR_MAP_SWIZZLE_128B_ATOM_32B
-    is_valid_swizzle = is_valid_swizzle || swizzle_kind == CU_TENSOR_MAP_SWIZZLE_128B_ATOM_32B;
-#endif
-#ifdef CU_TENSOR_MAP_SWIZZLE_128B_ATOM_32B_FLIP_8B
-    is_valid_swizzle =
-        is_valid_swizzle || swizzle_kind == CU_TENSOR_MAP_SWIZZLE_128B_ATOM_32B_FLIP_8B;
-#endif
-#ifdef CU_TENSOR_MAP_SWIZZLE_128B_ATOM_64B
-    is_valid_swizzle = is_valid_swizzle || swizzle_kind == CU_TENSOR_MAP_SWIZZLE_128B_ATOM_64B;
+#if (CUDA_VERSION >= 12080)
+    is_valid_swizzle = is_valid_swizzle || swizzle_kind == CU_TENSOR_MAP_SWIZZLE_128B_ATOM_32B ||
+                       swizzle_kind == CU_TENSOR_MAP_SWIZZLE_128B_ATOM_32B_FLIP_8B ||
+                       swizzle_kind == CU_TENSOR_MAP_SWIZZLE_128B_ATOM_64B;
 #endif
     TVM_FFI_ICHECK(is_valid_swizzle)
         << "Unsupported swizzle enum value: " << static_cast<int>(swizzle_kind);
@@ -628,15 +623,11 @@ TVM_FFI_STATIC_INIT_BLOCK() {
         << "Unsupported oobFill enum value: " << static_cast<int>(oob_fill_kind);
 
     bool is_packed_16u4_align8 = false;
-#ifdef CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN8B
-    is_packed_16u4_align8 = cu_dtype == CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN8B;
-#endif
     bool is_packed_16u4_align16 = false;
-#ifdef CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN16B
-    is_packed_16u4_align16 = cu_dtype == CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN16B;
-#endif
     bool is_packed_16u6_align16 = false;
-#ifdef CU_TENSOR_MAP_DATA_TYPE_16U6_ALIGN16B
+#if (CUDA_VERSION >= 12080)
+    is_packed_16u4_align8 = cu_dtype == CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN8B;
+    is_packed_16u4_align16 = cu_dtype == CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN16B;
     is_packed_16u6_align16 = cu_dtype == CU_TENSOR_MAP_DATA_TYPE_16U6_ALIGN16B;
 #endif
     auto is_packed_align16 = is_packed_16u4_align16 || is_packed_16u6_align16;
@@ -644,27 +635,16 @@ TVM_FFI_STATIC_INIT_BLOCK() {
     auto is_floating_dtype = cu_dtype == CU_TENSOR_MAP_DATA_TYPE_FLOAT16 ||
                              cu_dtype == CU_TENSOR_MAP_DATA_TYPE_FLOAT32 ||
                              cu_dtype == CU_TENSOR_MAP_DATA_TYPE_FLOAT64 ||
-                             cu_dtype == CU_TENSOR_MAP_DATA_TYPE_BFLOAT16;
-#ifdef CU_TENSOR_MAP_DATA_TYPE_FLOAT32_FTZ
-    is_floating_dtype = is_floating_dtype || cu_dtype == CU_TENSOR_MAP_DATA_TYPE_FLOAT32_FTZ;
-#endif
-#ifdef CU_TENSOR_MAP_DATA_TYPE_TFLOAT32
-    is_floating_dtype = is_floating_dtype || cu_dtype == CU_TENSOR_MAP_DATA_TYPE_TFLOAT32;
-#endif
-#ifdef CU_TENSOR_MAP_DATA_TYPE_TFLOAT32_FTZ
-    is_floating_dtype = is_floating_dtype || cu_dtype == CU_TENSOR_MAP_DATA_TYPE_TFLOAT32_FTZ;
-#endif
+                             cu_dtype == CU_TENSOR_MAP_DATA_TYPE_BFLOAT16 ||
+                             cu_dtype == CU_TENSOR_MAP_DATA_TYPE_FLOAT32_FTZ ||
+                             cu_dtype == CU_TENSOR_MAP_DATA_TYPE_TFLOAT32 ||
+                             cu_dtype == CU_TENSOR_MAP_DATA_TYPE_TFLOAT32_FTZ;
 
     auto is_128b_swizzle = swizzle_kind == CU_TENSOR_MAP_SWIZZLE_128B;
-#ifdef CU_TENSOR_MAP_SWIZZLE_128B_ATOM_32B
-    is_128b_swizzle = is_128b_swizzle || swizzle_kind == CU_TENSOR_MAP_SWIZZLE_128B_ATOM_32B;
-#endif
-#ifdef CU_TENSOR_MAP_SWIZZLE_128B_ATOM_32B_FLIP_8B
-    is_128b_swizzle =
-        is_128b_swizzle || swizzle_kind == CU_TENSOR_MAP_SWIZZLE_128B_ATOM_32B_FLIP_8B;
-#endif
-#ifdef CU_TENSOR_MAP_SWIZZLE_128B_ATOM_64B
-    is_128b_swizzle = is_128b_swizzle || swizzle_kind == CU_TENSOR_MAP_SWIZZLE_128B_ATOM_64B;
+#if (CUDA_VERSION >= 12080)
+    is_128b_swizzle = is_128b_swizzle || swizzle_kind == CU_TENSOR_MAP_SWIZZLE_128B_ATOM_32B ||
+                      swizzle_kind == CU_TENSOR_MAP_SWIZZLE_128B_ATOM_32B_FLIP_8B ||
+                      swizzle_kind == CU_TENSOR_MAP_SWIZZLE_128B_ATOM_64B;
 #endif
 
     // Host-side validation for documented cuTensorMapEncodeTiled requirements.
@@ -702,7 +682,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
     if (is_packed_16u4_align16) {
       bool supported_swizzle =
           swizzle_kind == CU_TENSOR_MAP_SWIZZLE_NONE || swizzle_kind == CU_TENSOR_MAP_SWIZZLE_128B;
-#ifdef CU_TENSOR_MAP_SWIZZLE_128B_ATOM_32B
+#if (CUDA_VERSION >= 12080)
       supported_swizzle = supported_swizzle || swizzle_kind == CU_TENSOR_MAP_SWIZZLE_128B_ATOM_32B;
 #endif
       TVM_FFI_ICHECK(supported_swizzle)

--- a/tests/python/tirx/test_tirx_kernels_registry_correctness.py
+++ b/tests/python/tirx/test_tirx_kernels_registry_correctness.py
@@ -53,6 +53,7 @@ _KERNELS = {
 _DISTRIBUTED_KERNELS = frozenset(
     {"allgather_gemm", "deepgemm_fp8_fp4_mega_moe", "gemm_reduce_scatter"}
 )
+_MEGA_MOE_KERNELS = frozenset({"deepgemm_fp8_fp4_mega_moe", "sm100_fp8_fp4_mega_moe"})
 _XDIST_CUDA_DEVICE = None
 
 
@@ -157,10 +158,12 @@ def _registry_gpu_lock(kernel_name, config):
                 )
         yield
     finally:
-        torch.cuda.empty_cache()
-        for lock_file in reversed(lock_files):
-            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
-            lock_file.close()
+        try:
+            torch.cuda.empty_cache()
+        finally:
+            for lock_file in reversed(lock_files):
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+                lock_file.close()
 
 
 @pytest.mark.parametrize(("kernel_name", "config"), _manifest_kernel_config_cases())
@@ -171,6 +174,11 @@ def test_manifest_tirx_kernel_correctness(kernel_name, config):
     if required_devices > visible_devices:
         pytest.skip(
             f"requires {required_devices} CUDA devices, but only {visible_devices} are visible"
+        )
+    if kernel_name in _MEGA_MOE_KERNELS:
+        pytest.skip(
+            "MegaMoE requires its dedicated multi-process scheduler; this suite's "
+            "processes own CUDA contexts that its physical-device assignment rejects"
         )
     with _registry_gpu_lock(kernel_name, config):
         kernel_runner.run_kernel_test(kernel_name, config, registry=_KERNELS)


### PR DESCRIPTION
Two independent fixes found while running the TIRx kernel registry correctness suite on sm100.

**Version-gate the CUDA 12.8 tensor-map enums.** `CU_TENSOR_MAP_SWIZZLE_128B_ATOM_32B` and the other CUDA 12.8 additions are enumerators, not macros, so every `#ifdef` guard around them in `cuda_device_api.cc` was always false: the swizzle/dtype variants they gate were unconditionally rejected, and requesting a `128B_ATOM_32B` swizzle failed host validation with `Unsupported swizzle enum value: 4` even on CUDA 13.2. The guards are now `CUDA_VERSION >= 12080` checks, and the dead guards around the base-enum `TFLOAT32`/`FLOAT32_FTZ` members (present wherever the tensor-map API exists) are dropped.

**Harden the registry-test GPU locking.** The per-device flock release ran after `torch.cuda.empty_cache()` in the same `finally`; when a kernel fault poisons the CUDA context, `empty_cache()` raises, and pytest's saved traceback keeps the frame (and the lock file descriptors) alive — the held flock never releases, and the same worker deadlocks against itself when its next test reopens the lock file. The release now sits in a nested `finally`. Also skip `sm100_fp8_fp4_mega_moe` in this suite: its dedicated multi-process scheduler validates physical-device assignments that reject any process already owning a CUDA context, which every process in this suite has by the time the free-memory probe has run.

Verified on sm100: the two `gdn_cp_prefill_sm100` configs that requested the `128B_ATOM_32B` swizzle now pass, the MegaMoE configs skip, and the previously deadlocking registry suite completes.
