### PR TITLE
fix: isolate tvm-ffi from TVM's C++20 build standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -672,7 +672,11 @@ if(USE_IOS_RPC)
   add_subdirectory("apps/ios_rpc")
 endif()
 
+set(TVM_CXX_STANDARD ${CMAKE_CXX_STANDARD})
+set(CMAKE_CXX_STANDARD 17)
 add_subdirectory(3rdparty/tvm-ffi)
+set(CMAKE_CXX_STANDARD ${TVM_CXX_STANDARD})
+unset(TVM_CXX_STANDARD)
 
 if(TVM_DEBUG_WITH_ABI_CHANGE)
   message(STATUS "Building with debug code that may cause ABI changes...")

--- a/tests/scripts/task_build.py
+++ b/tests/scripts/task_build.py
@@ -17,9 +17,11 @@
 # under the License.
 # ruff: noqa: E402
 import argparse
+import json
 import logging
 import multiprocessing
 import os
+import re
 import shutil
 import sys
 from pathlib import Path
@@ -28,6 +30,68 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.append(str(REPO_ROOT / "ci" / "scripts" / "jenkins"))
 from cmd_utils import REPO_ROOT, Sh, init_log
+
+
+def _check_cxx_standard(build_dir):
+    compile_commands_path = REPO_ROOT / build_dir / "compile_commands.json"
+    with open(compile_commands_path, encoding="utf-8") as compile_commands_file:
+        compile_commands = json.load(compile_commands_file)
+
+    standard_flag_pattern = re.compile(r"^(?:-std=(?:c|gnu)\+\+|/std:c\+\+)(.+)$", re.IGNORECASE)
+    tvm_ffi_commands = []
+    tvm_commands = []
+
+    for compile_command in compile_commands:
+        source = Path(compile_command["file"])
+        if not source.is_absolute():
+            source = Path(compile_command["directory"]) / source
+        try:
+            source = source.resolve().relative_to(REPO_ROOT)
+        except ValueError:
+            continue
+
+        if source.suffix.lower() not in {".cc", ".cpp", ".cxx"}:
+            continue
+
+        arguments = compile_command.get("arguments")
+        if arguments is None:
+            arguments = compile_command["command"].split()
+        standard_flags = []
+        for argument in arguments:
+            argument = argument.strip("\"'")
+            match = standard_flag_pattern.match(argument)
+            if match:
+                standard_flags.append((argument, match.group(1).lower()))
+
+        if source.parts[:2] == ("3rdparty", "tvm-ffi"):
+            tvm_ffi_commands.append((source, standard_flags, compile_command))
+        elif source.parts[0] == "src":
+            tvm_commands.append((source, standard_flags, compile_command))
+
+    if not tvm_ffi_commands:
+        raise RuntimeError("No C++ compile commands found for 3rdparty/tvm-ffi")
+    if not tvm_commands:
+        raise RuntimeError("No C++ compile commands found for TVM src/")
+
+    for source, standard_flags, compile_command in tvm_ffi_commands:
+        if standard_flags and standard_flags[-1][1] not in {"17", "1z"}:
+            raise RuntimeError(
+                f"tvm-ffi source {source} must use C++17, but its compile command contains "
+                f"{', '.join(flag for flag, _ in standard_flags)}: {compile_command}"
+            )
+
+    for source, standard_flags, compile_command in tvm_commands:
+        if not standard_flags or standard_flags[-1][1] not in {"20", "2a"}:
+            raise RuntimeError(
+                f"TVM source {source} must use C++20, but its compile command is: {compile_command}"
+            )
+
+    logging.info(
+        "Verified C++ standards in %s tvm-ffi and %s TVM compile commands",
+        len(tvm_ffi_commands),
+        len(tvm_commands),
+    )
+
 
 if __name__ == "__main__":
     init_log()
@@ -89,6 +153,8 @@ if __name__ == "__main__":
         sh.run("cmake -GNinja -DCMAKE_BUILD_TYPE=Debug ..", cwd=build_dir)
     else:
         sh.run("cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo ..", cwd=build_dir)
+
+    _check_cxx_standard(build_dir)
 
     target = ""
     if args.cmake_target:


### PR DESCRIPTION
TVM sets `CMAKE_CXX_STANDARD` to 20 globally, then adds the vendored `tvm-ffi` project, whose sources are intended to compile as C++17. Because CMake's `cxx_std_17` feature is a minimum rather than an exact standard, the parent setting causes `tvm-ffi` sources to compile as C++20 and exposes a recursive `std::optional` constraint failure with the reporter's newer Clang/GCC standard-library combination. The reporter's attempted local standard isolation allowed compilation to progress through the original error, while the later LLVM link errors came from the separately configured ROCm LLVM toolchain. No prior or competing PR is recorded in the supplied issue bundle.

## Testing

- Configure a normal Ninja build and confirm compile commands for `3rdparty/tvm-ffi` contain an explicit C++17 mode or no newer-standard flag, while TVM `src/` commands retain C++20.
- Configure with a compiler whose default language mode is already C++17 and confirm the validation accepts an omitted explicit C++17 flag for `tvm-ffi` without weakening the C++20 assertion for TVM.
- Exercise the existing CI build path and confirm the original `std::optional<tvm::ffi::Optional<VisitInterrupt>>` compilation failure no longer occurs on a modern Clang using GCC 16 standard-library headers.
- Deliberately allow the dependency to inherit a C++20 flag and confirm the build driver stops before compilation with a diagnostic that identifies the mismatched `tvm-ffi` compile command.

## What changed

In `CMakeLists.txt`, save TVM's C++20 setting immediately before `add_subdirectory(3rdparty/tvm-ffi)`, temporarily select C++17 while the dependency creates its targets, and restore the saved value immediately afterward so all subsequent TVM targets retain the project standard. Keep the change at the parent/dependency boundary rather than altering `tvm-ffi` headers or adding a source-level workaround for the reported template instantiation. Extend `tests/scripts/task_build.py` after CMake configuration to inspect the generated compile database and assert that C++ sources under `3rdparty/tvm-ffi` are not compiled with a C++20 flag while representative TVM C++ sources still are.

Fixes #20042
