### PR TITLE
[CUDA][BugFix] Guard tensor map enums by toolkit version

### DIFF
--- a/src/backend/cuda/runtime/cuda_device_api.cc
+++ b/src/backend/cuda/runtime/cuda_device_api.cc
@@ -602,14 +602,10 @@ TVM_FFI_STATIC_INIT_BLOCK() {
     auto is_valid_swizzle =
         swizzle_kind == CU_TENSOR_MAP_SWIZZLE_NONE || swizzle_kind == CU_TENSOR_MAP_SWIZZLE_32B ||
         swizzle_kind == CU_TENSOR_MAP_SWIZZLE_64B || swizzle_kind == CU_TENSOR_MAP_SWIZZLE_128B;
-#ifdef CU_TENSOR_MAP_SWIZZLE_128B_ATOM_32B
+#if CUDA_VERSION >= 12080
     is_valid_swizzle = is_valid_swizzle || swizzle_kind == CU_TENSOR_MAP_SWIZZLE_128B_ATOM_32B;
-#endif
-#ifdef CU_TENSOR_MAP_SWIZZLE_128B_ATOM_32B_FLIP_8B
     is_valid_swizzle =
         is_valid_swizzle || swizzle_kind == CU_TENSOR_MAP_SWIZZLE_128B_ATOM_32B_FLIP_8B;
-#endif
-#ifdef CU_TENSOR_MAP_SWIZZLE_128B_ATOM_64B
     is_valid_swizzle = is_valid_swizzle || swizzle_kind == CU_TENSOR_MAP_SWIZZLE_128B_ATOM_64B;
 #endif
     TVM_FFI_ICHECK(is_valid_swizzle)
@@ -628,15 +624,11 @@ TVM_FFI_STATIC_INIT_BLOCK() {
         << "Unsupported oobFill enum value: " << static_cast<int>(oob_fill_kind);
 
     bool is_packed_16u4_align8 = false;
-#ifdef CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN8B
-    is_packed_16u4_align8 = cu_dtype == CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN8B;
-#endif
     bool is_packed_16u4_align16 = false;
-#ifdef CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN16B
-    is_packed_16u4_align16 = cu_dtype == CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN16B;
-#endif
     bool is_packed_16u6_align16 = false;
-#ifdef CU_TENSOR_MAP_DATA_TYPE_16U6_ALIGN16B
+#if CUDA_VERSION >= 12080
+    is_packed_16u4_align8 = cu_dtype == CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN8B;
+    is_packed_16u4_align16 = cu_dtype == CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN16B;
     is_packed_16u6_align16 = cu_dtype == CU_TENSOR_MAP_DATA_TYPE_16U6_ALIGN16B;
 #endif
     auto is_packed_align16 = is_packed_16u4_align16 || is_packed_16u6_align16;
@@ -645,25 +637,17 @@ TVM_FFI_STATIC_INIT_BLOCK() {
                              cu_dtype == CU_TENSOR_MAP_DATA_TYPE_FLOAT32 ||
                              cu_dtype == CU_TENSOR_MAP_DATA_TYPE_FLOAT64 ||
                              cu_dtype == CU_TENSOR_MAP_DATA_TYPE_BFLOAT16;
-#ifdef CU_TENSOR_MAP_DATA_TYPE_FLOAT32_FTZ
+#if CUDA_VERSION >= 12080
     is_floating_dtype = is_floating_dtype || cu_dtype == CU_TENSOR_MAP_DATA_TYPE_FLOAT32_FTZ;
-#endif
-#ifdef CU_TENSOR_MAP_DATA_TYPE_TFLOAT32
     is_floating_dtype = is_floating_dtype || cu_dtype == CU_TENSOR_MAP_DATA_TYPE_TFLOAT32;
-#endif
-#ifdef CU_TENSOR_MAP_DATA_TYPE_TFLOAT32_FTZ
     is_floating_dtype = is_floating_dtype || cu_dtype == CU_TENSOR_MAP_DATA_TYPE_TFLOAT32_FTZ;
 #endif
 
     auto is_128b_swizzle = swizzle_kind == CU_TENSOR_MAP_SWIZZLE_128B;
-#ifdef CU_TENSOR_MAP_SWIZZLE_128B_ATOM_32B
+#if CUDA_VERSION >= 12080
     is_128b_swizzle = is_128b_swizzle || swizzle_kind == CU_TENSOR_MAP_SWIZZLE_128B_ATOM_32B;
-#endif
-#ifdef CU_TENSOR_MAP_SWIZZLE_128B_ATOM_32B_FLIP_8B
     is_128b_swizzle =
         is_128b_swizzle || swizzle_kind == CU_TENSOR_MAP_SWIZZLE_128B_ATOM_32B_FLIP_8B;
-#endif
-#ifdef CU_TENSOR_MAP_SWIZZLE_128B_ATOM_64B
     is_128b_swizzle = is_128b_swizzle || swizzle_kind == CU_TENSOR_MAP_SWIZZLE_128B_ATOM_64B;
 #endif
 
@@ -702,7 +686,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
     if (is_packed_16u4_align16) {
       bool supported_swizzle =
           swizzle_kind == CU_TENSOR_MAP_SWIZZLE_NONE || swizzle_kind == CU_TENSOR_MAP_SWIZZLE_128B;
-#ifdef CU_TENSOR_MAP_SWIZZLE_128B_ATOM_32B
+#if CUDA_VERSION >= 12080
       supported_swizzle = supported_swizzle || swizzle_kind == CU_TENSOR_MAP_SWIZZLE_128B_ATOM_32B;
 #endif
       TVM_FFI_ICHECK(supported_swizzle)


### PR DESCRIPTION
CUDA tensor-map enum members are C++ identifiers, not preprocessor macros. The existing `#ifdef` checks therefore evaluated false even when CUDA 12.8+ `cuda.h` declared packed tensor-map data types and atomic 128-byte swizzle modes. This caused host validation to reject supported swizzles and to skip their packed/128-byte validation rules.\n\nThis change uses the existing `CUDA_VERSION >= 12080` availability contract consistently for every affected dtype and swizzle validation path. Older toolkits still compile without referencing the newer enum members.\n\nTesting:\n- `pre-commit run clang-format --files src/backend/cuda/runtime/cuda_device_api.cc`\n- CUDA 13 build with `USE_NVSHMEM=ON`: `cmake --build build --parallel 16`\n- Downstream TIRx GDN swizzle path: 10 correctness launches and 3 benchmark rounds passed