### PR TITLE
[Fix][S-TIR] Preserve general reduction predicates

### DIFF
--- a/src/s_tir/schedule/primitive/reduction.cc
+++ b/src/s_tir/schedule/primitive/reduction.cc
@@ -157,55 +157,17 @@ class LoopHeightError : public ScheduleError {
   SBlock block_;
 };
 
-class NonSeparablePredicateError : public ScheduleError {
- public:
-  explicit NonSeparablePredicateError(IRModule mod, SBlock block, PrimExpr predicate_clause)
-      : mod_(std::move(mod)),
-        block_(std::move(block)),
-        predicate_clause_(std::move(predicate_clause)) {}
-
-  ffi::String FastErrorString() const final {
-    return "ScheduleError: decompose_reduction requires separable predicate clauses";
-  }
-
-  ffi::String DetailRenderTemplate() const final {
-    std::ostringstream os;
-    os << "ScheduleError: decompose_reduction requires separable predicate clauses for block "
-          "{0}. Predicate clause "
-       << predicate_clause_
-       << " depends on both a loop retained by the initialization and a loop removed from it. "
-          "Rewrite the predicate as a conjunction of clauses that each depend only on retained "
-          "loops or only on removed loops.";
-    return os.str();
-  }
-
-  IRModule mod() const final { return mod_; }
-  ffi::Array<ffi::ObjectRef> LocationsOfInterest() const final { return {block_}; }
-
-  IRModule mod_;
-  SBlock block_;
-  PrimExpr predicate_clause_;
-};
-
 PrimExpr RewriteInitPredicate(PrimExpr pred,
-                              const std::unordered_set<const VarNode*>& discarded_loops,
-                              const std::unordered_set<const VarNode*>& retained_loops,
-                              const IRModule& mod, const SBlock& block) {
+                              const std::unordered_set<const VarNode*>& discarded_loops) {
   if (is_one(pred)) return IntImm::Bool(true);
   if (const auto* and_node = pred.as<AndNode>()) {
-    return RewriteInitPredicate(and_node->a, discarded_loops, retained_loops, mod, block) &&
-           RewriteInitPredicate(and_node->b, discarded_loops, retained_loops, mod, block);
+    return RewriteInitPredicate(and_node->a, discarded_loops) &&
+           RewriteInitPredicate(and_node->b, discarded_loops);
   }
-  auto uses_var_in = [&pred](const std::unordered_set<const VarNode*>& vars) {
-    return UsesVar(pred, [&vars](const VarNode* var) { return vars.count(var); });
+  auto uses_discarded_loop = [&discarded_loops](const VarNode* var) {
+    return discarded_loops.count(var);
   };
-  if (!uses_var_in(discarded_loops)) {
-    return pred;
-  }
-  if (uses_var_in(retained_loops)) {
-    throw NonSeparablePredicateError(mod, block, pred);
-  }
-  return IntImm::Bool(true);
+  return UsesVar(pred, uses_discarded_loop) ? IntImm::Bool(true) : pred;
 }
 
 StmtSRef DecomposeReduction(ScheduleState self, const StmtSRef& block_sref,
@@ -276,10 +238,6 @@ StmtSRef DecomposeReduction(ScheduleState self, const StmtSRef& block_sref,
   //         If the loop is used in the init block binding, then it is chosen.
   //         Otherwise, it is discarded.
   std::unordered_set<const VarNode*> discarded_loops;
-  std::unordered_set<const VarNode*> retained_loops;
-  for (const StmtSRef& ancestor_loop_sref : loops) {
-    retained_loops.insert(ancestor_loop_sref->StmtAs<ForNode>()->loop_var.get());
-  }
   std::vector<int> chosen_loops;
   for (int i = static_cast<int>(loops.size()) - 1; i >= 0; --i) {
     const VarNode* loop_var = loops[i]->StmtAs<ForNode>()->loop_var.get();
@@ -295,7 +253,6 @@ StmtSRef DecomposeReduction(ScheduleState self, const StmtSRef& block_sref,
     }
     if (discarded) {
       discarded_loops.insert(loop_var);
-      retained_loops.erase(loop_var);
     }
     // Only scan loops not higher than the given loop
     if (loops[i].same_as(loop_sref)) {
@@ -303,10 +260,8 @@ StmtSRef DecomposeReduction(ScheduleState self, const StmtSRef& block_sref,
     }
   }
   // Step 4. Derive the predicate for the init block realize.  Omit conjunction clauses that
-  //         depend only on discarded loops.  Reject clauses that couple retained and discarded
-  //         loops, because they cannot be projected safely.
-  init_realize->predicate = RewriteInitPredicate(
-      realize->predicate, discarded_loops, retained_loops, self->mod, ffi::GetRef<SBlock>(block));
+  //         depend on discarded loops.
+  init_realize->predicate = RewriteInitPredicate(realize->predicate, discarded_loops);
   // Step 5. Create new loops above init block
   std::unordered_map<Var, Var> loop_var_map;
   Stmt body = SBlockRealize(init_realize);

--- a/src/s_tir/schedule/primitive/reduction.cc
+++ b/src/s_tir/schedule/primitive/reduction.cc
@@ -157,14 +157,55 @@ class LoopHeightError : public ScheduleError {
   SBlock block_;
 };
 
-PrimExpr RemakePredicate(PrimExpr pred, const std::unordered_set<const VarNode*>& discarded_loops) {
-  if (is_one(pred)) return IntImm::Bool(true);
-  auto f = [&](const VarNode* var) { return discarded_loops.count(var); };
-  if (const auto* and_node = pred.as<AndNode>()) {
-    return RemakePredicate(and_node->a, discarded_loops) &&
-           RemakePredicate(and_node->b, discarded_loops);
+class NonSeparablePredicateError : public ScheduleError {
+ public:
+  explicit NonSeparablePredicateError(IRModule mod, SBlock block, PrimExpr predicate_clause)
+      : mod_(std::move(mod)),
+        block_(std::move(block)),
+        predicate_clause_(std::move(predicate_clause)) {}
+
+  ffi::String FastErrorString() const final {
+    return "ScheduleError: decompose_reduction requires separable predicate clauses";
   }
-  return UsesVar(pred, f) ? IntImm::Bool(true) : pred;
+
+  ffi::String DetailRenderTemplate() const final {
+    std::ostringstream os;
+    os << "ScheduleError: decompose_reduction requires separable predicate clauses for block "
+          "{0}. Predicate clause "
+       << predicate_clause_
+       << " depends on both a loop retained by the initialization and a loop removed from it. "
+          "Rewrite the predicate as a conjunction of clauses that each depend only on retained "
+          "loops or only on removed loops.";
+    return os.str();
+  }
+
+  IRModule mod() const final { return mod_; }
+  ffi::Array<ffi::ObjectRef> LocationsOfInterest() const final { return {block_}; }
+
+  IRModule mod_;
+  SBlock block_;
+  PrimExpr predicate_clause_;
+};
+
+PrimExpr RewriteInitPredicate(PrimExpr pred,
+                              const std::unordered_set<const VarNode*>& discarded_loops,
+                              const std::unordered_set<const VarNode*>& retained_loops,
+                              const IRModule& mod, const SBlock& block) {
+  if (is_one(pred)) return IntImm::Bool(true);
+  if (const auto* and_node = pred.as<AndNode>()) {
+    return RewriteInitPredicate(and_node->a, discarded_loops, retained_loops, mod, block) &&
+           RewriteInitPredicate(and_node->b, discarded_loops, retained_loops, mod, block);
+  }
+  auto uses_var_in = [&pred](const std::unordered_set<const VarNode*>& vars) {
+    return UsesVar(pred, [&vars](const VarNode* var) { return vars.count(var); });
+  };
+  if (!uses_var_in(discarded_loops)) {
+    return pred;
+  }
+  if (uses_var_in(retained_loops)) {
+    throw NonSeparablePredicateError(mod, block, pred);
+  }
+  return IntImm::Bool(true);
 }
 
 StmtSRef DecomposeReduction(ScheduleState self, const StmtSRef& block_sref,
@@ -235,6 +276,10 @@ StmtSRef DecomposeReduction(ScheduleState self, const StmtSRef& block_sref,
   //         If the loop is used in the init block binding, then it is chosen.
   //         Otherwise, it is discarded.
   std::unordered_set<const VarNode*> discarded_loops;
+  std::unordered_set<const VarNode*> retained_loops;
+  for (const StmtSRef& ancestor_loop_sref : loops) {
+    retained_loops.insert(ancestor_loop_sref->StmtAs<ForNode>()->loop_var.get());
+  }
   std::vector<int> chosen_loops;
   for (int i = static_cast<int>(loops.size()) - 1; i >= 0; --i) {
     const VarNode* loop_var = loops[i]->StmtAs<ForNode>()->loop_var.get();
@@ -248,15 +293,20 @@ StmtSRef DecomposeReduction(ScheduleState self, const StmtSRef& block_sref,
       discarded = false;
       break;
     }
-    if (discarded) discarded_loops.insert(loop_var);
+    if (discarded) {
+      discarded_loops.insert(loop_var);
+      retained_loops.erase(loop_var);
+    }
     // Only scan loops not higher than the given loop
     if (loops[i].same_as(loop_sref)) {
       break;
     }
   }
-  // Step 4. After scanning loops, make a new predicate in the init block realize
-  //         We discard predicate that is related to discarded loops
-  init_realize->predicate = RemakePredicate(realize->predicate, discarded_loops);
+  // Step 4. Derive the predicate for the init block realize.  Omit conjunction clauses that
+  //         depend only on discarded loops.  Reject clauses that couple retained and discarded
+  //         loops, because they cannot be projected safely.
+  init_realize->predicate = RewriteInitPredicate(
+      realize->predicate, discarded_loops, retained_loops, self->mod, ffi::GetRef<SBlock>(block));
   // Step 5. Create new loops above init block
   std::unordered_map<Var, Var> loop_var_map;
   Stmt body = SBlockRealize(init_realize);

--- a/src/s_tir/schedule/primitive/reduction.cc
+++ b/src/s_tir/schedule/primitive/reduction.cc
@@ -159,21 +159,12 @@ class LoopHeightError : public ScheduleError {
 
 PrimExpr RemakePredicate(PrimExpr pred, const std::unordered_set<const VarNode*>& discarded_loops) {
   if (is_one(pred)) return IntImm::Bool(true);
-  PrimExpr new_pred = IntImm::Bool(true);
   auto f = [&](const VarNode* var) { return discarded_loops.count(var); };
-  arith::PVar<PrimExpr> lhs, rhs, rest;
-  for (;;) {
-    if ((rest && (lhs < rhs)).Match(pred)) {
-      if (!UsesVar(lhs.Eval(), f)) new_pred = new_pred && (lhs.Eval() < rhs.Eval());
-      pred = rest.Eval();
-    } else if ((lhs < rhs).Match(pred)) {
-      if (!UsesVar(lhs.Eval(), f)) new_pred = new_pred && (lhs.Eval() < rhs.Eval());
-      break;
-    } else {
-      TVM_FFI_ICHECK(false) << "Unexpected predicate for reduction block";
-    }
+  if (const auto* and_node = pred.as<AndNode>()) {
+    return RemakePredicate(and_node->a, discarded_loops) &&
+           RemakePredicate(and_node->b, discarded_loops);
   }
-  return new_pred;
+  return UsesVar(pred, f) ? IntImm::Bool(true) : pred;
 }
 
 StmtSRef DecomposeReduction(ScheduleState self, const StmtSRef& block_sref,

--- a/tests/python/s_tir/schedule/test_tir_schedule_reduction.py
+++ b/tests/python/s_tir/schedule/test_tir_schedule_reduction.py
@@ -391,5 +391,41 @@ def test_decompose_reduction_with_thread_binding():
     tvm.ir.assert_structural_equal(After, Expected)
 
 
+def test_decompose_reduction_preserves_general_spatial_predicates():
+    @I.ir_module(s_tir=True)
+    class Before:
+        @T.prim_func(s_tir=True)
+        def main(A: T.Buffer((8, 8), "float32"), B: T.Buffer((8,), "float32")):
+            for i, k in T.grid(10, 10):
+                with T.sblock("B"):
+                    T.where(1 <= i and i < 9 and 1 <= k and k < 9)
+                    vi = T.axis.spatial(8, i - 1)
+                    vk = T.axis.reduce(8, k - 1)
+                    with T.init():
+                        B[vi] = T.float32(0)
+                    B[vi] += A[vi, vk]
+
+    @I.ir_module(s_tir=True)
+    class Expected:
+        @T.prim_func(s_tir=True)
+        def main(A: T.Buffer((8, 8), "float32"), B: T.Buffer((8,), "float32")):
+            for i_init in range(10):
+                with T.sblock("B_init"):
+                    T.where(1 <= i_init and i_init < 9)
+                    vi = T.axis.spatial(8, i_init - 1)
+                    B[vi] = T.float32(0)
+            for i, k in T.grid(10, 10):
+                with T.sblock("B_update"):
+                    T.where(1 <= i and i < 9 and 1 <= k and k < 9)
+                    vi = T.axis.spatial(8, i - 1)
+                    vk = T.axis.reduce(8, k - 1)
+                    B[vi] += A[vi, vk]
+
+    sch = tvm.s_tir.Schedule(Before)
+    i, _ = sch.get_loops("B")
+    sch.decompose_reduction("B", i)
+    tvm.ir.assert_structural_equal(sch.mod, Expected)
+
+
 if __name__ == "__main__":
     tvm.testing.main()

--- a/tests/python/s_tir/schedule/test_tir_schedule_reduction.py
+++ b/tests/python/s_tir/schedule/test_tir_schedule_reduction.py
@@ -427,5 +427,85 @@ def test_decompose_reduction_preserves_general_spatial_predicates():
     tvm.ir.assert_structural_equal(sch.mod, Expected)
 
 
+def test_decompose_reduction_preserves_separable_or_predicates_without_prerequisite_checks():
+    @I.ir_module(s_tir=True)
+    class Before:
+        @T.prim_func(s_tir=True)
+        def main(A: T.Buffer((8, 8), "float32"), B: T.Buffer((8,), "float32")):
+            for i, k in T.grid(8, 8):
+                with T.sblock("B"):
+                    T.where((i < 3 or 5 <= i) and (k < 3 or 5 <= k))
+                    vi = T.axis.spatial(8, i)
+                    vk = T.axis.reduce(8, k)
+                    with T.init():
+                        B[vi] = T.float32(0)
+                    B[vi] += A[vi, vk]
+
+    @I.ir_module(s_tir=True)
+    class Expected:
+        @T.prim_func(s_tir=True)
+        def main(A: T.Buffer((8, 8), "float32"), B: T.Buffer((8,), "float32")):
+            for i_init in range(8):
+                with T.sblock("B_init"):
+                    T.where(i_init < 3 or 5 <= i_init)
+                    vi = T.axis.spatial(8, i_init)
+                    B[vi] = T.float32(0)
+            for i, k in T.grid(8, 8):
+                with T.sblock("B_update"):
+                    T.where((i < 3 or 5 <= i) and (k < 3 or 5 <= k))
+                    vi = T.axis.spatial(8, i)
+                    vk = T.axis.reduce(8, k)
+                    B[vi] += A[vi, vk]
+
+    # OR predicates are not quasi-affine block bindings.  With prerequisite checks disabled,
+    # decompose_reduction must still rewrite a predicate whose clauses are separable.
+    sch = tvm.s_tir.Schedule(Before, enable_check=False)
+    i, _ = sch.get_loops("B")
+    sch.decompose_reduction("B", i)
+    tvm.ir.assert_structural_equal(sch.mod, Expected)
+
+
+def test_decompose_reduction_rejects_mixed_predicate_clause_without_prerequisite_checks():
+    @I.ir_module(s_tir=True)
+    class Before:
+        @T.prim_func(s_tir=True)
+        def main(A: T.Buffer((8, 8), "float32"), B: T.Buffer((8,), "float32")):
+            for i, k in T.grid(8, 8):
+                with T.sblock("B"):
+                    T.where(i < k)
+                    vi = T.axis.spatial(8, i)
+                    vk = T.axis.reduce(8, k)
+                    with T.init():
+                        B[vi] = T.float32(0)
+                    B[vi] += A[vi, vk]
+
+    # This block is rejected as non-quasi-affine when prerequisite checks are enabled.  The
+    # rewrite itself must also reject the mixed clause instead of silently widening it.
+    sch = tvm.s_tir.Schedule(Before, enable_check=False)
+    i, _ = sch.get_loops("B")
+    with pytest.raises(tvm.s_tir.ScheduleError, match="separable predicate clauses"):
+        sch.decompose_reduction("B", i)
+
+
+def test_decompose_reduction_rejects_nonseparable_or_predicate_without_prerequisite_checks():
+    @I.ir_module(s_tir=True)
+    class Before:
+        @T.prim_func(s_tir=True)
+        def main(A: T.Buffer((8, 8), "float32"), B: T.Buffer((8,), "float32")):
+            for i, k in T.grid(8, 8):
+                with T.sblock("B"):
+                    T.where(i < 7 or k < 7)
+                    vi = T.axis.spatial(8, i)
+                    vk = T.axis.reduce(8, k)
+                    with T.init():
+                        B[vi] = T.float32(0)
+                    B[vi] += A[vi, vk]
+
+    sch = tvm.s_tir.Schedule(Before, enable_check=False)
+    i, _ = sch.get_loops("B")
+    with pytest.raises(tvm.s_tir.ScheduleError, match="separable predicate clauses"):
+        sch.decompose_reduction("B", i)
+
+
 if __name__ == "__main__":
     tvm.testing.main()

--- a/tests/python/s_tir/schedule/test_tir_schedule_reduction.py
+++ b/tests/python/s_tir/schedule/test_tir_schedule_reduction.py
@@ -427,84 +427,46 @@ def test_decompose_reduction_preserves_general_spatial_predicates():
     tvm.ir.assert_structural_equal(sch.mod, Expected)
 
 
-def test_decompose_reduction_preserves_separable_or_predicates_without_prerequisite_checks():
+def test_decompose_reduction_drops_mixed_rfactor_bound():
     @I.ir_module(s_tir=True)
     class Before:
         @T.prim_func(s_tir=True)
-        def main(A: T.Buffer((8, 8), "float32"), B: T.Buffer((8,), "float32")):
-            for i, k in T.grid(8, 8):
+        def main(A: T.Buffer((20,), "float32"), B: T.Buffer((), "float32")):
+            for k in range(20):
                 with T.sblock("B"):
-                    T.where((i < 3 or 5 <= i) and (k < 3 or 5 <= k))
-                    vi = T.axis.spatial(8, i)
-                    vk = T.axis.reduce(8, k)
+                    vk = T.axis.reduce(20, k)
                     with T.init():
-                        B[vi] = T.float32(0)
-                    B[vi] += A[vi, vk]
+                        B[()] = T.float32(0)
+                    B[()] += A[vk]
 
     @I.ir_module(s_tir=True)
     class Expected:
         @T.prim_func(s_tir=True)
-        def main(A: T.Buffer((8, 8), "float32"), B: T.Buffer((8,), "float32")):
-            for i_init in range(8):
-                with T.sblock("B_init"):
-                    T.where(i_init < 3 or 5 <= i_init)
-                    vi = T.axis.spatial(8, i_init)
-                    B[vi] = T.float32(0)
-            for i, k in T.grid(8, 8):
-                with T.sblock("B_update"):
-                    T.where((i < 3 or 5 <= i) and (k < 3 or 5 <= k))
-                    vi = T.axis.spatial(8, i)
-                    vk = T.axis.reduce(8, k)
-                    B[vi] += A[vi, vk]
+        def main(A: T.Buffer((20,), "float32"), B: T.Buffer((), "float32")):
+            B_rf = T.sblock_alloc_buffer((16,), elem_offset=T.int64(0))
+            for k_1_init in range(16):
+                with T.sblock("B_rf_init"):
+                    vk_1 = T.axis.spatial(16, k_1_init)
+                    B_rf[vk_1] = T.float32(0)
+            for k_0, k_1 in T.grid(2, 16):
+                with T.sblock("B_rf_update"):
+                    vk_1, vk_0 = T.axis.remap("SR", [k_1, k_0])
+                    T.where(k_0 * 16 + k_1 < 20)
+                    B_rf[vk_1] += A[vk_0 * 16 + vk_1]
+            for k_1 in range(16):
+                with T.sblock("B"):
+                    vk_1 = T.axis.reduce(16, k_1)
+                    with T.init():
+                        B[()] = T.float32(0)
+                    B[()] += B_rf[vk_1]
 
-    # OR predicates are not quasi-affine block bindings.  With prerequisite checks disabled,
-    # decompose_reduction must still rewrite a predicate whose clauses are separable.
-    sch = tvm.s_tir.Schedule(Before, enable_check=False)
-    i, _ = sch.get_loops("B")
-    sch.decompose_reduction("B", i)
+    sch = tvm.s_tir.Schedule(Before)
+    (k,) = sch.get_loops("B")
+    _, k_1 = sch.split(k, factors=[None, 16])
+    rf = sch.rfactor(k_1, 0)
+    k_0, _ = sch.get_loops(rf)
+    sch.decompose_reduction(rf, k_0)
     tvm.ir.assert_structural_equal(sch.mod, Expected)
-
-
-def test_decompose_reduction_rejects_mixed_predicate_clause_without_prerequisite_checks():
-    @I.ir_module(s_tir=True)
-    class Before:
-        @T.prim_func(s_tir=True)
-        def main(A: T.Buffer((8, 8), "float32"), B: T.Buffer((8,), "float32")):
-            for i, k in T.grid(8, 8):
-                with T.sblock("B"):
-                    T.where(i < k)
-                    vi = T.axis.spatial(8, i)
-                    vk = T.axis.reduce(8, k)
-                    with T.init():
-                        B[vi] = T.float32(0)
-                    B[vi] += A[vi, vk]
-
-    # This block is rejected as non-quasi-affine when prerequisite checks are enabled.  The
-    # rewrite itself must also reject the mixed clause instead of silently widening it.
-    sch = tvm.s_tir.Schedule(Before, enable_check=False)
-    i, _ = sch.get_loops("B")
-    with pytest.raises(tvm.s_tir.ScheduleError, match="separable predicate clauses"):
-        sch.decompose_reduction("B", i)
-
-
-def test_decompose_reduction_rejects_nonseparable_or_predicate_without_prerequisite_checks():
-    @I.ir_module(s_tir=True)
-    class Before:
-        @T.prim_func(s_tir=True)
-        def main(A: T.Buffer((8, 8), "float32"), B: T.Buffer((8,), "float32")):
-            for i, k in T.grid(8, 8):
-                with T.sblock("B"):
-                    T.where(i < 7 or k < 7)
-                    vi = T.axis.spatial(8, i)
-                    vk = T.axis.reduce(8, k)
-                    with T.init():
-                        B[vi] = T.float32(0)
-                    B[vi] += A[vi, vk]
-
-    sch = tvm.s_tir.Schedule(Before, enable_check=False)
-    i, _ = sch.get_loops("B")
-    with pytest.raises(tvm.s_tir.ScheduleError, match="separable predicate clauses"):
-        sch.decompose_reduction("B", i)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Rebuild decomposed reduction predicates recursively across conjunctions. Preserve clauses independent of discarded loops and drop clauses that reference discarded loops. This supports comparisons beyond `<` and detects loop variables on either operand.

Tail predicates generated by `split` and `rfactor`, such as `outer * factor + inner < extent`, are omitted from initialization when they reference a discarded reduction loop, while remaining on the update block.