### PR TITLE
[TIRx][CUDA] Fix single-CTA clusterCtaIdx resolution and accept packed sub-byte tensor-map dtypes

### DIFF
--- a/src/backend/cuda/runtime/cuda_device_api.cc
+++ b/src/backend/cuda/runtime/cuda_device_api.cc
@@ -586,10 +586,36 @@ TVM_FFI_STATIC_INIT_BLOCK() {
     // bypass the dtype-derived mapping so the descriptor uses the requested
     // CUtensorMapDataType. Same byte size, different on-load rounding semantics.
     if (force_cu_dtype >= 0) {
-      TVM_FFI_ICHECK_EQ(force_cu_dtype, 11)
-          << "force_cu_dtype only supports CU_TENSOR_MAP_DATA_TYPE_TFLOAT32 (11)";
-      TVM_FFI_ICHECK(tensor_dtype.code == kDLFloat && tensor_dtype.bits == 32)
-          << "CU_TENSOR_MAP_DATA_TYPE_TFLOAT32 requires a scalar float32 tensor_dtype";
+      // The accepted set widens inside the version gate rather than around a
+      // branch, so the preprocessor never straddles a brace.
+#if (CUDA_VERSION >= 12080)
+      const bool is_packed_sub_byte = force_cu_dtype == CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN8B ||
+                                      force_cu_dtype == CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN16B ||
+                                      force_cu_dtype == CU_TENSOR_MAP_DATA_TYPE_16U6_ALIGN16B;
+      const char* accepted = "CU_TENSOR_MAP_DATA_TYPE_TFLOAT32 or a packed sub-byte type";
+#else
+      const bool is_packed_sub_byte = false;
+      const char* accepted = "CU_TENSOR_MAP_DATA_TYPE_TFLOAT32";
+#endif
+      if (force_cu_dtype == CU_TENSOR_MAP_DATA_TYPE_TFLOAT32) {
+        TVM_FFI_ICHECK(tensor_dtype.code == kDLFloat && tensor_dtype.bits == 32)
+            << "CU_TENSOR_MAP_DATA_TYPE_TFLOAT32 requires a scalar float32 tensor_dtype";
+      } else if (is_packed_sub_byte) {
+        // A packed sub-byte payload reaches this API either as its logical
+        // sub-byte dtype or as the byte storage holding it. The caller states
+        // which packing and alignment the TMA should apply; the derived mapping
+        // above can only reach ALIGN16B, so an ALIGN8B tile is expressible only
+        // through this override.
+        bool is_byte_storage =
+            (tensor_dtype.code == kDLUInt || tensor_dtype.code == kDLInt) && tensor_dtype.bits == 8;
+        bool is_sub_byte = tensor_dtype.bits > 0 && tensor_dtype.bits < 8;
+        TVM_FFI_ICHECK(is_byte_storage || is_sub_byte)
+            << "a packed sub-byte CUtensorMapDataType requires sub-byte or 8-bit storage, got "
+            << ffi::DLDataTypeToString(tensor_dtype);
+      } else {
+        TVM_FFI_THROW(InternalError)
+            << "force_cu_dtype accepts " << accepted << ", got " << force_cu_dtype;
+      }
       cu_dtype = static_cast<CUtensorMapDataType>(force_cu_dtype);
     }
 

--- a/src/tirx/ir/exec_scope.cc
+++ b/src/tirx/ir/exec_scope.cc
@@ -363,10 +363,12 @@ PrimExpr GetLinearThreadIndex(const LaunchParams& params) {
   return tx + ty * ex + tz * ex * ey;
 }
 
-ffi::Array<PrimExpr> Trivial3DResolve(const LaunchParams& params, const char* prefix, int out_dim) {
+ffi::Array<PrimExpr> Trivial3DResolve(const LaunchParams& params, const char* prefix, int out_dim,
+                                      bool allow_missing = false) {
   ffi::Array<PrimExpr> ret;
   for (int i = 0; i < out_dim; ++i) {
-    ret.push_back(GetThread(std::string(prefix) + static_cast<char>('x' + i), params).first);
+    ret.push_back(
+        GetThread(std::string(prefix) + static_cast<char>('x' + i), params, allow_missing).first);
   }
   return ret;
 }
@@ -379,7 +381,11 @@ ffi::Array<PrimExpr> ResolveCuda(ScopeBinding binding,
     case ScopeBinding::kKernelCta:
       return Trivial3DResolve(params, "blockIdx.", out_dim);
     case ScopeBinding::kClusterCta:
-      return Trivial3DResolve(params, "clusterCtaIdx.", out_dim);
+      // A launch whose cluster is a single CTA binds no clusterCtaIdx var; the
+      // coordinate is then the constant 0, which is what GetThread returns for a
+      // missing tag. blockIdx and threadIdx are always bound, so they keep the
+      // strict lookup.
+      return Trivial3DResolve(params, "clusterCtaIdx.", out_dim, /*allow_missing=*/true);
     case ScopeBinding::kCtaThread:
       return Trivial3DResolve(params, "threadIdx.", out_dim);
     case ScopeBinding::kKernelCluster: {


### PR DESCRIPTION
Two small backend fixes.

**`clusterCtaIdx` on single-CTA launches.** A launch whose cluster is a single
CTA binds no `clusterCtaIdx` variable, so resolving a cluster-CTA scope
coordinate through the strict thread lookup fails on a binding that
legitimately does not exist. The coordinate is the constant `0` there, which is
what `GetThread` already returns for a missing tag. `allow_missing` is threaded
through `Trivial3DResolve` and passed only for the `clusterCtaIdx` prefix;
`blockIdx` and `threadIdx` are always bound and keep the strict lookup.
Follow-up to #20159.

**Packed sub-byte types in `force_cu_dtype`.** The override admitted only
`CU_TENSOR_MAP_DATA_TYPE_TFLOAT32`. The dtype-derived mapping above it can
reach `16U4_ALIGN16B` but never `16U4_ALIGN8B`, so an FP4 tile needing 8-byte
alignment was not expressible at all. This admits the three packed sub-byte
types alongside `TFLOAT32`, gated on CUDA 12.8 where the enums appear, and
checks the storage each requires: such a payload arrives either as its logical
sub-byte dtype or as the 8-bit byte storage holding it. The version gate widens
a bool rather than wrapping a branch, matching the swizzle and packed-dtype
checks later in the same function, and the rejection message names what the
build actually accepts. Follow-up to #20154.

Both translation units compile.