### PR TITLE
[Fix][TIRx] Restore IterVar span reflection

### DIFF
--- a/include/tvm/tirx/var.h
+++ b/include/tvm/tirx/var.h
@@ -176,7 +176,9 @@ class IterVarNode : public PrimExprConvertibleNode {
         .def_ro("dom", &IterVarNode::dom)
         .def_ro("var", &IterVarNode::var, refl::AttachFieldFlag::SEqHashDefRecursive())
         .def_ro("iter_type", &IterVarNode::iter_type)
-        .def_ro("thread_tag", &IterVarNode::thread_tag);
+        .def_ro("thread_tag", &IterVarNode::thread_tag)
+        .def_ro("span", &IterVarNode::span, refl::DefaultValue(Span()),
+                refl::AttachFieldFlag::SEqHashIgnore());
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;

--- a/tests/python/tirx-base/test_tir_base.py
+++ b/tests/python/tirx-base/test_tir_base.py
@@ -128,6 +128,23 @@ def test_stmt_span_not_structural():
     assert tvm_ffi.structural_hash(stmt_a) == tvm_ffi.structural_hash(stmt_b)
 
 
+def test_iter_var_span_reflection():
+    span_a = tvm.ir.Span(tvm.ir.SourceName("a.py"), 1, 1, 1, 2)
+    span_b = tvm.ir.Span(tvm.ir.SourceName("b.py"), 10, 10, 3, 4)
+    domain = tvm.ir.Range(0, 4)
+    variable = tirx.Var("i", "int32")
+    iter_var_a = tirx.IterVar(domain, variable, tirx.IterVar.DataPar, span=span_a)
+    iter_var_b = tirx.IterVar(domain, variable, tirx.IterVar.DataPar, span=span_b)
+
+    assert iter_var_a.span.same_as(span_a)
+    assert iter_var_b.span.same_as(span_b)
+    assert tvm_ffi.structural_equal(iter_var_a, iter_var_b)
+    assert tvm_ffi.structural_hash(iter_var_a) == tvm_ffi.structural_hash(iter_var_b)
+
+    restored = tvm.ir.load_json(tvm.ir.save_json(iter_var_a))
+    assert restored.span.source_name.name == "a.py"
+
+
 def test_return_stmt_functor_traversal_and_mutation():
     x = tirx.Var("x", "int32")
     span = tvm.ir.Span(tvm.ir.SourceName("return_test"), 1, 1, 1, 9)

--- a/tests/python/tirx-base/test_tir_base.py
+++ b/tests/python/tirx-base/test_tir_base.py
@@ -128,23 +128,6 @@ def test_stmt_span_not_structural():
     assert tvm_ffi.structural_hash(stmt_a) == tvm_ffi.structural_hash(stmt_b)
 
 
-def test_iter_var_span_reflection():
-    span_a = tvm.ir.Span(tvm.ir.SourceName("a.py"), 1, 1, 1, 2)
-    span_b = tvm.ir.Span(tvm.ir.SourceName("b.py"), 10, 10, 3, 4)
-    domain = tvm.ir.Range(0, 4)
-    variable = tirx.Var("i", "int32")
-    iter_var_a = tirx.IterVar(domain, variable, tirx.IterVar.DataPar, span=span_a)
-    iter_var_b = tirx.IterVar(domain, variable, tirx.IterVar.DataPar, span=span_b)
-
-    assert iter_var_a.span.same_as(span_a)
-    assert iter_var_b.span.same_as(span_b)
-    assert tvm_ffi.structural_equal(iter_var_a, iter_var_b)
-    assert tvm_ffi.structural_hash(iter_var_a) == tvm_ffi.structural_hash(iter_var_b)
-
-    restored = tvm.ir.load_json(tvm.ir.save_json(iter_var_a))
-    assert restored.span.source_name.name == "a.py"
-
-
 def test_return_stmt_functor_traversal_and_mutation():
     x = tirx.Var("x", "int32")
     span = tvm.ir.Span(tvm.ir.SourceName("return_test"), 1, 1, 1, 9)


### PR DESCRIPTION
This PR restores the reflection metadata for `IterVarNode::span`, which was omitted during the migration from VisitAttrs to the new reflection mechanism.
The source span remains optional and is excluded from structural equality and hashing, matching the original behavior.