### PR TITLE
[REFACTOR][TIR] Split masked buffer access into special calls

### DIFF
--- a/include/tvm/tirx/buffer.h
+++ b/include/tvm/tirx/buffer.h
@@ -232,20 +232,14 @@ class BufferVar : public Var {
    * \brief Create an Expr that does a vector load at begin index.
    * \param begin The beginning index
    * \param dtype The data type to be loaded.
-   * \param predicate A vector mask of boolean values indicating which lanes of a vector are to be
-   * loaded. The number lanes of the mask must be equal to the number of lanes in being loaded.
    */
-  TVM_DLL PrimExpr vload(ffi::Array<PrimExpr> begin, PrimType dtype,
-                         ffi::Optional<PrimExpr> predicate = std::nullopt) const;
+  TVM_DLL PrimExpr vload(ffi::Array<PrimExpr> begin, PrimType dtype) const;
   /*!
    * \brief Create a Stmt that does a vector store at begin index.
    * \param begin The beginning index
    * \param value The value to be stored.
-   * \param predicate A vector mask of boolean values indicating which lanes of a vector are to be
-   * stored. The number lanes of the mask must be equal to the number of lanes in value.
    */
-  TVM_DLL Stmt vstore(ffi::Array<PrimExpr> begin, PrimExpr value,
-                      ffi::Optional<PrimExpr> predicate = std::nullopt) const;
+  TVM_DLL Stmt vstore(ffi::Array<PrimExpr> begin, PrimExpr value) const;
 
   /*!
    * \brief Get a flattened version of the buffer.

--- a/include/tvm/tirx/builtin.h
+++ b/include/tvm/tirx/builtin.h
@@ -771,6 +771,12 @@ TVM_DLL const Op& vscale();
  */
 TVM_DLL const Op& get_active_lane_mask();
 
+/*! \brief Masked buffer load, represented as a checked special Call. */
+TVM_DLL const Op& masked_load();
+
+/*! \brief Masked buffer store, represented as a checked special Call. */
+TVM_DLL const Op& masked_store();
+
 /*! \brief Annotate a predicate not be considered as target condition of loop partition. */
 TVM_DLL const Op& ignore_loop_partition();
 /*!

--- a/include/tvm/tirx/builtin.h
+++ b/include/tvm/tirx/builtin.h
@@ -771,10 +771,20 @@ TVM_DLL const Op& vscale();
  */
 TVM_DLL const Op& get_active_lane_mask();
 
-/*! \brief Masked buffer load. */
+/*!
+ * \brief Masked buffer load.
+ *
+ * Arguments are the buffer variable, one or more indices, and a trailing boolean lane mask.
+ * The result type is the vector type loaded from the selected lanes.
+ */
 TVM_DLL const Op& masked_load();
 
-/*! \brief Masked buffer store. */
+/*!
+ * \brief Masked buffer store.
+ *
+ * Arguments are the buffer variable, value, one or more indices, and a trailing boolean lane
+ * mask. The result type is void.
+ */
 TVM_DLL const Op& masked_store();
 
 /*! \brief Annotate a predicate not be considered as target condition of loop partition. */

--- a/include/tvm/tirx/builtin.h
+++ b/include/tvm/tirx/builtin.h
@@ -771,10 +771,10 @@ TVM_DLL const Op& vscale();
  */
 TVM_DLL const Op& get_active_lane_mask();
 
-/*! \brief Masked buffer load, represented as a checked special Call. */
+/*! \brief Masked buffer load. */
 TVM_DLL const Op& masked_load();
 
-/*! \brief Masked buffer store, represented as a checked special Call. */
+/*! \brief Masked buffer store. */
 TVM_DLL const Op& masked_store();
 
 /*! \brief Annotate a predicate not be considered as target condition of loop partition. */

--- a/include/tvm/tirx/expr.h
+++ b/include/tvm/tirx/expr.h
@@ -40,6 +40,7 @@
 #include <algorithm>
 #include <iostream>
 #include <limits>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -548,14 +549,11 @@ class BufferLoadNode : public ExprNode {
   BufferVar buffer;
   /*! \brief The indices location to be loaded. */
   ffi::Array<PrimExpr> indices;
-  /*! \brief The predicate mask for loading values. */
-  ffi::Optional<PrimExpr> predicate;
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<BufferLoadNode>()
         .def_ro("buffer", &BufferLoadNode::buffer, refl::AttachFieldFlag::SEqHashDefRecursive())
-        .def_ro("indices", &BufferLoadNode::indices)
-        .def_ro("predicate", &BufferLoadNode::predicate);
+        .def_ro("indices", &BufferLoadNode::indices);
   }
   TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tirx.BufferLoad", BufferLoadNode, ExprNode);
 
@@ -582,12 +580,27 @@ class BufferLoadNode : public ExprNode {
  */
 class BufferLoad : public PrimExpr {
  public:
-  TVM_DLL explicit BufferLoad(BufferVar buffer, ffi::Array<PrimExpr> indices,
-                              ffi::Optional<PrimExpr> predicate = std::nullopt, Span span = Span());
+  TVM_DLL explicit BufferLoad(BufferVar buffer, ffi::Array<PrimExpr> indices, Span span = Span());
   TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(BufferLoad, PrimExpr, BufferLoadNode);
   static constexpr bool _type_container_is_exact = true;
   TVM_DEFINE_OBJECT_REF_COW_METHOD(BufferLoadNode);
 };
+
+/*! \brief Checked non-node view of a tirx.masked_load Call. */
+class MaskedBufferLoad {
+ public:
+  TVM_DLL explicit MaskedBufferLoad(Call call);
+  TVM_DLL static std::optional<MaskedBufferLoad> TryMatch(const Expr& expr);
+
+  Call call;
+  BufferVar buffer;
+  ffi::Array<PrimExpr> indices;
+  PrimExpr predicate;
+};
+
+/*! \brief Construct a validated tirx.masked_load Call. */
+TVM_DLL PrimExpr MakeMaskedBufferLoad(BufferVar buffer, ffi::Array<PrimExpr> indices,
+                                      PrimExpr predicate, Span span = Span());
 
 /*!
  * \brief Construct a vector with lanes elements

--- a/include/tvm/tirx/expr.h
+++ b/include/tvm/tirx/expr.h
@@ -40,7 +40,6 @@
 #include <algorithm>
 #include <iostream>
 #include <limits>
-#include <optional>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -585,22 +584,6 @@ class BufferLoad : public PrimExpr {
   static constexpr bool _type_container_is_exact = true;
   TVM_DEFINE_OBJECT_REF_COW_METHOD(BufferLoadNode);
 };
-
-/*! \brief Checked non-node view of a tirx.masked_load Call. */
-class MaskedBufferLoad {
- public:
-  TVM_DLL explicit MaskedBufferLoad(Call call);
-  TVM_DLL static std::optional<MaskedBufferLoad> TryMatch(const Expr& expr);
-
-  Call call;
-  BufferVar buffer;
-  ffi::Array<PrimExpr> indices;
-  PrimExpr predicate;
-};
-
-/*! \brief Construct a validated tirx.masked_load Call. */
-TVM_DLL PrimExpr MakeMaskedBufferLoad(BufferVar buffer, ffi::Array<PrimExpr> indices,
-                                      PrimExpr predicate, Span span = Span());
 
 /*!
  * \brief Construct a vector with lanes elements

--- a/include/tvm/tirx/script/builder/ir.h
+++ b/include/tvm/tirx/script/builder/ir.h
@@ -498,11 +498,8 @@ Var EnvThread(ffi::String thread_tag, PrimType dtype = PrimType::Int(32));
  * \param buffer The buffer.
  * \param value The value to be stored.
  * \param indices The indices location to be stored.
- * \param predicate A vector mask of boolean values indicating which lanes of a vector are to be
- * stored. The number lanes of the mask must be equal to the number of lanes in value.
  */
-void BufferStore(BufferVar buffer, PrimExpr value, ffi::Array<PrimExpr> indices,
-                 ffi::Optional<PrimExpr> predicate);
+void BufferStore(BufferVar buffer, PrimExpr value, ffi::Array<PrimExpr> indices);
 
 /*!
  * \brief Evaluate the input expression.

--- a/include/tvm/tirx/stmt.h
+++ b/include/tvm/tirx/stmt.h
@@ -361,23 +361,6 @@ class Evaluate : public Stmt {
   TVM_DEFINE_OBJECT_REF_COW_METHOD(EvaluateNode);
 };
 
-/*! \brief Checked non-node view of a tirx.masked_store Call. */
-class MaskedBufferStore {
- public:
-  TVM_DLL explicit MaskedBufferStore(Call call);
-  TVM_DLL static std::optional<MaskedBufferStore> TryMatch(const Expr& expr);
-
-  Call call;
-  BufferVar buffer;
-  PrimExpr value;
-  ffi::Array<PrimExpr> indices;
-  PrimExpr predicate;
-};
-
-/*! \brief Construct a validated Evaluate(tirx.masked_store(...)). */
-TVM_DLL Stmt MakeMaskedBufferStore(BufferVar buffer, PrimExpr value, ffi::Array<PrimExpr> indices,
-                                   PrimExpr predicate, Span span = Span());
-
 /*! \brief Sequence statement. */
 class SeqStmt : public Stmt {
  public:

--- a/include/tvm/tirx/stmt.h
+++ b/include/tvm/tirx/stmt.h
@@ -207,16 +207,13 @@ class BufferStoreNode : public StmtNode {
   PrimExpr value;
   /*! \brief The indices location to be stored. */
   ffi::Array<PrimExpr> indices;
-  /*! \brief The predicate mask for storing values. */
-  ffi::Optional<PrimExpr> predicate;
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<BufferStoreNode>()
         .def_ro("buffer", &BufferStoreNode::buffer, refl::AttachFieldFlag::SEqHashDefRecursive())
         .def_ro("value", &BufferStoreNode::value)
-        .def_ro("indices", &BufferStoreNode::indices)
-        .def_ro("predicate", &BufferStoreNode::predicate);
+        .def_ro("indices", &BufferStoreNode::indices);
   }
   TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tirx.BufferStore", BufferStoreNode, StmtNode);
 };
@@ -228,7 +225,6 @@ class BufferStoreNode : public StmtNode {
 class BufferStore : public Stmt {
  public:
   TVM_DLL explicit BufferStore(BufferVar buffer, PrimExpr value, ffi::Array<PrimExpr> indices,
-                               ffi::Optional<PrimExpr> predicate = std::nullopt,
                                Span span = Span());
 
   TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(BufferStore, Stmt, BufferStoreNode);
@@ -364,6 +360,23 @@ class Evaluate : public Stmt {
   TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Evaluate, Stmt, EvaluateNode);
   TVM_DEFINE_OBJECT_REF_COW_METHOD(EvaluateNode);
 };
+
+/*! \brief Checked non-node view of a tirx.masked_store Call. */
+class MaskedBufferStore {
+ public:
+  TVM_DLL explicit MaskedBufferStore(Call call);
+  TVM_DLL static std::optional<MaskedBufferStore> TryMatch(const Expr& expr);
+
+  Call call;
+  BufferVar buffer;
+  PrimExpr value;
+  ffi::Array<PrimExpr> indices;
+  PrimExpr predicate;
+};
+
+/*! \brief Construct a validated Evaluate(tirx.masked_store(...)). */
+TVM_DLL Stmt MakeMaskedBufferStore(BufferVar buffer, PrimExpr value, ffi::Array<PrimExpr> indices,
+                                   PrimExpr predicate, Span span = Span());
 
 /*! \brief Sequence statement. */
 class SeqStmt : public Stmt {

--- a/include/tvm/tirx/stmt_functor.h
+++ b/include/tvm/tirx/stmt_functor.h
@@ -342,6 +342,7 @@ class TVM_DLL StmtExprVisitor : public ExprVisitor, public StmtVisitor {
   using StmtVisitor::VisitStmt;
 
   void VisitExpr(const Expr& e) override { return ExprVisitor::VisitExpr(e); }
+  void VisitExpr_(const CallNode* op) override;
   void VisitExpr_(const BufferLoadNode* op) override;
 };
 
@@ -361,6 +362,7 @@ class TVM_DLL StmtExprMutator : public ExprMutator, public StmtMutator {
 
   Expr VisitExpr(const Expr& e) override { return ExprMutator::VisitExpr(e); }
   Expr VisitExpr_(const VarNode* op) override;
+  Expr VisitExpr_(const CallNode* op) override;
   Expr VisitExpr_(const BufferLoadNode* op) override;
 };
 

--- a/include/tvm/tirx/stmt_functor.h
+++ b/include/tvm/tirx/stmt_functor.h
@@ -342,7 +342,6 @@ class TVM_DLL StmtExprVisitor : public ExprVisitor, public StmtVisitor {
   using StmtVisitor::VisitStmt;
 
   void VisitExpr(const Expr& e) override { return ExprVisitor::VisitExpr(e); }
-  void VisitExpr_(const CallNode* op) override;
   void VisitExpr_(const BufferLoadNode* op) override;
 };
 
@@ -362,7 +361,6 @@ class TVM_DLL StmtExprMutator : public ExprMutator, public StmtMutator {
 
   Expr VisitExpr(const Expr& e) override { return ExprMutator::VisitExpr(e); }
   Expr VisitExpr_(const VarNode* op) override;
-  Expr VisitExpr_(const CallNode* op) override;
   Expr VisitExpr_(const BufferLoadNode* op) override;
 };
 

--- a/python/tvm/tirx/buffer.py
+++ b/python/tvm/tirx/buffer.py
@@ -148,7 +148,7 @@ class _BufferMethods:
             extent,  # type: ignore
         )
 
-    def vload(self, begin, dtype=None, predicate=None):
+    def vload(self, begin, dtype=None):
         """Generate an Expr that loads dtype from begin index.
 
         Parameters
@@ -160,10 +160,6 @@ class _BufferMethods:
             The data type to be loaded,
             can be vector type which have lanes that is multiple of Buffer.dtype
 
-        predicate : Optional[Expr]
-            A vector mask of boolean values indicating which lanes of a vector are to be
-            loaded. The number lanes of the mask must be equal to the number of lanes being loaded.
-
         Returns
         -------
         load : Expr
@@ -171,9 +167,9 @@ class _BufferMethods:
         """
         begin = (begin,) if isinstance(begin, int) or tvm.ir.is_prim_expr(begin) else begin
         dtype = dtype if dtype else self.ty.dtype
-        return _ffi_api.BufferVLoad(self, begin, dtype, predicate)  # type: ignore
+        return _ffi_api.BufferVLoad(self, begin, dtype)  # type: ignore
 
-    def vstore(self, begin, value, predicate=None):
+    def vstore(self, begin, value):
         """Generate a Stmt that store value into begin index.
 
         Parameters
@@ -184,18 +180,13 @@ class _BufferMethods:
         value : Expr
             The value to be stored.
 
-        predicate : Optional[Expr]
-            A vector mask of boolean values indicating which lanes of a vector are to be
-            stored. The number lanes of the mask must be equal to the number of lanes in
-            value.
-
         Returns
         -------
         store : Stmt
             The corresponding store stmt.
         """
         begin = (begin,) if isinstance(begin, int) or tvm.ir.is_prim_expr(begin) else begin
-        return _ffi_api.BufferVStore(self, begin, value, predicate)  # type: ignore
+        return _ffi_api.BufferVStore(self, begin, value)  # type: ignore
 
     def scope(self):
         """Return the storage scope associated with this buffer.

--- a/python/tvm/tirx/expr.py
+++ b/python/tvm/tirx/expr.py
@@ -1186,9 +1186,6 @@ class BufferLoad(ExprWithOp):
     span : Optional[Span]
         The location of this expression in the source code.
 
-    predicate : Optional[Expr]
-        A vector mask of boolean values indicating which lanes of a vector are to be
-        loaded. The number lanes of the mask must be equal to the number of lanes being loaded.
     """
 
     buffer: Buffer
@@ -1198,14 +1195,12 @@ class BufferLoad(ExprWithOp):
         self,
         buffer: Buffer,
         indices: list[Expr],
-        predicate: Expr | None = None,
         span: Span | None = None,
     ) -> None:
         self.__init_handle_by_constructor__(
             _ffi_api.BufferLoad,
             buffer,
             indices,
-            predicate,
             span,  # type: ignore
         )
 

--- a/python/tvm/tirx/expr_functor.py
+++ b/python/tvm/tirx/expr_functor.py
@@ -472,7 +472,7 @@ class ExprMutator(ExprFunctor):
         if all(old_index is new_index for old_index, new_index in zip(op.indices, indices)):
             return op
         else:
-            return tvm.tirx.BufferLoad(op.buffer, indices, op.predicate)
+            return tvm.tirx.BufferLoad(op.buffer, indices)
 
     def visit_opaque_expr_(self, op):
         """Mutator implementation for an opaque construction-time expression."""

--- a/python/tvm/tirx/op.py
+++ b/python/tvm/tirx/op.py
@@ -3003,6 +3003,16 @@ def get_active_lane_mask(dtype, base, limit):
     return call_intrin(dtype, "tirx.get_active_lane_mask", base, limit)
 
 
+def masked_load(dtype, buffer, *indices_and_mask):
+    """Load vector lanes selected by a predicate mask."""
+    return call_intrin(dtype, "tirx.masked_load", buffer, *indices_and_mask)
+
+
+def masked_store(buffer, value, *indices_and_mask):
+    """Store vector lanes selected by a predicate mask."""
+    return call_intrin("void", "tirx.masked_store", buffer, value, *indices_and_mask)
+
+
 def get_vscale_expr(dtype: str | tvm_ffi.dtype, min_size: int = 128) -> Expr:
     """
     Create a datatype dependent scalable expression.

--- a/python/tvm/tirx/op.py
+++ b/python/tvm/tirx/op.py
@@ -3004,12 +3004,48 @@ def get_active_lane_mask(dtype, base, limit):
 
 
 def masked_load(dtype, buffer, *indices_and_mask):
-    """Load vector lanes selected by a predicate mask."""
+    """Load vector lanes selected by a predicate mask.
+
+    Parameters
+    ----------
+    dtype : str
+        The vector data type to load.
+
+    buffer : Buffer
+        The buffer to load.
+
+    indices_and_mask : Expr
+        The buffer indices followed by a boolean lane mask. The mask must match the
+        lane count and scalability of the loaded vector.
+
+    Returns
+    -------
+    call : Expr
+        A ``tirx.masked_load`` call with result type ``dtype``.
+    """
     return call_intrin(dtype, "tirx.masked_load", buffer, *indices_and_mask)
 
 
 def masked_store(buffer, value, *indices_and_mask):
-    """Store vector lanes selected by a predicate mask."""
+    """Store vector lanes selected by a predicate mask.
+
+    Parameters
+    ----------
+    buffer : Buffer
+        The buffer to update.
+
+    value : Expr
+        The vector value to store.
+
+    indices_and_mask : Expr
+        The buffer indices followed by a boolean lane mask. The mask must match the
+        lane count and scalability of ``value``.
+
+    Returns
+    -------
+    call : Expr
+        A void-typed ``tirx.masked_store`` call.
+    """
     return call_intrin("void", "tirx.masked_store", buffer, value, *indices_and_mask)
 
 

--- a/python/tvm/tirx/script/builder/ir.py
+++ b/python/tvm/tirx/script/builder/ir.py
@@ -2336,7 +2336,6 @@ def buffer_store(
     buffer: Buffer,  # pylint: disable=redefined-outer-name
     value: Expr,
     indices: list[Expr | slice],
-    predicate: Expr | None = None,
 ) -> None:
     """Buffer store node.
 
@@ -2351,10 +2350,6 @@ def buffer_store(
     indices : List[Union[Expr, slice]]
         The indices location to be stored.
 
-    predicate : Optional[Expr]
-        A vector mask of boolean values indicating which lanes of a vector are to be
-        stored. The number lanes of the mask must be equal to the number of lanes in
-        value.
     """
     from tvm.arith import Analyzer  # pylint: disable=import-outside-toplevel
 
@@ -2377,7 +2372,7 @@ def buffer_store(
     if isinstance(value, bool) and buffer.ty.dtype == "bool":
         value = IntImm("bool", value)
     return _ffi_api.BufferStore(  # type: ignore[attr-defined] # pylint: disable=no-member
-        buffer, value, expr_indices, predicate
+        buffer, value, expr_indices
     )
 
 
@@ -3223,6 +3218,8 @@ vectorlow = _dtype_forward(_tir_op.vectorlow)
 vectorhigh = _dtype_forward(_tir_op.vectorhigh)
 vectorcombine = _dtype_forward(_tir_op.vectorcombine)
 get_active_lane_mask = _dtype_forward(_tir_op.get_active_lane_mask)
+masked_load = _dtype_forward(_tir_op.masked_load)
+masked_store = _op_wrapper(_tir_op.masked_store)
 dp4a = _dtype_forward(_tir_op.dp4a)
 
 
@@ -3589,6 +3586,8 @@ __all__ = [
     "Range",
     "vscale",
     "get_active_lane_mask",
+    "masked_load",
+    "masked_store",
     "call_kernel",
     "ignore_loop_partition",
 ]

--- a/python/tvm/tirx/script/parser/parser.py
+++ b/python/tvm/tirx/script/parser/parser.py
@@ -1043,8 +1043,12 @@ def visit_expr_stmt(self: Parser, node: doc.Expr) -> None:
     elif isinstance(res, str):
         # Ignore docstrings
         pass
+    elif isinstance(res, tvm.tirx.stmt.Evaluate):
+        # Statement-valued helpers such as Buffer.vstore(predicate=...) return
+        # an already-formed Evaluate of a special side-effecting Call.
+        T.evaluate(res.value)
     elif isinstance(res, tvm.tirx.stmt.BufferStore):
-        T.buffer_store(res.buffer, res.value, res.indices, res.predicate)
+        T.buffer_store(res.buffer, res.value, res.indices)
     elif is_buffer_var(res):
         # ``T.match_buffer(...)`` used as a bare statement (no LHS) — the
         # buffer object is discarded; the underlying side effect (the

--- a/python/tvm/tirx/script/parser/parser.py
+++ b/python/tvm/tirx/script/parser/parser.py
@@ -1044,8 +1044,7 @@ def visit_expr_stmt(self: Parser, node: doc.Expr) -> None:
         # Ignore docstrings
         pass
     elif isinstance(res, tvm.tirx.stmt.Evaluate):
-        # Statement-valued helpers such as Buffer.vstore(predicate=...) return
-        # an already-formed Evaluate of a special side-effecting Call.
+        # Statement-valued helpers may return an already-formed Evaluate.
         T.evaluate(res.value)
     elif isinstance(res, tvm.tirx.stmt.BufferStore):
         T.buffer_store(res.buffer, res.value, res.indices)

--- a/python/tvm/tirx/script/parser/parser.py
+++ b/python/tvm/tirx/script/parser/parser.py
@@ -1043,9 +1043,6 @@ def visit_expr_stmt(self: Parser, node: doc.Expr) -> None:
     elif isinstance(res, str):
         # Ignore docstrings
         pass
-    elif isinstance(res, tvm.tirx.stmt.Evaluate):
-        # Statement-valued helpers may return an already-formed Evaluate.
-        T.evaluate(res.value)
     elif isinstance(res, tvm.tirx.stmt.BufferStore):
         T.buffer_store(res.buffer, res.value, res.indices)
     elif is_buffer_var(res):

--- a/python/tvm/tirx/stmt.py
+++ b/python/tvm/tirx/stmt.py
@@ -288,11 +288,6 @@ class BufferStore(Stmt):
     indices : List[Expr]
         The indices location to be stored.
 
-    predicate : Optional[Expr]
-        A vector mask of boolean values indicating which lanes of a vector are to be
-        stored. The number lanes of the mask must be equal to the number of lanes in
-        value.
-
     span : Optional[Span]
         The location of the stmt in the source code.
     """
@@ -300,7 +295,6 @@ class BufferStore(Stmt):
     buffer: Buffer
     value: Expr
     indices: list[Expr]
-    predicate: Expr | None
     span: Span | None
 
     def __init__(
@@ -308,7 +302,6 @@ class BufferStore(Stmt):
         buffer: Buffer,
         value: Expr,
         indices: list[Expr],
-        predicate: Expr | None = None,
         span: Span | None = None,
     ) -> None:
         self.__init_handle_by_constructor__(
@@ -316,7 +309,6 @@ class BufferStore(Stmt):
             buffer,
             value,
             indices,
-            predicate,
             span,  # type: ignore
         )
 

--- a/python/tvm/tirx/stmt_functor.py
+++ b/python/tvm/tirx/stmt_functor.py
@@ -292,8 +292,6 @@ class StmtVisitor(StmtFunctor):
         """Visitor implementation for BufferStore."""
         self.visit_expr(op.value)
         _visit_array(op.indices, lambda x: self.visit_expr(x))
-        if op.predicate is not None:
-            self.visit_expr(op.predicate)
 
     def visit_assert_(self, op):
         """Visitor implementation for AssertStmt."""
@@ -546,14 +544,12 @@ class StmtMutator(StmtFunctor):
         """Mutator implementation for BufferStore."""
         value = self.visit_expr(op.value)
         indices = [self.visit_expr(idx) for idx in op.indices]
-        predicate = self.visit_expr(op.predicate) if op.predicate is not None else None
-
         indices_changed = any(old is not new for old, new in zip(op.indices, indices))
 
-        if value is op.value and not indices_changed and predicate is op.predicate:
+        if value is op.value and not indices_changed:
             return op
 
-        return tvm.tirx.BufferStore(op.buffer, value, indices, predicate, op.span)
+        return tvm.tirx.BufferStore(op.buffer, value, indices, op.span)
 
     def visit_buffer_realize_(self, op):
         """Mutator implementation for BufferRealize."""

--- a/src/backend/vulkan/codegen/codegen_spirv.cc
+++ b/src/backend/vulkan/codegen/codegen_spirv.cc
@@ -331,6 +331,10 @@ spirv::Value CodeGenSPIRV::VisitExpr_(const LetNode* op) {
 }
 
 spirv::Value CodeGenSPIRV::VisitExpr_(const CallNode* op) {
+  TVM_FFI_ICHECK(!op->op.same_as(builtin::masked_load()))
+      << "Predicated buffer load is not supported.";
+  TVM_FFI_ICHECK(!op->op.same_as(builtin::masked_store()))
+      << "Predicated buffer store is not supported.";
   if (op->op.same_as(builtin::buffer_data())) {
     TVM_FFI_ICHECK_EQ(op->args.size(), 1U);
     return MakeValue(op->args[0]);
@@ -594,7 +598,6 @@ spirv::Value CodeGenSPIRV::VisitExpr_(const BroadcastNode* op) {
 
 spirv::Value CodeGenSPIRV::VisitExpr_(const BufferLoadNode* op) {
   TVM_FFI_ICHECK_EQ(op->indices.size(), 1) << "SPIR-V codegen expects flat memory buffers";
-  TVM_FFI_ICHECK(!op->predicate.has_value()) << "Predicated buffer load is not supported.";
   Var buffer_var = op->buffer.var();
   PrimExpr prim_index = op->indices[0];
 
@@ -681,7 +684,6 @@ spirv::Value CodeGenSPIRV::VisitExpr_(const ShuffleNode* op) {
 
 void CodeGenSPIRV::VisitStmt_(const BufferStoreNode* op) {
   TVM_FFI_ICHECK_EQ(op->indices.size(), 1) << "SPIR-V codegen expects flat memory buffers";
-  TVM_FFI_ICHECK(!op->predicate.has_value()) << "Predicated buffer store is not supported.";
   Var buffer_var = op->buffer.var();
   PrimExpr prim_index = op->indices[0];
 

--- a/src/backend/webgpu/codegen/codegen_webgpu.cc
+++ b/src/backend/webgpu/codegen/codegen_webgpu.cc
@@ -453,6 +453,10 @@ PrimExpr CodeGenWebGPU::EnforceU32(PrimExpr value) {
 }
 
 void CodeGenWebGPU::VisitExpr_(const CallNode* op, std::ostream& os) {  // NOLINT(*)
+  TVM_FFI_ICHECK(!op->op.same_as(builtin::masked_load()))
+      << "Predicated buffer load is not supported.";
+  TVM_FFI_ICHECK(!op->op.same_as(builtin::masked_store()))
+      << "Predicated buffer store is not supported.";
   if (op->op.same_as(builtin::reinterpret())) {
     // generate bitcast<TYPE>(ARG)
     os << "bitcast<";
@@ -583,7 +587,6 @@ void CodeGenWebGPU::VisitExpr_(const BufferLoadNode* op, std::ostream& os) {  //
   // to ensure correctness in the case of nested-expression
   // do not try to lift common printings from each case
   TVM_FFI_ICHECK_EQ(op->indices.size(), 1) << "Load from non-flat memory not supported.";
-  TVM_FFI_ICHECK(!op->predicate.has_value()) << "Predicated buffer load is not supported.";
 
   PrimType value_ty = op->ty.as_or_throw<PrimType>();
   PrimExpr index = op->indices[0];
@@ -655,7 +658,6 @@ void CodeGenWebGPU::VisitStmt_(const BindNode* op) {
 
 void CodeGenWebGPU::VisitStmt_(const BufferStoreNode* op) {
   TVM_FFI_ICHECK_EQ(op->indices.size(), 1) << "Store to non-flat memory not supported.";
-  TVM_FFI_ICHECK(!op->predicate.has_value()) << "Predicated buffer store is not supported.";
 
   PrimType value_ty = op->value.ty();
   const PrimType& element_ty = op->buffer->dtype;

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -180,9 +180,6 @@ void ExprVisitor::VisitExpr_(const tirx::BufferLoadNode* op) {
   for (const PrimExpr& index : op->indices) {
     this->VisitExpr(index);
   }
-  if (op->predicate.has_value()) {
-    this->VisitExpr(op->predicate.value());
-  }
   VisitExprDepTypeFieldIfNeeded(this, op->ty);
 }
 
@@ -536,16 +533,10 @@ Expr ExprMutatorBase::VisitExpr_(const CallNode* call_node) {
 Expr ExprMutatorBase::VisitExpr_(const tirx::BufferLoadNode* op) {
   ffi::Array<PrimExpr> indices = op->indices.Map(
       [this](const PrimExpr& e) { return this->VisitExpr(e).as_or_throw<PrimExpr>(); });
-  ffi::Optional<PrimExpr> predicate = op->predicate;
-  if (predicate.has_value()) {
-    predicate = this->VisitExpr(predicate.value()).as_or_throw<PrimExpr>();
-  }
-  bool predicate_unchanged =
-      !op->predicate.has_value() || predicate.value().same_as(op->predicate.value());
-  if (indices.same_as(op->indices) && predicate_unchanged) {
+  if (indices.same_as(op->indices)) {
     return ffi::GetRef<Expr>(op);
   }
-  return tirx::BufferLoad(op->buffer, indices, predicate, op->span);
+  return tirx::BufferLoad(op->buffer, indices, op->span);
 }
 
 #define RELAX_MUTATE_TIRX_BINOP(OP)                              \

--- a/src/s_tir/analysis/sblock_access_region_detector.cc
+++ b/src/s_tir/analysis/sblock_access_region_detector.cc
@@ -224,15 +224,15 @@ void BlockReadWriteDetector::VisitExpr_(const CallNode* op) {
     }
     Update(buffers, regions, buffer, relaxed_region);
   };
-  Call call = ffi::GetRef<Call>(op);
-  if (auto load = MaskedBufferLoad::TryMatch(call)) {
-    update_masked_access(load->buffer, load->indices, &read_buffers_, &read_regions_);
-    StmtExprVisitor::VisitExpr_(op);
-    return;
-  }
-  if (op->op.same_as(builtin::masked_store())) {
-    MaskedBufferStore store(call);
-    update_masked_access(store.buffer, store.indices, &writes_buffers_, &write_regions_);
+  if (op->op.same_as(builtin::masked_load()) || op->op.same_as(builtin::masked_store())) {
+    bool is_load = op->op.same_as(builtin::masked_load());
+    BufferVar buffer(op->args[0].as_or_throw<Var>());
+    ffi::Array<PrimExpr> indices;
+    for (size_t i = is_load ? 1 : 2; i + 1 < op->args.size(); ++i) {
+      indices.push_back(op->args[i].as_or_throw<PrimExpr>());
+    }
+    update_masked_access(buffer, indices, is_load ? &read_buffers_ : &writes_buffers_,
+                         is_load ? &read_regions_ : &write_regions_);
     StmtExprVisitor::VisitExpr_(op);
     return;
   }

--- a/src/s_tir/analysis/sblock_access_region_detector.cc
+++ b/src/s_tir/analysis/sblock_access_region_detector.cc
@@ -233,7 +233,9 @@ void BlockReadWriteDetector::VisitExpr_(const CallNode* op) {
     }
     update_masked_access(buffer, indices, is_load ? &read_buffers_ : &writes_buffers_,
                          is_load ? &read_regions_ : &write_regions_);
-    StmtExprVisitor::VisitExpr_(op);
+    for (size_t i = 1; i < op->args.size(); ++i) {
+      VisitExpr(op->args[i]);
+    }
     return;
   }
   if (op->op.same_as(builtin::tvm_access_ptr())) {

--- a/src/s_tir/analysis/sblock_access_region_detector.cc
+++ b/src/s_tir/analysis/sblock_access_region_detector.cc
@@ -210,6 +210,32 @@ void BlockReadWriteDetector::VisitStmt_(const BindNode* op) {
 }
 
 void BlockReadWriteDetector::VisitExpr_(const CallNode* op) {
+  auto update_masked_access = [this](const BufferVar& buffer, const ffi::Array<PrimExpr>& indices,
+                                     std::vector<BufferVar>* buffers,
+                                     std::vector<std::vector<arith::IntSet>>* regions) {
+    std::vector<arith::IntSet> relaxed_region;
+    for (PrimExpr index : indices) {
+      PrimExpr remapped_index = Substitute(index, let_bindings_);
+      while (!remapped_index.same_as(index)) {
+        index = remapped_index;
+        remapped_index = Substitute(index, let_bindings_);
+      }
+      relaxed_region.push_back(arith::EvalSet(arith::IntSet::Vector(remapped_index), dom_map_));
+    }
+    Update(buffers, regions, buffer, relaxed_region);
+  };
+  Call call = ffi::GetRef<Call>(op);
+  if (auto load = MaskedBufferLoad::TryMatch(call)) {
+    update_masked_access(load->buffer, load->indices, &read_buffers_, &read_regions_);
+    StmtExprVisitor::VisitExpr_(op);
+    return;
+  }
+  if (op->op.same_as(builtin::masked_store())) {
+    MaskedBufferStore store(call);
+    update_masked_access(store.buffer, store.indices, &writes_buffers_, &write_regions_);
+    StmtExprVisitor::VisitExpr_(op);
+    return;
+  }
   if (op->op.same_as(builtin::tvm_access_ptr())) {
     const VarNode* buffer_var = op->args[1].as<VarNode>();
     if (const auto* data = op->args[1].as<CallNode>();

--- a/src/s_tir/analysis/sblock_buffer_access_lca_detector.cc
+++ b/src/s_tir/analysis/sblock_buffer_access_lca_detector.cc
@@ -265,16 +265,6 @@ class LCADetector : public StmtExprVisitor {
     StmtExprVisitor::VisitStmt_(op);
   }
 
-  void VisitExpr_(const CallNode* op) final {
-    Call call = ffi::GetRef<Call>(op);
-    if (auto load = MaskedBufferLoad::TryMatch(call)) {
-      UpdateBufferLCA(load->buffer.get(), ancestor_scopes_.back());
-    } else if (auto store = MaskedBufferStore::TryMatch(call)) {
-      UpdateBufferLCA(store->buffer.get(), ancestor_scopes_.back());
-    }
-    StmtExprVisitor::VisitExpr_(op);
-  }
-
   // Works for Load/Store and opaque access.
   void VisitExpr_(const VarNode* op) final { VisitBufferVar(op); }
 

--- a/src/s_tir/analysis/sblock_buffer_access_lca_detector.cc
+++ b/src/s_tir/analysis/sblock_buffer_access_lca_detector.cc
@@ -265,6 +265,16 @@ class LCADetector : public StmtExprVisitor {
     StmtExprVisitor::VisitStmt_(op);
   }
 
+  void VisitExpr_(const CallNode* op) final {
+    Call call = ffi::GetRef<Call>(op);
+    if (auto load = MaskedBufferLoad::TryMatch(call)) {
+      UpdateBufferLCA(load->buffer.get(), ancestor_scopes_.back());
+    } else if (auto store = MaskedBufferStore::TryMatch(call)) {
+      UpdateBufferLCA(store->buffer.get(), ancestor_scopes_.back());
+    }
+    StmtExprVisitor::VisitExpr_(op);
+  }
+
   // Works for Load/Store and opaque access.
   void VisitExpr_(const VarNode* op) final { VisitBufferVar(op); }
 

--- a/src/s_tir/transform/inject_virtual_thread.cc
+++ b/src/s_tir/transform/inject_virtual_thread.cc
@@ -75,7 +75,18 @@ class ExprTouched final : public StmtExprVisitor {
   }
   void VisitExpr_(const VarNode* op) final { HandleUseVar(op); }
   void VisitExpr_(const CallNode* op) final {
-    if (op->op.same_as(builtin::tvm_access_ptr())) {
+    if (op->op.same_as(builtin::masked_load()) || op->op.same_as(builtin::masked_store())) {
+      bool is_load = op->op.same_as(builtin::masked_load());
+      const VarNode* buffer = op->args[0].as_or_throw<Var>().get();
+      if (is_load) {
+        HandleUseVar(buffer);
+      } else {
+        HandleWriteVar(buffer);
+      }
+      for (size_t i = 1; i < op->args.size(); ++i) {
+        this->VisitExpr(op->args[i]);
+      }
+    } else if (op->op.same_as(builtin::tvm_access_ptr())) {
       const auto* rw_mask = op->args[4].as<IntImmNode>();
       auto buffer = GetBufferDataVar(op->args[1]);
       if (!buffer.has_value()) {
@@ -240,7 +251,29 @@ class VTInjector : public arith::IRMutatorWithAnalyzer {
   }
   // Expression.
   Expr VisitExpr_(const CallNode* op) final {
-    if (op->op.same_as(builtin::buffer_data())) {
+    if (op->op.same_as(builtin::masked_load()) || op->op.same_as(builtin::masked_store())) {
+      bool is_load = op->op.same_as(builtin::masked_load());
+      BufferVar buffer(op->args[0].as_or_throw<Var>());
+      PrimExpr value;
+      if (!is_load) value = this->VisitPrimExpr(op->args[1].as_or_throw<PrimExpr>());
+      ffi::Array<PrimExpr> indices;
+      for (size_t i = is_load ? 1 : 2; i + 1 < op->args.size(); ++i) {
+        indices.push_back(this->VisitPrimExpr(op->args[i].as_or_throw<PrimExpr>()));
+      }
+      PrimExpr predicate = this->VisitPrimExpr(op->args.back().as_or_throw<PrimExpr>());
+      if (is_load) {
+        BufferLoad access = VisitBufferAccess(BufferLoad(buffer, indices, op->span));
+        ffi::Array<Expr> args{access->buffer.var()};
+        for (const PrimExpr& index : access->indices) args.push_back(index);
+        args.push_back(predicate);
+        return Call(op->ty, op->op, args, op->attrs, op->ty_args, op->span);
+      }
+      BufferStore access = VisitBufferAccess(BufferStore(buffer, value, indices, op->span));
+      ffi::Array<Expr> args{access->buffer.var(), access->value};
+      for (const PrimExpr& index : access->indices) args.push_back(index);
+      args.push_back(predicate);
+      return Call(op->ty, op->op, args, op->attrs, op->ty_args, op->span);
+    } else if (op->op.same_as(builtin::buffer_data())) {
       auto buffer = GetBufferDataVar(ffi::GetRef<Call>(op)).value();
       auto it = alloc_remap_.find(buffer.get());
       if (it == alloc_remap_.end()) {

--- a/src/s_tir/transform/lower_match_buffer.cc
+++ b/src/s_tir/transform/lower_match_buffer.cc
@@ -63,7 +63,7 @@ class MatchBufferLower : public StmtExprMutator {
     for (const auto& kv : match_buffers_) {
       orig_buffers.push_back(kv.first);
     }
-    Stmt stmt = StmtExprMutator ::VisitStmt_(op);
+    Stmt stmt = StmtExprMutator::VisitStmt_(op);
     // Add remapped buffer keys to match_buffers_
     for (const BufferVar& orig_buf : orig_buffers) {
       if (auto remap_it = buffer_remap_.find(orig_buf); remap_it != buffer_remap_.end()) {
@@ -107,6 +107,14 @@ class MatchBufferLower : public StmtExprMutator {
   }
 
   Expr VisitExpr_(const CallNode* op) final {
+    if ((op->op.same_as(builtin::masked_load()) || op->op.same_as(builtin::masked_store())) &&
+        !op->args.empty()) {
+      if (auto var = op->args[0].as<Var>(); var && var.value()->ty.as<BufferTypeNode>()) {
+        BufferVar buffer(var.value());
+        TVM_FFI_ICHECK(!match_buffers_.count(buffer))
+            << "Predicated buffer access is not currently supported in lower match buffer pass.";
+      }
+    }
     if (op->op.same_as(builtin::buffer_data()) && op->args.size() == 1) {
       if (auto var = op->args[0].as<Var>();
           var.has_value() && var.value()->ty.as<BufferTypeNode>()) {

--- a/src/s_tir/transform/lower_match_buffer.cc
+++ b/src/s_tir/transform/lower_match_buffer.cc
@@ -137,8 +137,6 @@ class MatchBufferLower : public StmtExprMutator {
       auto n = CopyOnWrite(op);
       n->indices = ConvertIndices(MatchBufferRegion(buffer, source), op->indices);
       n->buffer = source->buffer;
-      TVM_FFI_ICHECK(!op->predicate.has_value())
-          << "Predicated buffer store is not currently supported in lower match buffer pass.";
       return Stmt(n);
     }
   }
@@ -157,8 +155,6 @@ class MatchBufferLower : public StmtExprMutator {
       const BufferVar& buffer = (*it).first;
       const BufferRegion& source = (*it).second;
       ffi::Array<PrimExpr> indices = ConvertIndices(MatchBufferRegion(buffer, source), op->indices);
-      TVM_FFI_ICHECK(!op->predicate.has_value())
-          << "Predicated buffer load is not currently supported in lower match buffer pass.";
       return BufferLoad(source->buffer, indices);
     }
   }

--- a/src/s_tir/transform/manifest_shared_memory_local_stage.cc
+++ b/src/s_tir/transform/manifest_shared_memory_local_stage.cc
@@ -72,9 +72,6 @@ class IntermediateStageRewriter {
     Stmt local_stage = MakeLocalStage(block, new_buffer, buffer_indices, relaxed_loops, store);
 
     // Step 3: Create BufferLoad from the intermediate buffer
-    TVM_FFI_ICHECK(!store->predicate.has_value())
-        << "Predicated buffer store is not currently supported in "
-           "manifest shared memory local stage pass.";
     BufferLoad new_buffer_load = BufferLoad(new_buffer, buffer_indices);
     BufferStore new_buffer_store = block->body.as_or_throw<BufferStore>();
     new_buffer_store.CopyOnWrite()->value = new_buffer_load;

--- a/src/s_tir/transform/storage_access.cc
+++ b/src/s_tir/transform/storage_access.cc
@@ -261,37 +261,23 @@ void StorageAccessVisitor::VisitStmt_(const WhileNode* op) {
 
 void StorageAccessVisitor::VisitExpr_(const CallNode* op) {
   Call call = ffi::GetRef<Call>(op);
-  if (auto load = MaskedBufferLoad::TryMatch(call)) {
-    Var buf = ResolveBuffer(load->buffer.var());
-    StorageScope scope = StorageScope::Create(load->buffer.scope());
+  if (op->op.same_as(builtin::masked_load()) || op->op.same_as(builtin::masked_store())) {
+    bool is_load = op->op.same_as(builtin::masked_load());
+    BufferVar buffer(op->args[0].as_or_throw<Var>());
+    PrimType value_dtype =
+        is_load ? op->ty.as_or_throw<PrimType>() : op->args[1].as_or_throw<PrimExpr>().ty();
+    Var buf = ResolveBuffer(buffer.var());
+    StorageScope scope = StorageScope::Create(buffer.scope());
     if (Enabled(buf.get(), scope)) {
       TVM_FFI_ICHECK(allow_append_) << call << " " << scope.to_string();
       AccessEntry e;
       e.threads = env_threads();
       e.buffer = buf;
-      e.dtype = load->call->ty.as_or_throw<PrimType>().WithLanes(1);
-      for (const PrimExpr& index : load->indices) {
-        e.touched.push_back(arith::IntSet::Vector(index));
+      e.dtype = value_dtype.WithLanes(1);
+      for (size_t i = is_load ? 1 : 2; i + 1 < op->args.size(); ++i) {
+        e.touched.push_back(arith::IntSet::Vector(op->args[i].as_or_throw<PrimExpr>()));
       }
-      e.type = kRead;
-      e.scope = scope;
-      curr_stmt_.access.emplace_back(std::move(e));
-    }
-    StmtExprVisitor::VisitExpr_(op);
-  } else if (op->op.same_as(builtin::masked_store())) {
-    MaskedBufferStore store(call);
-    Var buf = ResolveBuffer(store.buffer.var());
-    StorageScope scope = StorageScope::Create(store.buffer.scope());
-    if (Enabled(buf.get(), scope)) {
-      TVM_FFI_ICHECK(allow_append_) << call << " " << scope.to_string();
-      AccessEntry e;
-      e.threads = env_threads();
-      e.buffer = buf;
-      e.dtype = store.value.ty().WithLanes(1);
-      for (const PrimExpr& index : store.indices) {
-        e.touched.push_back(arith::IntSet::Vector(index));
-      }
-      e.type = kWrite;
+      e.type = is_load ? kRead : kWrite;
       e.scope = scope;
       curr_stmt_.access.emplace_back(std::move(e));
     }

--- a/src/s_tir/transform/storage_access.cc
+++ b/src/s_tir/transform/storage_access.cc
@@ -260,7 +260,43 @@ void StorageAccessVisitor::VisitStmt_(const WhileNode* op) {
 }
 
 void StorageAccessVisitor::VisitExpr_(const CallNode* op) {
-  if (op->op.same_as(builtin::address_of())) {
+  Call call = ffi::GetRef<Call>(op);
+  if (auto load = MaskedBufferLoad::TryMatch(call)) {
+    Var buf = ResolveBuffer(load->buffer.var());
+    StorageScope scope = StorageScope::Create(load->buffer.scope());
+    if (Enabled(buf.get(), scope)) {
+      TVM_FFI_ICHECK(allow_append_) << call << " " << scope.to_string();
+      AccessEntry e;
+      e.threads = env_threads();
+      e.buffer = buf;
+      e.dtype = load->call->ty.as_or_throw<PrimType>().WithLanes(1);
+      for (const PrimExpr& index : load->indices) {
+        e.touched.push_back(arith::IntSet::Vector(index));
+      }
+      e.type = kRead;
+      e.scope = scope;
+      curr_stmt_.access.emplace_back(std::move(e));
+    }
+    StmtExprVisitor::VisitExpr_(op);
+  } else if (op->op.same_as(builtin::masked_store())) {
+    MaskedBufferStore store(call);
+    Var buf = ResolveBuffer(store.buffer.var());
+    StorageScope scope = StorageScope::Create(store.buffer.scope());
+    if (Enabled(buf.get(), scope)) {
+      TVM_FFI_ICHECK(allow_append_) << call << " " << scope.to_string();
+      AccessEntry e;
+      e.threads = env_threads();
+      e.buffer = buf;
+      e.dtype = store.value.ty().WithLanes(1);
+      for (const PrimExpr& index : store.indices) {
+        e.touched.push_back(arith::IntSet::Vector(index));
+      }
+      e.type = kWrite;
+      e.scope = scope;
+      curr_stmt_.access.emplace_back(std::move(e));
+    }
+    StmtExprVisitor::VisitExpr_(op);
+  } else if (op->op.same_as(builtin::address_of())) {
     if (const auto* load = op->args[0].as<BufferLoadNode>()) {
       // Taking an address does not read the buffer value.  Visit only the
       // load's children so index expressions still contribute accesses.

--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -1888,55 +1888,73 @@ llvm::Value* CodeGenLLVM::VisitExpr_(const BufferLoadNode* op) {
   return ret;
 }
 
+llvm::Value* CodeGenLLVM::CreateMaskedLoad(const CallNode* op) {
+  TVM_FFI_ICHECK_GE(op->args.size(), 3U);
+  BufferVar buffer(op->args[0].as_or_throw<Var>());
+  ffi::Array<PrimExpr> indices;
+  for (size_t i = 1; i + 1 < op->args.size(); ++i) {
+    indices.push_back(op->args[i].as_or_throw<PrimExpr>());
+  }
+  PrimExpr predicate = op->args.back().as_or_throw<PrimExpr>();
+  PrimType value_dtype = op->ty.as_or_throw<PrimType>();
+  PrimType access_dtype = BufferAccessType(value_dtype);
+  std::vector<llvm::Value*> loads;
+  auto make_load =
+      [this, &loads](TypedPointer buffer_ptr, int /*subelement_i*/, llvm::Value* predicate,
+                     int alignment, bool is_volatile) {
+        TVM_FFI_ICHECK(!is_volatile)
+            << "The masked load intrinsic does not support declaring load as volatile.";
+        llvm::Instruction* value = builder_->CreateMaskedLoad(buffer_ptr.type, buffer_ptr.addr,
+                                                              llvm::Align(alignment), predicate);
+        loads.push_back(value);
+        return value;
+      };
+  BufferAccessHelper(buffer, indices, predicate, access_dtype, make_load);
+  llvm::Value* ret =
+      loads.size() == 1 ? loads[0] : llvm::UndefValue::get(DTypeToLLVMType(access_dtype));
+  for (size_t i = 0; loads.size() > 1 && i < loads.size(); ++i) {
+    ret = builder_->CreateInsertElement(ret, loads[i], ConstInt32(i));
+  }
+  return access_dtype.same_as(value_dtype) ? ret : CreateCast(access_dtype, value_dtype, ret);
+}
+
+llvm::Value* CodeGenLLVM::CreateMaskedStore(const CallNode* op) {
+  TVM_FFI_ICHECK_GE(op->args.size(), 4U);
+  BufferVar buffer(op->args[0].as_or_throw<Var>());
+  PrimExpr value_expr = op->args[1].as_or_throw<PrimExpr>();
+  ffi::Array<PrimExpr> indices;
+  for (size_t i = 2; i + 1 < op->args.size(); ++i) {
+    indices.push_back(op->args[i].as_or_throw<PrimExpr>());
+  }
+  PrimExpr predicate = op->args.back().as_or_throw<PrimExpr>();
+  PrimType value_dtype = value_expr.ty();
+  llvm::Value* value = MakeValue(value_expr);
+  PrimType access_dtype = BufferAccessType(value_dtype);
+  if (!access_dtype.same_as(value_dtype)) {
+    value = CreateCast(value_dtype, access_dtype, value);
+    value_dtype = access_dtype;
+  }
+  llvm::Instruction* last_store = nullptr;
+  auto make_store =
+      [this, value, &last_store](TypedPointer buffer_ptr, int subelement_i, llvm::Value* predicate,
+                                 int alignment, bool is_volatile) {
+        TVM_FFI_ICHECK(!is_volatile)
+            << "The masked store intrinsic does not support declaring store as volatile.";
+        llvm::Value* to_store =
+            subelement_i == -1 ? value : builder_->CreateExtractElement(value, subelement_i);
+        last_store = builder_->CreateMaskedStore(to_store, buffer_ptr.addr, llvm::Align(alignment),
+                                                 predicate);
+        return last_store;
+      };
+  BufferAccessHelper(buffer, indices, predicate, value_dtype, make_store);
+  TVM_FFI_ICHECK(last_store != nullptr);
+  return last_store;
+}
+
 llvm::Value* CodeGenLLVM::VisitExpr_(const CallNode* op) {
   const ffi::Array<Expr>& args = op->args;
-  if (op->op.same_as(builtin::masked_load())) {
-    MaskedBufferLoad load(ffi::GetRef<Call>(op));
-    PrimType value_dtype = load.call->ty.as_or_throw<PrimType>();
-    PrimType access_dtype = BufferAccessType(value_dtype);
-    std::vector<llvm::Value*> loads;
-    auto make_load = [this, &loads](TypedPointer buffer_ptr, int /*subelement_i*/,
-                                    llvm::Value* predicate, int alignment, bool is_volatile) {
-      TVM_FFI_ICHECK(!is_volatile)
-          << "The masked load intrinsic does not support declaring load as volatile.";
-      llvm::Instruction* value = builder_->CreateMaskedLoad(buffer_ptr.type, buffer_ptr.addr,
-                                                            llvm::Align(alignment), predicate);
-      loads.push_back(value);
-      return value;
-    };
-    BufferAccessHelper(load.buffer, load.indices, load.predicate, access_dtype, make_load);
-    llvm::Value* ret =
-        loads.size() == 1 ? loads[0] : llvm::UndefValue::get(DTypeToLLVMType(access_dtype));
-    for (size_t i = 0; loads.size() > 1 && i < loads.size(); ++i) {
-      ret = builder_->CreateInsertElement(ret, loads[i], ConstInt32(i));
-    }
-    return access_dtype.same_as(value_dtype) ? ret : CreateCast(access_dtype, value_dtype, ret);
-  }
-  if (op->op.same_as(builtin::masked_store())) {
-    MaskedBufferStore store(ffi::GetRef<Call>(op));
-    PrimType value_dtype = store.value.ty();
-    llvm::Value* value = MakeValue(store.value);
-    PrimType access_dtype = BufferAccessType(value_dtype);
-    if (!access_dtype.same_as(value_dtype)) {
-      value = CreateCast(value_dtype, access_dtype, value);
-      value_dtype = access_dtype;
-    }
-    llvm::Instruction* last_store = nullptr;
-    auto make_store = [this, value, &last_store](TypedPointer buffer_ptr, int subelement_i,
-                                                 llvm::Value* predicate, int alignment,
-                                                 bool is_volatile) {
-      TVM_FFI_ICHECK(!is_volatile)
-          << "The masked store intrinsic does not support declaring store as volatile.";
-      llvm::Value* to_store =
-          subelement_i == -1 ? value : builder_->CreateExtractElement(value, subelement_i);
-      last_store =
-          builder_->CreateMaskedStore(to_store, buffer_ptr.addr, llvm::Align(alignment), predicate);
-      return last_store;
-    };
-    BufferAccessHelper(store.buffer, store.indices, store.predicate, value_dtype, make_store);
-    TVM_FFI_ICHECK(last_store != nullptr);
-    return last_store;
-  }
+  if (op->op.same_as(builtin::masked_load())) return CreateMaskedLoad(op);
+  if (op->op.same_as(builtin::masked_store())) return CreateMaskedStore(op);
   if (op->op.same_as(builtin::buffer_data())) {
     TVM_FFI_ICHECK_EQ(args.size(), 1U);
     return MakeValue(args[0]);

--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -1871,7 +1871,7 @@ llvm::Value* CodeGenLLVM::VisitExpr_(const BufferLoadNode* op) {
   // Pass all indices into BufferAccessHelper.  In CodeGenLLVM,
   // non-flat indices will result in an error in CreateBufferPtr, but
   // a subclass may override CreateBufferPtr.
-  BufferAccessHelper(op->buffer, op->indices, op->predicate, access_dtype, make_load);
+  BufferAccessHelper(op->buffer, op->indices, std::nullopt, access_dtype, make_load);
 
   llvm::Value* ret;
   if (loads.size() == 1) {
@@ -1890,6 +1890,53 @@ llvm::Value* CodeGenLLVM::VisitExpr_(const BufferLoadNode* op) {
 
 llvm::Value* CodeGenLLVM::VisitExpr_(const CallNode* op) {
   const ffi::Array<Expr>& args = op->args;
+  if (op->op.same_as(builtin::masked_load())) {
+    MaskedBufferLoad load(ffi::GetRef<Call>(op));
+    PrimType value_dtype = load.call->ty.as_or_throw<PrimType>();
+    PrimType access_dtype = BufferAccessType(value_dtype);
+    std::vector<llvm::Value*> loads;
+    auto make_load = [this, &loads](TypedPointer buffer_ptr, int /*subelement_i*/,
+                                    llvm::Value* predicate, int alignment, bool is_volatile) {
+      TVM_FFI_ICHECK(!is_volatile)
+          << "The masked load intrinsic does not support declaring load as volatile.";
+      llvm::Instruction* value = builder_->CreateMaskedLoad(buffer_ptr.type, buffer_ptr.addr,
+                                                            llvm::Align(alignment), predicate);
+      loads.push_back(value);
+      return value;
+    };
+    BufferAccessHelper(load.buffer, load.indices, load.predicate, access_dtype, make_load);
+    llvm::Value* ret =
+        loads.size() == 1 ? loads[0] : llvm::UndefValue::get(DTypeToLLVMType(access_dtype));
+    for (size_t i = 0; loads.size() > 1 && i < loads.size(); ++i) {
+      ret = builder_->CreateInsertElement(ret, loads[i], ConstInt32(i));
+    }
+    return access_dtype.same_as(value_dtype) ? ret : CreateCast(access_dtype, value_dtype, ret);
+  }
+  if (op->op.same_as(builtin::masked_store())) {
+    MaskedBufferStore store(ffi::GetRef<Call>(op));
+    PrimType value_dtype = store.value.ty();
+    llvm::Value* value = MakeValue(store.value);
+    PrimType access_dtype = BufferAccessType(value_dtype);
+    if (!access_dtype.same_as(value_dtype)) {
+      value = CreateCast(value_dtype, access_dtype, value);
+      value_dtype = access_dtype;
+    }
+    llvm::Instruction* last_store = nullptr;
+    auto make_store = [this, value, &last_store](TypedPointer buffer_ptr, int subelement_i,
+                                                 llvm::Value* predicate, int alignment,
+                                                 bool is_volatile) {
+      TVM_FFI_ICHECK(!is_volatile)
+          << "The masked store intrinsic does not support declaring store as volatile.";
+      llvm::Value* to_store =
+          subelement_i == -1 ? value : builder_->CreateExtractElement(value, subelement_i);
+      last_store =
+          builder_->CreateMaskedStore(to_store, buffer_ptr.addr, llvm::Align(alignment), predicate);
+      return last_store;
+    };
+    BufferAccessHelper(store.buffer, store.indices, store.predicate, value_dtype, make_store);
+    TVM_FFI_ICHECK(last_store != nullptr);
+    return last_store;
+  }
   if (op->op.same_as(builtin::buffer_data())) {
     TVM_FFI_ICHECK_EQ(args.size(), 1U);
     return MakeValue(args[0]);
@@ -2037,7 +2084,7 @@ void CodeGenLLVM::VisitStmt_(const BufferStoreNode* op) {
   // Pass all indices into BufferAccessHelper.  In CodeGenLLVM,
   // non-flat indices will result in an error in CreateBufferPtr, but
   // a subclass may override CreateBufferPtr.
-  BufferAccessHelper(op->buffer, op->indices, op->predicate, value_dtype, make_store);
+  BufferAccessHelper(op->buffer, op->indices, std::nullopt, value_dtype, make_store);
 }
 
 void CodeGenLLVM::VisitStmt_(const ForNode* op) {

--- a/src/target/llvm/codegen_llvm.h
+++ b/src/target/llvm/codegen_llvm.h
@@ -363,6 +363,8 @@ class CodeGenLLVM : public ExprFunctor<llvm::Value*(const Expr&)>,
       std::function<llvm::Instruction*(TypedPointer buffer_ptr, int subelement_i,
                                        llvm::Value* predicate, int alignment, bool is_volatile)>
           make_instruction);
+  llvm::Value* CreateMaskedLoad(const CallNode* op);
+  llvm::Value* CreateMaskedStore(const CallNode* op);
   const VarNode* GetBufferPhysicalRoot(const VarNode* buffer) const;
   // Initialize target
   virtual void InitTarget();

--- a/src/target/source/codegen_c.cc
+++ b/src/target/source/codegen_c.cc
@@ -671,6 +671,10 @@ void CodeGenC::PrintCallExtern(Type ret_type, ffi::String global_symbol,
 }
 
 void CodeGenC::VisitExpr_(const CallNode* op, std::ostream& os) {  // NOLINT(*)
+  TVM_FFI_ICHECK(!op->op.same_as(builtin::masked_load()))
+      << "Predicated buffer load is not supported.";
+  TVM_FFI_ICHECK(!op->op.same_as(builtin::masked_store()))
+      << "Predicated buffer store is not supported.";
   if (auto opt_call_op = op->op.as<Op>()) {
     auto call_op = opt_call_op.value();
 
@@ -951,7 +955,6 @@ void CodeGenC::VisitStmt_(const DeclBufferNode* op) {
 
 void CodeGenC::VisitExpr_(const BufferLoadNode* op, std::ostream& os) {  // NOLINT(*)
   TVM_FFI_ICHECK_EQ(op->indices.size(), 1) << "Load from non-flat memory not supported.";
-  TVM_FFI_ICHECK(!op->predicate.has_value()) << "Predicated buffer load is not supported.";
 
   PrimType value_ty = op->ty.as_or_throw<PrimType>();
   PrimExpr index = op->indices[0];
@@ -1026,7 +1029,6 @@ void CodeGenC::VisitExpr_(const BufferLoadNode* op, std::ostream& os) {  // NOLI
 
 void CodeGenC::VisitStmt_(const BufferStoreNode* op) {
   TVM_FFI_ICHECK_EQ(op->indices.size(), 1) << "Store to non-flat memory not supported.";
-  TVM_FFI_ICHECK(!op->predicate.has_value()) << "Predicated buffer store is not supported.";
 
   PrimType value_ty = op->value.ty();
   const PrimType& element_ty = op->buffer->dtype;

--- a/src/te/operation/create_primfunc.cc
+++ b/src/te/operation/create_primfunc.cc
@@ -84,7 +84,7 @@ class TensorLoadToBufferTransformer : public StmtExprMutator {
     auto it = tensor2buffers_.find(tensor);
     TVM_FFI_ICHECK(it != tensor2buffers_.end()) << "IndexError: Cannot find the tensor " << tensor;
     const BufferVar& buffer = it->second;
-    return BufferLoad(buffer, te::GetTensorLoadIndices(call), std::nullopt, call->span);
+    return BufferLoad(buffer, te::GetTensorLoadIndices(call), call->span);
   }
 
  private:
@@ -111,7 +111,7 @@ class BufferSubstituter : public StmtExprMutator {
     auto load = StmtExprMutator::VisitExpr_(op).as_or_throw<BufferLoad>();
     auto it = buffer_map_.find(load->buffer.get());
     if (it != buffer_map_.end()) {
-      return BufferLoad(it->second, load->indices, load->predicate, load->span);
+      return BufferLoad(it->second, load->indices, load->span);
     }
     return load;
   }
@@ -120,7 +120,7 @@ class BufferSubstituter : public StmtExprMutator {
     auto store = StmtExprMutator::VisitStmt_(op).as_or_throw<BufferStore>();
     auto it = buffer_map_.find(store->buffer.get());
     if (it != buffer_map_.end()) {
-      return BufferStore(it->second, store->value, store->indices, store->predicate, store->span);
+      return BufferStore(it->second, store->value, store->indices, store->span);
     }
     return store;
   }

--- a/src/tirx/analysis/deep_equal.cc
+++ b/src/tirx/analysis/deep_equal.cc
@@ -142,8 +142,7 @@ class ExprDeepEqualChecker : private ExprFunctor<bool(const Expr&, const PrimExp
     const auto* prhs = rhs.as<BufferLoadNode>();
     // we run pointer comparison of the buffer
     return plhs->ty.as_or_throw<PrimType>() == prhs->ty.as_or_throw<PrimType>() &&
-           plhs->buffer.same_as(prhs->buffer) && ArrayDeepEqual(plhs->indices, prhs->indices) &&
-           OptionalDeepEqual(plhs->predicate, prhs->predicate);
+           plhs->buffer.same_as(prhs->buffer) && ArrayDeepEqual(plhs->indices, prhs->indices);
   }
 
   bool VisitExpr_(const LetNode* plhs, const PrimExpr& rhs) final {

--- a/src/tirx/analysis/var_touch.cc
+++ b/src/tirx/analysis/var_touch.cc
@@ -54,16 +54,6 @@ class VarTouchVisitor : public StmtExprVisitor {
     ExprVisitor::VisitExpr_(op);
   }
 
-  void VisitExpr_(const CallNode* op) final {
-    Call call = ffi::GetRef<Call>(op);
-    if (auto load = MaskedBufferLoad::TryMatch(call)) {
-      Handle(load->buffer.get());
-    } else if (auto store = MaskedBufferStore::TryMatch(call)) {
-      Handle(store->buffer.get());
-    }
-    StmtExprVisitor::VisitExpr_(op);
-  }
-
   void Handle(const VarNode* var) {
     if (var_set_(var)) use_var_ = true;
   }

--- a/src/tirx/analysis/var_touch.cc
+++ b/src/tirx/analysis/var_touch.cc
@@ -54,6 +54,16 @@ class VarTouchVisitor : public StmtExprVisitor {
     ExprVisitor::VisitExpr_(op);
   }
 
+  void VisitExpr_(const CallNode* op) final {
+    Call call = ffi::GetRef<Call>(op);
+    if (auto load = MaskedBufferLoad::TryMatch(call)) {
+      Handle(load->buffer.get());
+    } else if (auto store = MaskedBufferStore::TryMatch(call)) {
+      Handle(store->buffer.get());
+    }
+    StmtExprVisitor::VisitExpr_(op);
+  }
+
   void Handle(const VarNode* var) {
     if (var_set_(var)) use_var_ = true;
   }

--- a/src/tirx/analysis/verify_memory.cc
+++ b/src/tirx/analysis/verify_memory.cc
@@ -98,6 +98,16 @@ class MemoryAccessVerifier final : protected StmtExprVisitor {
     HandleLoadStoreToVariable(op->buffer.var());
     return StmtExprVisitor::VisitStmt_(op);
   }
+
+  void VisitExpr_(const CallNode* op) final {
+    Call call = ffi::GetRef<Call>(op);
+    if (auto load = MaskedBufferLoad::TryMatch(call)) {
+      HandleLoadStoreToVariable(load->buffer.var());
+    } else if (auto store = MaskedBufferStore::TryMatch(call)) {
+      HandleLoadStoreToVariable(store->buffer.var());
+    }
+    StmtExprVisitor::VisitExpr_(op);
+  }
   //@}
 
   /// Check if the value of a Variable comes from function argument.

--- a/src/tirx/analysis/verify_memory.cc
+++ b/src/tirx/analysis/verify_memory.cc
@@ -100,11 +100,9 @@ class MemoryAccessVerifier final : protected StmtExprVisitor {
   }
 
   void VisitExpr_(const CallNode* op) final {
-    Call call = ffi::GetRef<Call>(op);
-    if (auto load = MaskedBufferLoad::TryMatch(call)) {
-      HandleLoadStoreToVariable(load->buffer.var());
-    } else if (auto store = MaskedBufferStore::TryMatch(call)) {
-      HandleLoadStoreToVariable(store->buffer.var());
+    if ((op->op.same_as(builtin::masked_load()) || op->op.same_as(builtin::masked_store())) &&
+        !op->args.empty()) {
+      HandleLoadStoreToVariable(op->args[0].as_or_throw<Var>());
     }
     StmtExprVisitor::VisitExpr_(op);
   }

--- a/src/tirx/ir/buffer.cc
+++ b/src/tirx/ir/buffer.cc
@@ -397,7 +397,10 @@ PrimExpr BufferVar::vload(ffi::Array<PrimExpr> begin, PrimType value_dtype,
       indices.Set(indices.size() - 1, Ramp(base, 1, factor));
     }
   }
-  return BufferLoad(*this, indices, predicate);
+  if (predicate.has_value()) {
+    return MakeMaskedBufferLoad(*this, indices, predicate.value());
+  }
+  return BufferLoad(*this, indices);
 }
 
 Stmt BufferVar::vstore(ffi::Array<PrimExpr> begin, PrimExpr value,
@@ -423,7 +426,10 @@ Stmt BufferVar::vstore(ffi::Array<PrimExpr> begin, PrimExpr value,
       indices.Set(indices.size() - 1, Ramp(base, 1, factor));
     }
   }
-  return BufferStore(*this, value, indices, predicate);
+  if (predicate.has_value()) {
+    return MakeMaskedBufferStore(*this, value, indices, predicate.value());
+  }
+  return BufferStore(*this, value, indices);
 }
 
 ffi::String BufferVar::scope() const { return (*this)->storage_scope; }

--- a/src/tirx/ir/buffer.cc
+++ b/src/tirx/ir/buffer.cc
@@ -375,8 +375,7 @@ BufferVar BufferVar::GetFlattenedBuffer() const {
   }
 }
 
-PrimExpr BufferVar::vload(ffi::Array<PrimExpr> begin, PrimType value_dtype,
-                          ffi::Optional<PrimExpr> predicate) const {
+PrimExpr BufferVar::vload(ffi::Array<PrimExpr> begin, PrimType value_dtype) const {
   const BufferTypeNode* n = operator->();
   TVM_FFI_ICHECK(n != nullptr);
   PrimType buffer_dtype(n->dtype);
@@ -397,14 +396,10 @@ PrimExpr BufferVar::vload(ffi::Array<PrimExpr> begin, PrimType value_dtype,
       indices.Set(indices.size() - 1, Ramp(base, 1, factor));
     }
   }
-  if (predicate.has_value()) {
-    return MakeMaskedBufferLoad(*this, indices, predicate.value());
-  }
   return BufferLoad(*this, indices);
 }
 
-Stmt BufferVar::vstore(ffi::Array<PrimExpr> begin, PrimExpr value,
-                       ffi::Optional<PrimExpr> predicate) const {
+Stmt BufferVar::vstore(ffi::Array<PrimExpr> begin, PrimExpr value) const {
   const BufferTypeNode* n = operator->();
   TVM_FFI_ICHECK(n != nullptr);
   PrimType value_dtype = value.ty();
@@ -425,9 +420,6 @@ Stmt BufferVar::vstore(ffi::Array<PrimExpr> begin, PrimExpr value,
     if (factor > 1 && !base_ty.IsFixedLengthVector() && !base_ty.IsScalableVector()) {
       indices.Set(indices.size() - 1, Ramp(base, 1, factor));
     }
-  }
-  if (predicate.has_value()) {
-    return MakeMaskedBufferStore(*this, value, indices, predicate.value());
   }
   return BufferStore(*this, value, indices);
 }
@@ -587,10 +579,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
       .def_method("tirx.BufferGetFlattenedBuffer", &BufferVar::GetFlattenedBuffer)
       .def_method("tirx.BufferOffsetOf", &BufferVar::OffsetOf)
       .def_method("tirx.BufferOffsetOfp", &BufferVar::OffsetOf_p)
-      .def_method(
-          "tirx.BufferVLoad",
-          static_cast<PrimExpr (BufferVar::*)(ffi::Array<PrimExpr>, PrimType,
-                                              ffi::Optional<PrimExpr>) const>(&BufferVar::vload))
+      .def_method("tirx.BufferVLoad", &BufferVar::vload)
       .def_method("tirx.BufferVStore", &BufferVar::vstore)
       .def_method("tirx.BufferStorageScope", &BufferVar::scope)
       .def_method("tirx.BufferWithAllocatedAddr", &BufferVar::with_allocated_addr)

--- a/src/tirx/ir/expr.cc
+++ b/src/tirx/ir/expr.cc
@@ -748,38 +748,15 @@ void BufferLoadNode::LegalizeDType() {
   }
 }
 
-BufferLoad::BufferLoad(BufferVar buffer, ffi::Array<PrimExpr> indices,
-                       ffi::Optional<PrimExpr> predicate, Span span) {
+BufferLoad::BufferLoad(BufferVar buffer, ffi::Array<PrimExpr> indices, Span span) {
   TVM_FFI_ICHECK_EQ(buffer->shape.size(), indices.size())
       << "BufferVar " << buffer.name() << " is " << buffer->shape.size()
       << "-dimensional, cannot be indexed with the " << indices.size()
       << "-dimensional indices provided.";
 
-  if (predicate.has_value()) {
-    PrimType predicate_ty = predicate.value().ty();
-    bool is_index_scalable = indices.empty() ? false : indices.back().ty().IsScalableVector();
-    bool is_predicate_scalable = predicate_ty.IsScalableVector();
-    TVM_FFI_ICHECK_EQ(is_index_scalable, is_predicate_scalable)
-        << "Predicate mask dtype and load indices must both be scalable.";
-
-    int16_t buffer_encoded_lanes = static_cast<int16_t>(buffer->dtype->dtype.lanes);
-    int buffer_lanes = buffer_encoded_lanes < -1 ? -buffer_encoded_lanes : buffer_encoded_lanes;
-    int index_lanes = indices.empty() ? 1 : GetLanesOrVScaleFactor(indices.back().ty());
-    int predicate_lanes = GetLanesOrVScaleFactor(predicate_ty);
-    TVM_FFI_ICHECK_EQ(index_lanes * buffer_lanes, predicate_lanes)
-        << "Got a predicate mask with " << predicate_lanes
-        << " lanes, but trying to load a vector with " << index_lanes
-        << " lanes. The number of lanes must match.";
-
-    TVM_FFI_ICHECK(predicate_ty.MatchesCode(DLDataTypeCode::kDLBool) ||
-                   predicate_ty.MatchesElementType(DLDataTypeCode::kDLUInt, 1))
-        << "Predicate mask elements must be boolean values, but got " << predicate_ty->dtype << ".";
-  }
-
   ffi::ObjectPtr<BufferLoadNode> node = ffi::make_object<BufferLoadNode>();
   node->buffer = std::move(buffer);
   node->indices = std::move(indices);
-  node->predicate = std::move(predicate);
   node->span = std::move(span);
   node->LegalizeDType();
   data_ = std::move(node);
@@ -787,10 +764,65 @@ BufferLoad::BufferLoad(BufferVar buffer, ffi::Array<PrimExpr> indices,
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
-  refl::GlobalDef().def("tirx.BufferLoad", [](BufferVar buffer, ffi::Array<PrimExpr> indices,
-                                              ffi::Optional<PrimExpr> predicate, Span span) {
-    return BufferLoad(buffer, indices, predicate, span);
-  });
+  refl::GlobalDef()
+      .def("tirx.BufferLoad", [](BufferVar buffer, ffi::Array<PrimExpr> indices,
+                                 Span span) { return BufferLoad(buffer, indices, span); })
+      .def("tirx.MaskedBufferLoad",
+           [](BufferVar buffer, ffi::Array<PrimExpr> indices, PrimExpr predicate, Span span) {
+             return MakeMaskedBufferLoad(buffer, indices, predicate, span);
+           });
+}
+
+namespace {
+void ValidateMask(const PrimExpr& predicate, const PrimType& value_ty) {
+  PrimType predicate_ty = predicate.ty();
+  TVM_FFI_ICHECK_EQ(value_ty.IsScalableVector(), predicate_ty.IsScalableVector())
+      << "Mask dtype and accessed value dtype must both be scalable or both fixed-length.";
+  TVM_FFI_ICHECK_EQ(GetLanesOrVScaleFactor(value_ty), GetLanesOrVScaleFactor(predicate_ty))
+      << "Mask lane count must match the accessed value lane count.";
+  PrimType element_ty = predicate_ty.WithLanes(1);
+  TVM_FFI_ICHECK(element_ty.MatchesCode(DLDataTypeCode::kDLBool) ||
+                 element_ty.MatchesElementType(DLDataTypeCode::kDLUInt, 1))
+      << "Mask elements must be boolean values, but got " << element_ty << ".";
+}
+}  // namespace
+
+MaskedBufferLoad::MaskedBufferLoad(Call call) : call(std::move(call)) {
+  TVM_FFI_ICHECK(this->call->op.same_as(builtin::masked_load()))
+      << "Expected a tirx.masked_load Call";
+  TVM_FFI_ICHECK_GE(this->call->args.size(), 2U)
+      << "tirx.masked_load expects a buffer, its indices, and a mask";
+  const auto* buffer_var = this->call->args.front().as<VarNode>();
+  TVM_FFI_ICHECK(buffer_var != nullptr && buffer_var->ty.as<BufferTypeNode>() != nullptr)
+      << "tirx.masked_load first argument must be a BufferVar";
+  buffer = GetBufferVar(buffer_var);
+  TVM_FFI_ICHECK_EQ(this->call->args.size(), buffer->shape.size() + 2)
+      << "tirx.masked_load index count must match buffer rank";
+  indices.reserve(buffer->shape.size());
+  for (size_t i = 0; i < buffer->shape.size(); ++i) {
+    indices.push_back(this->call->args[i + 1].as_or_throw<PrimExpr>());
+  }
+  predicate = this->call->args.back().as_or_throw<PrimExpr>();
+  BufferLoad load(buffer, indices, this->call->span);
+  TVM_FFI_ICHECK(this->call->ty == load->ty)
+      << "tirx.masked_load result type must match the corresponding buffer load";
+  ValidateMask(predicate, load.ty());
+}
+
+std::optional<MaskedBufferLoad> MaskedBufferLoad::TryMatch(const Expr& expr) {
+  auto call = expr.as<Call>();
+  if (!call.has_value() || !call.value()->op.same_as(builtin::masked_load())) return std::nullopt;
+  return MaskedBufferLoad(call.value());
+}
+
+PrimExpr MakeMaskedBufferLoad(BufferVar buffer, ffi::Array<PrimExpr> indices, PrimExpr predicate,
+                              Span span) {
+  BufferLoad load(buffer, indices, span);
+  ValidateMask(predicate, load.ty());
+  ffi::Array<Expr> args{buffer.var()};
+  for (const PrimExpr& index : indices) args.push_back(index);
+  args.push_back(predicate);
+  return Call(load->ty, builtin::masked_load(), args, {}, {}, span).as_or_throw<PrimExpr>();
 }
 
 }  // namespace tirx

--- a/src/tirx/ir/expr.cc
+++ b/src/tirx/ir/expr.cc
@@ -764,65 +764,10 @@ BufferLoad::BufferLoad(BufferVar buffer, ffi::Array<PrimExpr> indices, Span span
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
-  refl::GlobalDef()
-      .def("tirx.BufferLoad", [](BufferVar buffer, ffi::Array<PrimExpr> indices,
-                                 Span span) { return BufferLoad(buffer, indices, span); })
-      .def("tirx.MaskedBufferLoad",
-           [](BufferVar buffer, ffi::Array<PrimExpr> indices, PrimExpr predicate, Span span) {
-             return MakeMaskedBufferLoad(buffer, indices, predicate, span);
-           });
-}
-
-namespace {
-void ValidateMask(const PrimExpr& predicate, const PrimType& value_ty) {
-  PrimType predicate_ty = predicate.ty();
-  TVM_FFI_ICHECK_EQ(value_ty.IsScalableVector(), predicate_ty.IsScalableVector())
-      << "Mask dtype and accessed value dtype must both be scalable or both fixed-length.";
-  TVM_FFI_ICHECK_EQ(GetLanesOrVScaleFactor(value_ty), GetLanesOrVScaleFactor(predicate_ty))
-      << "Mask lane count must match the accessed value lane count.";
-  PrimType element_ty = predicate_ty.WithLanes(1);
-  TVM_FFI_ICHECK(element_ty.MatchesCode(DLDataTypeCode::kDLBool) ||
-                 element_ty.MatchesElementType(DLDataTypeCode::kDLUInt, 1))
-      << "Mask elements must be boolean values, but got " << element_ty << ".";
-}
-}  // namespace
-
-MaskedBufferLoad::MaskedBufferLoad(Call call) : call(std::move(call)) {
-  TVM_FFI_ICHECK(this->call->op.same_as(builtin::masked_load()))
-      << "Expected a tirx.masked_load Call";
-  TVM_FFI_ICHECK_GE(this->call->args.size(), 2U)
-      << "tirx.masked_load expects a buffer, its indices, and a mask";
-  const auto* buffer_var = this->call->args.front().as<VarNode>();
-  TVM_FFI_ICHECK(buffer_var != nullptr && buffer_var->ty.as<BufferTypeNode>() != nullptr)
-      << "tirx.masked_load first argument must be a BufferVar";
-  buffer = GetBufferVar(buffer_var);
-  TVM_FFI_ICHECK_EQ(this->call->args.size(), buffer->shape.size() + 2)
-      << "tirx.masked_load index count must match buffer rank";
-  indices.reserve(buffer->shape.size());
-  for (size_t i = 0; i < buffer->shape.size(); ++i) {
-    indices.push_back(this->call->args[i + 1].as_or_throw<PrimExpr>());
-  }
-  predicate = this->call->args.back().as_or_throw<PrimExpr>();
-  BufferLoad load(buffer, indices, this->call->span);
-  TVM_FFI_ICHECK(this->call->ty == load->ty)
-      << "tirx.masked_load result type must match the corresponding buffer load";
-  ValidateMask(predicate, load.ty());
-}
-
-std::optional<MaskedBufferLoad> MaskedBufferLoad::TryMatch(const Expr& expr) {
-  auto call = expr.as<Call>();
-  if (!call.has_value() || !call.value()->op.same_as(builtin::masked_load())) return std::nullopt;
-  return MaskedBufferLoad(call.value());
-}
-
-PrimExpr MakeMaskedBufferLoad(BufferVar buffer, ffi::Array<PrimExpr> indices, PrimExpr predicate,
-                              Span span) {
-  BufferLoad load(buffer, indices, span);
-  ValidateMask(predicate, load.ty());
-  ffi::Array<Expr> args{buffer.var()};
-  for (const PrimExpr& index : indices) args.push_back(index);
-  args.push_back(predicate);
-  return Call(load->ty, builtin::masked_load(), args, {}, {}, span).as_or_throw<PrimExpr>();
+  refl::GlobalDef().def("tirx.BufferLoad",
+                        [](BufferVar buffer, ffi::Array<PrimExpr> indices, Span span) {
+                          return BufferLoad(buffer, indices, span);
+                        });
 }
 
 }  // namespace tirx

--- a/src/tirx/ir/expr_functor.cc
+++ b/src/tirx/ir/expr_functor.cc
@@ -124,7 +124,7 @@ Expr ExprMutator::VisitExpr_(const BufferLoadNode* op) {
   if (indices.same_as(op->indices)) {
     return ffi::GetRef<PrimExpr>(op);
   } else {
-    return BufferLoad(op->buffer, indices, op->predicate);
+    return BufferLoad(op->buffer, indices);
   }
 }
 

--- a/src/tirx/ir/stmt.cc
+++ b/src/tirx/ir/stmt.cc
@@ -422,7 +422,7 @@ TVM_FFI_INLINE int GetLanesOrVScaleFactor(const PrimType& ty) {
 }
 
 BufferStore::BufferStore(BufferVar buffer, PrimExpr value, ffi::Array<PrimExpr> indices,
-                         ffi::Optional<PrimExpr> predicate, Span span) {
+                         Span span) {
   TVM_FFI_ICHECK_EQ(buffer->shape.size(), indices.size())
       << "BufferVar " << buffer.name() << " is " << buffer->shape.size()
       << "-dimensional, cannot be indexed with the " << indices.size()
@@ -442,12 +442,6 @@ BufferStore::BufferStore(BufferVar buffer, PrimExpr value, ffi::Array<PrimExpr> 
   TVM_FFI_ICHECK(!(is_index_scalable && is_buffer_dtype_scalable))
       << "Index dtype and buffer dtype can't both be scalable.";
 
-  if (predicate.has_value()) {
-    bool is_predicate_dtype_scalable = predicate.value().ty().IsScalableVector();
-    TVM_FFI_ICHECK_EQ(is_value_dtype_scalable, is_predicate_dtype_scalable)
-        << "Predicate mask dtype and value dtype must both be scalable.";
-  }
-
   if (is_index_scalable || is_buffer_dtype_scalable) {
     TVM_FFI_ICHECK(is_value_dtype_scalable) << "Can't store non-scalable data into scalable buffer";
   }
@@ -460,21 +454,6 @@ BufferStore::BufferStore(BufferVar buffer, PrimExpr value, ffi::Array<PrimExpr> 
       << "Cannot store value with " << value_dtype_lanes << ", expected value with "
       << index_lanes * buffer_lanes << " (" << index_lanes << " index lanes * " << buffer_lanes
       << " buffer element lanes)";
-
-  if (predicate.has_value()) {
-    PrimType predicate_ty = predicate.value().ty();
-    int predicate_dtype_lanes = GetLanesOrVScaleFactor(predicate_ty);
-    TVM_FFI_ICHECK_EQ(value_dtype_lanes, predicate_dtype_lanes)
-        << "Got a predicate mask with " << predicate_dtype_lanes
-        << " lanes, but trying to store a value with " << value_dtype_lanes
-        << " lanes. The number of lanes must match.";
-
-    PrimType predicate_element_ty = predicate_ty.WithLanes(1);
-    TVM_FFI_ICHECK(predicate_element_ty.MatchesCode(DLDataTypeCode::kDLBool) ||
-                   predicate_element_ty.MatchesElementType(DLDataTypeCode::kDLUInt, 1))
-        << "Predicate mask elements must be boolean values, but got "
-        << ffi::DLDataTypeToString(predicate_element_ty->dtype) << ".";
-  }
 
   PrimType buffer_dtype = PrimType::Void();
   if (is_index_scalable || is_buffer_dtype_scalable) {
@@ -495,18 +474,71 @@ BufferStore::BufferStore(BufferVar buffer, PrimExpr value, ffi::Array<PrimExpr> 
   node->buffer = std::move(buffer);
   node->value = std::move(value);
   node->indices = std::move(indices);
-  node->predicate = std::move(predicate);
   node->span = std::move(span);
   data_ = std::move(node);
 }
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
-  refl::GlobalDef().def("tirx.BufferStore",
-                        [](BufferVar buffer, PrimExpr value, ffi::Array<PrimExpr> indices,
-                           ffi::Optional<PrimExpr> predicate, Span span) {
-                          return BufferStore(buffer, value, indices, predicate, span);
-                        });
+  refl::GlobalDef()
+      .def("tirx.BufferStore", [](BufferVar buffer, PrimExpr value, ffi::Array<PrimExpr> indices,
+                                  Span span) { return BufferStore(buffer, value, indices, span); })
+      .def(
+          "tirx.MaskedBufferStore",
+          [](BufferVar buffer, PrimExpr value, ffi::Array<PrimExpr> indices, PrimExpr predicate,
+             Span span) { return MakeMaskedBufferStore(buffer, value, indices, predicate, span); });
+}
+
+namespace {
+void ValidateStoreMask(const PrimExpr& predicate, const PrimType& value_ty) {
+  PrimType predicate_ty = predicate.ty();
+  TVM_FFI_ICHECK_EQ(value_ty.IsScalableVector(), predicate_ty.IsScalableVector())
+      << "Mask dtype and stored value dtype must both be scalable or both fixed-length.";
+  TVM_FFI_ICHECK_EQ(GetLanesOrVScaleFactor(value_ty), GetLanesOrVScaleFactor(predicate_ty))
+      << "Mask lane count must match the stored value lane count.";
+  PrimType element_ty = predicate_ty.WithLanes(1);
+  TVM_FFI_ICHECK(element_ty.MatchesCode(DLDataTypeCode::kDLBool) ||
+                 element_ty.MatchesElementType(DLDataTypeCode::kDLUInt, 1))
+      << "Mask elements must be boolean values, but got " << element_ty << ".";
+}
+}  // namespace
+
+MaskedBufferStore::MaskedBufferStore(Call call) : call(std::move(call)) {
+  TVM_FFI_ICHECK(this->call->op.same_as(builtin::masked_store()))
+      << "Expected a tirx.masked_store Call";
+  TVM_FFI_ICHECK_GE(this->call->args.size(), 3U)
+      << "tirx.masked_store expects a buffer, value, indices, and a mask";
+  const auto* buffer_var = this->call->args.front().as<VarNode>();
+  TVM_FFI_ICHECK(buffer_var != nullptr && buffer_var->ty.as<BufferTypeNode>() != nullptr)
+      << "tirx.masked_store first argument must be a BufferVar";
+  buffer = GetBufferVar(buffer_var);
+  TVM_FFI_ICHECK_EQ(this->call->args.size(), buffer->shape.size() + 3)
+      << "tirx.masked_store index count must match buffer rank";
+  value = this->call->args[1].as_or_throw<PrimExpr>();
+  indices.reserve(buffer->shape.size());
+  for (size_t i = 0; i < buffer->shape.size(); ++i) {
+    indices.push_back(this->call->args[i + 2].as_or_throw<PrimExpr>());
+  }
+  predicate = this->call->args.back().as_or_throw<PrimExpr>();
+  BufferStore store(buffer, value, indices, this->call->span);
+  TVM_FFI_ICHECK(this->call->ty == PrimType::Void()) << "tirx.masked_store must return void";
+  ValidateStoreMask(predicate, value.ty());
+}
+
+std::optional<MaskedBufferStore> MaskedBufferStore::TryMatch(const Expr& expr) {
+  auto call = expr.as<Call>();
+  if (!call.has_value() || !call.value()->op.same_as(builtin::masked_store())) return std::nullopt;
+  return MaskedBufferStore(call.value());
+}
+
+Stmt MakeMaskedBufferStore(BufferVar buffer, PrimExpr value, ffi::Array<PrimExpr> indices,
+                           PrimExpr predicate, Span span) {
+  BufferStore store(buffer, value, indices, span);
+  ValidateStoreMask(predicate, value.ty());
+  ffi::Array<Expr> args{buffer.var(), value};
+  for (const PrimExpr& index : indices) args.push_back(index);
+  args.push_back(predicate);
+  return Evaluate(Call(PrimType::Void(), builtin::masked_store(), args, {}, {}, span), span);
 }
 
 // BufferRegion

--- a/src/tirx/ir/stmt.cc
+++ b/src/tirx/ir/stmt.cc
@@ -480,65 +480,9 @@ BufferStore::BufferStore(BufferVar buffer, PrimExpr value, ffi::Array<PrimExpr> 
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
-  refl::GlobalDef()
-      .def("tirx.BufferStore", [](BufferVar buffer, PrimExpr value, ffi::Array<PrimExpr> indices,
-                                  Span span) { return BufferStore(buffer, value, indices, span); })
-      .def(
-          "tirx.MaskedBufferStore",
-          [](BufferVar buffer, PrimExpr value, ffi::Array<PrimExpr> indices, PrimExpr predicate,
-             Span span) { return MakeMaskedBufferStore(buffer, value, indices, predicate, span); });
-}
-
-namespace {
-void ValidateStoreMask(const PrimExpr& predicate, const PrimType& value_ty) {
-  PrimType predicate_ty = predicate.ty();
-  TVM_FFI_ICHECK_EQ(value_ty.IsScalableVector(), predicate_ty.IsScalableVector())
-      << "Mask dtype and stored value dtype must both be scalable or both fixed-length.";
-  TVM_FFI_ICHECK_EQ(GetLanesOrVScaleFactor(value_ty), GetLanesOrVScaleFactor(predicate_ty))
-      << "Mask lane count must match the stored value lane count.";
-  PrimType element_ty = predicate_ty.WithLanes(1);
-  TVM_FFI_ICHECK(element_ty.MatchesCode(DLDataTypeCode::kDLBool) ||
-                 element_ty.MatchesElementType(DLDataTypeCode::kDLUInt, 1))
-      << "Mask elements must be boolean values, but got " << element_ty << ".";
-}
-}  // namespace
-
-MaskedBufferStore::MaskedBufferStore(Call call) : call(std::move(call)) {
-  TVM_FFI_ICHECK(this->call->op.same_as(builtin::masked_store()))
-      << "Expected a tirx.masked_store Call";
-  TVM_FFI_ICHECK_GE(this->call->args.size(), 3U)
-      << "tirx.masked_store expects a buffer, value, indices, and a mask";
-  const auto* buffer_var = this->call->args.front().as<VarNode>();
-  TVM_FFI_ICHECK(buffer_var != nullptr && buffer_var->ty.as<BufferTypeNode>() != nullptr)
-      << "tirx.masked_store first argument must be a BufferVar";
-  buffer = GetBufferVar(buffer_var);
-  TVM_FFI_ICHECK_EQ(this->call->args.size(), buffer->shape.size() + 3)
-      << "tirx.masked_store index count must match buffer rank";
-  value = this->call->args[1].as_or_throw<PrimExpr>();
-  indices.reserve(buffer->shape.size());
-  for (size_t i = 0; i < buffer->shape.size(); ++i) {
-    indices.push_back(this->call->args[i + 2].as_or_throw<PrimExpr>());
-  }
-  predicate = this->call->args.back().as_or_throw<PrimExpr>();
-  BufferStore store(buffer, value, indices, this->call->span);
-  TVM_FFI_ICHECK(this->call->ty == PrimType::Void()) << "tirx.masked_store must return void";
-  ValidateStoreMask(predicate, value.ty());
-}
-
-std::optional<MaskedBufferStore> MaskedBufferStore::TryMatch(const Expr& expr) {
-  auto call = expr.as<Call>();
-  if (!call.has_value() || !call.value()->op.same_as(builtin::masked_store())) return std::nullopt;
-  return MaskedBufferStore(call.value());
-}
-
-Stmt MakeMaskedBufferStore(BufferVar buffer, PrimExpr value, ffi::Array<PrimExpr> indices,
-                           PrimExpr predicate, Span span) {
-  BufferStore store(buffer, value, indices, span);
-  ValidateStoreMask(predicate, value.ty());
-  ffi::Array<Expr> args{buffer.var(), value};
-  for (const PrimExpr& index : indices) args.push_back(index);
-  args.push_back(predicate);
-  return Evaluate(Call(PrimType::Void(), builtin::masked_store(), args, {}, {}, span), span);
+  refl::GlobalDef().def("tirx.BufferStore",
+                        [](BufferVar buffer, PrimExpr value, ffi::Array<PrimExpr> indices,
+                           Span span) { return BufferStore(buffer, value, indices, span); });
 }
 
 // BufferRegion

--- a/src/tirx/ir/stmt_functor.cc
+++ b/src/tirx/ir/stmt_functor.cc
@@ -23,7 +23,6 @@
 #include <tvm/ffi/function.h>
 #include <tvm/ffi/reflection/registry.h>
 #include <tvm/ir/module.h>
-#include <tvm/tirx/builtin.h>
 #include <tvm/tirx/function.h>
 #include <tvm/tirx/layout.h>
 #include <tvm/tirx/stmt_functor.h>
@@ -90,24 +89,6 @@ void StmtVisitor::VisitBufferDef(const BufferVar& buffer, bool alloc_data) {
 // re-visited at each use site, as the use site may be in a different scope
 // where the buffer's shape variables are not defined.
 void StmtVisitor::VisitBufferUse(const BufferVar& buffer) {}
-
-void StmtExprVisitor::VisitExpr_(const CallNode* op) {
-  Call call = ffi::GetRef<Call>(op);
-  if (auto load = MaskedBufferLoad::TryMatch(call)) {
-    this->VisitBufferUse(load->buffer);
-    VisitArray(load->indices, [this](const PrimExpr& e) { this->VisitExpr(e); });
-    this->VisitExpr(load->predicate);
-    return;
-  }
-  if (auto store = MaskedBufferStore::TryMatch(call)) {
-    this->VisitBufferUse(store->buffer);
-    this->VisitExpr(store->value);
-    VisitArray(store->indices, [this](const PrimExpr& e) { this->VisitExpr(e); });
-    this->VisitExpr(store->predicate);
-    return;
-  }
-  ExprVisitor::VisitExpr_(op);
-}
 
 void StmtExprVisitor::VisitExpr_(const BufferLoadNode* op) {
   this->VisitBufferUse(op->buffer);
@@ -468,35 +449,6 @@ Expr StmtExprMutator::VisitExpr_(const VarNode* op) {
     return VisitBufferUse(BufferVar(var)).var();
   }
   return var;
-}
-
-Expr StmtExprMutator::VisitExpr_(const CallNode* op) {
-  Call call = ffi::GetRef<Call>(op);
-  if (auto load = MaskedBufferLoad::TryMatch(call)) {
-    BufferVar buffer = this->VisitBufferUse(load->buffer);
-    ffi::Array<PrimExpr> indices =
-        load->indices.Map([this](const PrimExpr& e) { return this->VisitPrimExpr(e); });
-    PrimExpr predicate = this->VisitPrimExpr(load->predicate);
-    if (buffer.same_as(load->buffer) && indices.same_as(load->indices) &&
-        predicate.same_as(load->predicate)) {
-      return call;
-    }
-    return MakeMaskedBufferLoad(buffer, indices, predicate, op->span);
-  }
-  if (auto store = MaskedBufferStore::TryMatch(call)) {
-    BufferVar buffer = this->VisitBufferUse(store->buffer);
-    PrimExpr value = this->VisitPrimExpr(store->value);
-    ffi::Array<PrimExpr> indices =
-        store->indices.Map([this](const PrimExpr& e) { return this->VisitPrimExpr(e); });
-    PrimExpr predicate = this->VisitPrimExpr(store->predicate);
-    if (buffer.same_as(store->buffer) && value.same_as(store->value) &&
-        indices.same_as(store->indices) && predicate.same_as(store->predicate)) {
-      return call;
-    }
-    Stmt stmt = MakeMaskedBufferStore(buffer, value, indices, predicate, op->span);
-    return stmt.as_or_throw<Evaluate>()->value;
-  }
-  return ExprMutator::VisitExpr_(op);
 }
 
 Expr StmtExprMutator::VisitExpr_(const BufferLoadNode* op) {

--- a/src/tirx/ir/stmt_functor.cc
+++ b/src/tirx/ir/stmt_functor.cc
@@ -23,6 +23,7 @@
 #include <tvm/ffi/function.h>
 #include <tvm/ffi/reflection/registry.h>
 #include <tvm/ir/module.h>
+#include <tvm/tirx/builtin.h>
 #include <tvm/tirx/function.h>
 #include <tvm/tirx/layout.h>
 #include <tvm/tirx/stmt_functor.h>
@@ -89,6 +90,24 @@ void StmtVisitor::VisitBufferDef(const BufferVar& buffer, bool alloc_data) {
 // re-visited at each use site, as the use site may be in a different scope
 // where the buffer's shape variables are not defined.
 void StmtVisitor::VisitBufferUse(const BufferVar& buffer) {}
+
+void StmtExprVisitor::VisitExpr_(const CallNode* op) {
+  Call call = ffi::GetRef<Call>(op);
+  if (auto load = MaskedBufferLoad::TryMatch(call)) {
+    this->VisitBufferUse(load->buffer);
+    VisitArray(load->indices, [this](const PrimExpr& e) { this->VisitExpr(e); });
+    this->VisitExpr(load->predicate);
+    return;
+  }
+  if (auto store = MaskedBufferStore::TryMatch(call)) {
+    this->VisitBufferUse(store->buffer);
+    this->VisitExpr(store->value);
+    VisitArray(store->indices, [this](const PrimExpr& e) { this->VisitExpr(e); });
+    this->VisitExpr(store->predicate);
+    return;
+  }
+  ExprVisitor::VisitExpr_(op);
+}
 
 void StmtExprVisitor::VisitExpr_(const BufferLoadNode* op) {
   this->VisitBufferUse(op->buffer);
@@ -449,6 +468,35 @@ Expr StmtExprMutator::VisitExpr_(const VarNode* op) {
     return VisitBufferUse(BufferVar(var)).var();
   }
   return var;
+}
+
+Expr StmtExprMutator::VisitExpr_(const CallNode* op) {
+  Call call = ffi::GetRef<Call>(op);
+  if (auto load = MaskedBufferLoad::TryMatch(call)) {
+    BufferVar buffer = this->VisitBufferUse(load->buffer);
+    ffi::Array<PrimExpr> indices =
+        load->indices.Map([this](const PrimExpr& e) { return this->VisitPrimExpr(e); });
+    PrimExpr predicate = this->VisitPrimExpr(load->predicate);
+    if (buffer.same_as(load->buffer) && indices.same_as(load->indices) &&
+        predicate.same_as(load->predicate)) {
+      return call;
+    }
+    return MakeMaskedBufferLoad(buffer, indices, predicate, op->span);
+  }
+  if (auto store = MaskedBufferStore::TryMatch(call)) {
+    BufferVar buffer = this->VisitBufferUse(store->buffer);
+    PrimExpr value = this->VisitPrimExpr(store->value);
+    ffi::Array<PrimExpr> indices =
+        store->indices.Map([this](const PrimExpr& e) { return this->VisitPrimExpr(e); });
+    PrimExpr predicate = this->VisitPrimExpr(store->predicate);
+    if (buffer.same_as(store->buffer) && value.same_as(store->value) &&
+        indices.same_as(store->indices) && predicate.same_as(store->predicate)) {
+      return call;
+    }
+    Stmt stmt = MakeMaskedBufferStore(buffer, value, indices, predicate, op->span);
+    return stmt.as_or_throw<Evaluate>()->value;
+  }
+  return ExprMutator::VisitExpr_(op);
 }
 
 Expr StmtExprMutator::VisitExpr_(const BufferLoadNode* op) {

--- a/src/tirx/op/builtin.cc
+++ b/src/tirx/op/builtin.cc
@@ -380,7 +380,9 @@ TIR_DEFINE_BUILTIN_FUNC(get_active_lane_mask)
                                          static_cast<int64_t>(ScriptDtypePrintLocation::kFirst));
 
 TIR_DEFINE_BUILTIN_FUNC(masked_load)
-    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kReadState));
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kReadState))
+    .set_attr<TScriptDtypePrintLocation>("TScriptDtypePrintLocation",
+                                         static_cast<int64_t>(ScriptDtypePrintLocation::kFirst));
 
 TIR_DEFINE_BUILTIN_FUNC(masked_store)
     .set_attr<TCallEffectKind>("TCallEffectKind",

--- a/src/tirx/op/builtin.cc
+++ b/src/tirx/op/builtin.cc
@@ -379,6 +379,13 @@ TIR_DEFINE_BUILTIN_FUNC(get_active_lane_mask)
     .set_attr<TScriptDtypePrintLocation>("TScriptDtypePrintLocation",
                                          static_cast<int64_t>(ScriptDtypePrintLocation::kFirst));
 
+TIR_DEFINE_BUILTIN_FUNC(masked_load)
+    .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kReadState));
+
+TIR_DEFINE_BUILTIN_FUNC(masked_store)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               static_cast<int64_t>(CallEffectKind::kUpdateState));
+
 TIR_DEFINE_BUILTIN_FUNC(ignore_loop_partition)
     .set_num_inputs(1)
     .set_attr<TCallEffectKind>("TCallEffectKind", static_cast<int64_t>(CallEffectKind::kPure))

--- a/src/tirx/script/builder/ir.cc
+++ b/src/tirx/script/builder/ir.cc
@@ -833,7 +833,10 @@ void BufferStore(BufferVar buffer, PrimExpr value, ffi::Array<PrimExpr> indices,
     }
     value = tvm::cast(lhs_dtype, value);
   }
-  tvm::tirx::BufferStore store(buffer, value, indices, predicate);
+  tvm::tirx::Stmt store =
+      predicate.has_value()
+          ? tvm::tirx::MakeMaskedBufferStore(buffer, value, indices, predicate.value())
+          : tvm::tirx::Stmt(tvm::tirx::BufferStore(buffer, value, indices));
   if (lhs_dtype != rhs_dtype) {
     if (lhs_dtype.code() != rhs_dtype.code()) {
       if ((lhs_dtype.MatchesCode(DLDataTypeCode::kDLInt, DLDataTypeCode::kDLUInt)) &&

--- a/src/tirx/script/builder/ir.cc
+++ b/src/tirx/script/builder/ir.cc
@@ -784,8 +784,7 @@ Var EnvThread(ffi::String thread_tag, PrimType dtype) {
   return var;
 }
 
-void BufferStore(BufferVar buffer, PrimExpr value, ffi::Array<PrimExpr> indices,
-                 ffi::Optional<PrimExpr> predicate = std::nullopt) {
+void BufferStore(BufferVar buffer, PrimExpr value, ffi::Array<PrimExpr> indices) {
   PrimType buffer_dtype = buffer->dtype;
   PrimType index_ty = indices.empty() ? PrimType::Int(32) : indices.back().ty();
   bool is_index_scalable = !indices.empty() && index_ty.IsScalableVector();
@@ -833,10 +832,7 @@ void BufferStore(BufferVar buffer, PrimExpr value, ffi::Array<PrimExpr> indices,
     }
     value = tvm::cast(lhs_dtype, value);
   }
-  tvm::tirx::Stmt store =
-      predicate.has_value()
-          ? tvm::tirx::MakeMaskedBufferStore(buffer, value, indices, predicate.value())
-          : tvm::tirx::Stmt(tvm::tirx::BufferStore(buffer, value, indices));
+  tvm::tirx::Stmt store = tvm::tirx::BufferStore(buffer, value, indices);
   if (lhs_dtype != rhs_dtype) {
     if (lhs_dtype.code() != rhs_dtype.code()) {
       if ((lhs_dtype.MatchesCode(DLDataTypeCode::kDLInt, DLDataTypeCode::kDLUInt)) &&

--- a/src/tirx/script/printer/buffer.cc
+++ b/src/tirx/script/printer/buffer.cc
@@ -413,8 +413,7 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
           ExprDoc value = d->AsDoc<ExprDoc>(store->value, p->Attr("value"));
 
           // special case for scalar buffers
-          if ((store->buffer.IsScalar(true) || store->buffer.IsScalar(false)) &&
-              !store->predicate.has_value()) {
+          if (store->buffer.IsScalar(true) || store->buffer.IsScalar(false)) {
             // TVM_FFI_ICHECK(store->indices.size() == 1 && tirx::is_zero(store->indices[0]))
             //     << "1-dim buffer with shape (1,) store with indices other than [0] is not "
             //        "supported";
@@ -422,14 +421,6 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
             TVM_FFI_ICHECK(doc.has_value())
                 << "buffer is not defined in the environment: " << store->buffer;
             return AssignDoc(doc.value(), value, std::nullopt);
-          }
-
-          // Use .vstore(...) syntax when there is a predicate
-          if (store->predicate.has_value()) {
-            ExprDoc indices = d->AsDoc<ExprDoc>(store->indices, p->Attr("indices"));
-            ExprDoc predicate = d->AsDoc<ExprDoc>(store->predicate, p->Attr("predicate"));
-            return ExprStmtDoc(
-                buffer->Attr("vstore")->Call({indices, value}, {"predicate"}, {predicate}));
           }
 
           return AssignDoc(
@@ -443,21 +434,13 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
           ExprDoc buffer = d->AsDoc<ExprDoc>(load->buffer, p->Attr("buffer"));
 
           // special case for scalar
-          if ((load->buffer.IsScalar(true) || load->buffer.IsScalar(false)) &&
-              !load->predicate.has_value()) {
+          if (load->buffer.IsScalar(true) || load->buffer.IsScalar(false)) {
             // TVM_FFI_ICHECK(load->indices.size() == 1 && tirx::is_zero(load->indices[0]))
             //     << "Scalar buffer load with indices other than [0] is not supported";
             ffi::Optional<ExprDoc> doc = d->GetVarDoc(load->buffer);
             TVM_FFI_ICHECK(doc.has_value())
                 << "Scalar buffer is not defined in the environment: " << load->buffer;
             return doc.value();
-          }
-
-          // Use .vload(...) syntax when there is a predicate
-          if (load->predicate.has_value()) {
-            ExprDoc indices = d->AsDoc<ExprDoc>(load->indices, p->Attr("indices"));
-            ExprDoc predicate = d->AsDoc<ExprDoc>(load->predicate, p->Attr("predicate"));
-            return buffer->Attr("vload")->Call({indices}, {"predicate"}, {predicate});
           }
 
           return buffer[BufferIndices(load->indices, p->Attr("indices"), d)];

--- a/src/tirx/script/printer/expr.cc
+++ b/src/tirx/script/printer/expr.cc
@@ -301,22 +301,6 @@ Doc PrintTIRCall(Call call, AccessPath call_p, IRDocsifier d) {
     TVM_FFI_ICHECK_EQ(call->args.size(), 1);
     return d->AsDoc<ExprDoc>(call->args[0], call_p->Attr("args")->ArrayItem(0))->Attr("data");
   }
-  if (auto load = tirx::MaskedBufferLoad::TryMatch(call)) {
-    ExprDoc buffer = d->AsDoc<ExprDoc>(load->buffer, call_p->Attr("args")->ArrayItem(0));
-    ExprDoc indices = d->AsDoc<ExprDoc>(load->indices, call_p->Attr("args"));
-    ExprDoc predicate =
-        d->AsDoc<ExprDoc>(load->predicate, call_p->Attr("args")->ArrayItem(call->args.size() - 1));
-    return buffer->Attr("vload")->Call({indices}, {"predicate"}, {predicate});
-  }
-  if (call->op.same_as(tirx::builtin::masked_store())) {
-    tirx::MaskedBufferStore store(call);
-    ExprDoc buffer = d->AsDoc<ExprDoc>(store.buffer, call_p->Attr("args")->ArrayItem(0));
-    ExprDoc value = d->AsDoc<ExprDoc>(store.value, call_p->Attr("args")->ArrayItem(1));
-    ExprDoc indices = d->AsDoc<ExprDoc>(store.indices, call_p->Attr("args"));
-    ExprDoc predicate =
-        d->AsDoc<ExprDoc>(store.predicate, call_p->Attr("args")->ArrayItem(call->args.size() - 1));
-    return buffer->Attr("vstore")->Call({indices, value}, {"predicate"}, {predicate});
-  }
   ffi::Optional<PrimType> call_prim_type = call->ty.as<PrimType>();
   auto get_call_type_doc = [&](AccessPath type_p) -> ExprDoc {
     if (call_prim_type.has_value()) {

--- a/src/tirx/script/printer/expr.cc
+++ b/src/tirx/script/printer/expr.cc
@@ -301,6 +301,22 @@ Doc PrintTIRCall(Call call, AccessPath call_p, IRDocsifier d) {
     TVM_FFI_ICHECK_EQ(call->args.size(), 1);
     return d->AsDoc<ExprDoc>(call->args[0], call_p->Attr("args")->ArrayItem(0))->Attr("data");
   }
+  if (auto load = tirx::MaskedBufferLoad::TryMatch(call)) {
+    ExprDoc buffer = d->AsDoc<ExprDoc>(load->buffer, call_p->Attr("args")->ArrayItem(0));
+    ExprDoc indices = d->AsDoc<ExprDoc>(load->indices, call_p->Attr("args"));
+    ExprDoc predicate =
+        d->AsDoc<ExprDoc>(load->predicate, call_p->Attr("args")->ArrayItem(call->args.size() - 1));
+    return buffer->Attr("vload")->Call({indices}, {"predicate"}, {predicate});
+  }
+  if (call->op.same_as(tirx::builtin::masked_store())) {
+    tirx::MaskedBufferStore store(call);
+    ExprDoc buffer = d->AsDoc<ExprDoc>(store.buffer, call_p->Attr("args")->ArrayItem(0));
+    ExprDoc value = d->AsDoc<ExprDoc>(store.value, call_p->Attr("args")->ArrayItem(1));
+    ExprDoc indices = d->AsDoc<ExprDoc>(store.indices, call_p->Attr("args"));
+    ExprDoc predicate =
+        d->AsDoc<ExprDoc>(store.predicate, call_p->Attr("args")->ArrayItem(call->args.size() - 1));
+    return buffer->Attr("vstore")->Call({indices, value}, {"predicate"}, {predicate});
+  }
   ffi::Optional<PrimType> call_prim_type = call->ty.as<PrimType>();
   auto get_call_type_doc = [&](AccessPath type_p) -> ExprDoc {
     if (call_prim_type.has_value()) {

--- a/src/tirx/script/printer/utils.h
+++ b/src/tirx/script/printer/utils.h
@@ -123,6 +123,12 @@ inline void AsDocBody(const tirx::Stmt& stmt, AccessPath p, TIRFrameNode* f, con
           if (load->buffer.same_as(buffer)) {
             found = true;
           }
+        } else if (const auto* call = node.as<CallNode>()) {
+          if (call->op.same_as(tirx::builtin::masked_load()) && !call->args.empty()) {
+            if (auto var = call->args[0].as<Var>(); var && var.value().same_as(buffer.var())) {
+              found = true;
+            }
+          }
         }
       });
       return found;

--- a/src/tirx/script/printer/utils.h
+++ b/src/tirx/script/printer/utils.h
@@ -137,8 +137,7 @@ inline void AsDocBody(const tirx::Stmt& stmt, AccessPath p, TIRFrameNode* f, con
       if (d->cfg->syntax_sugar && alloc != nullptr && alloc->buffer.IsScalar(true) && i + 1 < n) {
         const auto* store = body[i + 1].as<tirx::BufferStoreNode>();
         bool can_merge_init = store != nullptr && store->buffer.same_as(alloc->buffer) &&
-                              !store->predicate.has_value() && store->indices.size() == 1 &&
-                              tirx::is_zero(store->indices[0]) &&
+                              store->indices.size() == 1 && tirx::is_zero(store->indices[0]) &&
                               !value_refs_buffer(store->value, alloc->buffer);
         if (can_merge_init) {
           Doc alloc_doc = d->AsDoc(body[i], item_p);

--- a/src/tirx/transform/flatten_buffer.cc
+++ b/src/tirx/transform/flatten_buffer.cc
@@ -248,6 +248,29 @@ class BufferFlattener : public arith::IRMutatorWithAnalyzer {
   }
 
   Expr VisitExpr_(const CallNode* op) final {
+    Call call = ffi::GetRef<Call>(op);
+    if (auto load = MaskedBufferLoad::TryMatch(call)) {
+      BufferVar original = load->buffer;
+      auto indices =
+          load->indices.Map([this](const PrimExpr& e) { return this->VisitPrimExpr(e); });
+      PrimExpr predicate = this->VisitPrimExpr(load->predicate);
+      buffers_used_.insert(original);
+      const FlatInfo& info = Lookup(original);
+      return MakeMaskedBufferLoad(info.flattened, FoldIndices(info, indices), predicate, op->span);
+    }
+    if (op->op.same_as(builtin::masked_store())) {
+      MaskedBufferStore store(call);
+      BufferVar original = store.buffer;
+      PrimExpr value = this->VisitPrimExpr(store.value);
+      auto indices =
+          store.indices.Map([this](const PrimExpr& e) { return this->VisitPrimExpr(e); });
+      PrimExpr predicate = this->VisitPrimExpr(store.predicate);
+      buffers_used_.insert(original);
+      const FlatInfo& info = Lookup(original);
+      Stmt stmt = MakeMaskedBufferStore(info.flattened, value, FoldIndices(info, indices),
+                                        predicate, op->span);
+      return stmt.as_or_throw<Evaluate>()->value;
+    }
     if (op->op.same_as(builtin::buffer_data()) && op->args.size() == 1) {
       if (auto var = op->args[0].as<Var>()) {
         if (var.value()->ty.as<BufferTypeNode>()) {

--- a/src/tirx/transform/flatten_buffer.cc
+++ b/src/tirx/transform/flatten_buffer.cc
@@ -248,28 +248,20 @@ class BufferFlattener : public arith::IRMutatorWithAnalyzer {
   }
 
   Expr VisitExpr_(const CallNode* op) final {
-    Call call = ffi::GetRef<Call>(op);
-    if (auto load = MaskedBufferLoad::TryMatch(call)) {
-      BufferVar original = load->buffer;
-      auto indices =
-          load->indices.Map([this](const PrimExpr& e) { return this->VisitPrimExpr(e); });
-      PrimExpr predicate = this->VisitPrimExpr(load->predicate);
+    if (op->op.same_as(builtin::masked_load()) || op->op.same_as(builtin::masked_store())) {
+      bool is_load = op->op.same_as(builtin::masked_load());
+      BufferVar original(op->args[0].as_or_throw<Var>());
+      ffi::Array<PrimExpr> indices;
+      for (size_t i = is_load ? 1 : 2; i + 1 < op->args.size(); ++i) {
+        indices.push_back(this->VisitPrimExpr(op->args[i].as_or_throw<PrimExpr>()));
+      }
       buffers_used_.insert(original);
       const FlatInfo& info = Lookup(original);
-      return MakeMaskedBufferLoad(info.flattened, FoldIndices(info, indices), predicate, op->span);
-    }
-    if (op->op.same_as(builtin::masked_store())) {
-      MaskedBufferStore store(call);
-      BufferVar original = store.buffer;
-      PrimExpr value = this->VisitPrimExpr(store.value);
-      auto indices =
-          store.indices.Map([this](const PrimExpr& e) { return this->VisitPrimExpr(e); });
-      PrimExpr predicate = this->VisitPrimExpr(store.predicate);
-      buffers_used_.insert(original);
-      const FlatInfo& info = Lookup(original);
-      Stmt stmt = MakeMaskedBufferStore(info.flattened, value, FoldIndices(info, indices),
-                                        predicate, op->span);
-      return stmt.as_or_throw<Evaluate>()->value;
+      ffi::Array<Expr> args{info.flattened.var()};
+      if (!is_load) args.push_back(this->VisitExpr(op->args[1]));
+      for (const PrimExpr& index : FoldIndices(info, indices)) args.push_back(index);
+      args.push_back(this->VisitExpr(op->args.back()));
+      return Call(op->ty, op->op, args, op->attrs, op->ty_args, op->span);
     }
     if (op->op.same_as(builtin::buffer_data()) && op->args.size() == 1) {
       if (auto var = op->args[0].as<Var>()) {

--- a/src/tirx/transform/remove_no_op.cc
+++ b/src/tirx/transform/remove_no_op.cc
@@ -193,8 +193,7 @@ class NoOpRemover : public arith::IRMutatorWithAnalyzer {
 
     // A write whose destination is known to already contain the
     // values to be written is a no-op.
-    PrimExpr stores_existing_value =
-        store->value - BufferLoad(store->buffer, store->indices, store->predicate) == 0;
+    PrimExpr stores_existing_value = store->value - BufferLoad(store->buffer, store->indices) == 0;
     stores_existing_value = analyzer_->Simplify(stores_existing_value);
     if (is_one(stores_existing_value)) {
       return only_side_effects();

--- a/src/tirx/transform/storage_rewrite.cc
+++ b/src/tirx/transform/storage_rewrite.cc
@@ -159,20 +159,6 @@ class LinearAccessPatternFinder final : public StmtExprVisitor {
     RecordAccess(op->buffer);
   }
 
-  void VisitExpr_(const CallNode* op) final {
-    Call call = ffi::GetRef<Call>(op);
-    ffi::Optional<BufferVar> buffer = std::nullopt;
-    if (auto load = MaskedBufferLoad::TryMatch(call)) {
-      buffer = load->buffer;
-    } else if (op->op.same_as(builtin::masked_store())) {
-      buffer = MaskedBufferStore(call).buffer;
-    }
-    StmtExprVisitor::VisitExpr_(op);
-    if (buffer.has_value()) {
-      RecordAccess(buffer.value());
-    }
-  }
-
   void VisitStmt_(const EvaluateNode* op) final {
     scope_.push_back(StmtEntry());
     // visit subexpr
@@ -548,25 +534,30 @@ class StoragePlanRewriter : public StmtExprMutator {
     }
   }
   Expr VisitExpr_(const CallNode* op) final {
-    Call call = ffi::GetRef<Call>(op);
-    if (auto load = MaskedBufferLoad::TryMatch(call)) {
-      auto indices =
-          load->indices.Map([this](const PrimExpr& e) { return this->VisitPrimExpr(e); });
-      PrimExpr predicate = this->VisitPrimExpr(load->predicate);
-      BufferLoad access(load->buffer, indices, op->span);
-      access = VisitBufferAccess(std::move(access));
-      return MakeMaskedBufferLoad(access->buffer, access->indices, predicate, op->span);
-    } else if (op->op.same_as(builtin::masked_store())) {
-      MaskedBufferStore store(call);
-      PrimExpr value = this->VisitPrimExpr(store.value);
-      auto indices =
-          store.indices.Map([this](const PrimExpr& e) { return this->VisitPrimExpr(e); });
-      PrimExpr predicate = this->VisitPrimExpr(store.predicate);
-      BufferStore access(store.buffer, value, indices, op->span);
-      access = VisitBufferAccess(std::move(access));
-      Stmt stmt = MakeMaskedBufferStore(access->buffer, access->value, access->indices, predicate,
-                                        op->span);
-      return stmt.as_or_throw<Evaluate>()->value;
+    if (op->op.same_as(builtin::masked_load()) || op->op.same_as(builtin::masked_store())) {
+      bool is_load = op->op.same_as(builtin::masked_load());
+      BufferVar buffer(op->args[0].as_or_throw<Var>());
+      PrimExpr value;
+      if (!is_load) value = this->VisitPrimExpr(op->args[1].as_or_throw<PrimExpr>());
+      ffi::Array<PrimExpr> indices;
+      for (size_t i = is_load ? 1 : 2; i + 1 < op->args.size(); ++i) {
+        indices.push_back(this->VisitPrimExpr(op->args[i].as_or_throw<PrimExpr>()));
+      }
+      if (is_load) {
+        BufferLoad access(buffer, indices, op->span);
+        access = VisitBufferAccess(std::move(access));
+        ffi::Array<Expr> args{access->buffer.var()};
+        for (const PrimExpr& index : access->indices) args.push_back(index);
+        args.push_back(this->VisitExpr(op->args.back()));
+        return Call(access->ty, op->op, args, op->attrs, op->ty_args, op->span);
+      } else {
+        BufferStore access(buffer, value, indices, op->span);
+        access = VisitBufferAccess(std::move(access));
+        ffi::Array<Expr> args{access->buffer.var(), access->value};
+        for (const PrimExpr& index : access->indices) args.push_back(index);
+        args.push_back(this->VisitExpr(op->args.back()));
+        return Call(PrimType::Void(), op->op, args, op->attrs, op->ty_args, op->span);
+      }
     } else if (op->op.same_as(builtin::tvm_access_ptr())) {
       TVM_FFI_ICHECK_EQ(op->args.size(), 5U);
       PrimExpr dtype_marker = op->args[0].as_or_throw<PrimExpr>();
@@ -1329,14 +1320,16 @@ class VectorTypeAccessChecker : public StmtExprVisitor {
   }
 
   void VisitExpr_(const CallNode* op) final {
-    Call call = ffi::GetRef<Call>(op);
-    if (auto load = MaskedBufferLoad::TryMatch(call)) {
-      OnArrayAccess(load->call->ty.as_or_throw<PrimType>(), load->buffer.get(), load->indices,
-                    /*is_buffer_load=*/true);
-    } else if (op->op.same_as(builtin::masked_store())) {
-      MaskedBufferStore store(call);
-      OnArrayAccess(store.value.ty(), store.buffer.get(), store.indices,
-                    /*is_buffer_load=*/false);
+    if (op->op.same_as(builtin::masked_load()) || op->op.same_as(builtin::masked_store())) {
+      bool is_load = op->op.same_as(builtin::masked_load());
+      BufferVar buffer(op->args[0].as_or_throw<Var>());
+      PrimType dtype =
+          is_load ? op->ty.as_or_throw<PrimType>() : op->args[1].as_or_throw<PrimExpr>().ty();
+      ffi::Array<PrimExpr> indices;
+      for (size_t i = is_load ? 1 : 2; i + 1 < op->args.size(); ++i) {
+        indices.push_back(op->args[i].as_or_throw<PrimExpr>());
+      }
+      OnArrayAccess(dtype, buffer.get(), indices, is_load);
     } else if (op->op.same_as(builtin::tvm_access_ptr())) {
       PrimType dtype = op->args[0].as_or_throw<PrimExpr>().ty();
       auto buffer_var = GetBufferDataVar(op->args[1]);
@@ -1726,31 +1719,37 @@ class VectorTypeRewriter : public StmtExprMutator {
   }
 
   ffi::Optional<Expr> RewriteMaskedCall(const CallNode* op) {
-    Call call = ffi::GetRef<Call>(op);
-    if (auto load = MaskedBufferLoad::TryMatch(call)) {
-      auto indices =
-          load->indices.Map([this](const PrimExpr& e) { return this->VisitPrimExpr(e); });
-      PrimExpr predicate = this->VisitPrimExpr(load->predicate);
-      BufferLoad access(load->buffer, indices, op->span);
+    if (op->op.same_as(builtin::masked_load())) {
+      BufferVar buffer(op->args[0].as_or_throw<Var>());
+      ffi::Array<PrimExpr> indices;
+      for (size_t i = 1; i + 1 < op->args.size(); ++i) {
+        indices.push_back(this->VisitPrimExpr(op->args[i].as_or_throw<PrimExpr>()));
+      }
+      BufferLoad access(buffer, indices, op->span);
       auto [modified, shuffle_index] = VisitBufferAccess(access);
       TVM_FFI_ICHECK_LT(shuffle_index, 0)
           << "A masked vector load cannot be rewritten into a scalar shuffle.";
       if (!modified.same_as(access)) modified.CopyOnWrite()->LegalizeDType();
-      return MakeMaskedBufferLoad(modified->buffer, modified->indices, predicate, op->span);
+      ffi::Array<Expr> args{modified->buffer.var()};
+      for (const PrimExpr& index : modified->indices) args.push_back(index);
+      args.push_back(this->VisitExpr(op->args.back()));
+      return Call(modified->ty, op->op, args, op->attrs, op->ty_args, op->span);
     }
     if (op->op.same_as(builtin::masked_store())) {
-      MaskedBufferStore store(call);
-      PrimExpr value = this->VisitPrimExpr(store.value);
-      auto indices =
-          store.indices.Map([this](const PrimExpr& e) { return this->VisitPrimExpr(e); });
-      PrimExpr predicate = this->VisitPrimExpr(store.predicate);
-      BufferStore access(store.buffer, value, indices, op->span);
+      BufferVar buffer(op->args[0].as_or_throw<Var>());
+      PrimExpr value = this->VisitPrimExpr(op->args[1].as_or_throw<PrimExpr>());
+      ffi::Array<PrimExpr> indices;
+      for (size_t i = 2; i + 1 < op->args.size(); ++i) {
+        indices.push_back(this->VisitPrimExpr(op->args[i].as_or_throw<PrimExpr>()));
+      }
+      BufferStore access(buffer, value, indices, op->span);
       auto [modified, shuffle_index] = VisitBufferAccess(std::move(access));
       TVM_FFI_ICHECK_LT(shuffle_index, 0)
           << "A masked vector store cannot be rewritten into a scalar shuffle.";
-      Stmt stmt = MakeMaskedBufferStore(modified->buffer, modified->value, modified->indices,
-                                        predicate, op->span);
-      return stmt.as_or_throw<Evaluate>()->value;
+      ffi::Array<Expr> args{modified->buffer.var(), modified->value};
+      for (const PrimExpr& index : modified->indices) args.push_back(index);
+      args.push_back(this->VisitExpr(op->args.back()));
+      return Call(PrimType::Void(), op->op, args, op->attrs, op->ty_args, op->span);
     }
     return std::nullopt;
   }

--- a/src/tirx/transform/storage_rewrite.cc
+++ b/src/tirx/transform/storage_rewrite.cc
@@ -145,20 +145,7 @@ class LinearAccessPatternFinder final : public StmtExprVisitor {
     scope_.push_back(StmtEntry());
     // visit subexpr
     StmtExprVisitor::VisitStmt_(op);
-    // Add write access.
-    const VarNode* buffer_var =
-        buffer_aliases_.Get(op->buffer.var()).value_or(op->buffer.var()).get();
-    auto it = alloc_info_.find(buffer_var);
-    if (it != alloc_info_.end() && it->second.alloc) {
-      TVM_FFI_ICHECK_LT(it->second.level, scope_.size());
-      scope_[it->second.level].touched.push_back(buffer_var);
-
-      TVM_FFI_ICHECK_EQ(1, it->second.num_physical_dimensions)
-          << "BufferVar " << op->buffer.name() << " is allocated with "
-          << it->second.num_physical_dimensions
-          << " physical dimensions, but is accessed as having "
-          << "1 physical dimension" << std::endl;
-    }
+    RecordAccess(op->buffer);
     StmtEntry e = scope_.back();
     scope_.pop_back();
     if (e.touched.size() != 0) {
@@ -168,22 +155,21 @@ class LinearAccessPatternFinder final : public StmtExprVisitor {
   }
 
   void VisitExpr_(const BufferLoadNode* op) final {
-    // Add write access.
     StmtExprVisitor::VisitExpr_(op);
+    RecordAccess(op->buffer);
+  }
 
-    const VarNode* buffer_var =
-        buffer_aliases_.Get(op->buffer.var()).value_or(op->buffer.var()).get();
-    auto it = alloc_info_.find(buffer_var);
-    if (it != alloc_info_.end() && it->second.alloc) {
-      TVM_FFI_ICHECK_LT(it->second.level, scope_.size())
-          << "Load memory in places other than store.";
-      scope_[it->second.level].touched.push_back(buffer_var);
-
-      TVM_FFI_ICHECK_EQ(1, it->second.num_physical_dimensions)
-          << "BufferVar " << op->buffer.name() << " is allocated with "
-          << it->second.num_physical_dimensions
-          << " physical dimensions, but is accessed as having "
-          << "1 physical dimension" << std::endl;
+  void VisitExpr_(const CallNode* op) final {
+    Call call = ffi::GetRef<Call>(op);
+    ffi::Optional<BufferVar> buffer = std::nullopt;
+    if (auto load = MaskedBufferLoad::TryMatch(call)) {
+      buffer = load->buffer;
+    } else if (op->op.same_as(builtin::masked_store())) {
+      buffer = MaskedBufferStore(call).buffer;
+    }
+    StmtExprVisitor::VisitExpr_(op);
+    if (buffer.has_value()) {
+      RecordAccess(buffer.value());
     }
   }
 
@@ -277,6 +263,19 @@ class LinearAccessPatternFinder final : public StmtExprVisitor {
       e.stmt = op;
       linear_seq_.push_back(e);
     }
+  }
+
+  void RecordAccess(const BufferVar& buffer) {
+    const VarNode* buffer_var = buffer_aliases_.Get(buffer.var()).value_or(buffer.var()).get();
+    auto it = alloc_info_.find(buffer_var);
+    if (it == alloc_info_.end() || !it->second.alloc) return;
+    TVM_FFI_ICHECK_LT(it->second.level, scope_.size())
+        << "Buffer access occurs outside a statement scope.";
+    scope_[it->second.level].touched.push_back(buffer_var);
+    TVM_FFI_ICHECK_EQ(1, it->second.num_physical_dimensions)
+        << "BufferVar " << buffer.name() << " is allocated with "
+        << it->second.num_physical_dimensions << " physical dimensions, but is accessed as having "
+        << "1 physical dimension" << std::endl;
   }
 
   // linearized access sequence.
@@ -549,7 +548,26 @@ class StoragePlanRewriter : public StmtExprMutator {
     }
   }
   Expr VisitExpr_(const CallNode* op) final {
-    if (op->op.same_as(builtin::tvm_access_ptr())) {
+    Call call = ffi::GetRef<Call>(op);
+    if (auto load = MaskedBufferLoad::TryMatch(call)) {
+      auto indices =
+          load->indices.Map([this](const PrimExpr& e) { return this->VisitPrimExpr(e); });
+      PrimExpr predicate = this->VisitPrimExpr(load->predicate);
+      BufferLoad access(load->buffer, indices, op->span);
+      access = VisitBufferAccess(std::move(access));
+      return MakeMaskedBufferLoad(access->buffer, access->indices, predicate, op->span);
+    } else if (op->op.same_as(builtin::masked_store())) {
+      MaskedBufferStore store(call);
+      PrimExpr value = this->VisitPrimExpr(store.value);
+      auto indices =
+          store.indices.Map([this](const PrimExpr& e) { return this->VisitPrimExpr(e); });
+      PrimExpr predicate = this->VisitPrimExpr(store.predicate);
+      BufferStore access(store.buffer, value, indices, op->span);
+      access = VisitBufferAccess(std::move(access));
+      Stmt stmt = MakeMaskedBufferStore(access->buffer, access->value, access->indices, predicate,
+                                        op->span);
+      return stmt.as_or_throw<Evaluate>()->value;
+    } else if (op->op.same_as(builtin::tvm_access_ptr())) {
       TVM_FFI_ICHECK_EQ(op->args.size(), 5U);
       PrimExpr dtype_marker = op->args[0].as_or_throw<PrimExpr>();
       PrimType dtype = dtype_marker.ty();
@@ -1311,7 +1329,15 @@ class VectorTypeAccessChecker : public StmtExprVisitor {
   }
 
   void VisitExpr_(const CallNode* op) final {
-    if (op->op.same_as(builtin::tvm_access_ptr())) {
+    Call call = ffi::GetRef<Call>(op);
+    if (auto load = MaskedBufferLoad::TryMatch(call)) {
+      OnArrayAccess(load->call->ty.as_or_throw<PrimType>(), load->buffer.get(), load->indices,
+                    /*is_buffer_load=*/true);
+    } else if (op->op.same_as(builtin::masked_store())) {
+      MaskedBufferStore store(call);
+      OnArrayAccess(store.value.ty(), store.buffer.get(), store.indices,
+                    /*is_buffer_load=*/false);
+    } else if (op->op.same_as(builtin::tvm_access_ptr())) {
       PrimType dtype = op->args[0].as_or_throw<PrimExpr>().ty();
       auto buffer_var = GetBufferDataVar(op->args[1]);
       PrimExpr index = op->args[2].as_or_throw<PrimExpr>();
@@ -1699,6 +1725,36 @@ class VectorTypeRewriter : public StmtExprMutator {
     return modified;
   }
 
+  ffi::Optional<Expr> RewriteMaskedCall(const CallNode* op) {
+    Call call = ffi::GetRef<Call>(op);
+    if (auto load = MaskedBufferLoad::TryMatch(call)) {
+      auto indices =
+          load->indices.Map([this](const PrimExpr& e) { return this->VisitPrimExpr(e); });
+      PrimExpr predicate = this->VisitPrimExpr(load->predicate);
+      BufferLoad access(load->buffer, indices, op->span);
+      auto [modified, shuffle_index] = VisitBufferAccess(access);
+      TVM_FFI_ICHECK_LT(shuffle_index, 0)
+          << "A masked vector load cannot be rewritten into a scalar shuffle.";
+      if (!modified.same_as(access)) modified.CopyOnWrite()->LegalizeDType();
+      return MakeMaskedBufferLoad(modified->buffer, modified->indices, predicate, op->span);
+    }
+    if (op->op.same_as(builtin::masked_store())) {
+      MaskedBufferStore store(call);
+      PrimExpr value = this->VisitPrimExpr(store.value);
+      auto indices =
+          store.indices.Map([this](const PrimExpr& e) { return this->VisitPrimExpr(e); });
+      PrimExpr predicate = this->VisitPrimExpr(store.predicate);
+      BufferStore access(store.buffer, value, indices, op->span);
+      auto [modified, shuffle_index] = VisitBufferAccess(std::move(access));
+      TVM_FFI_ICHECK_LT(shuffle_index, 0)
+          << "A masked vector store cannot be rewritten into a scalar shuffle.";
+      Stmt stmt = MakeMaskedBufferStore(modified->buffer, modified->value, modified->indices,
+                                        predicate, op->span);
+      return stmt.as_or_throw<Evaluate>()->value;
+    }
+    return std::nullopt;
+  }
+
   Stmt VisitStmt_(const BindNode* op) final {
     auto it = rewrite_map_.find(op->var.get());
     Expr value = this->VisitExpr(op->value);
@@ -1764,6 +1820,9 @@ class VectorTypeRewriter : public StmtExprMutator {
   }
 
   Expr VisitExpr_(const CallNode* op) final {
+    if (auto rewritten = RewriteMaskedCall(op)) {
+      return rewritten.value();
+    }
     if (op->op.same_as(builtin::buffer_data()) && op->args.size() == 1) {
       if (auto var = op->args[0].as<Var>();
           var.has_value() && var.value()->ty.as<BufferTypeNode>()) {

--- a/src/tirx/transform/unsupported_dtype_legalize.cc
+++ b/src/tirx/transform/unsupported_dtype_legalize.cc
@@ -288,11 +288,9 @@ class ComputeLegalizer : public StmtExprMutator {
         return Call(type, op->op, args, op->attrs, op->ty_args, op->span);
       }
       if (MatchType(buffer->dtype)) {
-        int index_lanes = indices.empty() ? 1 : indices.back().ty().lanes();
-        PrimType legalized_dtype = buffer->dtype.WithLanes(index_lanes * buffer->dtype.lanes());
-        value = CastTargetToDType(value, legalized_dtype);
+        value = CastTargetToDType(value, BufferLoad(buffer, indices).ty());
       }
-      PrimType storage_dtype = buffer->dtype.WithLanes(value.ty().lanes());
+      PrimType storage_dtype = BufferLoad(buffer, indices).ty();
       if (value.ty() != storage_dtype) {
         TVM_FFI_ICHECK(MatchType(value.ty()));
         value = DTypeConversion(value, storage_dtype);
@@ -408,12 +406,9 @@ class ComputeLegalizer : public StmtExprMutator {
       return ffi::GetRef<Stmt>(op);
     } else {
       if (MatchType(new_buf->dtype)) {
-        int index_lanes = indices.size() ? indices.back().ty().lanes() : 1;
-        int buffer_lanes = new_buf->dtype.lanes();
-        PrimType legalized_dtype = new_buf->dtype.WithLanes(index_lanes * buffer_lanes);
-        value = CastTargetToDType(value, legalized_dtype);
+        value = CastTargetToDType(value, BufferLoad(new_buf, indices).ty());
       }
-      PrimType storage_dtype = new_buf->dtype.WithLanes(value.ty().lanes());
+      PrimType storage_dtype = BufferLoad(new_buf, indices).ty();
       if (value.ty() != storage_dtype) {
         // this happens when buffer get rewritten to f32
         // but values remain as fp8/bf16

--- a/src/tirx/transform/unsupported_dtype_legalize.cc
+++ b/src/tirx/transform/unsupported_dtype_legalize.cc
@@ -129,28 +129,20 @@ class ComputeLegalizePlanner : public StmtExprVisitor {
   }
 
   void VisitExpr_(const CallNode* op) final {
-    Call call = ffi::GetRef<Call>(op);
-    ffi::Optional<BufferVar> masked_buffer = std::nullopt;
-    if (auto load = MaskedBufferLoad::TryMatch(call)) {
-      masked_buffer = load->buffer;
-    } else if (auto store = MaskedBufferStore::TryMatch(call)) {
-      masked_buffer = store->buffer;
-    }
     if (op->op.same_as(builtin::buffer_data()) && op->args.size() == 1) {
       if (auto buffer = op->args[0].as<Var>()) {
         opaque_var_access_.insert(buffer.value());
       }
     }
     StmtExprVisitor::VisitExpr_(op);
-    if (masked_buffer.has_value()) {
-      this->PopulateBufferRemap(masked_buffer.value());
-    }
   }
 
   void VisitExpr_(const VarNode* op) final {
     StmtExprVisitor::VisitExpr_(op);
     Var buffer_var = ffi::GetRef<Var>(op);
-    if (buffer_var->ty.as<PointerTypeNode>()) {
+    if (buffer_var->ty.as<BufferTypeNode>()) {
+      this->PopulateBufferRemap(BufferVar(buffer_var));
+    } else if (buffer_var->ty.as<PointerTypeNode>()) {
       opaque_var_access_.insert(buffer_var);
     }
   }
@@ -275,39 +267,40 @@ class ComputeLegalizer : public StmtExprMutator {
   }
 
   Expr VisitExpr_(const CallNode* op) final {
-    Call call = ffi::GetRef<Call>(op);
-    if (auto load = MaskedBufferLoad::TryMatch(call)) {
-      BufferVar buffer = GetRemappedBuffer(load->buffer);
-      auto indices =
-          load->indices.Map([this](const PrimExpr& e) { return this->VisitPrimExpr(e); });
-      PrimExpr predicate = this->VisitPrimExpr(load->predicate);
-      if (buffer.same_as(load->buffer) && indices.same_as(load->indices) &&
-          predicate.same_as(load->predicate)) {
-        return call;
+    if (op->op.same_as(builtin::masked_load()) || op->op.same_as(builtin::masked_store())) {
+      bool is_load = op->op.same_as(builtin::masked_load());
+      BufferVar original(op->args[0].as_or_throw<Var>());
+      BufferVar buffer = GetRemappedBuffer(original);
+      ffi::Array<Expr> args{buffer.var()};
+      PrimExpr value;
+      if (!is_load) {
+        value = this->VisitPrimExpr(op->args[1].as_or_throw<PrimExpr>());
       }
-      return MakeMaskedBufferLoad(buffer, indices, predicate, op->span);
-    }
-    if (auto store = MaskedBufferStore::TryMatch(call)) {
-      PrimExpr value = this->VisitPrimExpr(store->value);
-      auto indices =
-          store->indices.Map([this](const PrimExpr& e) { return this->VisitPrimExpr(e); });
-      PrimExpr predicate = this->VisitPrimExpr(store->predicate);
-      BufferVar buffer = GetRemappedBuffer(store->buffer);
-      if (value.same_as(store->value) && indices.same_as(store->indices) &&
-          predicate.same_as(store->predicate) && buffer.same_as(store->buffer)) {
-        return call;
+      ffi::Array<PrimExpr> indices;
+      for (size_t i = is_load ? 1 : 2; i + 1 < op->args.size(); ++i) {
+        indices.push_back(this->VisitPrimExpr(op->args[i].as_or_throw<PrimExpr>()));
+      }
+      PrimExpr predicate = this->VisitPrimExpr(op->args.back().as_or_throw<PrimExpr>());
+      if (is_load) {
+        for (const PrimExpr& index : indices) args.push_back(index);
+        args.push_back(predicate);
+        Type type = BufferLoad(buffer, indices).ty();
+        return Call(type, op->op, args, op->attrs, op->ty_args, op->span);
       }
       if (MatchType(buffer->dtype)) {
         int index_lanes = indices.empty() ? 1 : indices.back().ty().lanes();
         PrimType legalized_dtype = buffer->dtype.WithLanes(index_lanes * buffer->dtype.lanes());
         value = CastTargetToDType(value, legalized_dtype);
       }
-      if (value.ty() != buffer->dtype) {
+      PrimType storage_dtype = buffer->dtype.WithLanes(value.ty().lanes());
+      if (value.ty() != storage_dtype) {
         TVM_FFI_ICHECK(MatchType(value.ty()));
-        value = DTypeConversion(value, buffer->dtype.WithLanes(value.ty().lanes()));
+        value = DTypeConversion(value, storage_dtype);
       }
-      Stmt stmt = MakeMaskedBufferStore(buffer, value, indices, predicate, op->span);
-      return stmt.as_or_throw<Evaluate>()->value;
+      args.push_back(value);
+      for (const PrimExpr& index : indices) args.push_back(index);
+      args.push_back(predicate);
+      return Call(PrimType::Void(), op->op, args, op->attrs, op->ty_args, op->span);
     }
     if (!op->ty.as<PrimTypeNode>()) {
       return StmtExprMutator::VisitExpr_(op);
@@ -420,11 +413,12 @@ class ComputeLegalizer : public StmtExprMutator {
         PrimType legalized_dtype = new_buf->dtype.WithLanes(index_lanes * buffer_lanes);
         value = CastTargetToDType(value, legalized_dtype);
       }
-      if (value.ty() != new_buf->dtype) {
+      PrimType storage_dtype = new_buf->dtype.WithLanes(value.ty().lanes());
+      if (value.ty() != storage_dtype) {
         // this happens when buffer get rewritten to f32
         // but values remain as fp8/bf16
         TVM_FFI_ICHECK(MatchType(value.ty()));
-        value = DTypeConversion(value, new_buf->dtype.WithLanes(value.ty().lanes()));
+        value = DTypeConversion(value, storage_dtype);
       }
       return BufferStore(new_buf, value, indices);
     }
@@ -726,25 +720,32 @@ class StorageLegalizer : public StmtExprMutator {
   }
 
   Expr VisitExpr_(const CallNode* op) final {
-    Call call = ffi::GetRef<Call>(op);
-    if (auto load = MaskedBufferLoad::TryMatch(call)) {
-      BufferVar buffer = GetRemappedBuffer(load->buffer);
-      auto indices =
-          load->indices.Map([this](const PrimExpr& e) { return this->VisitPrimExpr(e); });
-      PrimExpr predicate = this->VisitPrimExpr(load->predicate);
-      return MakeMaskedBufferLoad(buffer, indices, predicate, op->span);
-    }
-    if (auto store = MaskedBufferStore::TryMatch(call)) {
-      PrimExpr value = this->ChangeToUInt(this->VisitPrimExpr(store->value));
-      BufferVar buffer = GetRemappedBuffer(store->buffer);
-      auto indices =
-          store->indices.Map([this](const PrimExpr& e) { return this->VisitPrimExpr(e); });
-      PrimExpr predicate = this->VisitPrimExpr(store->predicate);
-      if (MatchType(store->value.ty())) {
-        TVM_FFI_ICHECK(buffer->dtype.MatchesCode(DLDataTypeCode::kDLUInt));
+    if (op->op.same_as(builtin::masked_load()) || op->op.same_as(builtin::masked_store())) {
+      bool is_load = op->op.same_as(builtin::masked_load());
+      BufferVar buffer = GetRemappedBuffer(BufferVar(op->args[0].as_or_throw<Var>()));
+      ffi::Array<Expr> args{buffer.var()};
+      PrimExpr value;
+      if (!is_load) {
+        PrimExpr original_value = op->args[1].as_or_throw<PrimExpr>();
+        value = this->ChangeToUInt(this->VisitPrimExpr(original_value));
+        if (MatchType(original_value.ty())) {
+          TVM_FFI_ICHECK(buffer->dtype.MatchesCode(DLDataTypeCode::kDLUInt));
+        }
+        args.push_back(value);
       }
-      Stmt stmt = MakeMaskedBufferStore(buffer, value, indices, predicate, op->span);
-      return stmt.as_or_throw<Evaluate>()->value;
+      ffi::Array<PrimExpr> indices;
+      for (size_t i = is_load ? 1 : 2; i + 1 < op->args.size(); ++i) {
+        PrimExpr index = this->VisitPrimExpr(op->args[i].as_or_throw<PrimExpr>());
+        indices.push_back(index);
+        args.push_back(index);
+      }
+      args.push_back(this->VisitExpr(op->args.back()));
+      if (is_load) {
+        Type type = BufferLoad(buffer, indices).ty();
+        return Call(type, op->op, args, op->attrs, op->ty_args, op->span);
+      } else {
+        return Call(PrimType::Void(), op->op, args, op->attrs, op->ty_args, op->span);
+      }
     }
     if (const auto* pointer_type = op->ty.as<PointerTypeNode>()) {
       Expr ret = StmtExprMutator::VisitExpr_(op);

--- a/src/tirx/transform/unsupported_dtype_legalize.cc
+++ b/src/tirx/transform/unsupported_dtype_legalize.cc
@@ -129,12 +129,22 @@ class ComputeLegalizePlanner : public StmtExprVisitor {
   }
 
   void VisitExpr_(const CallNode* op) final {
+    Call call = ffi::GetRef<Call>(op);
+    ffi::Optional<BufferVar> masked_buffer = std::nullopt;
+    if (auto load = MaskedBufferLoad::TryMatch(call)) {
+      masked_buffer = load->buffer;
+    } else if (auto store = MaskedBufferStore::TryMatch(call)) {
+      masked_buffer = store->buffer;
+    }
     if (op->op.same_as(builtin::buffer_data()) && op->args.size() == 1) {
       if (auto buffer = op->args[0].as<Var>()) {
         opaque_var_access_.insert(buffer.value());
       }
     }
     StmtExprVisitor::VisitExpr_(op);
+    if (masked_buffer.has_value()) {
+      this->PopulateBufferRemap(masked_buffer.value());
+    }
   }
 
   void VisitExpr_(const VarNode* op) final {
@@ -265,6 +275,40 @@ class ComputeLegalizer : public StmtExprMutator {
   }
 
   Expr VisitExpr_(const CallNode* op) final {
+    Call call = ffi::GetRef<Call>(op);
+    if (auto load = MaskedBufferLoad::TryMatch(call)) {
+      BufferVar buffer = GetRemappedBuffer(load->buffer);
+      auto indices =
+          load->indices.Map([this](const PrimExpr& e) { return this->VisitPrimExpr(e); });
+      PrimExpr predicate = this->VisitPrimExpr(load->predicate);
+      if (buffer.same_as(load->buffer) && indices.same_as(load->indices) &&
+          predicate.same_as(load->predicate)) {
+        return call;
+      }
+      return MakeMaskedBufferLoad(buffer, indices, predicate, op->span);
+    }
+    if (auto store = MaskedBufferStore::TryMatch(call)) {
+      PrimExpr value = this->VisitPrimExpr(store->value);
+      auto indices =
+          store->indices.Map([this](const PrimExpr& e) { return this->VisitPrimExpr(e); });
+      PrimExpr predicate = this->VisitPrimExpr(store->predicate);
+      BufferVar buffer = GetRemappedBuffer(store->buffer);
+      if (value.same_as(store->value) && indices.same_as(store->indices) &&
+          predicate.same_as(store->predicate) && buffer.same_as(store->buffer)) {
+        return call;
+      }
+      if (MatchType(buffer->dtype)) {
+        int index_lanes = indices.empty() ? 1 : indices.back().ty().lanes();
+        PrimType legalized_dtype = buffer->dtype.WithLanes(index_lanes * buffer->dtype.lanes());
+        value = CastTargetToDType(value, legalized_dtype);
+      }
+      if (value.ty() != buffer->dtype) {
+        TVM_FFI_ICHECK(MatchType(value.ty()));
+        value = DTypeConversion(value, buffer->dtype.WithLanes(value.ty().lanes()));
+      }
+      Stmt stmt = MakeMaskedBufferStore(buffer, value, indices, predicate, op->span);
+      return stmt.as_or_throw<Evaluate>()->value;
+    }
     if (!op->ty.as<PrimTypeNode>()) {
       return StmtExprMutator::VisitExpr_(op);
     }
@@ -682,6 +726,26 @@ class StorageLegalizer : public StmtExprMutator {
   }
 
   Expr VisitExpr_(const CallNode* op) final {
+    Call call = ffi::GetRef<Call>(op);
+    if (auto load = MaskedBufferLoad::TryMatch(call)) {
+      BufferVar buffer = GetRemappedBuffer(load->buffer);
+      auto indices =
+          load->indices.Map([this](const PrimExpr& e) { return this->VisitPrimExpr(e); });
+      PrimExpr predicate = this->VisitPrimExpr(load->predicate);
+      return MakeMaskedBufferLoad(buffer, indices, predicate, op->span);
+    }
+    if (auto store = MaskedBufferStore::TryMatch(call)) {
+      PrimExpr value = this->ChangeToUInt(this->VisitPrimExpr(store->value));
+      BufferVar buffer = GetRemappedBuffer(store->buffer);
+      auto indices =
+          store->indices.Map([this](const PrimExpr& e) { return this->VisitPrimExpr(e); });
+      PrimExpr predicate = this->VisitPrimExpr(store->predicate);
+      if (MatchType(store->value.ty())) {
+        TVM_FFI_ICHECK(buffer->dtype.MatchesCode(DLDataTypeCode::kDLUInt));
+      }
+      Stmt stmt = MakeMaskedBufferStore(buffer, value, indices, predicate, op->span);
+      return stmt.as_or_throw<Evaluate>()->value;
+    }
     if (const auto* pointer_type = op->ty.as<PointerTypeNode>()) {
       Expr ret = StmtExprMutator::VisitExpr_(op);
       const auto* element_type = pointer_type->element_type.as<PrimTypeNode>();

--- a/src/tirx/transform/unsupported_dtype_legalize.cc
+++ b/src/tirx/transform/unsupported_dtype_legalize.cc
@@ -365,15 +365,9 @@ class ComputeLegalizer : public StmtExprMutator {
     auto fmutate = [this](const PrimExpr& e) { return this->VisitPrimExpr(e); };
 
     ffi::Array<PrimExpr> indices = op->indices.Map(fmutate);
-    ffi::Optional<PrimExpr> predicate = std::nullopt;
-    if (op->predicate.has_value()) {
-      predicate = this->VisitPrimExpr(op->predicate.value());
-    }
-
     BufferVar new_buf = GetRemappedBuffer(op->buffer);
 
-    if (value.same_as(op->value) && indices.same_as(op->indices) &&
-        predicate.same_as(op->predicate) && new_buf.same_as(op->buffer)) {
+    if (value.same_as(op->value) && indices.same_as(op->indices) && new_buf.same_as(op->buffer)) {
       return ffi::GetRef<Stmt>(op);
     } else {
       if (MatchType(new_buf->dtype)) {
@@ -388,7 +382,7 @@ class ComputeLegalizer : public StmtExprMutator {
         TVM_FFI_ICHECK(MatchType(value.ty()));
         value = DTypeConversion(value, new_buf->dtype.WithLanes(value.ty().lanes()));
       }
-      return BufferStore(new_buf, value, indices, predicate);
+      return BufferStore(new_buf, value, indices);
     }
   }
 
@@ -477,7 +471,7 @@ class ComputeLegalizer : public StmtExprMutator {
     if (new_buf.same_as(op->buffer)) {
       return ret;
     } else {
-      return BufferLoad(new_buf, op->indices, op->predicate);
+      return BufferLoad(new_buf, op->indices);
     }
   }
 
@@ -648,18 +642,13 @@ class StorageLegalizer : public StmtExprMutator {
     PrimExpr value = this->ChangeToUInt(VisitPrimExpr(op->value));
     BufferVar new_buf = GetRemappedBuffer(op->buffer);
     auto indices = op->indices.Map([this](PrimExpr expr) { return this->VisitPrimExpr(expr); });
-    ffi::Optional<PrimExpr> predicate = std::nullopt;
-    if (op->predicate.has_value()) {
-      predicate = this->VisitPrimExpr(op->predicate.value());
-    }
-    if (new_buf.same_as(op->buffer) && indices.same_as(op->indices) &&
-        predicate.same_as(op->predicate) && value.same_as(op->value)) {
+    if (new_buf.same_as(op->buffer) && indices.same_as(op->indices) && value.same_as(op->value)) {
       return ffi::GetRef<Stmt>(op);
     } else {
       if (MatchType(op->value.ty())) {
         TVM_FFI_ICHECK(new_buf->dtype.MatchesCode(DLDataTypeCode::kDLUInt));
       }
-      return BufferStore(new_buf, value, indices, predicate);
+      return BufferStore(new_buf, value, indices);
     }
   }
 
@@ -688,7 +677,7 @@ class StorageLegalizer : public StmtExprMutator {
     if (new_buf.same_as(op->buffer)) {
       return ret;
     } else {
-      return BufferLoad(new_buf, op->indices, op->predicate);
+      return BufferLoad(new_buf, op->indices);
     }
   }
 

--- a/src/tirx/transform/vectorize_loop.cc
+++ b/src/tirx/transform/vectorize_loop.cc
@@ -214,20 +214,18 @@ class TryPredicateBufferAccesses : public StmtExprMutator {
     return TryPredicateBufferAccess(store);
   }
 
-  template <typename AccessNode>
-  AccessNode TryPredicateBufferAccess(AccessNode node) {
+  ffi::Optional<PrimExpr> GetLaneMask(const ffi::Array<PrimExpr>& indices) {
     num_accesses_analyzed_ += 1;
 
     // Do not try to predicate non-vectorized accesses
-    ffi::Array<PrimExpr> indices = node->indices;
     if (!indices.size() || !indices[0]->IsInstance<RampNode>()) {
-      return node;
+      return std::nullopt;
     }
-    Ramp ramp = node->indices[0].template as_or_throw<Ramp>();
+    Ramp ramp = indices[0].as_or_throw<Ramp>();
 
     if (!ffi::StructuralEqual()(ramp->stride, stride_) ||
         !ffi::StructuralEqual()(ramp->lanes, lanes_)) {
-      return node;
+      return std::nullopt;
     }
 
     bool same_base = ffi::StructuralEqual()(ramp->base, base_);
@@ -236,7 +234,7 @@ class TryPredicateBufferAccesses : public StmtExprMutator {
       // memory base.  This covers accesses such as A[offset + i] guarded by
       // a predicate over i.
       if (!allow_offset_predication_) {
-        return node;
+        return std::nullopt;
       }
     }
 
@@ -249,15 +247,22 @@ class TryPredicateBufferAccesses : public StmtExprMutator {
                              .as_or_throw<PrimExpr>();
 
     num_accesses_rewritten_ += 1;
-    auto writer = node.CopyOnWrite();
-    if (node->predicate.has_value() && allow_offset_predication_) {
-      // BufferVar predicates are uint1 lane masks, so mask merging uses bitwise
-      // and rather than logical &&.
-      writer->predicate = node->predicate.value() & lane_mask;
-    } else {
-      writer->predicate = lane_mask;
+    return lane_mask;
+  }
+
+  Expr TryPredicateBufferAccess(BufferLoad load) {
+    if (auto mask = GetLaneMask(load->indices)) {
+      return MakeMaskedBufferLoad(load->buffer, load->indices, mask.value(), load->span);
     }
-    return node;
+    return load;
+  }
+
+  Stmt TryPredicateBufferAccess(BufferStore store) {
+    if (auto mask = GetLaneMask(store->indices)) {
+      return MakeMaskedBufferStore(store->buffer, store->value, store->indices, mask.value(),
+                                   store->span);
+    }
+    return store;
   }
 
   /*! \brief The variable base expr of the predicate. */

--- a/src/tirx/transform/vectorize_loop.cc
+++ b/src/tirx/transform/vectorize_loop.cc
@@ -158,8 +158,10 @@ bool EnableBufferLevelPredication(Target target) {
  * After:
  * for i_0 in T.serial(4):
  *  predicate = T.get_active_lane_mask("uint1x4", i_0 * 4, 14)
- *  A_load = T.meta_var(A.vload([T.Ramp(i_0 * 4, 1, 4)], predicate=predicate))
- *  B.vstore([T.Ramp(i_0 * 4, 1, 4)], A_load, predicate=predicate)
+ *  A_load = T.meta_var(T.call_intrin("float32x4", "tirx.masked_load", A,
+ *                                    T.Ramp(i_0 * 4, 1, 4), predicate))
+ *  T.evaluate(T.call_intrin("void", "tirx.masked_store", B, A_load,
+ *                           T.Ramp(i_0 * 4, 1, 4), predicate))
  */
 class TryPredicateBufferAccesses : public StmtExprMutator {
  public:
@@ -252,15 +254,21 @@ class TryPredicateBufferAccesses : public StmtExprMutator {
 
   Expr TryPredicateBufferAccess(BufferLoad load) {
     if (auto mask = GetLaneMask(load->indices)) {
-      return MakeMaskedBufferLoad(load->buffer, load->indices, mask.value(), load->span);
+      ffi::Array<Expr> args{load->buffer.var()};
+      for (const PrimExpr& index : load->indices) args.push_back(index);
+      args.push_back(mask.value());
+      return Call(load->ty, builtin::masked_load(), args, {}, {}, load->span);
     }
     return load;
   }
 
   Stmt TryPredicateBufferAccess(BufferStore store) {
     if (auto mask = GetLaneMask(store->indices)) {
-      return MakeMaskedBufferStore(store->buffer, store->value, store->indices, mask.value(),
-                                   store->span);
+      ffi::Array<Expr> args{store->buffer.var(), store->value};
+      for (const PrimExpr& index : store->indices) args.push_back(index);
+      args.push_back(mask.value());
+      return Evaluate(Call(PrimType::Void(), builtin::masked_store(), args, {}, {}, store->span),
+                      store->span);
     }
     return store;
   }

--- a/src/tirx/transform/vectorize_loop.cc
+++ b/src/tirx/transform/vectorize_loop.cc
@@ -216,6 +216,27 @@ class TryPredicateBufferAccesses : public StmtExprMutator {
     return TryPredicateBufferAccess(store);
   }
 
+  Expr VisitExpr_(const CallNode* op) final {
+    Call call = StmtExprMutator::VisitExpr_(op).as_or_throw<Call>();
+    if (!call->op.same_as(builtin::masked_load()) && !call->op.same_as(builtin::masked_store())) {
+      return call;
+    }
+
+    bool is_load = call->op.same_as(builtin::masked_load());
+    ffi::Array<PrimExpr> indices;
+    for (size_t i = is_load ? 1 : 2; i + 1 < call->args.size(); ++i) {
+      indices.push_back(call->args[i].as_or_throw<PrimExpr>());
+    }
+    if (auto lane_mask = GetLaneMask(indices)) {
+      PrimExpr predicate = call->args.back().as_or_throw<PrimExpr>();
+      predicate = allow_offset_predication_ ? predicate & lane_mask.value() : lane_mask.value();
+      ffi::Array<Expr> args = call->args;
+      args.Set(args.size() - 1, predicate);
+      return Call(call->ty, call->op, args, call->attrs, call->ty_args, call->span);
+    }
+    return call;
+  }
+
   ffi::Optional<PrimExpr> GetLaneMask(const ffi::Array<PrimExpr>& indices) {
     num_accesses_analyzed_ += 1;
 

--- a/tests/python/codegen/test_target_codegen.py
+++ b/tests/python/codegen/test_target_codegen.py
@@ -30,7 +30,16 @@ def test_buffer_store_predicate_not_supported():
     @T.prim_func(s_tir=True)
     def func(b: T.handle):
         B = T.match_buffer(b, (8,), "float32")
-        B.vstore([T.Ramp(0, 2, 4)], T.Broadcast(1.0, 4), predicate=T.Broadcast(T.bool(True), 4))
+        T.evaluate(
+            T.call_intrin(
+                "void",
+                "tirx.masked_store",
+                B,
+                T.Broadcast(1.0, 4),
+                T.Ramp(0, 2, 4),
+                T.Broadcast(T.bool(True), 4),
+            )
+        )
 
     err_msg = "Predicated buffer store is not supported."
     with pytest.raises(RuntimeError, match=err_msg):
@@ -58,8 +67,15 @@ def test_buffer_store_predicate_not_supported_gpu(target):
         B = T.match_buffer(b, (6,), "float32")
         T.func_attr({"global_symbol": "main"})
         for i_0 in T.thread_binding(3, thread="threadIdx.x"):
-            B.vstore(
-                [T.Ramp(i_0, 1, 4)], T.Broadcast(1.0, 4), predicate=T.Broadcast(T.bool(True), 4)
+            T.evaluate(
+                T.call_intrin(
+                    "void",
+                    "tirx.masked_store",
+                    B,
+                    T.Broadcast(1.0, 4),
+                    T.Ramp(i_0, 1, 4),
+                    T.Broadcast(T.bool(True), 4),
+                )
             )
 
     err_msg = "Predicated buffer store is not supported."
@@ -78,7 +94,13 @@ def test_buffer_load_predicate_not_supported():
         for i_0 in range(4):
             B.vstore(
                 [T.Ramp(0, 2, 4)],
-                A.vload([T.Ramp(i_0, 1, 4)], predicate=T.Broadcast(T.bool(True), 4)),
+                T.call_intrin(
+                    "float32x4",
+                    "tirx.masked_load",
+                    A,
+                    T.Ramp(i_0, 1, 4),
+                    T.Broadcast(T.bool(True), 4),
+                ),
             )
 
     err_msg = "Predicated buffer load is not supported."
@@ -108,7 +130,13 @@ def test_buffer_load_predicate_not_supported_gpu(target):
         for i_0 in T.thread_binding(3, thread="threadIdx.x"):
             B.vstore(
                 [T.Ramp(0, 2, 4)],
-                A.vload([T.Ramp(i_0, 1, 4)], predicate=T.Broadcast(T.bool(True), 4)),
+                T.call_intrin(
+                    "float32x4",
+                    "tirx.masked_load",
+                    A,
+                    T.Ramp(i_0, 1, 4),
+                    T.Broadcast(T.bool(True), 4),
+                ),
             )
 
     err_msg = "Predicated buffer load is not supported."

--- a/tests/python/codegen/test_target_codegen_llvm.py
+++ b/tests/python/codegen/test_target_codegen_llvm.py
@@ -1255,7 +1255,13 @@ def test_invalid_volatile_masked_buffer_load():
         def main(b: T.handle):
             B = T.match_buffer(b, [4])
             A = T.alloc_buffer((4,), annotations={"tirx.volatile": True})
-            B[0:4] = A.vload([T.Ramp(0, 1, 4)], predicate=T.Broadcast(T.bool(True), 4))
+            B[0:4] = T.call_intrin(
+                "float32x4",
+                "tirx.masked_load",
+                A,
+                T.Ramp(0, 1, 4),
+                T.Broadcast(T.bool(True), 4),
+            )
 
     err_msg = "The masked load intrinsic does not support declaring load as volatile."
     with pytest.raises(RuntimeError, match=err_msg):
@@ -1271,7 +1277,13 @@ def test_invalid_volatile_masked_decl_buffer_load():
             B = T.match_buffer(b, [4])
             A = T.alloc_buffer((4,), annotations={"tirx.volatile": True})
             A_alias = T.decl_buffer((4,), data=A.data)
-            B[0:4] = A_alias.vload([T.Ramp(0, 1, 4)], predicate=T.Broadcast(T.bool(True), 4))
+            B[0:4] = T.call_intrin(
+                "float32x4",
+                "tirx.masked_load",
+                A_alias,
+                T.Ramp(0, 1, 4),
+                T.Broadcast(T.bool(True), 4),
+            )
 
     err_msg = "The masked load intrinsic does not support declaring load as volatile."
     with pytest.raises(RuntimeError, match=err_msg):
@@ -1285,10 +1297,15 @@ def test_invalid_volatile_masked_buffer_store():
         @T.prim_func(s_tir=True)
         def main():
             A = T.alloc_buffer((4,), annotations={"tirx.volatile": True})
-            A.vstore(
-                [T.Ramp(0, 1, 4)],
-                T.Broadcast(0.0, 4),
-                predicate=T.Broadcast(T.bool(True), 4),
+            T.evaluate(
+                T.call_intrin(
+                    "void",
+                    "tirx.masked_store",
+                    A,
+                    T.Broadcast(0.0, 4),
+                    T.Ramp(0, 1, 4),
+                    T.Broadcast(T.bool(True), 4),
+                )
             )
 
     err_msg = "The masked store intrinsic does not support declaring store as volatile."

--- a/tests/python/s_tir/analysis/test_sblock_access_region.py
+++ b/tests/python/s_tir/analysis/test_sblock_access_region.py
@@ -46,6 +46,16 @@ def func() -> None:
 
 
 @T.prim_func(s_tir=True)
+def masked_access_func() -> None:
+    A = T.sblock_alloc_buffer((16,), "float32")
+    B = T.sblock_alloc_buffer((16,), "float32")
+    with T.sblock():
+        mask = T.meta_var(T.Broadcast(T.bool(True), 4))
+        value = T.meta_var(T.masked_load("float32x4", A, T.Ramp(4, 1, 4), mask))
+        T.masked_store(B, value, T.Ramp(8, 1, 4), mask)
+
+
+@T.prim_func(s_tir=True)
 def match_buffer_func() -> None:
     with T.sblock("root"):
         A = T.sblock_alloc_buffer((128, 128), "float32")
@@ -230,6 +240,18 @@ def test_block_access_region_detector():
     tvm.ir.assert_structural_equal(
         [tvm.tirx.BufferRegion(D, [Range(0, 128), Range(0, 128)])], ret[2]
     )
+
+
+def test_masked_access_is_not_opaque():
+    root = masked_access_func.body.block
+    block = root.body.block
+    A, B = root.alloc_buffers
+    reads, writes, opaque = s_tir.analysis.get_sblock_access_region(block, {A: A, B: B})
+    tvm.ir.assert_structural_equal(reads, [tvm.tirx.BufferRegion(A, [Range.from_min_extent(4, 4)])])
+    tvm.ir.assert_structural_equal(
+        writes, [tvm.tirx.BufferRegion(B, [Range.from_min_extent(8, 4)])]
+    )
+    tvm.ir.assert_structural_equal(opaque, [])
 
 
 def test_opaque_block():

--- a/tests/python/s_tir/transform/test_s_tir_transform_inject_virtual_thread.py
+++ b/tests/python/s_tir/transform/test_s_tir_transform_inject_virtual_thread.py
@@ -213,5 +213,40 @@ def test_vthread_vectorized():
     assert allocate_node.buffer.ty.dtype == "int32x4"
 
 
+def test_vthread_rewrites_masked_accesses():
+    @T.prim_func(s_tir=True)
+    def before_func():
+        vthread = T.env_thread("vthread")
+        T.launch_thread(vthread, 2)
+        B = T.alloc_buffer((4,), "float32", scope="shared")
+        mask = T.meta_var(T.Broadcast(T.bool(True), 4))
+        loaded = T.meta_var(T.masked_load("float32x4", B, T.Ramp(0, 1, 4), mask))
+        value = T.meta_var(loaded + T.Broadcast(T.Cast("float32", vthread), 4))
+        T.masked_store(B, value, T.Ramp(0, 1, 4), mask)
+
+    after = tvm.s_tir.transform.InjectVirtualThread()(
+        tvm.IRModule.from_expr(before_func.with_attr("global_symbol", "main"))
+    )["main"]
+    masked_calls = []
+
+    def visitor(node):
+        if isinstance(node, tvm.ir.Call) and node.op.name in {
+            "tirx.masked_load",
+            "tirx.masked_store",
+        }:
+            masked_calls.append(node)
+
+    tvm.tirx.stmt_functor.post_order_visit(after.body, visitor)
+    assert len(masked_calls) == 4
+    assert all(list(call.args[0].ty.shape) == [8] for call in masked_calls)
+    analyzer = tvm.arith.Analyzer()
+    assert sorted(int(analyzer.simplify(call.args[-2].base)) for call in masked_calls) == [
+        0,
+        0,
+        4,
+        4,
+    ]
+
+
 if __name__ == "__main__":
     tvm.testing.main()

--- a/tests/python/s_tir/transform/test_s_tir_transform_lower_match_buffer.py
+++ b/tests/python/s_tir/transform/test_s_tir_transform_lower_match_buffer.py
@@ -587,5 +587,21 @@ def test_scalar_match_buffer_type_coercion():
     _check(scalar_match_buffer_type_coercion, transformed_scalar_match_buffer_type_coercion)
 
 
+@T.prim_func(s_tir=True)
+def masked_match_buffer(a: T.handle) -> None:
+    A = T.match_buffer(a, (8,), "float32")
+    with T.sblock():
+        T.reads(A[2:6])
+        sub_A = T.match_buffer(A[2:6], (4,), offset_factor=1)
+        mask = T.meta_var(T.Broadcast(T.bool(True), 4))
+        T.evaluate(T.masked_load("float32x4", sub_A, T.Ramp(0, 1, 4), mask))
+
+
+def test_masked_match_buffer_fails_explicitly():
+    mod = tvm.IRModule.from_expr(masked_match_buffer)
+    with pytest.raises(RuntimeError, match="Predicated buffer access is not currently supported"):
+        tvm.s_tir.transform.LowerMatchBuffer()(mod)
+
+
 if __name__ == "__main__":
     tvm.testing.main()

--- a/tests/python/tirx-base/test_tir_nodes.py
+++ b/tests/python/tirx-base/test_tir_nodes.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# ruff: noqa: F811, F841
+# ruff: noqa: F841
 import numpy as np
 import pytest
 
@@ -425,69 +425,6 @@ def test_buffer_store_scalable_vec():
 
     assert isinstance(store, tvm.tirx.BufferStore)
     assert store.value.ty.dtype == "int32xvscalex4"
-
-
-def test_buffer_store_predicate_invalid_scalability():
-    b = tvm.tirx.decl_buffer((24,), "int32")
-    value = tvm.tirx.expr.Broadcast(1, 4 * tvm.tirx.vscale())
-    index = tvm.tirx.expr.Ramp(0, 1, 4 * tvm.tirx.vscale())
-    predicate = tvm.tirx.expr.Broadcast(tvm.tirx.IntImm("int1", 1), 4)
-
-    err_msg = "Mask dtype and stored value dtype must both be scalable or both fixed-length."
-    with pytest.raises(RuntimeError, match=err_msg):
-        b.vstore([index], value, predicate)
-
-
-def test_buffer_store_predicate_invalid_lanes():
-    b = tvm.tirx.decl_buffer((24,), "int32")
-    value = tvm.tirx.expr.Broadcast(1, 4 * tvm.tirx.vscale())
-    index = tvm.tirx.expr.Ramp(0, 1, 4 * tvm.tirx.vscale())
-    predicate = tvm.tirx.expr.Broadcast(tvm.tirx.IntImm("int1", 1), 8 * tvm.tirx.vscale())
-
-    err_msg = "Mask lane count must match the stored value lane count."
-    with pytest.raises(RuntimeError, match=err_msg):
-        b.vstore([index], value, predicate)
-
-
-def test_buffer_store_predicate_elements_invalid_type():
-    b = tvm.tirx.decl_buffer((24,), "int32")
-    value = tvm.tirx.expr.Broadcast(1, 4 * tvm.tirx.vscale())
-    index = tvm.tirx.expr.Ramp(0, 1, 4 * tvm.tirx.vscale())
-    predicate = tvm.tirx.expr.Broadcast(1, 4 * tvm.tirx.vscale())
-
-    err_msg = "Mask elements must be boolean values, but got T.int32."
-    with pytest.raises(RuntimeError, match=err_msg):
-        b.vstore([index], value, predicate)
-
-
-def test_buffer_load_predicate_elements_invalid_type():
-    b = tvm.tirx.decl_buffer((24,), "int32")
-    index = tvm.tirx.expr.Ramp(0, 1, 4 * tvm.tirx.vscale())
-    predicate = tvm.tirx.expr.Broadcast(1, 4 * tvm.tirx.vscale())
-
-    err_msg = "Mask elements must be boolean values, but got T.int32."
-    with pytest.raises(RuntimeError, match=err_msg):
-        b.vload([index], predicate=predicate)
-
-
-def test_buffer_store_predicate_invalid_scalability():
-    b = tvm.tirx.decl_buffer((24,), "int32")
-    index = tvm.tirx.expr.Ramp(0, 1, 4 * tvm.tirx.vscale())
-    predicate = tvm.tirx.expr.Broadcast(tvm.tirx.IntImm("int1", 1), 4)
-
-    err_msg = "Mask dtype and accessed value dtype must both be scalable or both fixed-length."
-    with pytest.raises(RuntimeError, match=err_msg):
-        b.vload([index], predicate=predicate)
-
-
-def test_buffer_store_predicate_invalid_lanes():
-    b = tvm.tirx.decl_buffer((24,), "int32")
-    index = tvm.tirx.expr.Ramp(0, 1, 4 * tvm.tirx.vscale())
-    predicate = tvm.tirx.expr.Broadcast(tvm.tirx.IntImm("int1", 1), 8 * tvm.tirx.vscale())
-
-    err_msg = "Mask lane count must match the accessed value lane count."
-    with pytest.raises(RuntimeError, match=err_msg):
-        b.vload([index], predicate=predicate)
 
 
 def test_scalable_vec_cast():

--- a/tests/python/tirx-base/test_tir_nodes.py
+++ b/tests/python/tirx-base/test_tir_nodes.py
@@ -433,9 +433,9 @@ def test_buffer_store_predicate_invalid_scalability():
     index = tvm.tirx.expr.Ramp(0, 1, 4 * tvm.tirx.vscale())
     predicate = tvm.tirx.expr.Broadcast(tvm.tirx.IntImm("int1", 1), 4)
 
-    err_msg = "Predicate mask dtype and value dtype must both be scalable."
+    err_msg = "Mask dtype and stored value dtype must both be scalable or both fixed-length."
     with pytest.raises(RuntimeError, match=err_msg):
-        tvm.tirx.BufferStore(b, value, [index], predicate)
+        b.vstore([index], value, predicate)
 
 
 def test_buffer_store_predicate_invalid_lanes():
@@ -444,12 +444,9 @@ def test_buffer_store_predicate_invalid_lanes():
     index = tvm.tirx.expr.Ramp(0, 1, 4 * tvm.tirx.vscale())
     predicate = tvm.tirx.expr.Broadcast(tvm.tirx.IntImm("int1", 1), 8 * tvm.tirx.vscale())
 
-    err_msg = (
-        "Got a predicate mask with 8 lanes, but trying to store a "
-        "value with 4 lanes. The number of lanes must match."
-    )
+    err_msg = "Mask lane count must match the stored value lane count."
     with pytest.raises(RuntimeError, match=err_msg):
-        tvm.tirx.BufferStore(b, value, [index], predicate)
+        b.vstore([index], value, predicate)
 
 
 def test_buffer_store_predicate_elements_invalid_type():
@@ -458,9 +455,9 @@ def test_buffer_store_predicate_elements_invalid_type():
     index = tvm.tirx.expr.Ramp(0, 1, 4 * tvm.tirx.vscale())
     predicate = tvm.tirx.expr.Broadcast(1, 4 * tvm.tirx.vscale())
 
-    err_msg = "Predicate mask elements must be boolean values, but got int32."
+    err_msg = "Mask elements must be boolean values, but got T.int32."
     with pytest.raises(RuntimeError, match=err_msg):
-        tvm.tirx.BufferStore(b, value, [index], predicate)
+        b.vstore([index], value, predicate)
 
 
 def test_buffer_load_predicate_elements_invalid_type():
@@ -468,9 +465,9 @@ def test_buffer_load_predicate_elements_invalid_type():
     index = tvm.tirx.expr.Ramp(0, 1, 4 * tvm.tirx.vscale())
     predicate = tvm.tirx.expr.Broadcast(1, 4 * tvm.tirx.vscale())
 
-    err_msg = "Predicate mask elements must be boolean values, but got int32."
+    err_msg = "Mask elements must be boolean values, but got T.int32."
     with pytest.raises(RuntimeError, match=err_msg):
-        tvm.tirx.BufferLoad(b, [index], predicate)
+        b.vload([index], predicate=predicate)
 
 
 def test_buffer_store_predicate_invalid_scalability():
@@ -478,9 +475,9 @@ def test_buffer_store_predicate_invalid_scalability():
     index = tvm.tirx.expr.Ramp(0, 1, 4 * tvm.tirx.vscale())
     predicate = tvm.tirx.expr.Broadcast(tvm.tirx.IntImm("int1", 1), 4)
 
-    err_msg = "Predicate mask dtype and load indices must both be scalable."
+    err_msg = "Mask dtype and accessed value dtype must both be scalable or both fixed-length."
     with pytest.raises(RuntimeError, match=err_msg):
-        tvm.tirx.BufferLoad(b, [index], predicate)
+        b.vload([index], predicate=predicate)
 
 
 def test_buffer_store_predicate_invalid_lanes():
@@ -488,12 +485,9 @@ def test_buffer_store_predicate_invalid_lanes():
     index = tvm.tirx.expr.Ramp(0, 1, 4 * tvm.tirx.vscale())
     predicate = tvm.tirx.expr.Broadcast(tvm.tirx.IntImm("int1", 1), 8 * tvm.tirx.vscale())
 
-    err_msg = (
-        "Got a predicate mask with 8 lanes, but trying to load a "
-        "vector with 4 lanes. The number of lanes must match."
-    )
+    err_msg = "Mask lane count must match the accessed value lane count."
     with pytest.raises(RuntimeError, match=err_msg):
-        tvm.tirx.BufferLoad(b, [index], predicate)
+        b.vload([index], predicate=predicate)
 
 
 def test_scalable_vec_cast():

--- a/tests/python/tirx-transform/test_tir_transform_bf16_legalize.py
+++ b/tests/python/tirx-transform/test_tir_transform_bf16_legalize.py
@@ -106,6 +106,76 @@ def test_bf16_simple_store_will_legalize():
     tvm.ir.assert_structural_equal(after_storage, BindTarget(target)(after_storage_legalize()))
 
 
+def test_bf16_masked_load_store_will_legalize():
+    def get_before():
+        @tvm.script.ir_module
+        class Before:
+            @T.prim_func(s_tir=True)
+            def main(Aptr: T.handle("bfloat16"), Cptr: T.handle("bfloat16")):
+                T.func_attr({"global_symbol": "main"})
+                A = T.decl_buffer((16,), "bfloat16", data=Aptr)
+                B = T.decl_buffer((16,), "bfloat16")
+                C = T.decl_buffer((16,), "bfloat16", data=Cptr)
+                mask = T.Broadcast(T.bool(True), 4)
+                B.vstore(
+                    [T.Ramp(0, 1, 4)],
+                    A.vload([T.Ramp(0, 1, 4)], predicate=mask),
+                    predicate=mask,
+                )
+                C.vstore(
+                    [T.Ramp(0, 1, 4)],
+                    B.vload([T.Ramp(0, 1, 4)], predicate=mask),
+                    predicate=mask,
+                )
+
+        return Before
+
+    target = Target("nvidia/geforce-rtx-2080-ti")
+    before = BindTarget(target)(get_before())
+    after_compute = tvm.tirx.transform.BF16ComputeLegalize()(before)
+    after_storage = tvm.tirx.transform.BF16StorageLegalize()(after_compute)
+
+    def collect(mod):
+        nodes = []
+        tvm.tirx.stmt_functor.post_order_visit(mod["main"].body, nodes.append)
+        buffers = {
+            node.buffer.name: str(node.buffer.dtype)
+            for node in nodes
+            if isinstance(node, tvm.tirx.DeclBuffer | tvm.tirx.AllocBuffer)
+        }
+        masked_loads = [
+            node
+            for node in nodes
+            if isinstance(node, tvm.ir.Call) and node.op.name == "tirx.masked_load"
+        ]
+        masked_stores = [
+            node
+            for node in nodes
+            if isinstance(node, tvm.ir.Call) and node.op.name == "tirx.masked_store"
+        ]
+        return buffers, masked_loads, masked_stores
+
+    compute_buffers, compute_loads, compute_stores = collect(after_compute)
+    assert compute_buffers == {"A": "bfloat16", "B": "float32", "C": "bfloat16", "mask": "boolx4"}
+    assert sorted(str(load.ty) for load in compute_loads) == ["bfloat16x4", "float32x4"]
+    assert sorted(str(store.args[1].ty) for store in compute_stores) == [
+        "bfloat16x4",
+        "float32x4",
+    ]
+
+    storage_buffers, storage_loads, storage_stores = collect(after_storage)
+    assert storage_buffers == {"A": "uint16", "B": "float32", "C": "uint16", "mask": "boolx4"}
+    assert sorted(str(load.ty) for load in storage_loads) == [
+        "float32x4",
+        "float32x4",
+        "uint16x4",
+    ]
+    assert sorted(str(store.args[1].ty) for store in storage_stores) == [
+        "float32x4",
+        "uint16x4",
+    ]
+
+
 def test_bf16_storage_compute_scope_will_legalize():
     def get_before():
         @tvm.script.ir_module

--- a/tests/python/tirx-transform/test_tir_transform_bf16_legalize.py
+++ b/tests/python/tirx-transform/test_tir_transform_bf16_legalize.py
@@ -117,15 +117,25 @@ def test_bf16_masked_load_store_will_legalize():
                 B = T.decl_buffer((16,), "bfloat16")
                 C = T.decl_buffer((16,), "bfloat16", data=Cptr)
                 mask = T.Broadcast(T.bool(True), 4)
-                B.vstore(
-                    [T.Ramp(0, 1, 4)],
-                    A.vload([T.Ramp(0, 1, 4)], predicate=mask),
-                    predicate=mask,
+                T.evaluate(
+                    T.call_intrin(
+                        "void",
+                        "tirx.masked_store",
+                        B,
+                        T.call_intrin("bfloat16x4", "tirx.masked_load", A, T.Ramp(0, 1, 4), mask),
+                        T.Ramp(0, 1, 4),
+                        mask,
+                    )
                 )
-                C.vstore(
-                    [T.Ramp(0, 1, 4)],
-                    B.vload([T.Ramp(0, 1, 4)], predicate=mask),
-                    predicate=mask,
+                T.evaluate(
+                    T.call_intrin(
+                        "void",
+                        "tirx.masked_store",
+                        C,
+                        T.call_intrin("bfloat16x4", "tirx.masked_load", B, T.Ramp(0, 1, 4), mask),
+                        T.Ramp(0, 1, 4),
+                        mask,
+                    )
                 )
 
         return Before

--- a/tests/python/tirx-transform/test_tir_transform_vectorize.py
+++ b/tests/python/tirx-transform/test_tir_transform_vectorize.py
@@ -641,6 +641,37 @@ def test_vectorize_and_predicate_multiple_access_statements():
     tvm.ir.assert_structural_equal(after, expected)
 
 
+def test_vectorize_nested_predicates_preserve_both_masks():
+    rvv_target = tvm.target.Target(
+        {"kind": "llvm", "mtriple": "riscv64-unknown-linux-gnu", "mattr": ["+v"]}
+    )
+
+    @T.prim_func(s_tir=True)
+    def before(A: T.Buffer((16,), "float32"), B: T.Buffer((16,), "float32")):
+        for i_0 in T.serial(4):
+            for i_1 in T.vectorized(4):
+                if i_0 * 4 + i_1 < 15:
+                    if i_0 * 4 + i_1 < 14:
+                        A[i_0 * 4 + i_1] = T.float32(1)
+                    B[i_0 * 4 + i_1] = T.float32(2)
+
+    with tvm.target.Target(rvv_target):
+        after = tvm.tirx.transform.VectorizeLoop()(tvm.IRModule.from_expr(before))["before"]
+
+    predicates = []
+
+    def collect_predicates(node):
+        if isinstance(node, tvm.ir.Call) and node.op.name == "tirx.masked_store":
+            predicates.append(node.args[-1])
+
+    tvm.tirx.stmt_functor.post_order_visit(after.body, collect_predicates)
+    assert len(predicates) == 2
+    assert any(
+        isinstance(predicate, tvm.ir.Call) and predicate.op.name == "tirx.bitwise_and"
+        for predicate in predicates
+    )
+
+
 def test_vectorize_and_predicate_invalid_conditions():
     @T.prim_func(s_tir=True)
     def before(a: T.handle, b: T.handle):

--- a/tests/python/tirx-transform/test_tir_transform_vectorize.py
+++ b/tests/python/tirx-transform/test_tir_transform_vectorize.py
@@ -193,10 +193,15 @@ def test_vectorize_if_scalable_extent():
                     T.float32(1), extent
                 )
             else:
-                A.vstore(
-                    [T.Ramp(0, 1, T.vscale() * 4)],
-                    T.Broadcast(T.float32(2), T.vscale() * 4),
-                    predicate=T.get_active_lane_mask("uint1xvscalex4", 0, n),
+                T.evaluate(
+                    T.call_intrin(
+                        "void",
+                        "tirx.masked_store",
+                        A,
+                        T.Broadcast(T.float32(2), T.vscale() * 4),
+                        T.Ramp(0, 1, T.vscale() * 4),
+                        T.get_active_lane_mask("uint1xvscalex4", 0, n),
+                    )
                 )
 
     with tvm.target.Target(target):
@@ -537,16 +542,24 @@ def test_vectorize_and_predicate_all_buffer_loads_stores():
         T.func_attr({"global_symbol": "main", "tirx.noalias": True})
         for i_0 in range(4):
             load_a = T.meta_var(
-                A.vload(
-                    [T.Ramp(i_0 * 4, 1, 4)],
-                    predicate=T.get_active_lane_mask("uint1x4", i_0 * 4, 14),
+                T.call_intrin(
+                    "float32x4",
+                    "tirx.masked_load",
+                    A,
+                    T.Ramp(i_0 * 4, 1, 4),
+                    T.get_active_lane_mask("uint1x4", i_0 * 4, 14),
                 )
             )
             add_1 = T.meta_var(load_a + T.Broadcast(T.float32(1), 4))
-            B.vstore(
-                [T.Ramp(i_0 * 4, 1, 4)],
-                add_1,
-                predicate=T.get_active_lane_mask("uint1x4", i_0 * 4, 14),
+            T.evaluate(
+                T.call_intrin(
+                    "void",
+                    "tirx.masked_store",
+                    B,
+                    add_1,
+                    T.Ramp(i_0 * 4, 1, 4),
+                    T.get_active_lane_mask("uint1x4", i_0 * 4, 14),
+                )
             )
 
     mod = tvm.IRModule.from_expr(before)
@@ -601,15 +614,25 @@ def test_vectorize_and_predicate_multiple_access_statements():
         B = T.match_buffer(b, (16,), "float32")
         T.func_attr({"global_symbol": "main", "tirx.noalias": True})
         for i_0 in range(4):
-            A.vstore(
-                [T.Ramp(i_0 * 4, 1, 4)],
-                T.Broadcast(T.float32(2), 4),
-                predicate=T.get_active_lane_mask("uint1x4", i_0 * 4, 14),
+            T.evaluate(
+                T.call_intrin(
+                    "void",
+                    "tirx.masked_store",
+                    A,
+                    T.Broadcast(T.float32(2), 4),
+                    T.Ramp(i_0 * 4, 1, 4),
+                    T.get_active_lane_mask("uint1x4", i_0 * 4, 14),
+                )
             )
-            B.vstore(
-                [T.Ramp(i_0 * 4, 1, 4)],
-                T.Broadcast(T.float32(1), 4),
-                predicate=T.get_active_lane_mask("uint1x4", i_0 * 4, 14),
+            T.evaluate(
+                T.call_intrin(
+                    "void",
+                    "tirx.masked_store",
+                    B,
+                    T.Broadcast(T.float32(1), 4),
+                    T.Ramp(i_0 * 4, 1, 4),
+                    T.get_active_lane_mask("uint1x4", i_0 * 4, 14),
+                )
             )
 
     before_mod = tvm.IRModule.from_expr(before)
@@ -703,16 +726,24 @@ def test_vectorize_and_predicate_buffer_load_stores_with_sve_func_attr_target():
         T.func_attr({"global_symbol": "main", "tirx.noalias": True, "target": sve_target})
         for i_0 in range(4):
             load_a = T.meta_var(
-                A.vload(
-                    [T.Ramp(i_0 * 4, 1, 4)],
-                    predicate=T.get_active_lane_mask("uint1x4", i_0 * 4, 14),
+                T.call_intrin(
+                    "float32x4",
+                    "tirx.masked_load",
+                    A,
+                    T.Ramp(i_0 * 4, 1, 4),
+                    T.get_active_lane_mask("uint1x4", i_0 * 4, 14),
                 )
             )
             add_1 = T.meta_var(load_a + T.Broadcast(T.float32(1), 4))
-            B.vstore(
-                [T.Ramp(i_0 * 4, 1, 4)],
-                add_1,
-                predicate=T.get_active_lane_mask("uint1x4", i_0 * 4, 14),
+            T.evaluate(
+                T.call_intrin(
+                    "void",
+                    "tirx.masked_store",
+                    B,
+                    add_1,
+                    T.Ramp(i_0 * 4, 1, 4),
+                    T.get_active_lane_mask("uint1x4", i_0 * 4, 14),
+                )
             )
 
     mod = tvm.IRModule.from_expr(before)
@@ -740,16 +771,24 @@ def test_vectorize_and_predicate_buffer_load_stores_with_sve_attr_scope_target()
         with T.attr(sve_target, "target", 0):
             for i_0 in range(4):
                 load_a = T.meta_var(
-                    A.vload(
-                        [T.Ramp(i_0 * 4, 1, 4)],
-                        predicate=T.get_active_lane_mask("uint1x4", i_0 * 4, 14),
+                    T.call_intrin(
+                        "float32x4",
+                        "tirx.masked_load",
+                        A,
+                        T.Ramp(i_0 * 4, 1, 4),
+                        T.get_active_lane_mask("uint1x4", i_0 * 4, 14),
                     )
                 )
                 add_1 = T.meta_var(load_a + T.Broadcast(T.float32(1), 4))
-                B.vstore(
-                    [T.Ramp(i_0 * 4, 1, 4)],
-                    add_1,
-                    predicate=T.get_active_lane_mask("uint1x4", i_0 * 4, 14),
+                T.evaluate(
+                    T.call_intrin(
+                        "void",
+                        "tirx.masked_store",
+                        B,
+                        add_1,
+                        T.Ramp(i_0 * 4, 1, 4),
+                        T.get_active_lane_mask("uint1x4", i_0 * 4, 14),
+                    )
                 )
 
     mod = tvm.IRModule.from_expr(before)

--- a/tests/python/tirx/transform/test_stmt_functor.py
+++ b/tests/python/tirx/transform/test_stmt_functor.py
@@ -1217,7 +1217,7 @@ def test_op_call_pointer_config_visited_and_mutated():
         def visit_buffer_load_(self, op):
             new_op = super().visit_buffer_load_(op)
             if op.buffer.same_as(mbar_buffer):
-                return tir.BufferLoad(replacement, new_op.indices, new_op.predicate)
+                return tir.BufferLoad(replacement, new_op.indices)
             return new_op
 
     updated = ReplaceMbarLoad().visit_stmt(op_call)

--- a/tests/python/tvmscript/test_tvmscript_ir_builder_tir.py
+++ b/tests/python/tvmscript/test_tvmscript_ir_builder_tir.py
@@ -446,20 +446,6 @@ def test_ir_builder_tir_buffer_store_scalable_vec():
     assert_structural_equal(ir_actual, ir_expected, map_free_vars=True)
 
 
-def test_ir_builder_tir_buffer_store_predicate():
-    buffer_a = T.Buffer((30,), "float32")
-    value = T.broadcast(0.11, T.vscale() * 4)
-    index = T.ramp(0, 1, T.vscale() * 4)
-    predicate = T.broadcast(T.bool(True), T.vscale() * 4)
-
-    with IRBuilder() as ib:
-        T.buffer_store(buffer_a, value, [index], predicate)
-
-    ir_actual = ib.get()
-    ir_expected = buffer_a.vstore([index], value, predicate)
-    assert_structural_equal(ir_actual, ir_expected, map_free_vars=True)
-
-
 def test_ir_builder_tir_evaluate():
     with IRBuilder() as ib:
         T.evaluate(0)

--- a/tests/python/tvmscript/test_tvmscript_ir_builder_tir.py
+++ b/tests/python/tvmscript/test_tvmscript_ir_builder_tir.py
@@ -456,7 +456,7 @@ def test_ir_builder_tir_buffer_store_predicate():
         T.buffer_store(buffer_a, value, [index], predicate)
 
     ir_actual = ib.get()
-    ir_expected = tirx.BufferStore(buffer_a, value, [index], predicate)
+    ir_expected = buffer_a.vstore([index], value, predicate)
     assert_structural_equal(ir_actual, ir_expected, map_free_vars=True)
 
 

--- a/tests/python/tvmscript/test_tvmscript_printer_tir.py
+++ b/tests/python/tvmscript/test_tvmscript_printer_tir.py
@@ -1100,6 +1100,20 @@ def func(A: T.Buffer((128, 128), "float32"), B: T.Buffer((256, 256), "float32"))
     _assert_print(main, expected_output)
 
 
+def test_masked_load_prevents_scalar_allocation_init_fusion():
+    from tvm.script import tirx as T
+
+    @T.prim_func(s_tir=True)
+    def main():
+        A = T.alloc_buffer((1,), "float32x4")
+        A[0] = T.masked_load("float32x4", A, 0, T.Broadcast(T.bool(True), 4))
+
+    source = main.script()
+    assert "A = T.alloc_buffer" in source
+    assert "A[0] = T.masked_load" in source
+    tvm.ir.assert_structural_equal(tvm.script.from_source(source), main)
+
+
 def test_vload_with_explicit_scalable_data_type():
     from tvm.script import tirx as T
 

--- a/tests/python/tvmscript/test_tvmscript_printer_tir.py
+++ b/tests/python/tvmscript/test_tvmscript_printer_tir.py
@@ -993,8 +993,27 @@ def test_predicated_load_store():
         A = T.match_buffer(a, (128, 128), "float32")
         B = T.match_buffer(b, (256, 256), "float32")
         T.func_attr({"global_symbol": "func"})
-        a_load = T.meta_var(A.vload([0, T.Ramp(0, 4, 4)], predicate=T.Broadcast(T.bool(False), 4)))
-        A.vstore([0, T.Ramp(0, 2, 4)], a_load, predicate=T.Broadcast(T.bool(False), 4))
+        a_load = T.meta_var(
+            T.call_intrin(
+                "float32x4",
+                "tirx.masked_load",
+                A,
+                0,
+                T.Ramp(0, 4, 4),
+                T.Broadcast(T.bool(False), 4),
+            )
+        )
+        T.evaluate(
+            T.call_intrin(
+                "void",
+                "tirx.masked_store",
+                A,
+                a_load,
+                0,
+                T.Ramp(0, 2, 4),
+                T.Broadcast(T.bool(False), 4),
+            )
+        )
 
     expected_output = """
 # from tvm.script import tirx as T
@@ -1002,7 +1021,7 @@ def test_predicated_load_store():
 
 @T.prim_func(s_tir=True)
 def func(A: T.Buffer((128, 128), "float32"), B: T.Buffer((256, 256), "float32")):
-    A.vstore([0, T.Ramp(0, 2, 4)], A.vload([0, T.Ramp(0, 4, 4)], predicate=T.Broadcast(T.bool(False), 4)), predicate=T.Broadcast(T.bool(False), 4))
+    T.masked_store(A, T.masked_load("float32x4", A, 0, T.Ramp(0, 4, 4), T.Broadcast(T.bool(False), 4)), 0, T.Ramp(0, 2, 4), T.Broadcast(T.bool(False), 4))
     """
     _assert_print(main, expected_output)
 
@@ -1014,14 +1033,24 @@ def test_predicated_buffer_load_store():
         a: tirx.decl_buffer(shape=[128, 128], dtype="float32", name="A"),
         b: tirx.decl_buffer(shape=[256, 256], dtype="float32", name="B"),
     }
-    buffer_load = buffers[b].vload(
-        begin=[0, tirx.Ramp(0, 4, 4)],
-        predicate=tirx.Broadcast(tirx.IntImm("bool", 0), 4),
+    buffer_load = tirx.call_intrin(
+        "float32x4",
+        "tirx.masked_load",
+        buffers[b],
+        0,
+        tirx.Ramp(0, 4, 4),
+        tirx.Broadcast(tirx.IntImm("bool", 0), 4),
     )
-    body = buffers[a].vstore(
-        begin=[0, tirx.Ramp(0, 2, 4)],
-        value=buffer_load,
-        predicate=tirx.Broadcast(tirx.IntImm("bool", 0), 4),
+    body = tirx.Evaluate(
+        tirx.call_intrin(
+            "void",
+            "tirx.masked_store",
+            buffers[a],
+            buffer_load,
+            0,
+            tirx.Ramp(0, 2, 4),
+            tirx.Broadcast(tirx.IntImm("bool", 0), 4),
+        )
     )
     func = tirx.PrimFunc(
         params=[buffers[a], buffers[b]],
@@ -1035,7 +1064,7 @@ def test_predicated_buffer_load_store():
 
 @T.prim_func(private=True, s_tir=True)
 def main(A: T.Buffer((128, 128), "float32"), B: T.Buffer((256, 256), "float32")):
-    A.vstore([0, T.Ramp(0, 2, 4)], B.vload([0, T.Ramp(0, 4, 4)], predicate=T.Broadcast(T.bool(False), 4)), predicate=T.Broadcast(T.bool(False), 4))
+    T.masked_store(A, T.masked_load("float32x4", B, 0, T.Ramp(0, 4, 4), T.Broadcast(T.bool(False), 4)), 0, T.Ramp(0, 2, 4), T.Broadcast(T.bool(False), 4))
     """
     _assert_print(func, expected_output)
 
@@ -1049,8 +1078,16 @@ def test_predicated_scalable_load_store():
         B = T.match_buffer(b, (256, 256), "float32")
         T.func_attr({"global_symbol": "func"})
         mask = T.meta_var(T.get_active_lane_mask("uint1xvscalex4", 0, 13))
-        a_load = T.meta_var(A.vload([0, T.Ramp(0, 4, T.vscale() * 4)], predicate=mask))
-        A.vstore([0, T.Ramp(0, 2, T.vscale() * 4)], a_load, predicate=mask)
+        a_load = T.meta_var(
+            T.call_intrin(
+                "float32xvscalex4", "tirx.masked_load", A, 0, T.Ramp(0, 4, T.vscale() * 4), mask
+            )
+        )
+        T.evaluate(
+            T.call_intrin(
+                "void", "tirx.masked_store", A, a_load, 0, T.Ramp(0, 2, T.vscale() * 4), mask
+            )
+        )
 
     expected_output = """
 # from tvm.script import tirx as T
@@ -1058,7 +1095,7 @@ def test_predicated_scalable_load_store():
 
 @T.prim_func(s_tir=True)
 def func(A: T.Buffer((128, 128), "float32"), B: T.Buffer((256, 256), "float32")):
-    A.vstore([0, T.Ramp(0, 2, T.vscale() * 4)], A.vload([0, T.Ramp(0, 4, T.vscale() * 4)], predicate=T.get_active_lane_mask("uint1xvscalex4", 0, 13)), predicate=T.get_active_lane_mask("uint1xvscalex4", 0, 13))
+    T.masked_store(A, T.masked_load("float32xvscalex4", A, 0, T.Ramp(0, 4, T.vscale() * 4), T.get_active_lane_mask("uint1xvscalex4", 0, 13)), 0, T.Ramp(0, 2, T.vscale() * 4), T.get_active_lane_mask("uint1xvscalex4", 0, 13))
     """
     _assert_print(main, expected_output)
 

--- a/tests/python/tvmscript/test_tvmscript_printer_tir.py
+++ b/tests/python/tvmscript/test_tvmscript_printer_tir.py
@@ -1014,15 +1014,13 @@ def test_predicated_buffer_load_store():
         a: tirx.decl_buffer(shape=[128, 128], dtype="float32", name="A"),
         b: tirx.decl_buffer(shape=[256, 256], dtype="float32", name="B"),
     }
-    buffer_load = tirx.BufferLoad(
-        buffer=buffers[b],
-        indices=[0, tirx.Ramp(0, 4, 4)],
+    buffer_load = buffers[b].vload(
+        begin=[0, tirx.Ramp(0, 4, 4)],
         predicate=tirx.Broadcast(tirx.IntImm("bool", 0), 4),
     )
-    body = tirx.BufferStore(
-        buffer=buffers[a],
+    body = buffers[a].vstore(
+        begin=[0, tirx.Ramp(0, 2, 4)],
         value=buffer_load,
-        indices=[0, tirx.Ramp(0, 2, 4)],
         predicate=tirx.Broadcast(tirx.IntImm("bool", 0), 4),
     )
     func = tirx.PrimFunc(

--- a/tests/python/tvmscript/test_tvmscript_roundtrip.py
+++ b/tests/python/tvmscript/test_tvmscript_roundtrip.py
@@ -2456,9 +2456,24 @@ def predicated_buffer_load_store():
         B = T.match_buffer(b, (8,), "float32")
         for i_0 in range(4):
             load_a = T.meta_var(
-                A.vload([T.Ramp(i_0, 1, 4)], predicate=T.Broadcast(T.bool(True), 4))
+                T.call_intrin(
+                    "float32x4",
+                    "tirx.masked_load",
+                    A,
+                    T.Ramp(i_0, 1, 4),
+                    T.Broadcast(T.bool(True), 4),
+                )
             )
-            B.vstore([T.Ramp(0, 2, 4)], load_a, predicate=T.Broadcast(T.bool(True), 4))
+            T.evaluate(
+                T.call_intrin(
+                    "void",
+                    "tirx.masked_store",
+                    B,
+                    load_a,
+                    T.Ramp(0, 2, 4),
+                    T.Broadcast(T.bool(True), 4),
+                )
+            )
 
     return func
 


### PR DESCRIPTION
Move lane-mask semantics out of ordinary BufferLoad and BufferStore nodes into dedicated tirx.masked_load and tirx.masked_store calls.

Construct the intrinsic Calls directly, update the semantic consumers that require masked-memory knowledge, use BufferType-based reasoning elsewhere, and keep LLVM lowering in dedicated masked-load/store helpers while rejecting unsupported source backends.

Validation:
- LLVM-enabled build
- 756 focused and broad masked/script/LLVM/legalization tests passed, 10 skipped
- Clang-format, Ruff, and git diff --check passed