### PR TITLE
[Fix][Relax][Frontend][ONNX] Squeeze: raise an error when axes select a non-unit dimension

### DIFF
--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -2290,13 +2290,6 @@ class Squeeze(OnnxOpConverter):
 
     @classmethod
     def _validate_axes_unit_dims(cls, data, axis):
-        """ONNX Squeeze requires every selected axis to have a size-1 dimension:
-
-        "If an axis is selected with shape entry not equal to one, an error is
-        raised." relax.squeeze silently skips non-unit dims (PyTorch semantics),
-        so validate against the statically known input shape before delegating.
-        """
-
         shape = getattr(getattr(data, "ty", None), "shape", None)
         if shape is None:
             shape = getattr(getattr(data, "struct_info", None), "shape", None)

--- a/python/tvm/relax/frontend/onnx/onnx_frontend.py
+++ b/python/tvm/relax/frontend/onnx/onnx_frontend.py
@@ -2271,6 +2271,7 @@ class Squeeze(OnnxOpConverter):
             return relax.op.squeeze(data)
 
         if isinstance(axis, tuple):
+            cls._validate_axes_unit_dims(data, axis)
             return relax.op.squeeze(data, list(axis))
 
         data_ndim = _get_known_tensor_rank(data)
@@ -2286,6 +2287,38 @@ class Squeeze(OnnxOpConverter):
             bb, output_shape_tensor, data_ndim - axes_len, "squeeze_dim"
         )
         return relax.op.reshape(data, output_shape)
+
+    @classmethod
+    def _validate_axes_unit_dims(cls, data, axis):
+        """ONNX Squeeze requires every selected axis to have a size-1 dimension:
+
+        "If an axis is selected with shape entry not equal to one, an error is
+        raised." relax.squeeze silently skips non-unit dims (PyTorch semantics),
+        so validate against the statically known input shape before delegating.
+        """
+
+        shape = getattr(getattr(data, "ty", None), "shape", None)
+        if shape is None:
+            shape = getattr(getattr(data, "struct_info", None), "shape", None)
+        if isinstance(shape, relax.ShapeExpr):
+            shape = shape.values
+        if shape is None:
+            return
+        try:
+            rank = len(shape)
+        except TypeError:
+            return
+        if rank == 0:
+            return
+        for ax in _normalize_constant_axes(list(axis), rank, "Squeeze"):
+            dim = shape[ax]
+            if isinstance(dim, tirx.IntImm):
+                dim = int(dim.value)
+            if isinstance(dim, int) and dim != 1:
+                raise ValueError(
+                    "cannot select an axis to squeeze out which has size not equal "
+                    f"to one: axis {ax} has size {dim}"
+                )
 
 
 class Constant(OnnxOpConverter):

--- a/tests/python/relax/test_frontend_onnx.py
+++ b/tests/python/relax/test_frontend_onnx.py
@@ -4730,6 +4730,88 @@ def test_squeeze_dynamic_axes_rank_validation():
         from_onnx(model, opset=13, keep_params_in_input=True)
 
 
+@pytest.mark.parametrize(
+    "data_shape,axes",
+    [
+        ([2, 3], [0]),  # axis 0 has size 2 (not 1)
+        ([1, 2, 3], [1]),  # axis 1 has size 2 (not 1)
+        ([1, 2, 1, 3], [1]),  # only non-unit axis selected
+        ([2, 3, 1], [0, 2]),  # mix of non-unit and unit axes
+        ([2, 3], [-1]),  # negative axis pointing at a non-unit dim
+    ],
+)
+@pytest.mark.parametrize("opset", [11, 13])
+def test_squeeze_non_unit_axis_raises(data_shape, axes, opset):
+    """ONNX Squeeze spec: "If an axis is selected with shape entry not equal to one,
+    an error is raised." The converter must raise instead of silently ignoring the
+    offending axis (relax.squeeze's PyTorch-style no-op). opset <= 11 passes axes as
+    an attribute, opset >= 13 as an input."""
+    node = helper.make_node("Squeeze", ["x"], ["y"])
+    initializer = None
+    if opset >= 13:
+        node.input.append("axes")
+        initializer = [helper.make_tensor("axes", TensorProto.INT64, [len(axes)], axes)]
+    else:
+        node.attribute.append(helper.make_attribute("axes", axes))
+    graph = helper.make_graph(
+        [node],
+        "squeeze_non_unit_axis_test",
+        inputs=[helper.make_tensor_value_info("x", TensorProto.FLOAT, data_shape)],
+        initializer=initializer,
+        outputs=[helper.make_tensor_value_info("y", TensorProto.FLOAT, data_shape)],
+    )
+    model = helper.make_model(graph, producer_name="squeeze_non_unit_axis_test")
+    with pytest.raises(ValueError, match="not equal to one"):
+        from_onnx(model, opset=opset, keep_params_in_input=True)
+
+
+def test_squeeze_constant_non_unit_axis_raises():
+    """The constant-data path already raises (np.squeeze raises on a non-unit axis),
+    matching onnx.reference; keep it covered so the two paths stay consistent."""
+    shape = [2, 3]
+    data = np.arange(6, dtype="float32").reshape(shape)
+    constant = make_constant_node("x", onnx.TensorProto.FLOAT, shape, data.flatten().tolist())
+    squeeze_node = helper.make_node("Squeeze", ["x", "axes"], ["y"])
+    graph = helper.make_graph(
+        [constant, squeeze_node],
+        "squeeze_constant_non_unit_axis_test",
+        inputs=[],
+        initializer=[helper.make_tensor("axes", TensorProto.INT64, [1], [0])],
+        outputs=[helper.make_tensor_value_info("y", TensorProto.FLOAT, shape)],
+    )
+    model = helper.make_model(graph, producer_name="squeeze_constant_non_unit_axis_test")
+    with pytest.raises(ValueError, match="not equal to one"):
+        from_onnx(model, opset=13, keep_params_in_input=True)
+
+
+def test_squeeze_valid_axes_correctness():
+    """Squeeze with axes selecting only size-1 dims (and axes=None) still imports and
+    matches onnxruntime, i.e. the axis validation adds no regression."""
+    cases = [
+        ([1, 32, 1, 32], [0, 2], [32, 32]),
+        ([1, 2, 1, 3], [0], [2, 1, 3]),
+        ([2, 1, 3], [1], [2, 3]),
+        ([1, 2, 1], [-1], [1, 2]),
+        ([1, 2, 1, 3], [0, -2], [2, 3]),
+        ([1, 2, 1, 3], None, [2, 3]),
+    ]
+    for data_shape, axes, out_shape in cases:
+        node = helper.make_node("Squeeze", ["x"], ["y"])
+        initializer = None
+        if axes is not None:
+            node.input.append("axes")
+            initializer = [helper.make_tensor("axes", TensorProto.INT64, [len(axes)], axes)]
+        graph = helper.make_graph(
+            [node],
+            "squeeze_valid_axes_test",
+            inputs=[helper.make_tensor_value_info("x", TensorProto.FLOAT, data_shape)],
+            initializer=initializer,
+            outputs=[helper.make_tensor_value_info("y", TensorProto.FLOAT, out_shape)],
+        )
+        model = helper.make_model(graph, producer_name="squeeze_valid_axes_test")
+        check_correctness(model, opset=13)
+
+
 @pytest.mark.parametrize("axis", [[0]])
 def test_dynamic_shape_squeeze(axis):
     shape_node = helper.make_node("Shape", ["x"], ["y"])


### PR DESCRIPTION

Fixes: #20185

## Summary

The Relax ONNX frontend silently accepted a `Squeeze` whose `axes` select a
dimension with size **not equal to 1**, returning the input **unchanged** with no
error. The [ONNX Squeeze spec](https://onnx.ai/onnx/operators/onnx__Squeeze.html)
(opset 11+ and earlier) requires the opposite: *"If an axis is selected with shape
entry not equal to one, an error is raised."* Both onnxruntime and
`onnx.reference` reject such models; TVM diverged. The converter now validates
statically-known axes against the input shape and raises a `ValueError` before
delegating to `relax.op.squeeze`.

## Root cause

`Squeeze._squeeze` (`python/tvm/relax/frontend/onnx/onnx_frontend.py`) delegates
the non-constant path directly to `relax.op.squeeze(data, list(axis))`. The
underlying op's shape inference
(`src/relax/op/tensor/manipulate.cc:1269-1284`) deliberately implements PyTorch
semantics — *"If a dimension is not 1, silently skip it (no-op), matching PyTorch
behavior"* (and carries a `Todo(relax-team): revisit here for better check on if
the axis being squeezed has length 1`). So a non-unit selected axis was silently
ignored and the input returned unchanged. The ONNX frontend performed no
`dim == 1` check — unlike its constant path, where `np.squeeze` already raises
the same `ValueError` as `onnx.reference`.

```python
# Before: silently accepted e.g. data(2,3) with axes=[0]
if isinstance(axis, tuple):
    return relax.op.squeeze(data, list(axis))
```

## Fix

Validate before delegating: when `axis` is statically known (a tuple) and the
input shape is statically known, every selected (normalized, deduplicated,
bounds-checked) axis must have size 1:

```python
if isinstance(axis, tuple):
    cls._validate_axes_unit_dims(data, axis)
    return relax.op.squeeze(data, list(axis))
```

`_validate_axes_unit_dims` reuses `_normalize_constant_axes` (negative-axis
normalization, bounds and uniqueness checks) and raises the same `ValueError`
message as `np.squeeze`/`onnx.reference` when a known dim is `!= 1`. Dimensions
that are only known at runtime cannot be validated at import time and keep the
previous behavior — the shared `relax.op.squeeze` is intentionally left unchanged
because other frontends (e.g. PyTorch) rely on its no-op semantics.

## Validation

Differential test: Relax (build + `VirtualMachine`) vs onnxruntime on the same
model, cross-checked with `onnx.reference` (which is the reference for the
rejection semantics and for fp64), across valid, invalid-axis, constant, and
out-of-bounds cases.

| Case | onnxruntime | onnx.reference | TVM (after fix) | Result |
|---|---|---|---|---|
| `(2,3)` `axes=[0]` (non-unit) | ERR | ERR | `ValueError` | OK |
| `(1,2,3)` `axes=[1]` (non-unit) | ERR | ERR | `ValueError` | OK |
| `(1,2,1,3)` `axes=[1]` (only non-unit) | ERR | ERR | `ValueError` | OK |
| `(2,3,1)` `axes=[0,2]` (mixed) | ERR | ERR | `ValueError` | OK |
| `(2,3)` `axes=[-1]` (neg, non-unit) | ERR | ERR | `ValueError` | OK |
| `(1,2,1,3)` `axes=[0,2]` (valid, regression) | `(2,3)` | `(2,3)` | `(2,3)` max\|diff\|=0 | OK |
| `(1,2,1)` `axes=[-1]` (valid neg, regression) | `(1,2)` | `(1,2)` | `(1,2)` max\|diff\|=0 | OK |
| `(1,)` `axes=[0]` (scalar output, regression) | `()` | `()` | `()` max\|diff\|=0 | OK |

Totals: **25/25 OK** (pre-fix: 6/6 legal models diverged — onnxruntime/ref
rejected, TVM silently returned the input unchanged). Valid axes (incl. negative
axes, scalar output, opset 13/21), the constant-data path, and out-of-bounds
rejection are unchanged. Run:

```bash
TVM_LIBRARY_PATH=<tvm23>/build PYTHONPATH=<patched 262c6d2e04 source>/python \
  python results/TVM/deepseek-v4-flash/prove_hum/onnx_Squeeze/5修复_差分验证.py
```

New in-tree tests cover the raise behavior for both opset 11 (axes attribute) and
opset 13 (axes input), the constant path, and numeric correctness of valid axes
vs onnxruntime.

## Files changed

- `python/tvm/relax/frontend/onnx/onnx_frontend.py` — `Squeeze._squeeze`: validate
  that every selected axis has a size-1 dimension (ONNX spec) before delegating to
  `relax.op.squeeze`.
- `tests/python/relax/test_frontend_onnx.py` — add `test_squeeze_non_unit_axis_raises`,
  `test_squeeze_constant_non_unit_axis_raises`, `test_squeeze_valid_axes_correctness`.
