### PR TITLE
[TIRx][CUDA] Honor required CUDA thread extents in PTX

### DIFF
--- a/python/tvm/support/nvcc.py
+++ b/python/tvm/support/nvcc.py
@@ -929,6 +929,45 @@ def tvm_callback_cuda_compile(code):
     # caller no longer needs to push/pop a target scope.
     compiler = os.environ.get("TVM_CUDA_COMPILE_MODE", "nvrtc").lower()
 
+    required_threads = []
+    for line in str(code).splitlines():
+        fields = line.strip().split()
+        if len(fields) == 6 and fields[:2] == ["//", "tirx.reqntid"]:
+            kernel_name = fields[2]
+            dimensions = tuple(int(value) for value in fields[3:])
+            if dimensions[1:] != (1, 1):
+                raise ValueError(
+                    "tirx.reqntid currently requires a flat CUDA thread extent, "
+                    f"got {kernel_name} {dimensions}"
+                )
+            required_threads.append((kernel_name, dimensions))
+
+    if required_threads:
+        ptx = compile_cuda(code, target_format="ptx", compiler=compiler).decode()
+        for kernel_name, dimensions in required_threads:
+            entry = f".entry {kernel_name}("
+            entry_begin = ptx.find(entry)
+            if entry_begin < 0:
+                raise RuntimeError(
+                    f"tirx.reqntid kernel {kernel_name!r} is absent from generated PTX"
+                )
+            body_begin = ptx.find("{", entry_begin)
+            if body_begin < 0:
+                raise RuntimeError(f"tirx.reqntid kernel {kernel_name!r} has no PTX body")
+            launch_bound = f".maxntid {dimensions[0]}"
+            bound_begin = ptx.find(launch_bound, entry_begin, body_begin)
+            if bound_begin < 0:
+                raise RuntimeError(
+                    f"tirx.reqntid kernel {kernel_name!r} is missing {launch_bound!r}"
+                )
+            if ptx.find(launch_bound, bound_begin + 1, body_begin) >= 0:
+                raise RuntimeError(
+                    f"tirx.reqntid kernel {kernel_name!r} has duplicate launch bounds"
+                )
+            required = f".reqntid {dimensions[0]}, {dimensions[1]}, {dimensions[2]}"
+            ptx = ptx[:bound_begin] + required + ptx[bound_begin + len(launch_bound) :]
+        return bytearray(ptx.encode())
+
     if compiler == "nvrtc":
         return compile_cuda(code, target_format="cubin", compiler="nvrtc")
     if compiler == "nvcc":

--- a/tests/python/support/test_nvcc.py
+++ b/tests/python/support/test_nvcc.py
@@ -1,0 +1,65 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest
+
+from tvm.support import nvcc
+
+
+def test_tirx_reqntid_rewrites_only_the_named_ptx_entry(monkeypatch):
+    source = """
+// tirx.reqntid compressor_fwd_kernel 64 1 1
+extern "C" __global__ void compressor_fwd_kernel() {}
+"""
+    ptx = b"""
+.visible .entry compressor_fwd_kernel()
+.maxntid 64
+{
+  ret;
+}
+.visible .entry unrelated_kernel()
+.maxntid 32
+{
+  ret;
+}
+"""
+    calls = []
+
+    def compile_stub(code, *, target_format, compiler):
+        calls.append((code, target_format, compiler))
+        return ptx
+
+    monkeypatch.delenv("TVM_CUDA_COMPILE_MODE", raising=False)
+    monkeypatch.setattr(nvcc, "compile_cuda", compile_stub)
+
+    result = bytes(nvcc.tvm_callback_cuda_compile(source))
+
+    assert calls == [(source, "ptx", "nvrtc")]
+    assert b".reqntid 64, 1, 1" in result
+    assert b".maxntid 64" not in result
+    assert b".maxntid 32" in result
+
+
+def test_tirx_reqntid_rejects_nonflat_thread_extent(monkeypatch):
+    monkeypatch.setattr(
+        nvcc,
+        "compile_cuda",
+        lambda *_args, **_kwargs: pytest.fail("invalid metadata must fail before compilation"),
+    )
+
+    with pytest.raises(ValueError, match="flat CUDA thread extent"):
+        nvcc.tvm_callback_cuda_compile("// tirx.reqntid kernel 64 2 1")


### PR DESCRIPTION
## Summary

- recognize `// tirx.reqntid <kernel> <x> <y> <z>` directives emitted in generated CUDA
- compile annotated kernels to PTX and replace the matching entry `.maxntid` directive with `.reqntid`
- reject unsupported non-flat extents and add focused callback tests

## Motivation

The TIRx CSA compressor port must preserve the source kernel exact `64 x 1 x 1` CTA shape. CUDA `__launch_bounds__(64)` emits only `.maxntid 64`; `.reqntid 64, 1, 1` exposes the exact launch contract to `ptxas` and preserves the intended code generation.

The rewrite is opt-in, applies only to the named PTX entry, and leaves the existing NVRTC/NVCC cubin path unchanged when no directive is present.

## Testing

- `cmake --build build --parallel 16`
- `pytest -q tests/python/support/test_nvcc.py` (2 passed)
- `pre-commit run --files python/tvm/support/nvcc.py tests/python/support/test_nvcc.py`