### PR TITLE
[TIRx][CUDA] Accept packed sub-byte tensor-map dtypes in force_cu_dtype

### DIFF
--- a/src/backend/cuda/runtime/cuda_device_api.cc
+++ b/src/backend/cuda/runtime/cuda_device_api.cc
@@ -586,10 +586,36 @@ TVM_FFI_STATIC_INIT_BLOCK() {
     // bypass the dtype-derived mapping so the descriptor uses the requested
     // CUtensorMapDataType. Same byte size, different on-load rounding semantics.
     if (force_cu_dtype >= 0) {
-      TVM_FFI_ICHECK_EQ(force_cu_dtype, 11)
-          << "force_cu_dtype only supports CU_TENSOR_MAP_DATA_TYPE_TFLOAT32 (11)";
-      TVM_FFI_ICHECK(tensor_dtype.code == kDLFloat && tensor_dtype.bits == 32)
-          << "CU_TENSOR_MAP_DATA_TYPE_TFLOAT32 requires a scalar float32 tensor_dtype";
+      // The accepted set widens inside the version gate rather than around a
+      // branch, so the preprocessor never straddles a brace.
+#if (CUDA_VERSION >= 12080)
+      const bool is_packed_sub_byte = force_cu_dtype == CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN8B ||
+                                      force_cu_dtype == CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN16B ||
+                                      force_cu_dtype == CU_TENSOR_MAP_DATA_TYPE_16U6_ALIGN16B;
+      const char* accepted = "CU_TENSOR_MAP_DATA_TYPE_TFLOAT32 or a packed sub-byte type";
+#else
+      const bool is_packed_sub_byte = false;
+      const char* accepted = "CU_TENSOR_MAP_DATA_TYPE_TFLOAT32";
+#endif
+      if (force_cu_dtype == CU_TENSOR_MAP_DATA_TYPE_TFLOAT32) {
+        TVM_FFI_ICHECK(tensor_dtype.code == kDLFloat && tensor_dtype.bits == 32)
+            << "CU_TENSOR_MAP_DATA_TYPE_TFLOAT32 requires a scalar float32 tensor_dtype";
+      } else if (is_packed_sub_byte) {
+        // A packed sub-byte payload reaches this API either as its logical
+        // sub-byte dtype or as the byte storage holding it. The caller states
+        // which packing and alignment the TMA should apply; the derived mapping
+        // above can only reach ALIGN16B, so an ALIGN8B tile is expressible only
+        // through this override.
+        bool is_byte_storage =
+            (tensor_dtype.code == kDLUInt || tensor_dtype.code == kDLInt) && tensor_dtype.bits == 8;
+        bool is_sub_byte = tensor_dtype.bits > 0 && tensor_dtype.bits < 8;
+        TVM_FFI_ICHECK(is_byte_storage || is_sub_byte)
+            << "a packed sub-byte CUtensorMapDataType requires sub-byte or 8-bit storage, got "
+            << ffi::DLDataTypeToString(tensor_dtype);
+      } else {
+        TVM_FFI_THROW(InternalError)
+            << "force_cu_dtype accepts " << accepted << ", got " << force_cu_dtype;
+      }
       cu_dtype = static_cast<CUtensorMapDataType>(force_cu_dtype);
     }
 


### PR DESCRIPTION
`force_cu_dtype` admitted only `CU_TENSOR_MAP_DATA_TYPE_TFLOAT32`. The
dtype-derived mapping above it can reach `16U4_ALIGN16B` but never
`16U4_ALIGN8B`, so an FP4 tile that needs 8-byte alignment is not expressible
at all — neither through the derived mapping nor through the override that
exists precisely for cases the mapping cannot reach.

This admits the three packed sub-byte types alongside `TFLOAT32`, gated on CUDA
12.8 where those enums appear, and checks the storage each requires: a packed
sub-byte payload reaches this API either as its logical sub-byte dtype or as
the 8-bit byte storage holding it. Anything else now reports which values are
accepted instead of asserting that the argument equals 11.

Follow-up to #20154, which introduced the version gating this reuses.