### PR TITLE
[REFACTOR][IR] Introduce TensorLoad in core IR

### DIFF
--- a/include/tvm/ir/expr.h
+++ b/include/tvm/ir/expr.h
@@ -105,6 +105,34 @@ class TupleGetItem : public Expr {
   TVM_DEFINE_OBJECT_REF_COW_METHOD(TupleGetItemNode);
 };
 
+/*! \brief Load a value from an indexed expression source. */
+class TensorLoadNode : public ExprNode {
+ public:
+  /*! \brief The indexed source expression. */
+  Expr source;
+  /*! \brief The indices at which the source is loaded. */
+  ffi::Array<PrimExpr> indices;
+
+  static void RegisterReflection() {
+    namespace refl = tvm::ffi::reflection;
+    refl::ObjectDef<TensorLoadNode>()
+        .def_ro("source", &TensorLoadNode::source, refl::AttachFieldFlag::SEqHashDefRecursive())
+        .def_ro("indices", &TensorLoadNode::indices);
+  }
+
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("ir.TensorLoad", TensorLoadNode, ExprNode);
+};
+
+/*! \brief Managed reference to TensorLoadNode. */
+class TensorLoad : public PrimExpr {
+ public:
+  TVM_DLL TensorLoad(Type result_ty, Expr source, ffi::Array<PrimExpr> indices, Span span = Span());
+
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(TensorLoad, PrimExpr, TensorLoadNode);
+  static constexpr bool _type_container_is_exact = true;
+  TVM_DEFINE_OBJECT_REF_COW_METHOD(TensorLoadNode);
+};
+
 /*!
  * \brief add operator
  *
@@ -610,6 +638,8 @@ template <>
 inline constexpr bool object_ref_contains_v<PrimExpr, IntImmNode> = true;
 template <>
 inline constexpr bool object_ref_contains_v<PrimExpr, FloatImmNode> = true;
+template <>
+inline constexpr bool object_ref_contains_v<PrimExpr, TensorLoadNode> = true;
 
 // Type traits to enable automatic conversion into IntImm, Integer, and Bool
 // when called through the FFI

--- a/include/tvm/ir/expr.h
+++ b/include/tvm/ir/expr.h
@@ -126,8 +126,6 @@ class TensorLoadNode : public ExprNode {
 /*! \brief Managed reference to TensorLoadNode. */
 class TensorLoad : public PrimExpr {
  public:
-  TVM_DLL TensorLoad(Type result_ty, Expr source, ffi::Array<PrimExpr> indices, Span span = Span());
-
   TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(TensorLoad, PrimExpr, TensorLoadNode);
   static constexpr bool _type_container_is_exact = true;
   TVM_DEFINE_OBJECT_REF_COW_METHOD(TensorLoadNode);

--- a/include/tvm/relax/distributed/axis_group_graph.h
+++ b/include/tvm/relax/distributed/axis_group_graph.h
@@ -123,9 +123,9 @@ class BufferAxisGraphExtractor : public StmtExprVisitor {
     buffer_access_indices_.push_back({op->buffer, op->indices});
   }
 
-  void VisitExpr_(const BufferLoadNode* op) final {
+  void VisitExpr_(const TensorLoadNode* op) final {
     StmtExprVisitor::VisitExpr_(op);
-    buffer_access_indices_.push_back({op->buffer, op->indices});
+    buffer_access_indices_.push_back({op->source.as_or_throw<tvm::tirx::BufferVar>(), op->indices});
   }
 
   bool Match(PrimExpr a, PrimExpr buffer_shape_a, PrimExpr b, PrimExpr buffer_shape_b,

--- a/include/tvm/relax/expr_functor.h
+++ b/include/tvm/relax/expr_functor.h
@@ -155,7 +155,7 @@ class ExprFunctor<R(const Expr& n, Args...)> {
   virtual R VisitExpr_(const GlobalVarNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExpr_(const FunctionNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExpr_(const CallNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
-  virtual R VisitExpr_(const tirx::BufferLoadNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
+  virtual R VisitExpr_(const TensorLoadNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExpr_(const tirx::LetNode* op, Args...) EXPR_FUNCTOR_DISABLED;
   virtual R VisitExpr_(const tirx::ReduceNode* op, Args...) EXPR_FUNCTOR_DISABLED;
   virtual R VisitExpr_(const tirx::AddNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
@@ -212,7 +212,7 @@ class ExprFunctor<R(const Expr& n, Args...)> {
     RELAX_EXPR_FUNCTOR_DISPATCH(CallNode);
     RELAX_EXPR_FUNCTOR_DISPATCH(tirx::LetNode);
     RELAX_EXPR_FUNCTOR_DISPATCH(tirx::ReduceNode);
-    RELAX_EXPR_FUNCTOR_DISPATCH(tirx::BufferLoadNode);
+    RELAX_EXPR_FUNCTOR_DISPATCH(TensorLoadNode);
     RELAX_EXPR_FUNCTOR_DISPATCH(tirx::AddNode);
     RELAX_EXPR_FUNCTOR_DISPATCH(tirx::SubNode);
     RELAX_EXPR_FUNCTOR_DISPATCH(tirx::MulNode);
@@ -271,7 +271,7 @@ class ExprVisitor : public ExprFunctor<void(const Expr&)> {
   void VisitExpr_(const GlobalVarNode* op) override;
   void VisitExpr_(const FunctionNode* op) override;
   void VisitExpr_(const CallNode* op) override;
-  void VisitExpr_(const tirx::BufferLoadNode* op) override;
+  void VisitExpr_(const TensorLoadNode* op) override;
   void VisitExpr_(const tirx::AddNode* op) override;
   void VisitExpr_(const tirx::SubNode* op) override;
   void VisitExpr_(const tirx::MulNode* op) override;
@@ -426,7 +426,7 @@ class ExprMutatorBase : public ExprFunctor<Expr(const Expr&)> {
   Expr VisitExpr_(const GlobalVarNode* op) override;
   Expr VisitExpr_(const FunctionNode* op) override;
   Expr VisitExpr_(const CallNode* op) override;
-  Expr VisitExpr_(const tirx::BufferLoadNode* op) override;
+  Expr VisitExpr_(const TensorLoadNode* op) override;
   Expr VisitExpr_(const tirx::AddNode* op) override;
   Expr VisitExpr_(const tirx::SubNode* op) override;
   Expr VisitExpr_(const tirx::MulNode* op) override;

--- a/include/tvm/tirx/expr.h
+++ b/include/tvm/tirx/expr.h
@@ -533,57 +533,13 @@ class Select : public PrimExpr {
 };
 
 /*!
- * \brief Load value from the high dimension buffer.
+ * \brief Construct a TensorLoad from a BufferVar.
  *
- * \code
- *
- *  value = buffer[i, j];
- *
- * \endcode
- * \sa BufferStore
+ * This is the sole typed construction path for tirx loads.  The result type
+ * is derived from the buffer element type and index lanes, and every tirx
+ * TensorLoad is required to have a BufferVar source.
  */
-class BufferLoadNode : public ExprNode {
- public:
-  /*! \brief The buffer variable. */
-  BufferVar buffer;
-  /*! \brief The indices location to be loaded. */
-  ffi::Array<PrimExpr> indices;
-  static void RegisterReflection() {
-    namespace refl = tvm::ffi::reflection;
-    refl::ObjectDef<BufferLoadNode>()
-        .def_ro("buffer", &BufferLoadNode::buffer, refl::AttachFieldFlag::SEqHashDefRecursive())
-        .def_ro("indices", &BufferLoadNode::indices);
-  }
-  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tirx.BufferLoad", BufferLoadNode, ExprNode);
-
- private:
-  /*! \brief Set the dtype based on the buffer/indices
-   *
-   * Usually, the BufferLoad's dtype will be the same dtype as the
-   * buffer.  This may have a different number of lanes than the
-   * buffer's dtype if index values have more than 1 lane.
-   *
-   * This function should only be called during construction and after
-   * CopyOnWrite.  Friend class used here to restrict usage.
-   */
-  void LegalizeDType();
-  friend class BufferLoad;
-  friend class CustomDatatypesLowerer;
-  friend class VectorTypeRewriter;
-  friend class Vectorizer;
-};
-
-/*!
- * \brief Managed reference to BufferLoadNode.
- * \sa BufferLoadNode
- */
-class BufferLoad : public PrimExpr {
- public:
-  TVM_DLL explicit BufferLoad(BufferVar buffer, ffi::Array<PrimExpr> indices, Span span = Span());
-  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(BufferLoad, PrimExpr, BufferLoadNode);
-  static constexpr bool _type_container_is_exact = true;
-  TVM_DEFINE_OBJECT_REF_COW_METHOD(BufferLoadNode);
-};
+TVM_DLL TensorLoad BufferLoad(BufferVar buffer, ffi::Array<PrimExpr> indices, Span span = Span());
 
 /*!
  * \brief Construct a vector with lanes elements
@@ -882,8 +838,6 @@ template <>
 inline constexpr bool object_ref_contains_v<PrimExpr, tirx::NotNode> = true;
 template <>
 inline constexpr bool object_ref_contains_v<PrimExpr, tirx::SelectNode> = true;
-template <>
-inline constexpr bool object_ref_contains_v<PrimExpr, tirx::BufferLoadNode> = true;
 template <>
 inline constexpr bool object_ref_contains_v<PrimExpr, tirx::RampNode> = true;
 template <>

--- a/include/tvm/tirx/expr_functor.h
+++ b/include/tvm/tirx/expr_functor.h
@@ -115,7 +115,7 @@ class ExprFunctor<R(const Expr& n, Args...)> {
   }
   // Functions that can be overriden by subclass
   virtual R VisitExpr_(const VarNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
-  virtual R VisitExpr_(const BufferLoadNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
+  virtual R VisitExpr_(const TensorLoadNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExpr_(const OpaqueExprNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExpr_(const TupleNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
   virtual R VisitExpr_(const TupleGetItemNode* op, Args... args) EXPR_FUNCTOR_DEFAULT;
@@ -159,7 +159,7 @@ class ExprFunctor<R(const Expr& n, Args...)> {
     FType vtable;
     // Set dispatch
     IR_EXPR_FUNCTOR_DISPATCH(VarNode);
-    IR_EXPR_FUNCTOR_DISPATCH(BufferLoadNode);
+    IR_EXPR_FUNCTOR_DISPATCH(TensorLoadNode);
     IR_EXPR_FUNCTOR_DISPATCH(OpaqueExprNode);
     IR_EXPR_FUNCTOR_DISPATCH(TupleNode);
     IR_EXPR_FUNCTOR_DISPATCH(TupleGetItemNode);
@@ -211,7 +211,7 @@ class TVM_DLL ExprVisitor : public ExprFunctor<void(const Expr&)> {
   using ExprFunctor::VisitExpr;
   // list of functions to override.
   void VisitExpr_(const VarNode* op) override;
-  void VisitExpr_(const BufferLoadNode* op) override;
+  void VisitExpr_(const TensorLoadNode* op) override;
   void VisitExpr_(const OpaqueExprNode* op) override;
   void VisitExpr_(const TupleNode* op) override;
   void VisitExpr_(const TupleGetItemNode* op) override;
@@ -259,7 +259,7 @@ class TVM_DLL ExprMutator : protected ExprFunctor<Expr(const Expr&)> {
   PrimExpr VisitPrimExpr(const PrimExpr& expr) { return VisitExpr(expr).as_or_throw<PrimExpr>(); }
   // list of functions to override.
   Expr VisitExpr_(const VarNode* op) override;
-  Expr VisitExpr_(const BufferLoadNode* op) override;
+  Expr VisitExpr_(const TensorLoadNode* op) override;
   Expr VisitExpr_(const OpaqueExprNode* op) override;
   Expr VisitExpr_(const TupleNode* op) override;
   Expr VisitExpr_(const TupleGetItemNode* op) override;

--- a/include/tvm/tirx/stmt_functor.h
+++ b/include/tvm/tirx/stmt_functor.h
@@ -342,7 +342,7 @@ class TVM_DLL StmtExprVisitor : public ExprVisitor, public StmtVisitor {
   using StmtVisitor::VisitStmt;
 
   void VisitExpr(const Expr& e) override { return ExprVisitor::VisitExpr(e); }
-  void VisitExpr_(const BufferLoadNode* op) override;
+  void VisitExpr_(const TensorLoadNode* op) override;
 };
 
 /*!
@@ -361,7 +361,7 @@ class TVM_DLL StmtExprMutator : public ExprMutator, public StmtMutator {
 
   Expr VisitExpr(const Expr& e) override { return ExprMutator::VisitExpr(e); }
   Expr VisitExpr_(const VarNode* op) override;
-  Expr VisitExpr_(const BufferLoadNode* op) override;
+  Expr VisitExpr_(const TensorLoadNode* op) override;
 };
 
 /*!

--- a/include/tvm/tirx/transform.h
+++ b/include/tvm/tirx/transform.h
@@ -269,7 +269,7 @@ TVM_DLL Pass InlinePrivateFunctions();
 TVM_DLL Pass PointerValueTypeRewrite();
 
 /*!
- * \brief Flatten the multi-dimensional BufferLoad and BufferStore to single dimensional
+ * \brief Flatten the multi-dimensional TensorLoad and BufferStore to single dimensional
  *        BufferLoad/BufferStore for the TIR not contains opaque block.
  * \return The pass.
  */

--- a/python/tvm/backend/cuda/ptx/engine.py
+++ b/python/tvm/backend/cuda/ptx/engine.py
@@ -40,11 +40,11 @@ per-instruction generated or hand-written code:
 from tvm.backend.cuda.codegen.registry import register_codegen
 from tvm.backend.cuda.codegen.utils import parse_str
 from tvm.backend.cuda.op import cuda_cvta_generic_to_shared, cuda_func_call
-from tvm.ir import Call
+from tvm.ir import Call, TensorLoad
 from tvm.ir.op import register_op_attr
 from tvm.ir.type import PointerType, PrimType
 from tvm.runtime import const
-from tvm.tirx.expr import BufferLoad, CallEffectKind, IntImm
+from tvm.tirx.expr import CallEffectKind, IntImm
 from tvm.tirx.op import call_intrin, reinterpret
 
 from .render import render_variant
@@ -448,7 +448,7 @@ def _coerce_pred_operand(entry, slot, values):
         # The 0/1 materialization of a .pred result: a "=r" uint32 the caller
         # receives through a reference parameter, so it needs a writable
         # uint32 lvalue exactly like any other destination.
-        if not isinstance(value, BufferLoad) or arg_dtype(value) != "uint32":
+        if not isinstance(value, TensorLoad) or arg_dtype(value) != "uint32":
             raise ValueError(
                 f"{entry.name}: operand '{slot.name}' is a .pred result and must be "
                 f"a writable uint32 scalar or buffer element (declare it first, "
@@ -486,10 +486,10 @@ def _coerce_typed(entry, slot, values, mod_map):
     if slot.rw in ("w", "rw"):
         # A PTX destination is a register the caller declared, so every lane has
         # to be a writable lvalue: a scalar (`x: T.float32`) or a buffer element.
-        # Both are BufferLoad nodes, which the C codegen prints as the lvalue
+        # Both are buffer-backed TensorLoad nodes, which the C codegen prints as the lvalue
         # bound to the helper's reference parameter.
         for value in values:
-            if not isinstance(value, BufferLoad):
+            if not isinstance(value, TensorLoad):
                 raise ValueError(
                     f"{entry.name}: destination '{slot.name}' must be a writable scalar or "
                     f"buffer element (declare it first, e.g. `d: T.{allowed[0]}`), got "

--- a/python/tvm/ir/__init__.py
+++ b/python/tvm/ir/__init__.py
@@ -40,6 +40,7 @@ from .expr import (
     GlobalVar,
     OpaqueExpr,
     Range,
+    TensorLoad,
     Tuple,
     TupleGetItem,
     Var,

--- a/python/tvm/ir/expr.py
+++ b/python/tvm/ir/expr.py
@@ -390,6 +390,24 @@ class TupleGetItem(_ExprWithOp):
         self.__init_handle_by_constructor__(_ffi_api.TupleGetItem, tuple_value, index, span)
 
 
+@tvm_ffi.register_object("ir.TensorLoad")
+class TensorLoad(_ExprWithOp):
+    """An indexed load from an expression source.
+
+    TensorLoad objects are constructed by a dialect-specific helper that
+    validates the source and derives the result type.
+    """
+
+    source: Expr
+    indices: list[Expr]
+    span: Span | None
+
+    def __init__(self, *args, **kwargs):
+        raise TypeError(
+            "TensorLoad cannot be constructed directly; use a dialect-specific load helper"
+        )
+
+
 @tvm_ffi.register_object("ir.Call")
 class Call(_ExprWithOp):
     """Core function call node."""

--- a/python/tvm/relax/expr_functor.py
+++ b/python/tvm/relax/expr_functor.py
@@ -23,7 +23,7 @@ from collections.abc import Callable
 import tvm_ffi
 
 from tvm import tirx as _tirx
-from tvm.ir import Call, Op, is_prim_expr
+from tvm.ir import Call, Op, TensorLoad, is_prim_expr
 from tvm.ir.utils import derived_object
 from tvm.runtime import Object
 
@@ -152,7 +152,7 @@ class ExprFunctor:
             ret = self.visit_function_(expr)
         elif isinstance(expr, Call):  # type: ignore
             ret = self.visit_call_(expr)
-        elif isinstance(expr, _tirx.BufferLoad):
+        elif isinstance(expr, TensorLoad):
             ret = self.visit_buffer_load_(expr)
         elif isinstance(expr, _tirx.Add):
             ret = self.visit_add_(expr)
@@ -256,7 +256,7 @@ class ExprFunctor:
     def visit_call_(self, op: Call):
         raise NotImplementedError()
 
-    def visit_buffer_load_(self, op: _tirx.BufferLoad):
+    def visit_buffer_load_(self, op: TensorLoad):
         return self.visit_expr_fallback_(op)
 
     def visit_add_(self, op: _tirx.Add):

--- a/python/tvm/s_tir/dlight/gpu/rmsnorm.py
+++ b/python/tvm/s_tir/dlight/gpu/rmsnorm.py
@@ -19,10 +19,10 @@
 
 import tvm
 from tvm import tirx
-from tvm.ir import Call
+from tvm.ir import Call, TensorLoad
 from tvm.target import Target
 from tvm.tirx import BufferStore, SBlock
-from tvm.tirx.expr import BufferLoad, Cast
+from tvm.tirx.expr import Cast
 
 from ..base import ScheduleRule
 
@@ -36,11 +36,11 @@ def identify_cast_or_load_block(block: SBlock) -> bool:
     store = block.body
 
     # check types
-    if isinstance(store.value, BufferLoad):
+    if isinstance(store.value, TensorLoad):
         load = store.value
     elif isinstance(store.value, Cast):
         load = store.value.value
-        if not isinstance(load, BufferLoad):
+        if not isinstance(load, TensorLoad):
             return False
     else:
         return False

--- a/python/tvm/s_tir/dlight/gpu/transpose.py
+++ b/python/tvm/s_tir/dlight/gpu/transpose.py
@@ -17,6 +17,7 @@
 """Reduction rule for operators including softmax, layer norm, RMS norm, etc"""
 
 from tvm import arith, s_tir, tirx
+from tvm.ir import TensorLoad
 from tvm.s_tir import Schedule
 from tvm.s_tir.schedule import SBlockRV
 from tvm.target import Target
@@ -33,7 +34,7 @@ class Transpose(GPUScheduleRule):
         block = sch.get(block_rv)
         if isinstance(block.body, tirx.BufferStore):
             rhs = block.body.value
-            if isinstance(rhs, tirx.BufferLoad):
+            if isinstance(rhs, TensorLoad):
                 lhs_indices = block.body.indices
                 rhs_indices = rhs.indices
                 if list(lhs_indices) != list(rhs_indices) and set(lhs_indices) == set(rhs_indices):

--- a/python/tvm/tirx/expr.py
+++ b/python/tvm/tirx/expr.py
@@ -1171,9 +1171,8 @@ class Select(ExprWithOp):
         )
 
 
-@tvm_ffi.register_object("tirx.BufferLoad")
-class BufferLoad(ExprWithOp):
-    """Buffer load node.
+def BufferLoad(buffer: Buffer, indices: list[Expr], span: Span | None = None) -> tvm.ir.TensorLoad:
+    """Construct a validated buffer load.
 
     Parameters
     ----------
@@ -1188,21 +1187,7 @@ class BufferLoad(ExprWithOp):
 
     """
 
-    buffer: Buffer
-    indices: list[Expr]
-
-    def __init__(
-        self,
-        buffer: Buffer,
-        indices: list[Expr],
-        span: Span | None = None,
-    ) -> None:
-        self.__init_handle_by_constructor__(
-            _ffi_api.BufferLoad,
-            buffer,
-            indices,
-            span,  # type: ignore
-        )
+    return _ffi_api.BufferLoad(buffer, indices, span)
 
 
 @tvm_ffi.register_object("tirx.Ramp")

--- a/python/tvm/tirx/expr_functor.py
+++ b/python/tvm/tirx/expr_functor.py
@@ -50,7 +50,7 @@ class ExprFunctor:
     def __init__(self):
         self._dispatch_map = {
             "tirx.Var": self.visit_var_,
-            "tirx.BufferLoad": self.visit_buffer_load_,
+            "tirx.TensorLoad": self.visit_buffer_load_,
             "tirx.Tuple": self.visit_tuple_,
             "tirx.TupleGetItem": self.visit_tuple_get_item_,
             "tirx.Let": self.visit_let_,
@@ -118,7 +118,7 @@ class ExprFunctor:
         return None
 
     def visit_buffer_load_(self, op):
-        """Default visitor for BufferLoad node."""
+        """Default visitor for a buffer-backed TensorLoad node."""
         return self.visit_expr_default_(op)
 
     def visit_opaque_expr_(self, op):
@@ -472,7 +472,7 @@ class ExprMutator(ExprFunctor):
         if all(old_index is new_index for old_index, new_index in zip(op.indices, indices)):
             return op
         else:
-            return tvm.tirx.BufferLoad(op.buffer, indices)
+            return tvm.tirx.BufferLoad(op.source, indices)
 
     def visit_opaque_expr_(self, op):
         """Mutator implementation for an opaque construction-time expression."""

--- a/python/tvm/tirx/functor.py
+++ b/python/tvm/tirx/functor.py
@@ -22,7 +22,7 @@ from collections.abc import Callable
 
 import tvm_ffi
 
-from tvm.ir import Call, Expr
+from tvm.ir import Call, Expr, TensorLoad
 from tvm.ir.utils import derived_object
 
 from . import _ffi_api
@@ -36,7 +36,6 @@ from .expr import (
     Add,
     And,
     Broadcast,
-    BufferLoad,
     Cast,
     Div,
     FloatImm,
@@ -490,16 +489,16 @@ class PyStmtExprVisitor:
         """
         _ffi_api.PyStmtExprVisitorDefaultVisitExpr(self._outer(), op)  # type: ignore
 
-    def visit_buffer_load_(self, op: BufferLoad) -> None:
-        """Visit BufferLoad.
+    def visit_buffer_load_(self, op: TensorLoad) -> None:
+        """Visit a buffer-backed TensorLoad.
 
-        Users can customize this function to overwrite VisitBufferLoad_(const BufferLoadNode* op)
+        Users can customize this function to overwrite VisitBufferLoad_(const TensorLoadNode* op)
         on the C++ side.
 
         Parameters
         ----------
-        op : BufferLoad
-            The BufferLoad to be visited.
+        op : TensorLoad
+            The TensorLoad to be visited.
         """
         _ffi_api.PyStmtExprVisitorDefaultVisitExpr(self._outer(), op)  # type: ignore
 
@@ -1331,16 +1330,16 @@ class PyStmtExprMutator:
         """
         return _ffi_api.PyStmtExprMutatorDefaultVisitExpr(self._outer(), op)  # type: ignore
 
-    def visit_buffer_load_(self, op: BufferLoad) -> Expr:
-        """Visit BufferLoad.
+    def visit_buffer_load_(self, op: TensorLoad) -> Expr:
+        """Visit a buffer-backed TensorLoad.
 
-        Users can customize this function to overwrite VisitBufferLoad_(const BufferLoadNode* op)
+        Users can customize this function to overwrite VisitBufferLoad_(const TensorLoadNode* op)
         on the C++ side.
 
         Parameters
         ----------
-        op : BufferLoad
-            The BufferLoad to be visited.
+        op : TensorLoad
+            The TensorLoad to be visited.
 
         Returns
         -------

--- a/python/tvm/tirx/op.py
+++ b/python/tvm/tirx/op.py
@@ -24,7 +24,7 @@ from tvm_ffi import Array
 
 import tvm
 from tvm import tirx
-from tvm.ir import Call, Expr, Op, PointerType, PrimType
+from tvm.ir import Call, Expr, Op, PointerType, PrimType, TensorLoad
 from tvm.ir.base import Span
 from tvm.ir.type import TensorMapType
 from tvm.runtime import const
@@ -669,12 +669,12 @@ def _buffer_element_pointer_type(buffer: Buffer) -> PointerType:
     return PointerType(buffer.ty.dtype, buffer.ty.storage_scope)
 
 
-def address_of(obj: Buffer | BufferLoad | Var, span: Span | None = None) -> Expr:
+def address_of(obj: Buffer | TensorLoad | Var, span: Span | None = None) -> Expr:
     """Returns the address of a buffer element or addressable variable.
 
     Parameters
     ----------
-    obj: Union[Buffer, BufferLoad, Var]
+    obj: Union[Buffer, TensorLoad, Var]
         The buffer, buffer load, or addressable variable.
 
     span : Optional[Span]
@@ -700,12 +700,12 @@ def address_of(obj: Buffer | BufferLoad | Var, span: Span | None = None) -> Expr
         if not isinstance(obj.ty, tvm.ir.PrimType):
             raise TypeError(f"address_of expects a scalar or TensorMap Var, but got {obj.ty}")
         return Call("tirx.address_of", [obj], span=span, ret_ty=PointerType(obj.ty))
-    elif isinstance(obj, BufferLoad):
+    elif isinstance(obj, TensorLoad):
         return Call(
             "tirx.address_of",
             [obj],
             span=span,
-            ret_ty=_buffer_element_pointer_type(obj.buffer),
+            ret_ty=_buffer_element_pointer_type(obj.source),
         )
     else:
         raise ValueError(f"Invalid object type: {type(obj)}")

--- a/python/tvm/tirx/script/builder/ir.py
+++ b/python/tvm/tirx/script/builder/ir.py
@@ -34,7 +34,7 @@ from tvm_ffi.core import String
 
 from tvm import DataType, ir
 from tvm import tirx as tir
-from tvm.ir import Call, Type, is_prim_expr
+from tvm.ir import Call, TensorLoad, Type, is_prim_expr
 from tvm.ir import register_op_attr as _register_op_attr
 from tvm.ir.base import deprecated
 from tvm.runtime import convert
@@ -461,7 +461,7 @@ def Tuple(*fields: Type) -> Type:  # pylint: disable=invalid-name
 
 
 def match_buffer(
-    param: Var | BufferLoad | BufferRegion,
+    param: Var | TensorLoad | BufferRegion,
     shape: list[Expr] | tuple[Expr] | Expr | Integral = None,
     dtype: str = "float32",
     data: Var = None,
@@ -492,7 +492,7 @@ def match_buffer(
 
     Parameters
     ----------
-    param : Union[Var, BufferLoad, BufferRegion]
+    param : Union[Var, TensorLoad, BufferRegion]
         The parameter of the PrimFunc to match.
 
     shape : Union[List[Expr], Tuple[Expr], Expr, Integral]
@@ -768,12 +768,12 @@ def where(predicate: Expr | int) -> None:
     _ffi_api.Where(predicate)  # type: ignore[attr-defined] # pylint: disable=no-member
 
 
-def reads(*buffer_slices: list[BufferRegion | BufferLoad]) -> None:
+def reads(*buffer_slices: list[BufferRegion | TensorLoad]) -> None:
     """The block buffer region reading statement.
 
     Parameters
     ----------
-    buffer_slices : List[Union[BufferRegion, BufferLoad]]
+    buffer_slices : List[Union[BufferRegion, TensorLoad]]
         The array of buffer regions to read.
     """
     if len(buffer_slices) == 1:
@@ -788,12 +788,12 @@ def reads(*buffer_slices: list[BufferRegion | BufferLoad]) -> None:
     _ffi_api.Reads(buffer_slices)  # type: ignore[attr-defined] # pylint: disable=no-member
 
 
-def writes(*buffer_slices: list[BufferRegion | BufferLoad]) -> None:
+def writes(*buffer_slices: list[BufferRegion | TensorLoad]) -> None:
     """The block buffer region writing statement.
 
     Parameters
     ----------
-    buffer_slices : List[Union[BufferRegion, BufferLoad]]
+    buffer_slices : List[Union[BufferRegion, TensorLoad]]
         The array of buffer regions to write.
     """
     if len(buffer_slices) == 1:
@@ -1979,12 +1979,17 @@ else:
     class scalar_wrapper:
         """Internal wrapper to allow IRBuilder auto-naming on scalar assignment."""
 
-        def __init__(self, scalar: BufferLoad):
-            assert isinstance(scalar, BufferLoad)
+        def __init__(self, scalar: TensorLoad):
+            assert isinstance(scalar, TensorLoad)
             self.scalar = scalar
 
         def __getattr__(self, name: str) -> Any:
             return getattr(self.scalar, name)
+
+        @property
+        def buffer(self) -> Buffer:
+            """The backing buffer used by this scalar wrapper."""
+            return self.scalar.source
 
         def __add__(self, other):
             return self.scalar + other
@@ -2065,7 +2070,7 @@ else:
             return ~self.scalar
 
 
-def alloc_scalar(dtype: str = "float32", scope: str = "global") -> BufferLoad:
+def alloc_scalar(dtype: str = "float32", scope: str = "global") -> TensorLoad:
     """Allocate a zero-dimensional buffer (scalar)."""
     buf = alloc_buffer(shape=(1,), dtype=dtype, scope=scope, layout=TileLayout(S[1]))
     assert is_buffer_var(buf)
@@ -2075,7 +2080,7 @@ def alloc_scalar(dtype: str = "float32", scope: str = "global") -> BufferLoad:
     return scalar_wrapper(scalar)
 
 
-def decl_scalar(dtype, data, scope, elem_offset=None, byte_offset=None) -> BufferLoad:
+def decl_scalar(dtype, data, scope, elem_offset=None, byte_offset=None) -> TensorLoad:
     """Declare a zero-dimensional buffer (scalar) from a pointer."""
     buf = decl_buffer(
         shape=(1,),
@@ -2095,12 +2100,12 @@ def decl_scalar(dtype, data, scope, elem_offset=None, byte_offset=None) -> Buffe
     return scalar_wrapper(scalar)
 
 
-def shared_scalar(dtype: str = "float32") -> BufferLoad:
+def shared_scalar(dtype: str = "float32") -> TensorLoad:
     """Allocate a zero-dimensional buffer in shared memory."""
     return alloc_scalar(dtype=dtype, scope="shared")
 
 
-def local_scalar(dtype: str = "float32") -> BufferLoad:
+def local_scalar(dtype: str = "float32") -> TensorLoad:
     """Allocate a zero-dimensional buffer in local memory."""
     return alloc_scalar(dtype=dtype, scope="local")
 
@@ -2121,9 +2126,9 @@ def _sanitize_meta_name_part(value: Any, fallback: str) -> str:
 
 def _meta_resource_for_value(value: Any) -> Any | None:
     if isinstance(value, scalar_wrapper):
-        return value.scalar.buffer
-    if isinstance(value, BufferLoad):
-        return value.buffer
+        return value.scalar.source
+    if isinstance(value, TensorLoad):
+        return value.source
     if is_buffer_var(value):
         return value
     return None

--- a/python/tvm/tirx/script/builder/ir.py
+++ b/python/tvm/tirx/script/builder/ir.py
@@ -1986,11 +1986,6 @@ else:
         def __getattr__(self, name: str) -> Any:
             return getattr(self.scalar, name)
 
-        @property
-        def buffer(self) -> Buffer:
-            """The backing buffer used by this scalar wrapper."""
-            return self.scalar.source
-
         def __add__(self, other):
             return self.scalar + other
 

--- a/python/tvm/tirx/script/parser/parser.py
+++ b/python/tvm/tirx/script/parser/parser.py
@@ -23,7 +23,7 @@ from functools import partial
 from typing import Any, TypeVar
 
 import tvm
-from tvm.ir import Expr, GlobalVar, PointerType, PrimType
+from tvm.ir import Expr, GlobalVar, PointerType, PrimType, TensorLoad
 from tvm.script.ir_builder import ir as I
 from tvm.script.ir_builder.base import IRBuilder
 from tvm.script.ir_builder.base import IRBuilderFrame as Frame
@@ -228,9 +228,9 @@ def bind_assign_value(
         if _get_signature_match_var(self, var_name) is not None:
             return _reuse_signature_match_var(self, node, var_name, value)
     if isinstance(value, T.scalar_wrapper):  # pylint: disable=protected-access
-        # special case for scalar, name the buffer, but the var is used as BufferLoad
-        assert isinstance(value.scalar, T.BufferLoad)
-        IRBuilder.name(var_name, value.scalar.buffer)
+        # special case for scalar, name the buffer, but the var is used as TensorLoad
+        assert isinstance(value.scalar, TensorLoad)
+        IRBuilder.name(var_name, value.scalar.source)
         return value.scalar
     if isinstance(value, I.meta_var):
         return value.value
@@ -280,8 +280,8 @@ def bind_assign_value(
         else:
             # x = expr -> scalar (auto-typed from value)
             scalar = T.local_scalar(dtype=str(value.ty.dtype))
-            IRBuilder.name(var_name, scalar.scalar.buffer)
-            T.buffer_store(scalar.scalar.buffer, value, [0])
+            IRBuilder.name(var_name, scalar.scalar.source)
+            T.buffer_store(scalar.scalar.source, value, [0])
             return scalar.scalar
 
 
@@ -662,11 +662,11 @@ def visit_assign(self: Parser, node: doc.Assign) -> None:
         # that genuine errors (e.g. wrong shape, bad store) are not swallowed.
         # Only TypeError from FFI type mismatch (e.g. rhs is a meta_var, not
         # a Expr or auto-convertible scalar) triggers fallthrough.
-        if isinstance(lhs_value, T.scalar_wrapper | T.BufferLoad) or is_buffer_var(lhs_value):
+        if isinstance(lhs_value, T.scalar_wrapper | TensorLoad) or is_buffer_var(lhs_value):
             if isinstance(lhs_value, T.scalar_wrapper):
-                buffer = lhs_value.scalar.buffer
+                buffer = lhs_value.scalar.source
             else:
-                buffer = lhs_value.buffer if isinstance(lhs_value, T.BufferLoad) else lhs_value
+                buffer = lhs_value.source if isinstance(lhs_value, TensorLoad) else lhs_value
             if len(buffer.ty.shape) == 1 and bool(buffer.ty.shape[0] == 1):
                 # only 1-dim buffer with shape (1,) can be assigned directly
                 # Note that shape can be a Expr, so we only judge by
@@ -747,11 +747,11 @@ def visit_aug_assign(self: Parser, node: doc.AugAssign) -> None:
             lhs_value = self.eval_expr(lhs_copy)
         except Exception:  # pylint: disable=broad-except
             pass
-        if isinstance(lhs_value, T.scalar_wrapper | T.BufferLoad) or is_buffer_var(lhs_value):
+        if isinstance(lhs_value, T.scalar_wrapper | TensorLoad) or is_buffer_var(lhs_value):
             if isinstance(lhs_value, T.scalar_wrapper):
-                buffer = lhs_value.scalar.buffer
+                buffer = lhs_value.scalar.source
             else:
-                buffer = lhs_value.buffer if isinstance(lhs_value, T.BufferLoad) else lhs_value
+                buffer = lhs_value.source if isinstance(lhs_value, TensorLoad) else lhs_value
             if len(buffer.ty.shape) == 1 and bool(buffer.ty.shape[0] == 1):
                 try:
                     T.buffer_store(buffer, rhs, [0])
@@ -819,7 +819,7 @@ def visit_ann_assign(self: Parser, node: doc.AnnAssign) -> None:
         scalar = T.local_scalar(dtype=str(ann_var.ty))
         self.eval_assign(target=lhs, source=scalar, bind_value=bind_assign_value)
         if rhs is not None:
-            T.buffer_store(scalar.scalar.buffer, rhs, [0])
+            T.buffer_store(scalar.scalar.source, rhs, [0])
 
 
 @dispatch.register(token="tirx", type_name="With")

--- a/python/tvm/tirx/script/parser/parser.py
+++ b/python/tvm/tirx/script/parser/parser.py
@@ -644,7 +644,7 @@ def visit_assign(self: Parser, node: doc.Assign) -> None:
         T.buffer_store(self.eval_expr(lhs.value), rhs, indices)
     else:
         # special case for scalar buffers
-        # scalar = xxx <=> scalar.buffer[()] = xxx
+        # scalar = xxx <=> scalar.source[()] = xxx
         # or for a normal 1-dim buffer with shape (1,)
         # buffer = xxx <=> buffer[()] = xxx
         # Try to resolve lhs as a buffer/scalar variable. eval_expr may raise

--- a/python/tvm/tirx/transform/common.py
+++ b/python/tvm/tirx/transform/common.py
@@ -16,7 +16,7 @@
 # under the License.
 
 
-from tvm.ir import Call, Op, is_prim_expr
+from tvm.ir import Call, Op, TensorLoad, is_prim_expr
 from tvm.tirx import (
     AllocBuffer,
     BufferLoad,
@@ -112,8 +112,8 @@ class BufferReplacer(StmtExprMutator):
             return self.var_map[op]
         return super().visit_var_(op)
 
-    def visit_buffer_load_(self, op: BufferLoad):
-        new_buffer = self.mutate_buffer(op.buffer)
+    def visit_buffer_load_(self, op: TensorLoad):
+        new_buffer = self.mutate_buffer(op.source)
         op = super().visit_buffer_load_(op)
         if new_buffer is not None:
             return BufferLoad(new_buffer, op.indices)

--- a/src/arith/domain_touched.cc
+++ b/src/arith/domain_touched.cc
@@ -100,11 +100,17 @@ class BufferTouchedDomain final : public IRVisitorWithAnalyzer {
   using Parent::VisitExpr_;
   using Parent::VisitStmt_;
 
-  void VisitExpr_(const BufferLoadNode* op) final {
+  void VisitExpr_(const TensorLoadNode* op) final {
     // Record load-exclusive buffer access
-    Touch(&std::get<LoadAccess>(buffer_access_map_[op->buffer.get()]).set, op->indices);
+    Touch(&std::get<LoadAccess>(
+               buffer_access_map_[op->source.as_or_throw<tvm::tirx::BufferVar>().get()])
+               .set,
+          op->indices);
     // Record load-store inclusive buffer access
-    Touch(&std::get<CombinedAccess>(buffer_access_map_[op->buffer.get()]).set, op->indices);
+    Touch(&std::get<CombinedAccess>(
+               buffer_access_map_[op->source.as_or_throw<tvm::tirx::BufferVar>().get()])
+               .set,
+          op->indices);
     Parent::VisitExpr_(op);
   }
 

--- a/src/arith/domain_touched.cc
+++ b/src/arith/domain_touched.cc
@@ -101,16 +101,11 @@ class BufferTouchedDomain final : public IRVisitorWithAnalyzer {
   using Parent::VisitStmt_;
 
   void VisitExpr_(const TensorLoadNode* op) final {
+    BufferVar buffer = op->source.as_or_throw<tvm::tirx::BufferVar>();
     // Record load-exclusive buffer access
-    Touch(&std::get<LoadAccess>(
-               buffer_access_map_[op->source.as_or_throw<tvm::tirx::BufferVar>().get()])
-               .set,
-          op->indices);
+    Touch(&std::get<LoadAccess>(buffer_access_map_[buffer.get()]).set, op->indices);
     // Record load-store inclusive buffer access
-    Touch(&std::get<CombinedAccess>(
-               buffer_access_map_[op->source.as_or_throw<tvm::tirx::BufferVar>().get()])
-               .set,
-          op->indices);
+    Touch(&std::get<CombinedAccess>(buffer_access_map_[buffer.get()]).set, op->indices);
     Parent::VisitExpr_(op);
   }
 

--- a/src/arith/int_set.cc
+++ b/src/arith/int_set.cc
@@ -585,14 +585,14 @@ class IntervalSetEvaluator : public ExprFunctor<IntervalSet(const Expr&)> {
     return IntervalSet(min_value, max_value);
   }
 
-  IntervalSet VisitExpr_(const BufferLoadNode* op) final {
+  IntervalSet VisitExpr_(const TensorLoadNode* op) final {
     PrimType op_ty = op->ty.as_or_throw<PrimType>();
     if (!op_ty.MatchesCode(DLDataTypeCode::kDLInt, DLDataTypeCode::kDLUInt)) {
-      DLOG(WARNING) << "cannot evaluate set BufferLoad which loads from a " << op_ty->dtype
+      DLOG(WARNING) << "cannot evaluate set TensorLoad which loads from a " << op_ty->dtype
                     << " buffer";
       return IntervalSet::Everything();
     }
-    // If the indices do not contain any variables to be relaxed, return the BufferLoad itself.
+    // If the indices do not contain any variables to be relaxed, return the TensorLoad itself.
     // Otherwise return `IntervalSet::everything()` since we have no knowledge on the buffer data.
     for (const PrimExpr& index : op->indices) {
       if (UsesVar(index, [dom_map = &this->dom_map_](const VarNode* var) {

--- a/src/arith/z3_prover.cc
+++ b/src/arith/z3_prover.cc
@@ -735,7 +735,7 @@ class Z3Prover::Impl : ExprFunctor<z3::expr(const Expr&)> {
     if (memo_.count(e)) {
       return false;
     }
-    return e->IsInstance<CallNode>() || e->IsInstance<BufferLoadNode>() ||
+    return e->IsInstance<CallNode>() || e->IsInstance<TensorLoadNode>() ||
            e->IsInstance<ReduceNode>() ||
            (e->IsInstance<CastNode>() && !IsZ3SupportedExpr(e.as_or_throw<Cast>()->value.get()));
   }
@@ -796,7 +796,7 @@ class Z3Prover::Impl : ExprFunctor<z3::expr(const Expr&)> {
     }
   }
   z3::expr VisitExpr_(const VarNode* op) override { return Create(op); }
-  z3::expr VisitExpr_(const BufferLoadNode* op) override { return Create(op); }
+  z3::expr VisitExpr_(const TensorLoadNode* op) override { return Create(op); }
   z3::expr VisitExpr_(const ReduceNode* op) override { return Create(op); }
   z3::expr VisitExpr_(const MinNode* op) override {
     auto a = VisitInt(op->a);

--- a/src/backend/cuda/codegen/codegen_cuda.cc
+++ b/src/backend/cuda/codegen/codegen_cuda.cc
@@ -1310,9 +1310,10 @@ void CodeGenCUDA::VisitExpr_(const CallNode* op, std::ostream& os) {
     std::string reg = this->PrintExpr(op->args[0]);
     // get guard
     std::string guard = this->PrintExpr(op->args[1]);
-    const BufferLoadNode* addr_buffer = op->args[2].as<BufferLoadNode>();
+    const TensorLoadNode* addr_buffer = op->args[2].as<TensorLoadNode>();
     std::string global_addr = this->PrintExpr(addr_buffer->indices[0]);
-    std::string global_buffer = this->PrintExpr(addr_buffer->buffer.data());
+    std::string global_buffer =
+        this->PrintExpr(addr_buffer->source.as_or_throw<tvm::tirx::BufferVar>().data());
     std::string local_addr = this->PrintExpr(op->args[3]);
     this->stream << "asm volatile (\n";
     this->stream << "\"{.reg .pred p;\\n\"\n";
@@ -2083,7 +2084,7 @@ int32_t CodeGenCUDA::GetWmmaFragmentSize(const std::string& scope, const VarNode
     return 0;
 }
 
-void CodeGenCUDA::HandleVolatileLoads(const std::string& value, const BufferLoadNode* op,
+void CodeGenCUDA::HandleVolatileLoads(const std::string& value, const TensorLoadNode* op,
                                       std::ostream& os) {
   // Cast away volatile qualifier for fp16 types. That is, only loads and
   // stores are volatile. The loaded objects are not marked as volatile.
@@ -2091,7 +2092,7 @@ void CodeGenCUDA::HandleVolatileLoads(const std::string& value, const BufferLoad
   PrimType op_ty = op->ty.as_or_throw<PrimType>();
   if ((op_ty.MatchesElementType(DLDataTypeCode::kDLFloat, 16) ||
        op_ty.MatchesElementType(DLDataTypeCode::kDLBfloat, 16)) &&
-      IsVolatile(op->buffer.get())) {
+      IsVolatile(op->source.as_or_throw<tvm::tirx::BufferVar>().get())) {
     os << "(";
     PrintType(op_ty, os);
     os << ")(" << value << ")";

--- a/src/backend/cuda/codegen/codegen_cuda.h
+++ b/src/backend/cuda/codegen/codegen_cuda.h
@@ -91,7 +91,7 @@ class CodeGenCUDA final : public CodeGenC {
 
  private:
   // Handle volatile loads
-  void HandleVolatileLoads(const std::string& value, const BufferLoadNode* op,
+  void HandleVolatileLoads(const std::string& value, const TensorLoadNode* op,
                            std::ostream& os) final;
 
   // Whether scope such as "__shared__" or "__constant__"  is part of type.

--- a/src/backend/cuda/transforms/lower_iket.cc
+++ b/src/backend/cuda/transforms/lower_iket.cc
@@ -388,8 +388,8 @@ class TokenBufferCollector : public StmtExprVisitor {
     bool is_token_value = false;
     if (const auto* call = store->value.as<CallNode>()) {
       is_token_value = IsTokenProducer(call);
-    } else if (const auto* load = store->value.as<BufferLoadNode>()) {
-      is_token_value = buffers_->count(load->buffer.get());
+    } else if (const auto* load = store->value.as<TensorLoadNode>()) {
+      is_token_value = buffers_->count(load->source.as_or_throw<tvm::tirx::BufferVar>().get());
     }
     if (is_token_value && buffers_->insert(store->buffer.get()).second) changed = true;
     StmtExprVisitor::VisitStmt_(store);
@@ -423,8 +423,8 @@ class TokenDeclarationCollector : public StmtExprVisitor {
     std::set<DeclarationKey> possible;
     if (const auto* call = store->value.as<CallNode>(); call && IsTokenProducer(call)) {
       possible.insert(DeclarationKey{DeclarationKind::kRange, GetName(call)});
-    } else if (const auto* load = store->value.as<BufferLoadNode>()) {
-      auto it = declarations_->find(load->buffer.get());
+    } else if (const auto* load = store->value.as<TensorLoadNode>()) {
+      auto it = declarations_->find(load->source.as_or_throw<tvm::tirx::BufferVar>().get());
       if (it != declarations_->end()) possible = it->second;
     }
     if (!possible.empty()) {
@@ -462,9 +462,9 @@ class RangeEndSchemaVerifier : public StmtExprVisitor {
       StmtExprVisitor::VisitExpr_(call);
       return;
     }
-    const auto* token = call->args[0].as<BufferLoadNode>();
+    const auto* token = call->args[0].as<TensorLoadNode>();
     TVM_FFI_ICHECK(token != nullptr);
-    auto possible_it = token_declarations_.find(token->buffer.get());
+    auto possible_it = token_declarations_.find(token->source.as_or_throw<BufferVar>().get());
     TVM_FFI_ICHECK(possible_it != token_declarations_.end());
     bool has_payload = call->args.size() == 2;
     PayloadType payload_type = has_payload ? ValidatePayload(call->args[1]) : PayloadType::kNone;
@@ -533,8 +533,8 @@ class TokenVerifier : public StmtExprVisitor {
       allow_producer_ = valid_value;
       VisitExpr(store->value);
       allow_producer_ = false;
-    } else if (const auto* load = store->value.as<BufferLoadNode>()) {
-      valid_value = token_buffers_.count(load->buffer.get());
+    } else if (const auto* load = store->value.as<TensorLoadNode>()) {
+      valid_value = token_buffers_.count(load->source.as_or_throw<tvm::tirx::BufferVar>().get());
       allow_token_load_ = valid_value;
       VisitExpr(store->value);
       allow_token_load_ = false;
@@ -544,8 +544,8 @@ class TokenVerifier : public StmtExprVisitor {
     for (const PrimExpr& index : store->indices) VisitExpr(index);
   }
 
-  void VisitExpr_(const BufferLoadNode* load) final {
-    if (token_buffers_.count(load->buffer.get())) {
+  void VisitExpr_(const TensorLoadNode* load) final {
+    if (token_buffers_.count(load->source.as_or_throw<tvm::tirx::BufferVar>().get())) {
       TVM_FFI_CHECK(allow_token_load_, ValueError)
           << "RangeToken may only be assigned or passed directly to range_end";
     }
@@ -564,8 +564,10 @@ class TokenVerifier : public StmtExprVisitor {
     }
     if (call->op.same_as(IketRangeEndOp())) {
       TVM_FFI_CHECK_GE(call->args.size(), 1, TypeError) << "range_end requires a RangeToken";
-      const auto* token = call->args[0].as<BufferLoadNode>();
-      TVM_FFI_CHECK(token != nullptr && token_buffers_.count(token->buffer.get()), ValueError)
+      const auto* token = call->args[0].as<TensorLoadNode>();
+      TVM_FFI_CHECK(
+          token != nullptr && token_buffers_.count(token->source.as_or_throw<BufferVar>().get()),
+          ValueError)
           << "range_end requires a directly loaded RangeToken";
       allow_token_load_ = true;
       VisitExpr(call->args[0]);

--- a/src/backend/hexagon/codegen/llvm/codegen_hexagon.cc
+++ b/src/backend/hexagon/codegen/llvm/codegen_hexagon.cc
@@ -80,7 +80,7 @@ class CodeGenHexagon final : public CodeGenCPU {
   void InitTarget() final;
 
   using CodeGenCPU::VisitStmt_;
-  llvm::Value* VisitExpr_(const BufferLoadNode* op) override;
+  llvm::Value* VisitExpr_(const TensorLoadNode* op) override;
   llvm::Value* CreateIntrinsic(const CallNode* op) override;
 
   llvm::Value* CreateCallExtern(Type ret_type, ffi::String global_symbol,
@@ -199,10 +199,11 @@ llvm::Value* CodeGenHexagon::CreateCallExtern(Type ret_type, ffi::String global_
   return CodeGenCPU::CreateCallExtern(ret_type, global_symbol, args, skip_first_arg);
 }
 
-llvm::Value* CodeGenHexagon::VisitExpr_(const BufferLoadNode* op) {
+llvm::Value* CodeGenHexagon::VisitExpr_(const TensorLoadNode* op) {
   // Check if we can generate a vector lookup.
   if (!op->indices[0].as<RampNode>()) {
-    if (auto* vlut = VectorLookupLoad(op->buffer, op->ty.as_or_throw<PrimType>(), op->indices)) {
+    if (auto* vlut = VectorLookupLoad(op->source.as_or_throw<tvm::tirx::BufferVar>(),
+                                      op->ty.as_or_throw<PrimType>(), op->indices)) {
       return vlut;
     }
   }

--- a/src/backend/opencl/codegen/codegen_opencl.cc
+++ b/src/backend/opencl/codegen/codegen_opencl.cc
@@ -461,17 +461,17 @@ void CodeGenOpenCL::VisitStmt_(const AllocBufferNode* op) {
 void CodeGenOpenCL::VisitExpr_(const CallNode* op, std::ostream& os) {
   if (op->op.same_as(builtin::address_of())) {
     // Overload tvm_address_of to add storage scope (e.g. __global).
-    const BufferLoadNode* load = op->args[0].as<BufferLoadNode>();
+    const TensorLoadNode* load = op->args[0].as<TensorLoadNode>();
     TVM_FFI_ICHECK(op->args.size() == 1 && load);
     TVM_FFI_ICHECK_EQ(load->indices.size(), 1)
         << "CodeGenOpenCL only supports flat memory allocations.";
     os << "((";
-    auto it = alloc_storage_scope_.find(load->buffer.get());
+    auto it = alloc_storage_scope_.find(load->source.as_or_throw<tvm::tirx::BufferVar>().get());
     if (it != alloc_storage_scope_.end()) {
       PrintStorageScope(it->second, os);
     }
     this->PrintType(load->ty.as_or_throw<PrimType>().WithLanes(1), os);
-    os << " *)" << this->GetVarID(load->buffer.get()) << " + ";
+    os << " *)" << this->GetVarID(load->source.as_or_throw<tvm::tirx::BufferVar>().get()) << " + ";
     this->PrintExpr(load->indices[0], os);
     os << ')';
   } else if (op->op.same_as(builtin::texture2d_store())) {

--- a/src/backend/opencl/runtime/opencl_common.h
+++ b/src/backend/opencl/runtime/opencl_common.h
@@ -421,7 +421,7 @@ class OpenCLThreadEntry {
 /*! \brief OpenCL runtime buffer structure with tracked memory layout
     TODO(tvm-team): Uncouple use of storage scope and data layout by using the transform_layout
     schedule primitive to express the desired texture layout. This will require supporting Nd
-    indices in BufferLoad and BufferStore in CodegenOpenCL, and ensuring Nd allocations for
+    indices in TensorLoad and BufferStore in CodegenOpenCL, and ensuring Nd allocations for
     texture are correctly routed to the AllocateTexture packed function in the OpenCL DeviceAPI.
 */
 struct BufferDescriptor {

--- a/src/backend/trn/codegen/codegen_trn.cc
+++ b/src/backend/trn/codegen/codegen_trn.cc
@@ -341,12 +341,12 @@ void CodeGenTrainium::VisitStmt_(const EvaluateNode* op) {
   }
 }
 
-void CodeGenTrainium::VisitExpr_(const BufferLoadNode* op, std::ostream& os) {
+void CodeGenTrainium::VisitExpr_(const TensorLoadNode* op, std::ostream& os) {
   std::string buffer_str;
-  if (buffer_idmap_.count(op->buffer)) {
-    buffer_str = buffer_idmap_[op->buffer];
+  if (buffer_idmap_.count(op->source.as_or_throw<tvm::tirx::BufferVar>())) {
+    buffer_str = buffer_idmap_[op->source.as_or_throw<tvm::tirx::BufferVar>()];
   } else {
-    buffer_str = GetVarID(op->buffer.get());
+    buffer_str = GetVarID(op->source.as_or_throw<tvm::tirx::BufferVar>().get());
   }
   os << buffer_str << "[";
   os << PrintIndices(op->indices);

--- a/src/backend/trn/codegen/codegen_trn.h
+++ b/src/backend/trn/codegen/codegen_trn.h
@@ -65,7 +65,7 @@ class CodeGenTrainium final : public CodeGenC {
   void VisitStmt_(const BufferStoreNode* op) final;                   // NOLINT(*)=
   void VisitStmt_(const EvaluateNode* op) final;                      // NOLINT(*)
   std::string PrintIndices(const ffi::Array<PrimExpr>& indices);      // NOLINT(*)
-  void VisitExpr_(const BufferLoadNode* op, std::ostream& os) final;  // NOLINT(*)
+  void VisitExpr_(const TensorLoadNode* op, std::ostream& os) final;  // NOLINT(*)
   void VisitExpr_(const CallNode* op, std::ostream& os) final;        // NOLINT(*)
   void VisitExpr_(const FloatImmNode* op, std::ostream& os) final;    // NOLINT(*)
   void VisitExpr_(const CastNode* op, std::ostream& os) final;        // NOLINT(*)

--- a/src/backend/trn/transform/lower_trainium_layout.cc
+++ b/src/backend/trn/transform/lower_trainium_layout.cc
@@ -209,13 +209,14 @@ class TrainiumLayoutApplier : public arith::IRMutatorWithAnalyzer {
     return std::move(store);
   }
 
-  Expr VisitExpr_(const BufferLoadNode* op) final {
+  Expr VisitExpr_(const TensorLoadNode* op) final {
     PrimType load_ty = op->ty.as_or_throw<PrimType>();
     bool load_returns_bool = load_ty.MatchesCode(DLDataTypeCode::kDLBool);
-    BufferLoad load = StmtExprMutator::VisitExpr_(op).as_or_throw<BufferLoad>();
+    TensorLoad load = StmtExprMutator::VisitExpr_(op).as_or_throw<TensorLoad>();
     load = VisitBufferAccess(load);
     if (load_returns_bool) {
-      TVM_FFI_ICHECK_EQ(load->buffer->dtype->dtype, (DLDataType{kDLInt, 8, 1}))
+      TVM_FFI_ICHECK_EQ(load->source.as_or_throw<tvm::tirx::BufferVar>()->dtype->dtype,
+                        (DLDataType{kDLInt, 8, 1}))
           << "Expected int8 backing array for boolean tensor";
       load.CopyOnWrite()->ExprNode::ty = PrimType::Int(8);
       return tvm::cast(PrimType::Bool(), load);
@@ -283,6 +284,14 @@ class TrainiumLayoutApplier : public arith::IRMutatorWithAnalyzer {
     return node;
   }
 
+  TensorLoad VisitBufferAccess(TensorLoad node) {
+    BufferVar buffer = node->source.as_or_throw<tvm::tirx::BufferVar>();
+    TVM_FFI_ICHECK(buffer.defined());
+    if (!buffer->layout.has_value()) return node;
+    return BufferLoad(GetFlattenedBuffer(buffer), GetSimplifiedElemOffset(buffer, node->indices),
+                      node->span);
+  }
+
   std::unordered_map<BufferVar, BufferVar, ffi::ObjectPtrHash, ffi::ObjectPtrEqual> buffer_remap_;
 };
 
@@ -293,7 +302,7 @@ class TrainiumBufferOffsetRemover : public StmtExprMutator {
  private:
   Expr VisitExpr_(const CallNode* call) final {
     if (call->op.same_as(tirx::builtin::buffer_offset())) {
-      auto buffer_load = call->args[0].as_or_throw<BufferLoad>();
+      auto buffer_load = call->args[0].as_or_throw<TensorLoad>();
       TVM_FFI_ICHECK_EQ(buffer_load->indices.size(), 1) << "Expected a single index";
       return buffer_load->indices[0];
     }
@@ -325,8 +334,8 @@ class TrainiumBufferOffsetRemover : public StmtExprMutator {
     return std::move(store);
   }
 
-  Expr VisitExpr_(const BufferLoadNode* op) final {
-    BufferLoad load = StmtExprMutator::VisitExpr_(op).as_or_throw<BufferLoad>();
+  Expr VisitExpr_(const TensorLoadNode* op) final {
+    TensorLoad load = StmtExprMutator::VisitExpr_(op).as_or_throw<TensorLoad>();
     load = VisitBufferAccess(load);
     return std::move(load);
   }
@@ -341,6 +350,13 @@ class TrainiumBufferOffsetRemover : public StmtExprMutator {
       return node;
     }
     return node;
+  }
+
+  TensorLoad VisitBufferAccess(TensorLoad node) {
+    BufferVar buffer = node->source.as_or_throw<tvm::tirx::BufferVar>();
+    TVM_FFI_ICHECK(buffer.defined());
+    auto it = buffer_remap_.find(buffer);
+    return it == buffer_remap_.end() ? node : BufferLoad(it->second, node->indices, node->span);
   }
 
   std::unordered_map<BufferVar, BufferVar, ffi::ObjectPtrHash, ffi::ObjectPtrEqual> buffer_remap_;

--- a/src/backend/vulkan/codegen/codegen_spirv.cc
+++ b/src/backend/vulkan/codegen/codegen_spirv.cc
@@ -553,8 +553,8 @@ spirv::Value CodeGenSPIRV::VisitExpr_(const CallNode* op) {
                        (layout != "row_major") ? t_val : f_val);
     return spirv::Value();
   } else if (op->op.same_as(builtin::address_of())) {
-    const BufferLoadNode* load = op->args[0].as<BufferLoadNode>();
-    Var buffer_var = load->buffer.var();
+    const TensorLoadNode* load = op->args[0].as<TensorLoadNode>();
+    Var buffer_var = load->source.as_or_throw<tvm::tirx::BufferVar>().var();
     const VarNode* buffer_node = buffer_var.get();
     PrimExpr index = load->indices[0];
     PrimType ele_dtype = GetElementDataType(buffer_node);
@@ -596,9 +596,9 @@ spirv::Value CodeGenSPIRV::VisitExpr_(const BroadcastNode* op) {
   return builder_->Concat(values);
 }
 
-spirv::Value CodeGenSPIRV::VisitExpr_(const BufferLoadNode* op) {
+spirv::Value CodeGenSPIRV::VisitExpr_(const TensorLoadNode* op) {
   TVM_FFI_ICHECK_EQ(op->indices.size(), 1) << "SPIR-V codegen expects flat memory buffers";
-  Var buffer_var = op->buffer.var();
+  Var buffer_var = op->source.as_or_throw<tvm::tirx::BufferVar>().var();
   PrimExpr prim_index = op->indices[0];
 
   PrimType desired_read_type = op->ty.as_or_throw<PrimType>();

--- a/src/backend/vulkan/codegen/codegen_spirv.h
+++ b/src/backend/vulkan/codegen/codegen_spirv.h
@@ -102,7 +102,7 @@ class CodeGenSPIRV : public ExprFunctor<spirv::Value(const Expr&)>,
   spirv::Value VisitExpr_(const CallNode* op) override;
   spirv::Value VisitExpr_(const RampNode* op) override;
   spirv::Value VisitExpr_(const BroadcastNode* op) override;
-  spirv::Value VisitExpr_(const BufferLoadNode* op) override;
+  spirv::Value VisitExpr_(const TensorLoadNode* op) override;
   spirv::Value VisitExpr_(const ShuffleNode* op) override;
   // stmt
   void VisitStmt_(const BufferStoreNode* op) override;

--- a/src/backend/webgpu/codegen/codegen_webgpu.cc
+++ b/src/backend/webgpu/codegen/codegen_webgpu.cc
@@ -581,7 +581,7 @@ void CodeGenWebGPU::VisitExpr_(const FloatImmNode* op, std::ostream& os) {  // N
   os << temp.str();
 }
 
-void CodeGenWebGPU::VisitExpr_(const BufferLoadNode* op, std::ostream& os) {  // NOLINT(*)
+void CodeGenWebGPU::VisitExpr_(const TensorLoadNode* op, std::ostream& os) {  // NOLINT(*)
   // NOTE: direct impl of load/store for correctness
   // Each printing stmt must stand on their own after all preprocessing steps
   // to ensure correctness in the case of nested-expression
@@ -590,8 +590,8 @@ void CodeGenWebGPU::VisitExpr_(const BufferLoadNode* op, std::ostream& os) {  //
 
   PrimType value_ty = op->ty.as_or_throw<PrimType>();
   PrimExpr index = op->indices[0];
-  Var buffer_var = op->buffer.var();
-  const PrimType& element_ty = op->buffer->dtype;
+  Var buffer_var = op->source.as_or_throw<tvm::tirx::BufferVar>().var();
+  const PrimType& element_ty = op->source.as_or_throw<tvm::tirx::BufferVar>()->dtype;
 
   int lanes = value_ty.lanes();
   std::string buffer_vid = GetVarID(buffer_var.get());

--- a/src/backend/webgpu/codegen/codegen_webgpu.h
+++ b/src/backend/webgpu/codegen/codegen_webgpu.h
@@ -68,7 +68,7 @@ class CodeGenWebGPU final : public CodeGenC {
   // overload visitor
   void VisitExpr_(const BroadcastNode* op, std::ostream& os) final;   // NOLINT(*)
   void VisitExpr_(const CallNode* op, std::ostream& os) final;        // NOLINT(*)
-  void VisitExpr_(const BufferLoadNode* op, std::ostream& os) final;  // NOLINT(*)
+  void VisitExpr_(const TensorLoadNode* op, std::ostream& os) final;  // NOLINT(*)
   void VisitExpr_(const CastNode* op, std::ostream& os) final;        // NOLINT(*)
   void VisitExpr_(const SelectNode* op, std::ostream& os) final;      // NOLINT(*)
   void VisitExpr_(const LetNode* op, std::ostream& os) final;         // NOLINT(*)

--- a/src/ir/expr.cc
+++ b/src/ir/expr.cc
@@ -51,15 +51,6 @@ TVM_FFI_STATIC_INIT_BLOCK() {
   RangeNode::RegisterReflection();
 }
 
-TensorLoad::TensorLoad(Type result_ty, Expr source, ffi::Array<PrimExpr> indices, Span span) {
-  ffi::ObjectPtr<TensorLoadNode> node = ffi::make_object<TensorLoadNode>();
-  node->ty = std::move(result_ty);
-  node->source = std::move(source);
-  node->indices = std::move(indices);
-  node->span = std::move(span);
-  data_ = std::move(node);
-}
-
 Tuple::Tuple(ffi::Array<Expr> fields, Span span) {
   ffi::Optional<Type> tuple_ty = [&]() -> ffi::Optional<Type> {
     ffi::Array<Type> field_ty;

--- a/src/ir/expr.cc
+++ b/src/ir/expr.cc
@@ -45,9 +45,19 @@ TVM_FFI_STATIC_INIT_BLOCK() {
   CallNode::RegisterReflection();
   TupleNode::RegisterReflection();
   TupleGetItemNode::RegisterReflection();
+  TensorLoadNode::RegisterReflection();
   IntImmNode::RegisterReflection();
   FloatImmNode::RegisterReflection();
   RangeNode::RegisterReflection();
+}
+
+TensorLoad::TensorLoad(Type result_ty, Expr source, ffi::Array<PrimExpr> indices, Span span) {
+  ffi::ObjectPtr<TensorLoadNode> node = ffi::make_object<TensorLoadNode>();
+  node->ty = std::move(result_ty);
+  node->source = std::move(source);
+  node->indices = std::move(indices);
+  node->span = std::move(span);
+  data_ = std::move(node);
 }
 
 Tuple::Tuple(ffi::Array<Expr> fields, Span span) {

--- a/src/relax/analysis/layout_transformation.cc
+++ b/src/relax/analysis/layout_transformation.cc
@@ -510,9 +510,10 @@ class BlockAnalyzer : public StmtExprVisitor {
     access_info.Update(detected_spatial_layout);
   }
 
-  void VisitExpr_(const BufferLoadNode* op) final {
-    BufferVar read_buffer = op->buffer;
-    BufferAccessInfo& access_info = buffer_access_info_[op->buffer];
+  void VisitExpr_(const TensorLoadNode* op) final {
+    BufferVar read_buffer = op->source.as_or_throw<tvm::tirx::BufferVar>();
+    BufferAccessInfo& access_info =
+        buffer_access_info_[op->source.as_or_throw<tvm::tirx::BufferVar>()];
 
     auto detected_spatial_layout = DetectBufferAccessIterMap(op->indices);
 

--- a/src/relax/analysis/tir_op_pattern_kind.cc
+++ b/src/relax/analysis/tir_op_pattern_kind.cc
@@ -67,8 +67,8 @@ class PatternKindAnalyzer : public StmtExprVisitor {
     StmtVisitor::VisitStmt_(op);
   }
 
-  void VisitExpr_(const BufferLoadNode* op) final {
-    loads_.push_back(ffi::GetRef<BufferLoad>(op));
+  void VisitExpr_(const TensorLoadNode* op) final {
+    loads_.push_back(ffi::GetRef<TensorLoad>(op));
     ExprVisitor::VisitExpr_(op);
   }
 
@@ -97,7 +97,7 @@ class PatternKindAnalyzer : public StmtExprVisitor {
     // Step 3. Checking load store indices pattern
     OpPatternKind index_pair_pattern = kElemWise;
     bool has_elem_wise = false;
-    for (const BufferLoad& load : loads_) {
+    for (const TensorLoad& load : loads_) {
       // Since elemwise is stricter than broadcast and broadcast is stricter than injective,
       // while the order amount enums: kElemWise < kBroadcast < kInjective.
       // We can simply use `std::max` to detect these three patterns.
@@ -183,7 +183,7 @@ class PatternKindAnalyzer : public StmtExprVisitor {
    * It's elemwise pattern iff load indices and store indices are the same.
    * E.g A[i, j] = B[i, j]
    */
-  static bool IsElemwisePattern(const BufferStore& store, const BufferLoad& load) {
+  static bool IsElemwisePattern(const BufferStore& store, const TensorLoad& load) {
     return IsSameArray(store->indices, load->indices);
   }
 
@@ -194,12 +194,13 @@ class PatternKindAnalyzer : public StmtExprVisitor {
    *      A[i, j] = B[i, k] is not broadcast since `k` are not in the store indices.
    *      A[i, j] = B[j, i] is not broadcast the load indices are not in the same order as store's
    */
-  static bool IsBroadcastPattern(const BufferStore& store, const BufferLoad& load) {
-    size_t ndim_load_buf = load->buffer->shape.size();
+  static bool IsBroadcastPattern(const BufferStore& store, const TensorLoad& load) {
+    size_t ndim_load_buf = load->source.as_or_throw<tvm::tirx::BufferVar>()->shape.size();
     size_t ndim_store_buf = store->buffer->shape.size();
 
     for (size_t i = 0, j = 0; i < ndim_load_buf; ++i) {
-      if (is_const_int(load->buffer->shape[i], 1) && is_const_int(load->indices[i], 0)) {
+      if (is_const_int(load->source.as_or_throw<tvm::tirx::BufferVar>()->shape[i], 1) &&
+          is_const_int(load->indices[i], 0)) {
         // Skip unit load dimensions
         // E.g. A[i, j] = B[1, j] is still broadcast
         continue;
@@ -225,7 +226,7 @@ class PatternKindAnalyzer : public StmtExprVisitor {
    * E.g. A[i, j] = B[j, i] is injective.
    *      A[i, j] = B[i - j] is injective since the load index vars are only i, j
    */
-  static bool IsInjectivePattern(const BufferStore& store, const BufferLoad& load) {
+  static bool IsInjectivePattern(const BufferStore& store, const TensorLoad& load) {
     std::unordered_set<const tirx::VarNode*> vars;
     for (const PrimExpr& store_index : store->indices) {
       if (auto var = store_index.as<tirx::PrimVar>()) {
@@ -250,7 +251,7 @@ class PatternKindAnalyzer : public StmtExprVisitor {
    * E.g. Store = A[i, j] and Load = B[i, j, k] allow data reuse.
    *      Store = A[i, j] and Load = B[i, j + k] allow data reuse.
    */
-  static bool IsAllowReusePattern(const BufferStore& store, const BufferLoad& load) {
+  static bool IsAllowReusePattern(const BufferStore& store, const TensorLoad& load) {
     std::unordered_set<const tirx::VarNode*> vars;
     for (const PrimExpr& index : store->indices) {
       if (auto var = index.as<tirx::PrimVar>()) {
@@ -288,19 +289,20 @@ class PatternKindAnalyzer : public StmtExprVisitor {
     if (const auto* store = body.as<BufferStoreNode>()) {
       if (const auto* add = RemoveCast(store->value).as<tirx::AddNode>()) {
         if (const auto* mul = RemoveCast(add->b).as<tirx::MulNode>()) {
-          const auto* store_lhs = RemoveCast(add->a).as<tirx::BufferLoadNode>();
-          if (!store_lhs || !store->buffer.same_as(store_lhs->buffer) ||
+          const auto* store_lhs = RemoveCast(add->a).as<TensorLoadNode>();
+          if (!store_lhs ||
+              !store->buffer.same_as(store_lhs->source.as_or_throw<tvm::tirx::BufferVar>()) ||
               !IsSameArray(store->indices, store_lhs->indices)) {
             return false;
           }
-          const auto* lhs = RemoveCast(mul->a).as<tirx::BufferLoadNode>();
-          const auto* rhs = RemoveCast(mul->b).as<tirx::BufferLoadNode>();
+          const auto* lhs = RemoveCast(mul->a).as<TensorLoadNode>();
+          const auto* rhs = RemoveCast(mul->b).as<TensorLoadNode>();
           if (!lhs || !rhs) {
             return false;
           }
           return IsAllowReusePattern(ffi::GetRef<BufferStore>(store),
-                                     ffi::GetRef<BufferLoad>(lhs)) &&
-                 IsAllowReusePattern(ffi::GetRef<BufferStore>(store), ffi::GetRef<BufferLoad>(rhs));
+                                     ffi::GetRef<TensorLoad>(lhs)) &&
+                 IsAllowReusePattern(ffi::GetRef<BufferStore>(store), ffi::GetRef<TensorLoad>(rhs));
         }
       }
     }
@@ -341,8 +343,8 @@ class PatternKindAnalyzer : public StmtExprVisitor {
    * \note We only support one BufferStore node in a block (usually generated by TE compute)
    */
   ffi::Optional<BufferStore> store_;
-  /*! \brief The BufferLoad nodes in the current block. */
-  ffi::Array<BufferLoad> loads_;
+  /*! \brief The TensorLoad nodes in the current block. */
+  ffi::Array<TensorLoad> loads_;
   /*! \brief The result of op pattern. */
   OpPatternKind kind_ = kElemWise;
   /*! \brief The buffers from function params. I.e. the input and output buffers. */
@@ -416,19 +418,19 @@ bool HasReshapePattern(const PrimFunc& func) {
 
       // Step 1. Get the load/store pattern of the block body.
       // To detect the reshape pattern, we require the block body to be a
-      // BufferStore, which has a BufferLoad as value.
+      // BufferStore, which has a TensorLoad as value.
       const auto* buffer_store = block->body.as<BufferStoreNode>();
       if (buffer_store == nullptr) {
         return;
       }
-      const auto* buffer_load = buffer_store->value.as<BufferLoadNode>();
+      const auto* buffer_load = buffer_store->value.as<TensorLoadNode>();
       if (buffer_load == nullptr) {
         return;
       }
       // Further, we require the buffer being stored and being loaded to
       // match the parameter of the PrimFunc, namely `dst_buffer_` and `src_buffer_`.
       if (!(buffer_store->buffer.same_as(dst_buffer_) &&
-            buffer_load->buffer.same_as(src_buffer_))) {
+            buffer_load->source.as_or_throw<tvm::tirx::BufferVar>().same_as(src_buffer_))) {
         return;
       }
 

--- a/src/relax/backend/vm/codegen_vm_tir.cc
+++ b/src/relax/backend/vm/codegen_vm_tir.cc
@@ -299,7 +299,7 @@ class CodeGenVMTIR : public ExprFunctor<ffi::Optional<Expr>(const Expr&)> {
 #define VM_TIR_PRIM_EXPR(OP) \
   ffi::Optional<Expr> VisitExpr_(const OP* op) final { return ffi::GetRef<Expr>(op); }
 
-  VM_TIR_PRIM_EXPR(tirx::BufferLoadNode);
+  VM_TIR_PRIM_EXPR(TensorLoadNode);
   VM_TIR_PRIM_EXPR(tirx::AddNode);
   VM_TIR_PRIM_EXPR(tirx::SubNode);
   VM_TIR_PRIM_EXPR(tirx::MulNode);

--- a/src/relax/distributed/transform/lower_global_view_to_local_view.cc
+++ b/src/relax/distributed/transform/lower_global_view_to_local_view.cc
@@ -58,12 +58,11 @@ class DistBufferReplacer : public StmtExprMutator {
     return store;
   }
 
-  Expr VisitExpr_(const BufferLoadNode* _load) final {
-    BufferLoad load = StmtExprMutator::VisitExpr_(_load).as_or_throw<BufferLoad>();
-    if (buffer_map_.count(load->buffer)) {
-      ffi::ObjectPtr<BufferLoadNode> new_load = ffi::make_object<BufferLoadNode>(*load.get());
-      new_load->buffer = buffer_map_[load->buffer];
-      return BufferLoad(new_load);
+  Expr VisitExpr_(const TensorLoadNode* _load) final {
+    TensorLoad load = StmtExprMutator::VisitExpr_(_load).as_or_throw<TensorLoad>();
+    if (buffer_map_.count(load->source.as_or_throw<tvm::tirx::BufferVar>())) {
+      return BufferLoad(buffer_map_[load->source.as_or_throw<tvm::tirx::BufferVar>()],
+                        load->indices, load->span);
     }
     return load;
   }
@@ -87,8 +86,8 @@ class DistSBlockInfoCollector : public StmtExprVisitor {
     StmtExprVisitor::VisitStmt_(op);
   }
 
-  void VisitExpr_(const BufferLoadNode* op) final {
-    buffer_access_indices[op->buffer].push_back(op->indices);
+  void VisitExpr_(const TensorLoadNode* op) final {
+    buffer_access_indices[op->source.as_or_throw<tvm::tirx::BufferVar>()].push_back(op->indices);
     StmtExprVisitor::VisitExpr_(op);
   }
 
@@ -103,8 +102,8 @@ class DistSBlockInfoCollector : public StmtExprVisitor {
   }
 
   bool IsReduceBufferAccess(const PrimExpr& expr) {
-    if (const auto* buffer_load = expr.as<BufferLoadNode>()) {
-      return buffer_load->buffer.same_as(reduce_buffer_);
+    if (const auto* buffer_load = expr.as<TensorLoadNode>()) {
+      return buffer_load->source.as_or_throw<tvm::tirx::BufferVar>().same_as(reduce_buffer_);
     }
     return false;
   }

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -175,7 +175,7 @@ void ExprVisitor::VisitExpr_(const CallNode* op) {
   VisitExprDepTypeFieldIfNeeded(this, op->ty);
 }
 
-void ExprVisitor::VisitExpr_(const tirx::BufferLoadNode* op) {
+void ExprVisitor::VisitExpr_(const TensorLoadNode* op) {
   this->VisitSpan(op->span);
   for (const PrimExpr& index : op->indices) {
     this->VisitExpr(index);
@@ -530,13 +530,13 @@ Expr ExprMutatorBase::VisitExpr_(const CallNode* call_node) {
   }
 }
 
-Expr ExprMutatorBase::VisitExpr_(const tirx::BufferLoadNode* op) {
+Expr ExprMutatorBase::VisitExpr_(const TensorLoadNode* op) {
   ffi::Array<PrimExpr> indices = op->indices.Map(
       [this](const PrimExpr& e) { return this->VisitExpr(e).as_or_throw<PrimExpr>(); });
   if (indices.same_as(op->indices)) {
     return ffi::GetRef<Expr>(op);
   }
-  return tirx::BufferLoad(op->buffer, indices, op->span);
+  return tirx::BufferLoad(op->source.as_or_throw<tirx::BufferVar>(), indices, op->span);
 }
 
 #define RELAX_MUTATE_TIRX_BINOP(OP)                              \

--- a/src/relax/transform/compute_prim_value.cc
+++ b/src/relax/transform/compute_prim_value.cc
@@ -61,7 +61,7 @@ class PrimExprComputeInjector : public ExprMutator {
     return LiftPrimValue(ffi::GetRef<Expr>(op).as_or_throw<PrimExpr>()); \
   }
 
-  RELAX_LIFT_PRIM_EXPR(tirx::BufferLoadNode);
+  RELAX_LIFT_PRIM_EXPR(TensorLoadNode);
   RELAX_LIFT_PRIM_EXPR(tirx::AddNode);
   RELAX_LIFT_PRIM_EXPR(tirx::SubNode);
   RELAX_LIFT_PRIM_EXPR(tirx::MulNode);

--- a/src/relax/transform/dataflow_inplace.cc
+++ b/src/relax/transform/dataflow_inplace.cc
@@ -771,11 +771,10 @@ tirx::Stmt RemapBuffers(const tirx::Stmt& stmt,
 
     tirx::Stmt Remap(const tirx::Stmt& stmt) { return VisitStmt(stmt); }
 
-    Expr VisitExpr_(const tirx::BufferLoadNode* op) final {
-      auto node = tirx::StmtExprMutator::VisitExpr_(op).as_or_throw<tirx::BufferLoad>();
-      auto* node_cow = node.CopyOnWrite();
-      node_cow->buffer = AttemptRemap(node->buffer);
-      return node;
+    Expr VisitExpr_(const TensorLoadNode* op) final {
+      auto node = tirx::StmtExprMutator::VisitExpr_(op).as_or_throw<TensorLoad>();
+      return tirx::BufferLoad(AttemptRemap(node->source.as_or_throw<tirx::BufferVar>()),
+                              node->indices, node->span);
     }
 
     tirx::Stmt VisitStmt_(const tirx::BufferStoreNode* op) final {

--- a/src/relax/transform/fuse_tir.cc
+++ b/src/relax/transform/fuse_tir.cc
@@ -208,16 +208,14 @@ class FuseTIRBufferSubstitutor : private StmtExprMutator {
     }
   }
 
-  Expr VisitExpr_(const BufferLoadNode* _op) final {
-    BufferLoad load = StmtExprMutator::VisitExpr_(_op).as_or_throw<BufferLoad>();
-    const BufferVar& buffer = SubstituteBuffer(load->buffer);
-    if (buffer.same_as(load->buffer)) {
+  Expr VisitExpr_(const TensorLoadNode* _op) final {
+    TensorLoad load = StmtExprMutator::VisitExpr_(_op).as_or_throw<TensorLoad>();
+    const BufferVar& buffer = SubstituteBuffer(load->source.as_or_throw<tvm::tirx::BufferVar>());
+    if (buffer.same_as(load->source.as_or_throw<tvm::tirx::BufferVar>())) {
       return load;
 
     } else {
-      auto n = ffi::make_object<BufferLoadNode>(*load.get());
-      n->buffer = buffer;
-      return BufferLoad(n);
+      return BufferLoad(buffer, load->indices, load->span);
     }
   }
 

--- a/src/relax/transform/split_call_tir_by_pattern.cc
+++ b/src/relax/transform/split_call_tir_by_pattern.cc
@@ -318,8 +318,8 @@ class ForMatcher : public TensorizeComparator {
     return CompareBufferAccess(op, rhs) && VisitExpr(op->value, rhs->value);
   }
 
-  bool VisitExpr_(const BufferLoadNode* op, const PrimExpr& other) {
-    const auto* rhs = other.as<BufferLoadNode>();
+  bool VisitExpr_(const TensorLoadNode* op, const PrimExpr& other) {
+    const auto* rhs = other.as<TensorLoadNode>();
     return CompareBufferAccess(op, rhs);
   }
 
@@ -354,6 +354,15 @@ class ForMatcher : public TensorizeComparator {
   template <typename T>
   bool CompareBufferAccess(const T* lhs, const T* rhs) {
     if (!CompareBuffer(lhs->buffer, rhs->buffer)) return false;
+    return CompareArray(lhs->indices, rhs->indices, &ForMatcher::VisitExpr);
+  }
+
+  bool CompareBufferAccess(const TensorLoadNode* lhs, const TensorLoadNode* rhs) {
+    if (rhs == nullptr) return false;
+    if (!CompareBuffer(lhs->source.as_or_throw<BufferVar>(),
+                       rhs->source.as_or_throw<BufferVar>())) {
+      return false;
+    }
     return CompareArray(lhs->indices, rhs->indices, &ForMatcher::VisitExpr);
   }
 

--- a/src/relax/transform/split_layout_rewrite_preproc.cc
+++ b/src/relax/transform/split_layout_rewrite_preproc.cc
@@ -189,7 +189,7 @@ class SplitPrimFuncLayoutRewrite : public StmtMutator {
       const BufferVar& preproc_buffer = op->reads[0]->buffer;
       int buffer_index = -1;
       for (size_t i = 0; i < original_func_->params.size(); ++i) {
-        BufferVar buffer = original_func_->params[i].as_or_throw<BufferVar>();
+        BufferVar buffer = original_func_->params[i].as_or_throw<tvm::tirx::BufferVar>();
         if (buffer == preproc_buffer) {
           buffer_index = i;
           break;

--- a/src/s_tir/analysis/estimate_flops.cc
+++ b/src/s_tir/analysis/estimate_flops.cc
@@ -137,7 +137,7 @@ class FlopEstimator : private ExprFunctor<TResult(const Expr& n)>,
     return result;
   }
 
-  TResult VisitExpr_(const BufferLoadNode* op) override { return TResult(); }
+  TResult VisitExpr_(const TensorLoadNode* op) override { return TResult(); }
   TResult VisitStmt_(const AttrStmtNode* op) override {
     TResult result = VisitStmt(op->body);
     result += VisitExpr(op->value);

--- a/src/s_tir/analysis/identify_memcpy.cc
+++ b/src/s_tir/analysis/identify_memcpy.cc
@@ -71,8 +71,8 @@ std::variant<MemCpyDetails, std::string> IdentifyMemCpyImpl(const For& loop,
         .str();
   }
 
-  BufferLoad load;
-  if (auto opt = store->value.as<BufferLoad>()) {
+  TensorLoad load;
+  if (auto opt = store->value.as<TensorLoad>()) {
     load = opt.value();
   } else {
     return static_cast<const std::stringstream&>(
@@ -86,7 +86,8 @@ std::variant<MemCpyDetails, std::string> IdentifyMemCpyImpl(const For& loop,
   // non-flat physical indices are target-dependent, only handle cases
   // where the buffer will be flattened to a 1-d physical buffer.
   ffi::Array<PrimExpr> flattened_dst = store->buffer.OffsetOf(store->indices);
-  ffi::Array<PrimExpr> flattened_src = load->buffer.OffsetOf(load->indices);
+  ffi::Array<PrimExpr> flattened_src =
+      load->source.as_or_throw<tvm::tirx::BufferVar>().OffsetOf(load->indices);
 
   if (flattened_dst.size() != 1 || flattened_src.size() != 1) {
     return static_cast<const std::stringstream&>(
@@ -271,7 +272,9 @@ std::variant<MemCpyDetails, std::string> IdentifyMemCpyImpl(const For& loop,
     }
   }
 
-  BufferRegion src_region(load->buffer, arith::DomainTouched(loop, load->buffer, true, true));
+  BufferRegion src_region(
+      load->source.as_or_throw<tvm::tirx::BufferVar>(),
+      arith::DomainTouched(loop, load->source.as_or_throw<tvm::tirx::BufferVar>(), true, true));
   BufferRegion dst_region(store->buffer, arith::DomainTouched(loop, store->buffer, true, true));
 
   return MemCpyDetails{src_region, dst_region};

--- a/src/s_tir/analysis/oob_checker.cc
+++ b/src/s_tir/analysis/oob_checker.cc
@@ -76,21 +76,21 @@ class OOBCheckerVisitor final : public arith::IRVisitorWithAnalyzer {
  public:
   void VisitStmt_(const BufferStoreNode* node) final {
     for (size_t i = 0; i < node->buffer->shape.size(); i++) {
-      CheckBounds(node, i);
+      CheckBounds(node, node->buffer, i);
     }
     IRVisitorWithAnalyzer::VisitStmt_(node);
   }
-  void VisitExpr_(const BufferLoadNode* node) final {
-    for (size_t i = 0; i < node->buffer->shape.size(); i++) {
-      CheckBounds(node, i);
+  void VisitExpr_(const TensorLoadNode* node) final {
+    for (size_t i = 0; i < node->source.as_or_throw<tvm::tirx::BufferVar>()->shape.size(); i++) {
+      CheckBounds(node, node->source.as_or_throw<tvm::tirx::BufferVar>(), i);
     }
     IRVisitorWithAnalyzer::VisitExpr_(node);
   }
 
   template <class T>
-  void CheckBounds(const T* node, size_t i) {
+  void CheckBounds(const T* node, const BufferVar& buffer, size_t i) {
     auto ind_bounds = analyzer_->int_set(node->indices[i]);
-    auto shape_bounds = analyzer_->int_set(node->buffer->shape[i]);
+    auto shape_bounds = analyzer_->int_set(buffer->shape[i]);
     // We would expect that
     // `analyzer_.CanProve(node->indices[i] < 0 || node->indices[i] >= node->buffer->shape[i])`
     // would be the way to check if any out of bounds access occurs here, but `CanProve` checks if
@@ -104,7 +104,7 @@ class OOBCheckerVisitor final : public arith::IRVisitorWithAnalyzer {
     // us to the following check: are the bounds of the index outside the bounds of the shape.
     if (analyzer_->CanProve(ind_bounds.max() >= shape_bounds.min()) ||
         analyzer_->CanProve(ind_bounds.min() < 0)) {
-      errors.push_back({node->buffer, i, node->indices[i], ind_bounds, shape_bounds});
+      errors.push_back({buffer, i, node->indices[i], ind_bounds, shape_bounds});
     }
   }
 

--- a/src/s_tir/analysis/oob_checker.cc
+++ b/src/s_tir/analysis/oob_checker.cc
@@ -81,8 +81,9 @@ class OOBCheckerVisitor final : public arith::IRVisitorWithAnalyzer {
     IRVisitorWithAnalyzer::VisitStmt_(node);
   }
   void VisitExpr_(const TensorLoadNode* node) final {
-    for (size_t i = 0; i < node->source.as_or_throw<tvm::tirx::BufferVar>()->shape.size(); i++) {
-      CheckBounds(node, node->source.as_or_throw<tvm::tirx::BufferVar>(), i);
+    BufferVar buffer = node->source.as_or_throw<tvm::tirx::BufferVar>();
+    for (size_t i = 0; i < buffer->shape.size(); i++) {
+      CheckBounds(node, buffer, i);
     }
     IRVisitorWithAnalyzer::VisitExpr_(node);
   }

--- a/src/s_tir/analysis/sblock_access_region_detector.cc
+++ b/src/s_tir/analysis/sblock_access_region_detector.cc
@@ -125,7 +125,7 @@ class BlockReadWriteDetector : public StmtExprVisitor {
   void VisitStmt_(const DeclBufferNode* op) override;
   void VisitStmt_(const BufferStoreNode* op) override;
   void VisitStmt_(const BindNode* op) override;
-  void VisitExpr_(const BufferLoadNode* op) override;
+  void VisitExpr_(const TensorLoadNode* op) override;
   void VisitExpr_(const VarNode* op) override;
   void VisitExpr_(const CallNode* op) override;
 };
@@ -161,7 +161,7 @@ ffi::Array<BufferRegion> BlockReadWriteDetector::CollectOpaques() {
 
 void BlockReadWriteDetector::VisitExpr_(const VarNode* op) { UpdateOpaque(ffi::GetRef<Var>(op)); }
 
-void BlockReadWriteDetector::VisitExpr_(const BufferLoadNode* op) {
+void BlockReadWriteDetector::VisitExpr_(const TensorLoadNode* op) {
   std::vector<arith::IntSet> relaxed_region;
   for (PrimExpr index : op->indices) {
     PrimExpr remapped_index = Substitute(index, let_bindings_);
@@ -171,7 +171,8 @@ void BlockReadWriteDetector::VisitExpr_(const BufferLoadNode* op) {
     }
     relaxed_region.push_back(arith::EvalSet(arith::IntSet::Vector(remapped_index), dom_map_));
   }
-  Update(&read_buffers_, &read_regions_, op->buffer, relaxed_region);
+  Update(&read_buffers_, &read_regions_, op->source.as_or_throw<tvm::tirx::BufferVar>(),
+         relaxed_region);
   ExprVisitor::VisitExpr_(op);
 }
 

--- a/src/s_tir/analysis/sblock_buffer_access_lca_detector.cc
+++ b/src/s_tir/analysis/sblock_buffer_access_lca_detector.cc
@@ -255,8 +255,8 @@ class LCADetector : public StmtExprVisitor {
     StmtExprVisitor::VisitStmt_(op);
   }
 
-  void VisitExpr_(const BufferLoadNode* op) final {
-    UpdateBufferLCA(op->buffer.get(), ancestor_scopes_.back());
+  void VisitExpr_(const TensorLoadNode* op) final {
+    UpdateBufferLCA(op->source.as_or_throw<tvm::tirx::BufferVar>().get(), ancestor_scopes_.back());
     StmtExprVisitor::VisitExpr_(op);
   }
 

--- a/src/s_tir/analysis/verify_gpu_code.cc
+++ b/src/s_tir/analysis/verify_gpu_code.cc
@@ -229,7 +229,7 @@ class GPUCodeVerifier : public StmtExprVisitor {
     ExprVisitor::VisitExpr_(op);
   }
 
-  void VisitExpr_(const BufferLoadNode* op) {
+  void VisitExpr_(const TensorLoadNode* op) {
     PrimType op_ty = op->ty.as_or_throw<PrimType>();
     if (op_ty.IsFixedLengthVector()) {
       if (ElementBytes(op_ty) > max_vector_bytes_) {

--- a/src/s_tir/backend/adreno/texture_flatten.cc
+++ b/src/s_tir/backend/adreno/texture_flatten.cc
@@ -102,15 +102,18 @@ class TextureFlattener : public TextureLoweringBase {
     return stmt;
   }
 
-  Expr VisitExpr_(const BufferLoadNode* op) final {
+  Expr VisitExpr_(const TensorLoadNode* op) final {
     PrimExpr expr = StmtExprMutator::VisitExpr_(op).as_or_throw<PrimExpr>();
-    op = expr.as<BufferLoadNode>();
+    op = expr.as<TensorLoadNode>();
     // Lower to two dimensional access
-    std::string storage_scope = GetStorageScope(op->buffer);
+    std::string storage_scope = GetStorageScope(op->source.as_or_throw<tvm::tirx::BufferVar>());
     if (IsTextureStorage(storage_scope)) {
-      ffi::Array<Expr> args = GetTextureAccessArgs(op, op->buffer);
+      ffi::Array<Expr> args =
+          GetTextureAccessArgs(op, op->source.as_or_throw<tvm::tirx::BufferVar>());
       args.push_back(op->indices.back());
-      expr = Call(op->buffer->dtype, builtin::texture2d_load(), args).as_or_throw<PrimExpr>();
+      expr = Call(op->source.as_or_throw<tvm::tirx::BufferVar>()->dtype, builtin::texture2d_load(),
+                  args)
+                 .as_or_throw<PrimExpr>();
     }
 
     return expr;
@@ -120,22 +123,22 @@ class TextureFlattener : public TextureLoweringBase {
   template <typename T>
   ffi::Array<Expr> GetTextureAccessArgs(const T* op, const BufferVar& buffer) {
     ffi::Array<Expr> args;
-    if (let_binding_.count(op->buffer.var())) {
-      args.push_back(let_binding_[op->buffer.var()]);
+    if (let_binding_.count(buffer.var())) {
+      args.push_back(let_binding_[buffer.var()]);
     } else {
       args.push_back(buffer.data());
     }
     ffi::Array<PrimExpr> row_dims, row_indices, col_dims, col_indices, depth_dims, depth_indices;
-    size_t axis = DefaultTextureLayoutSeparator(op->buffer->shape.size(), GetStorageScope(buffer));
-    for (size_t i = 0; i < op->buffer->shape.size() - 1; i++) {
+    size_t axis = DefaultTextureLayoutSeparator(buffer->shape.size(), GetStorageScope(buffer));
+    for (size_t i = 0; i < buffer->shape.size() - 1; i++) {
       if (i < (axis - 1)) {
-        depth_dims.push_back(op->buffer->shape[i]);
+        depth_dims.push_back(buffer->shape[i]);
         depth_indices.push_back(op->indices[i]);
       } else if (i < axis) {
-        col_dims.push_back(op->buffer->shape[i]);
+        col_dims.push_back(buffer->shape[i]);
         col_indices.push_back(op->indices[i]);
       } else {
-        row_dims.push_back(op->buffer->shape[i]);
+        row_dims.push_back(buffer->shape[i]);
         row_indices.push_back(op->indices[i]);
       }
     }

--- a/src/s_tir/meta_schedule/feature_extractor/per_store_feature.cc
+++ b/src/s_tir/meta_schedule/feature_extractor/per_store_feature.cc
@@ -263,7 +263,7 @@ Pass SimplifyForFeatureExtraction() {
     static bool HasBufferLoad(const PrimExpr& expr) {
       bool found = false;
       PostOrderVisit(expr, [&found](const ffi::ObjectRef& node) {
-        if (node->IsInstance<BufferLoadNode>()) {
+        if (node->IsInstance<TensorLoadNode>()) {
           found = true;
         }
       });
@@ -798,8 +798,8 @@ void Feature::Init(const BufferStoreNode* store, int n_loops) {
     info.multi_indices.push_back({store->indices.begin(), store->indices.end()});
   }
   PostOrderVisit(store->value, [&buffer_info](const ffi::ObjectRef& obj) -> void {
-    if (const BufferLoadNode* load = obj.as<BufferLoadNode>()) {
-      BufferVar buffer = load->buffer;
+    if (const TensorLoadNode* load = obj.as<TensorLoadNode>()) {
+      BufferVar buffer = load->source.as_or_throw<tvm::tirx::BufferVar>();
       Info& info = buffer_info[buffer];
       switch (info.access_type) {
         case AccessType::kRead:

--- a/src/s_tir/meta_schedule/postproc/disallow_async_strided_mem_copy.cc
+++ b/src/s_tir/meta_schedule/postproc/disallow_async_strided_mem_copy.cc
@@ -71,7 +71,7 @@ struct AsyncStridedMemCopyFinder : private StmtExprVisitor {
           StmtExprVisitor::VisitStmt_(attrStmt);
         }
 
-        auto bufferloadnode = bufferstorenode->value.as<BufferLoadNode>();
+        auto bufferloadnode = bufferstorenode->value.as<TensorLoadNode>();
         if (!bufferloadnode) {
           StmtExprVisitor::VisitStmt_(attrStmt);
         }
@@ -80,7 +80,8 @@ struct AsyncStridedMemCopyFinder : private StmtExprVisitor {
         auto bufferstore = bufferstorenode->buffer.as<BufferTypeNode>();
 
         // get load buffer; assert it exists and is contiguous given it uses a single index
-        auto bufferload = bufferloadnode->buffer.as<BufferTypeNode>();
+        BufferVar load_buffer = bufferloadnode->source.as_or_throw<BufferVar>();
+        auto bufferload = load_buffer.as<BufferTypeNode>();
 
         if (!bufferstore || !bufferload) {
           StmtExprVisitor::VisitStmt_(attrStmt);

--- a/src/s_tir/meta_schedule/postproc/rewrite_cooperative_fetch.cc
+++ b/src/s_tir/meta_schedule/postproc/rewrite_cooperative_fetch.cc
@@ -94,7 +94,7 @@ size_t GetMaxUsedDtypeBytes(SBlock block) {
   tirx::PostOrderVisit(block->body, [&](const ffi::ObjectRef& obj) {
     if (const auto* store = obj.as<tirx::BufferStoreNode>()) {
       max_bytes = std::max(max_bytes, store->value.ty().StorageBytes());
-    } else if (const auto* load = obj.as<tirx::BufferLoadNode>()) {
+    } else if (const auto* load = obj.as<TensorLoadNode>()) {
       max_bytes = std::max(max_bytes, load->ty.as_or_throw<PrimType>().StorageBytes());
     } else if (const auto* call = obj.as<CallNode>()) {
       static const Op& q_multiply_shift_per_axis_op = Op::Get("tirx.q_multiply_shift_per_axis");

--- a/src/s_tir/meta_schedule/postproc/rewrite_layout.cc
+++ b/src/s_tir/meta_schedule/postproc/rewrite_layout.cc
@@ -55,10 +55,10 @@ class BufferReadPosCollector : public StmtExprVisitor {
     std::swap(cur_realize_, outer_block_realize);
   }
 
-  void VisitExpr_(const BufferLoadNode* op) final {
-    TVM_FFI_ICHECK(cur_realize_.defined()) << "BufferLoad occurred outside of any block";
+  void VisitExpr_(const TensorLoadNode* op) final {
+    TVM_FFI_ICHECK(cur_realize_.defined()) << "TensorLoad occurred outside of any block";
 
-    const BufferVar& buffer = op->buffer;
+    const BufferVar& buffer = op->source.as_or_throw<tvm::tirx::BufferVar>();
     if (buffer_ == buffer.get()) {
       ffi::Map<Var, PrimExpr> subst_map;
       for (size_t i = 0; i < cur_realize_->iter_values.size(); i++) {
@@ -129,7 +129,7 @@ ffi::Array<BufferVar> CollectLayoutFreeBuffers(const PrimFuncNode* func) {
   for (int64_t index : layout_free_buffer_index) {
     TVM_FFI_ICHECK(static_cast<size_t>(index) < func->params.size());
     const Var& param = func->params[index];
-    layout_free_buffers.push_back(param.as_or_throw<BufferVar>());
+    layout_free_buffers.push_back(param.as_or_throw<tvm::tirx::BufferVar>());
   }
 
   LayoutFreeBufferCollector collector;

--- a/src/s_tir/schedule/analysis/reducer.cc
+++ b/src/s_tir/schedule/analysis/reducer.cc
@@ -245,12 +245,14 @@ class PatternMatcher : public ExprVisitor {
     match_success_ = ptr != nullptr && op->value == ptr->value;
   }
 
-  void VisitExpr_(const BufferLoadNode* op) final {
-    const auto* ptr = expr_to_match_.as<BufferLoadNode>();
+  void VisitExpr_(const TensorLoadNode* op) final {
+    const auto* ptr = expr_to_match_.as<TensorLoadNode>();
     if (ptr == nullptr) {
       match_success_ = false;
     } else {
-      if (!op->buffer.same_as(ptr->buffer) || op->indices.size() != ptr->indices.size()) {
+      if (!op->source.as_or_throw<tvm::tirx::BufferVar>().same_as(
+              ptr->source.as_or_throw<tvm::tirx::BufferVar>()) ||
+          op->indices.size() != ptr->indices.size()) {
         match_success_ = false;
       } else {
         Expr tmp = expr_to_match_;
@@ -654,7 +656,7 @@ std::tuple<CommReducer, ffi::Array<PrimExpr>, ffi::Array<PrimExpr>> GetReducerAn
 
 bool MatchReducer(const CommReducer& reducer, const ffi::Array<PrimExpr>& identities,
                   const ffi::Array<PrimExpr>& combined_values,
-                  const ffi::Array<BufferLoad>& buf_loads, ffi::Array<PrimExpr>* lhs,
+                  const ffi::Array<TensorLoad>& buf_loads, ffi::Array<PrimExpr>* lhs,
                   ffi::Array<PrimExpr>* rhs) {
   ExprDeepEqual equal;
   TVM_FFI_ICHECK_EQ(identities.size(), combined_values.size());
@@ -692,7 +694,7 @@ bool FromIdentityCombiner(const ffi::Array<PrimExpr>& identities,
                           const ffi::Array<BufferStore>& combiners, CommReducer* result_reducer,
                           ffi::Array<PrimExpr>* lhs, ffi::Array<PrimExpr>* rhs) {
   int n = identities.size();
-  ffi::Array<BufferLoad> buf_loads;
+  ffi::Array<TensorLoad> buf_loads;
   ffi::Array<PrimExpr> stored_values;
   buf_loads.reserve(n);
   stored_values.reserve(n);

--- a/src/s_tir/schedule/ir_comparator.cc
+++ b/src/s_tir/schedule/ir_comparator.cc
@@ -385,8 +385,8 @@ bool TensorizeComparator::VisitExpr_(const VarNode* op, const PrimExpr& other) {
   return it != equal_map_.end() && it->second.same_as(other);
 }
 
-bool TensorizeComparator::VisitExpr_(const BufferLoadNode* op, const PrimExpr& other) {
-  const auto* rhs = other.as<BufferLoadNode>();
+bool TensorizeComparator::VisitExpr_(const TensorLoadNode* op, const PrimExpr& other) {
+  const auto* rhs = other.as<TensorLoadNode>();
   return CompareBufferAccess(op, rhs);
 }
 
@@ -625,10 +625,17 @@ bool TensorizeComparator::CompareBufferRegion(const BufferRegion& lhs, const Buf
   return true;
 }
 
-// Comparator for BufferStoreNode and BufferLoadNode
+// Comparator for BufferStoreNode and TensorLoadNode
+inline BufferVar GetBufferAccessBuffer(const BufferStoreNode* op) { return op->buffer; }
+inline BufferVar GetBufferAccessBuffer(const TensorLoadNode* op) {
+  return op->source.as_or_throw<tvm::tirx::BufferVar>();
+}
+
 template <typename T>
 bool TensorizeComparator::CompareBufferAccess(const T* lhs, const T* rhs) {
-  if (!CompareBuffer(lhs->buffer, rhs->buffer)) return false;
+  BufferVar lhs_buffer = GetBufferAccessBuffer(lhs);
+  BufferVar rhs_buffer = GetBufferAccessBuffer(rhs);
+  if (!CompareBuffer(lhs_buffer, rhs_buffer)) return false;
   int offset = static_cast<int>(lhs->indices.size()) - static_cast<int>(rhs->indices.size());
   if (offset < 0) {
     if (assert_mode_) {
@@ -640,7 +647,7 @@ bool TensorizeComparator::CompareBufferAccess(const T* lhs, const T* rhs) {
     }
     return false;
   }
-  auto it = buffer_indices_.find(lhs->buffer);
+  auto it = buffer_indices_.find(lhs_buffer);
   TVM_FFI_ICHECK(it != buffer_indices_.end());
   const std::vector<PrimExpr>& indices_base = (*it).second;
   TVM_FFI_ICHECK_EQ(indices_base.size(), rhs->indices.size() + offset);
@@ -775,17 +782,19 @@ bool AutoTensorizeComparator::VisitStmt_(const BufferStoreNode* op, const Stmt& 
   return CompareBufferAccess(op, rhs) && VisitExpr(op->value, rhs->value);
 }
 
-bool AutoTensorizeComparator::VisitExpr_(const BufferLoadNode* op, const PrimExpr& other) {
-  const auto* rhs = other.as<BufferLoadNode>();
+bool AutoTensorizeComparator::VisitExpr_(const TensorLoadNode* op, const PrimExpr& other) {
+  const auto* rhs = other.as<TensorLoadNode>();
   return CompareBufferAccess(op, rhs);
 }
 
 template <typename T>
 bool AutoTensorizeComparator::CompareBufferAccess(const T* lhs, const T* rhs) {
-  if (!CompareBuffer(lhs->buffer, rhs->buffer)) return false;
-  auto it_lhs = lhs_buffer_indices_map_.find(lhs->buffer);
+  BufferVar lhs_buffer = GetBufferAccessBuffer(lhs);
+  BufferVar rhs_buffer = GetBufferAccessBuffer(rhs);
+  if (!CompareBuffer(lhs_buffer, rhs_buffer)) return false;
+  auto it_lhs = lhs_buffer_indices_map_.find(lhs_buffer);
   if (it_lhs == lhs_buffer_indices_map_.end()) {
-    if (rhs_buffer_indices_map_.find(rhs->buffer) != rhs_buffer_indices_map_.end()) {
+    if (rhs_buffer_indices_map_.find(rhs_buffer) != rhs_buffer_indices_map_.end()) {
       return false;
     }
     std::vector<PrimExpr> lhs_indices;
@@ -804,10 +813,10 @@ bool AutoTensorizeComparator::CompareBufferAccess(const T* lhs, const T* rhs) {
     for (const auto& index : rhs->indices) {
       if (!index.template as<PrimVar>() && !is_scalar_access(rhs->indices, index)) return false;
     }
-    lhs_buffer_indices_map_[lhs->buffer] = lhs_indices;
-    rhs_buffer_indices_map_[rhs->buffer] = rhs->indices;
+    lhs_buffer_indices_map_[lhs_buffer] = lhs_indices;
+    rhs_buffer_indices_map_[rhs_buffer] = rhs->indices;
   } else {
-    auto it_rhs = rhs_buffer_indices_map_.find(rhs->buffer);
+    auto it_rhs = rhs_buffer_indices_map_.find(rhs_buffer);
     if (it_rhs == rhs_buffer_indices_map_.end()) {
       return false;
     }

--- a/src/s_tir/schedule/ir_comparator.h
+++ b/src/s_tir/schedule/ir_comparator.h
@@ -75,7 +75,7 @@ class TensorizeComparator : public ExprComparator, public StmtComparator {
   bool VisitExpr_(const FloatImmNode* op, const PrimExpr& other) override;
   bool VisitExpr_(const CastNode* op, const PrimExpr& other) override;
   bool VisitExpr_(const VarNode* op, const PrimExpr& other) override;
-  bool VisitExpr_(const BufferLoadNode* op, const PrimExpr& other) override;
+  bool VisitExpr_(const TensorLoadNode* op, const PrimExpr& other) override;
   bool VisitExpr_(const SelectNode* op, const PrimExpr& other) override;
 
   /*! \brief Map from RHS buffer to LHS buffer */
@@ -142,7 +142,7 @@ class AutoTensorizeComparator : public TensorizeComparator {
   bool VisitStmt_(const SBlockNode* op, const Stmt& other) override;
   bool VisitStmt_(const BufferStoreNode* op, const Stmt& other) override;
 
-  bool VisitExpr_(const BufferLoadNode* op, const PrimExpr& other) override;
+  bool VisitExpr_(const TensorLoadNode* op, const PrimExpr& other) override;
 
   bool CompareBuffer(const BufferVar& lhs, const BufferVar& rhs) override;
   template <typename T>

--- a/src/s_tir/schedule/primitive/block_annotate.cc
+++ b/src/s_tir/schedule/primitive/block_annotate.cc
@@ -335,9 +335,9 @@ class DTypeMutator : private ReplaceBufferMutator {
     return node;
   }
 
-  Expr VisitExpr_(const BufferLoadNode* op) final {
-    BufferLoad node = StmtExprMutator::VisitExpr_(op).as_or_throw<BufferLoad>();
-    auto it = buffer_var_map_.find(node->buffer.get());
+  Expr VisitExpr_(const TensorLoadNode* op) final {
+    TensorLoad node = StmtExprMutator::VisitExpr_(op).as_or_throw<TensorLoad>();
+    auto it = buffer_var_map_.find(node->source.as_or_throw<tvm::tirx::BufferVar>().get());
     if (it != buffer_var_map_.end()) {
       return Cast(src_dtype_, BufferLoad(it->second, node->indices));
     }

--- a/src/s_tir/schedule/primitive/blockize_tensorize.cc
+++ b/src/s_tir/schedule/primitive/blockize_tensorize.cc
@@ -796,8 +796,8 @@ void Tensorize(ScheduleState self, const StmtSRef& sref, const TensorIntrin& int
   std::unordered_map<BufferVar, BufferVar, ffi::ObjectPtrHash, ffi::ObjectPtrEqual> impl2desc;
   TVM_FFI_ICHECK_EQ(intrin_desc->params.size(), intrin_impl->params.size());
   for (int i = 0, n = intrin_desc->params.size(); i < n; ++i) {
-    BufferVar desc = intrin_desc->params[i].as_or_throw<BufferVar>();
-    BufferVar impl = intrin_impl->params[i].as_or_throw<BufferVar>();
+    BufferVar desc = intrin_desc->params[i].as_or_throw<tvm::tirx::BufferVar>();
+    BufferVar impl = intrin_impl->params[i].as_or_throw<tvm::tirx::BufferVar>();
     impl2desc[impl] = desc;
   }
   std::unordered_map<BufferVar, BufferVar, ffi::ObjectPtrHash, ffi::ObjectPtrEqual> impl2cur;
@@ -821,7 +821,7 @@ void Tensorize(ScheduleState self, const StmtSRef& sref, const TensorIntrin& int
   ffi::Array<MatchBufferRegion> match_buffer_regions;
   match_buffer_regions.reserve(intrin_impl->params.size());
   for (int i = 0, n = intrin_impl->params.size(); i < n; ++i) {
-    BufferVar impl = intrin_impl->params[i].as_or_throw<BufferVar>();
+    BufferVar impl = intrin_impl->params[i].as_or_throw<tvm::tirx::BufferVar>();
     const BufferVar& cur = impl2cur.at(impl);
     const ffi::Array<Range>& old_region = impl2region.at(impl);
     const std::vector<PrimExpr>& indices_base = comparator.buffer_indices_.at(cur);

--- a/src/s_tir/schedule/primitive/cache_index.cc
+++ b/src/s_tir/schedule/primitive/cache_index.cc
@@ -418,7 +418,7 @@ class CacheIndexRewriter : public StmtExprMutator {
             [computation](const PrimExpr& current_expr) {
               return (EquivalentTerms(current_expr, computation, true));
             };
-        BufferLoad load = BufferLoad(info_->cache_buffer[i], cache_indices_[i]);
+        TensorLoad load = BufferLoad(info_->cache_buffer[i], cache_indices_[i]);
         ret_stmt = ReplaceSelectedExpr::ReplaceSelectedExprInStmt(
             ret_stmt, predicate_selector, std::move(load),
             [](const PrimExpr& expr) { return true; });

--- a/src/s_tir/schedule/primitive/cache_read_write.cc
+++ b/src/s_tir/schedule/primitive/cache_read_write.cc
@@ -1024,14 +1024,14 @@ class CacheReadRewriter : public StmtExprMutator {
     return ret;
   }
 
-  Expr VisitExpr_(const BufferLoadNode* load) override {
-    if (load->buffer.same_as(info_->read_buffer) && current_block_consumes) {
-      ffi::ObjectPtr<BufferLoadNode> n = ffi::make_object<BufferLoadNode>(*load);
-      n->buffer = info_->write_buffer;
+  Expr VisitExpr_(const TensorLoadNode* load) override {
+    if (load->source.as_or_throw<tvm::tirx::BufferVar>().same_as(info_->read_buffer) &&
+        current_block_consumes) {
+      ffi::Array<PrimExpr> indices = load->indices;
       if (!cache_full_region_) {
-        n->indices = RewriteIndices(load->indices);
+        indices = RewriteIndices(load->indices);
       }
-      return PrimExpr(n);
+      return BufferLoad(info_->write_buffer, indices, load->span);
     }
     return ExprMutator::VisitExpr_(load);
   }
@@ -1117,12 +1117,10 @@ class ReindexCacheReadRewriter : public CacheReadRewriter {
     };
   }
 
-  Expr VisitExpr_(const BufferLoadNode* load) final {
-    if (load->buffer.same_as(info_->read_buffer) && current_block_consumes) {
-      ffi::ObjectPtr<BufferLoadNode> n = ffi::make_object<BufferLoadNode>(*load);
-      n->buffer = info_->write_buffer;
-      n->indices = new_indices_;
-      return PrimExpr(n);
+  Expr VisitExpr_(const TensorLoadNode* load) final {
+    if (load->source.as_or_throw<tvm::tirx::BufferVar>().same_as(info_->read_buffer) &&
+        current_block_consumes) {
+      return BufferLoad(info_->write_buffer, new_indices_, load->span);
     }
     return ExprMutator::VisitExpr_(load);
   }
@@ -1308,14 +1306,13 @@ class CacheWriteRewriter : public StmtExprMutator {
     }
   }
 
-  Expr VisitExpr_(const BufferLoadNode* load) override {
-    if (load->buffer.same_as(info_->write_buffer)) {
-      ffi::ObjectPtr<BufferLoadNode> n = ffi::make_object<BufferLoadNode>(*load);
-      n->buffer = info_->read_buffer;
+  Expr VisitExpr_(const TensorLoadNode* load) override {
+    if (load->source.as_or_throw<tvm::tirx::BufferVar>().same_as(info_->write_buffer)) {
+      ffi::Array<PrimExpr> indices = load->indices;
       if (!cache_full_region_) {
-        n->indices = RewriteIndices(n->indices);
+        indices = RewriteIndices(indices);
       }
-      return PrimExpr(n);
+      return BufferLoad(info_->read_buffer, indices, load->span);
     }
     return ExprMutator::VisitExpr_(load);
   }
@@ -1418,12 +1415,9 @@ class ReindexCacheWriteRewriter : public CacheWriteRewriter {
     }
   }
 
-  Expr VisitExpr_(const BufferLoadNode* load) final {
-    if (load->buffer.same_as(info_->write_buffer)) {
-      ffi::ObjectPtr<BufferLoadNode> n = ffi::make_object<BufferLoadNode>(*load);
-      n->buffer = info_->read_buffer;
-      n->indices = new_indices_;
-      return PrimExpr(n);
+  Expr VisitExpr_(const TensorLoadNode* load) final {
+    if (load->source.as_or_throw<tvm::tirx::BufferVar>().same_as(info_->write_buffer)) {
+      return BufferLoad(info_->read_buffer, new_indices_, load->span);
     }
     return ExprMutator::VisitExpr_(load);
   }
@@ -1487,14 +1481,14 @@ class InvalidBufferAccessError : public ScheduleError {
   InvalidBufferAccessError(IRModule mod, BufferVar buffer, SBlock block, ErrorKind kind)
       : mod_(std::move(mod)), buffer_(std::move(buffer)), block_(std::move(block)), kind_(kind) {}
   ffi::String FastErrorString() const final {
-    return "ScheduleError: The target buffer should be accessed via BufferLoad or BufferStore. The "
+    return "ScheduleError: The target buffer should be accessed via TensorLoad or BufferStore. The "
            "indices should be the same if there are multiple accesses to the target buffer.";
   }
 
   ffi::String DetailRenderTemplate() const final {
     std::ostringstream os;
     os << "The target buffer " << buffer_.name()
-       << " should be accessed in the leaf block {0} via BufferLoad or BufferStore. The indices "
+       << " should be accessed in the leaf block {0} via TensorLoad or BufferStore. The indices "
           "should be the same if there are multiple accesses to the target buffer. ";
     if (kind_ == ErrorKind::kNoAccess) {
       os << "No buffer accesses found.";
@@ -1533,9 +1527,9 @@ class ReIndexCollector : public StmtExprVisitor {
   explicit ReIndexCollector(const IRModule& mod, const BufferVar& buffer, const SBlock& block)
       : mod_(mod), buffer_(buffer), block_(block) {}
 
-  void VisitExpr_(const BufferLoadNode* load) final {
+  void VisitExpr_(const TensorLoadNode* load) final {
     StmtExprVisitor::VisitExpr_(load);
-    if (load->buffer.same_as(buffer_)) {
+    if (load->source.as_or_throw<tvm::tirx::BufferVar>().same_as(buffer_)) {
       CheckAndUpdateBufferAccessIndices(load->indices);
     }
   }
@@ -1651,13 +1645,18 @@ class ReIndexRewriter : public StmtExprMutator {
     }
     return node;
   }
+  TensorLoad VisitBufferAccess(TensorLoad node) {
+    return node->source.as_or_throw<tvm::tirx::BufferVar>().same_as(old_buffer_)
+               ? BufferLoad(new_buffer_, indices_, node->span)
+               : node;
+  }
   Stmt VisitStmt_(const BufferStoreNode* op) final {
     BufferStore buffer_store = StmtExprMutator::VisitStmt_(op).as_or_throw<BufferStore>();
     return VisitBufferAccess(std::move(buffer_store));
   }
 
-  Expr VisitExpr_(const BufferLoadNode* op) final {
-    BufferLoad buffer_load = StmtExprMutator::VisitExpr_(op).as_or_throw<BufferLoad>();
+  Expr VisitExpr_(const TensorLoadNode* op) final {
+    TensorLoad buffer_load = StmtExprMutator::VisitExpr_(op).as_or_throw<TensorLoad>();
     return VisitBufferAccess(std::move(buffer_load));
   }
 

--- a/src/s_tir/schedule/primitive/compute_inline.cc
+++ b/src/s_tir/schedule/primitive/compute_inline.cc
@@ -534,15 +534,15 @@ class ComputeInliner : public BaseInliner {
   using BaseInliner::VisitExpr_;
   using BaseInliner::VisitStmt_;
 
-  Expr VisitExpr_(const BufferLoadNode* _load) final {
-    BufferLoad load = StmtExprMutator::VisitExpr_(_load).as_or_throw<BufferLoad>();
-    if (!load->buffer.same_as(inlined_buffer_)) {
+  Expr VisitExpr_(const TensorLoadNode* _load) final {
+    TensorLoad load = StmtExprMutator::VisitExpr_(_load).as_or_throw<TensorLoad>();
+    if (!load->source.as_or_throw<tvm::tirx::BufferVar>().same_as(inlined_buffer_)) {
       return load;
     }
     return ReplaceInlinedBuffer(std::move(load));
   }
 
-  PrimExpr ReplaceInlinedBuffer(BufferLoad load) {
+  PrimExpr ReplaceInlinedBuffer(TensorLoad load) {
     SetIndexSubstitution(load->indices);
     return Substitute(store_value_, idx_sub_);
   }
@@ -588,9 +588,11 @@ class ReverseComputeInliner : public BaseInliner {
       return (*it).second;
     }
 
-    Expr VisitExpr_(const BufferLoadNode* _load) final {
-      BufferLoad load = StmtExprMutator::VisitExpr_(_load).as_or_throw<BufferLoad>();
-      return load->buffer.same_as(self_->inlined_buffer_) ? self_->producer_rhs_ : load;
+    Expr VisitExpr_(const TensorLoadNode* _load) final {
+      TensorLoad load = StmtExprMutator::VisitExpr_(_load).as_or_throw<TensorLoad>();
+      return load->source.as_or_throw<tvm::tirx::BufferVar>().same_as(self_->inlined_buffer_)
+                 ? self_->producer_rhs_
+                 : load;
     }
 
     ReverseComputeInliner* self_;
@@ -609,9 +611,9 @@ class ReverseComputeInliner : public BaseInliner {
       return (*it).second;
     }
 
-    Expr VisitExpr_(const BufferLoadNode* _load) final {
-      BufferLoad load = StmtExprMutator::VisitExpr_(_load).as_or_throw<BufferLoad>();
-      return load->buffer.same_as(self_->inlined_buffer_)
+    Expr VisitExpr_(const TensorLoadNode* _load) final {
+      TensorLoad load = StmtExprMutator::VisitExpr_(_load).as_or_throw<TensorLoad>();
+      return load->source.as_or_throw<tvm::tirx::BufferVar>().same_as(self_->inlined_buffer_)
                  ? StmtExprMutator::VisitExpr(
                        BufferLoad(self_->inlined_store_->buffer, self_->inlined_store_->indices))
                  : load;
@@ -647,9 +649,9 @@ class ReverseComputeInliner : public BaseInliner {
       // Failure: block body is not BufferStore
       return false;
     }
-    std::vector<const BufferLoadNode*> loads = ExtractBufferLoad(inlined_buffer_, inlined_store_);
+    std::vector<const TensorLoadNode*> loads = ExtractBufferLoad(inlined_buffer_, inlined_store_);
     if (loads.size() == 0) {
-      // Failure: no BufferLoad from the `inlined_buffer_`
+      // Failure: no TensorLoad from the `inlined_buffer_`
       return false;
     }
 
@@ -663,7 +665,7 @@ class ReverseComputeInliner : public BaseInliner {
       }
     }
 
-    for (const BufferLoadNode* load : loads) {
+    for (const TensorLoadNode* load : loads) {
       if (!UpdateAndCheckIndexExprs(load->indices)) {
         return false;
       }
@@ -678,7 +680,7 @@ class ReverseComputeInliner : public BaseInliner {
         /*simplify_trivial_iterators=*/false);
     buffer_load_iter_map_ = res->indices;
     if (buffer_load_iter_map_.empty()) {
-      // Failure: indices of BufferLoad are not bijective affine
+      // Failure: indices of TensorLoad are not bijective affine
       return false;
     }
 
@@ -830,17 +832,17 @@ class ReverseComputeInliner : public BaseInliner {
    * \param from The BufferStore statement to be extracted from
    * \return A list of `BufferLoad` expressions
    */
-  static std::vector<const BufferLoadNode*> ExtractBufferLoad(const BufferVar& buffer,
+  static std::vector<const TensorLoadNode*> ExtractBufferLoad(const BufferVar& buffer,
                                                               const BufferStoreNode* from) {
     struct Extractor : public ExprVisitor {
-      void VisitExpr_(const BufferLoadNode* load) final {
-        if (load->buffer.get() == buffer) {
+      void VisitExpr_(const TensorLoadNode* load) final {
+        if (load->source.as_or_throw<tvm::tirx::BufferVar>().get() == buffer) {
           result.push_back(load);
         }
         ExprVisitor::VisitExpr_(load);
       }
       const VarNode* buffer;
-      std::vector<const BufferLoadNode*> result;
+      std::vector<const TensorLoadNode*> result;
     } extractor;
     extractor.buffer = buffer.get();
     for (const PrimExpr& expr : from->indices) {
@@ -1025,19 +1027,19 @@ class ReductionEpilogueFuser : public BaseInliner {
  private:
   bool IsReductionBlock(const SBlockNode* block);
   void ExtractEpilogueInfo();
-  // Helper function to extract BufferLoad nodes from BufferStore
-  static std::vector<const BufferLoadNode*> ExtractBufferLoad(const BufferVar& buffer,
+  // Helper function to extract TensorLoad nodes from BufferStore
+  static std::vector<const TensorLoadNode*> ExtractBufferLoad(const BufferVar& buffer,
                                                               const BufferStoreNode* from) {
     struct Extractor : public ExprVisitor {
-      void VisitExpr_(const BufferLoadNode* load) final {
-        if (load->buffer.same_as(buffer)) {
+      void VisitExpr_(const TensorLoadNode* load) final {
+        if (load->source.as_or_throw<tvm::tirx::BufferVar>().same_as(buffer)) {
           result.push_back(load);
         }
         // Continue visiting child nodes (indices)
         ExprVisitor::VisitExpr_(load);
       }
       BufferVar buffer;
-      std::vector<const BufferLoadNode*> result;
+      std::vector<const TensorLoadNode*> result;
     } extractor;
     extractor.buffer = buffer;
     // Visit indices first (though they typically don't contain BufferLoad)
@@ -1054,7 +1056,7 @@ class ReductionEpilogueFuser : public BaseInliner {
   // Generalized approach: store the entire epilogue expression
   PrimExpr epilogue_expression_{
       nullptr};  // The entire epilogue expression (e.g., temp + C, max(temp + C, 0))
-  const BufferLoadNode* reduction_buffer_load_{
+  const TensorLoadNode* reduction_buffer_load_{
       nullptr};                                // The reduction buffer load in epilogue expression
   BufferVar epilogue_output_buffer_{nullptr};  // Output buffer D
   ffi::Array<PrimExpr> epilogue_output_indices_{nullptr};  // Indices of D[vi, vj]
@@ -1077,9 +1079,9 @@ bool ReductionEpilogueFuser::BodyPatternAllowFusion(const SBlockRealize& epilogu
   }
 
   // 3. Check if epilogue reads from reduction buffer
-  std::vector<const BufferLoadNode*> loads = ExtractBufferLoad(inlined_buffer_, inlined_store_);
+  std::vector<const TensorLoadNode*> loads = ExtractBufferLoad(inlined_buffer_, inlined_store_);
   if (loads.size() == 0) {
-    // Failure: no BufferLoad from the reduction buffer
+    // Failure: no TensorLoad from the reduction buffer
     return false;
   }
 
@@ -1122,8 +1124,8 @@ bool ReductionEpilogueFuser::BodyPatternAllowFusion(const SBlockRealize& epilogu
         }
 
        private:
-        void VisitExpr_(const BufferLoadNode* op) final {
-          if (op->buffer.same_as(buffer_)) {
+        void VisitExpr_(const TensorLoadNode* op) final {
+          if (op->source.as_or_throw<tvm::tirx::BufferVar>().same_as(buffer_)) {
             found_ = true;
             return;
           }
@@ -1217,9 +1219,9 @@ void ReductionEpilogueFuser::ExtractEpilogueInfo() {
   // Generalized approach: extract all non-reduction buffers from epilogue expression
   // Find all buffers in epilogue expression (except the reduction buffer)
   struct BufferExtractor : public ExprVisitor {
-    void VisitExpr_(const BufferLoadNode* load) final {
-      if (!load->buffer.same_as(reduction_buffer)) {
-        other_buffers.insert(load->buffer.get());
+    void VisitExpr_(const TensorLoadNode* load) final {
+      if (!load->source.as_or_throw<tvm::tirx::BufferVar>().same_as(reduction_buffer)) {
+        other_buffers.insert(load->source.as_or_throw<tvm::tirx::BufferVar>().get());
       }
       ExprVisitor::VisitExpr_(load);
     }
@@ -1278,9 +1280,9 @@ SBlock ReductionEpilogueFuser::CreateFusedReductionBlock(
     InitSubstituter(const BufferVar& target_buffer, PrimExpr identity_elem)
         : target_buffer_(target_buffer), identity_elem_(identity_elem) {}
 
-    Expr VisitExpr_(const BufferLoadNode* op) final {
-      BufferLoad load = ExprMutator::VisitExpr_(op).as_or_throw<BufferLoad>();
-      if (load->buffer.same_as(target_buffer_)) {
+    Expr VisitExpr_(const TensorLoadNode* op) final {
+      TensorLoad load = ExprMutator::VisitExpr_(op).as_or_throw<TensorLoad>();
+      if (load->source.as_or_throw<tvm::tirx::BufferVar>().same_as(target_buffer_)) {
         return identity_elem_;
       }
       return load;
@@ -1333,9 +1335,9 @@ SBlock ReductionEpilogueFuser::CreateFusedReductionBlock(
           ReductionUpdateReplacer(const BufferVar& old_buf, const BufferVar& new_buf)
               : old_buffer_(old_buf), new_buffer_(new_buf) {}
 
-          Expr VisitExpr_(const BufferLoadNode* op) final {
-            BufferLoad load = ExprMutator::VisitExpr_(op).as_or_throw<BufferLoad>();
-            if (load->buffer.same_as(old_buffer_)) {
+          Expr VisitExpr_(const TensorLoadNode* op) final {
+            TensorLoad load = ExprMutator::VisitExpr_(op).as_or_throw<TensorLoad>();
+            if (load->source.as_or_throw<tvm::tirx::BufferVar>().same_as(old_buffer_)) {
               return BufferLoad(new_buffer_, load->indices);
             }
             return load;
@@ -1361,9 +1363,9 @@ SBlock ReductionEpilogueFuser::CreateFusedReductionBlock(
                 replacement_(replacement),
                 found_target_load_(false) {}
 
-          Expr VisitExpr_(const BufferLoadNode* op) final {
-            BufferLoad load = ExprMutator::VisitExpr_(op).as_or_throw<BufferLoad>();
-            if (load->buffer.same_as(target_buffer_)) {
+          Expr VisitExpr_(const TensorLoadNode* op) final {
+            TensorLoad load = ExprMutator::VisitExpr_(op).as_or_throw<TensorLoad>();
+            if (load->source.as_or_throw<tvm::tirx::BufferVar>().same_as(target_buffer_)) {
               found_target_load_ = true;
               // Check if parent is Add (will be checked in VisitExpr_(const AddNode*))
               return replacement_;
@@ -1390,8 +1392,9 @@ SBlock ReductionEpilogueFuser::CreateFusedReductionBlock(
               bool other_is_reduction = false;
               if (found_in_a) {
                 // Check if b is from reduction buffer
-                if (const auto* load_b = b.as<BufferLoadNode>()) {
-                  other_is_reduction = load_b->buffer.same_as(reduction_buffer_);
+                if (const auto* load_b = b.as<TensorLoadNode>()) {
+                  other_is_reduction =
+                      load_b->source.as_or_throw<tvm::tirx::BufferVar>().same_as(reduction_buffer_);
                 }
                 if (!other_is_reduction) {
                   // b is the bias addend, remove it
@@ -1399,8 +1402,9 @@ SBlock ReductionEpilogueFuser::CreateFusedReductionBlock(
                 }
               } else {  // found_in_b
                 // Check if a is from reduction buffer
-                if (const auto* load_a = a.as<BufferLoadNode>()) {
-                  other_is_reduction = load_a->buffer.same_as(reduction_buffer_);
+                if (const auto* load_a = a.as<TensorLoadNode>()) {
+                  other_is_reduction =
+                      load_a->source.as_or_throw<tvm::tirx::BufferVar>().same_as(reduction_buffer_);
                 }
                 if (!other_is_reduction) {
                   // a is the bias addend, remove it
@@ -1434,9 +1438,9 @@ SBlock ReductionEpilogueFuser::CreateFusedReductionBlock(
       return store;
     }
 
-    Expr VisitExpr_(const BufferLoadNode* op) final {
-      BufferLoad load = StmtExprMutator::VisitExpr_(op).as_or_throw<BufferLoad>();
-      if (load->buffer.same_as(old_buffer_)) {
+    Expr VisitExpr_(const TensorLoadNode* op) final {
+      TensorLoad load = StmtExprMutator::VisitExpr_(op).as_or_throw<TensorLoad>();
+      if (load->source.as_or_throw<tvm::tirx::BufferVar>().same_as(old_buffer_)) {
         return BufferLoad(new_buffer_, load->indices);
       }
       return load;

--- a/src/s_tir/schedule/primitive/layout_transformation.cc
+++ b/src/s_tir/schedule/primitive/layout_transformation.cc
@@ -36,7 +36,7 @@ using namespace tvm::tirx;
  *
  * There are four ways that transformation may be handled.  Each
  * updates the buffer shape and the indices used to acces the buffer
- * in BufferStore/BufferLoad nodes, but differ in how they handle the
+ * in BufferStore/TensorLoad nodes, but differ in how they handle the
  * `pad_value`.  In order of preference, the different strategies are
  * as follows:
  *
@@ -834,11 +834,13 @@ class TransformLayoutRewriter : private arith::IRMutatorWithAnalyzer {
     return Parent::VisitStmt_(op);
   }
 
-  Expr VisitExpr_(const BufferLoadNode* op) final {
-    BufferLoad buffer_load = Parent::VisitExpr_(op).as_or_throw<BufferLoad>();
-    if (buffer_load->buffer.same_as(old_buffer_)) {
-      auto* n = buffer_load.CopyOnWrite();
-      RewriteBufferAccess(&n->buffer, &n->indices);
+  Expr VisitExpr_(const TensorLoadNode* op) final {
+    TensorLoad buffer_load = Parent::VisitExpr_(op).as_or_throw<TensorLoad>();
+    if (buffer_load->source.as_or_throw<tvm::tirx::BufferVar>().same_as(old_buffer_)) {
+      BufferVar buffer = buffer_load->source.as_or_throw<tvm::tirx::BufferVar>();
+      ffi::Array<PrimExpr> indices = buffer_load->indices;
+      RewriteBufferAccess(&buffer, &indices);
+      return BufferLoad(buffer, indices, buffer_load->span);
     }
     return buffer_load;
   }
@@ -1042,30 +1044,31 @@ class TransformationPaddingExpressionError : public ScheduleError {
   struct Visitor : ExprVisitor {
     explicit Visitor(const BufferVar& buffer) : buffer_(buffer) {}
 
-    void VisitExpr_(const BufferLoadNode* op) final {
-      if (!op->buffer.same_as(buffer_)) {
-        illegal_load = ffi::GetRef<BufferLoad>(op);
+    void VisitExpr_(const TensorLoadNode* op) final {
+      if (!op->source.as_or_throw<tvm::tirx::BufferVar>().same_as(buffer_)) {
+        illegal_load = ffi::GetRef<TensorLoad>(op);
       }
       ExprVisitor::VisitExpr_(op);
     }
 
     const BufferVar& buffer_;
-    ffi::Optional<BufferLoad> illegal_load;
+    ffi::Optional<TensorLoad> illegal_load;
   };
 
   TransformationPaddingExpressionError(IRModule mod, BufferVar buffer, IndexMap pad_value,
-                                       BufferLoad illegal_load)
+                                       TensorLoad illegal_load)
       : mod_(mod), buffer_(buffer), pad_value_(pad_value), illegal_load_(illegal_load) {}
 
   ffi::String FastErrorString() const final {
     std::ostringstream ss;
-    ss << "ScheduleError: Pad value may not contain load from " << illegal_load_->buffer.name();
+    ss << "ScheduleError: Pad value may not contain load from "
+       << illegal_load_->source.as_or_throw<tvm::tirx::BufferVar>().name();
     return ss.str();
   }
 
   ffi::String DetailRenderTemplate() const final {
     std::ostringstream ss;
-    ss << "ScheduleError: Pad value may only contain BufferLoad from the transformed buffer "
+    ss << "ScheduleError: Pad value may only contain TensorLoad from the transformed buffer "
        << buffer_.name() << ", but pad_value " << pad_value_ << " contains expression "
        << illegal_load_;
     return ss.str();
@@ -1077,7 +1080,7 @@ class TransformationPaddingExpressionError : public ScheduleError {
   IRModule mod_;
   BufferVar buffer_;
   IndexMap pad_value_;
-  BufferLoad illegal_load_;
+  TensorLoad illegal_load_;
 };
 
 class TransformationIntroducesPaddingError : public ScheduleError {

--- a/src/s_tir/schedule/primitive/loop_transformation.cc
+++ b/src/s_tir/schedule/primitive/loop_transformation.cc
@@ -492,7 +492,7 @@ class BufferIndicesMapExtractor : public StmtExprVisitor {
     StmtExprVisitor::VisitStmt_(store);
   }
 
-  void VisitExpr_(const BufferLoadNode* load) final {
+  void VisitExpr_(const TensorLoadNode* load) final {
     ffi::Array<ffi::String> indices;
     bool check_ = false;
     for (size_t i = 0; i < load->indices.size(); i++) {
@@ -503,8 +503,10 @@ class BufferIndicesMapExtractor : public StmtExprVisitor {
       }
       indices.push_back(var.value()->name);
     }
-    if (buffer_indices_map.find(load->buffer.name()) == buffer_indices_map.end() && !check_)
-      buffer_indices_map.Set(load->buffer.name(), indices);
+    if (buffer_indices_map.find(load->source.as_or_throw<tvm::tirx::BufferVar>().name()) ==
+            buffer_indices_map.end() &&
+        !check_)
+      buffer_indices_map.Set(load->source.as_or_throw<tvm::tirx::BufferVar>().name(), indices);
     StmtExprVisitor::VisitExpr_(load);
   }
 

--- a/src/s_tir/schedule/primitive/loop_transformation.cc
+++ b/src/s_tir/schedule/primitive/loop_transformation.cc
@@ -503,10 +503,10 @@ class BufferIndicesMapExtractor : public StmtExprVisitor {
       }
       indices.push_back(var.value()->name);
     }
-    if (buffer_indices_map.find(load->source.as_or_throw<tvm::tirx::BufferVar>().name()) ==
-            buffer_indices_map.end() &&
-        !check_)
-      buffer_indices_map.Set(load->source.as_or_throw<tvm::tirx::BufferVar>().name(), indices);
+    BufferVar buffer = load->source.as_or_throw<tvm::tirx::BufferVar>();
+    if (buffer_indices_map.find(buffer.name()) == buffer_indices_map.end() && !check_) {
+      buffer_indices_map.Set(buffer.name(), indices);
+    }
     StmtExprVisitor::VisitExpr_(load);
   }
 

--- a/src/s_tir/schedule/primitive/pad_einsum.cc
+++ b/src/s_tir/schedule/primitive/pad_einsum.cc
@@ -28,7 +28,7 @@ using namespace tvm::tirx;
 
 /*!
  * \brief Check if buffer indices are all Vars and expr
- * \param buffer_access The BufferLoad or BufferStore
+ * \param buffer_access The TensorLoad or BufferStore
  * \return The indices if the indices are all Vars, otherwise std::nullopt
  */
 ffi::Optional<ffi::Array<Var>> CheckTrivialBufferIndices(
@@ -361,9 +361,10 @@ class PadEinsumBufferReplacer : public StmtExprMutator {
     }
   }
 
-  Expr VisitExpr_(const BufferLoadNode* old_load_ptr) final {
-    BufferLoad load = ExprMutator::VisitExpr_(old_load_ptr).as_or_throw<BufferLoad>();
-    if (ffi::Optional<BufferVar> buffer = buffer_map_.Get(load->buffer)) {
+  Expr VisitExpr_(const TensorLoadNode* old_load_ptr) final {
+    TensorLoad load = ExprMutator::VisitExpr_(old_load_ptr).as_or_throw<TensorLoad>();
+    if (ffi::Optional<BufferVar> buffer =
+            buffer_map_.Get(load->source.as_or_throw<tvm::tirx::BufferVar>())) {
       return BufferLoad(buffer.value(), load->indices);
     } else {
       return load;

--- a/src/s_tir/schedule/primitive/read_write_at.cc
+++ b/src/s_tir/schedule/primitive/read_write_at.cc
@@ -99,12 +99,10 @@ class ReadWriteAtBufferReplacer : public StmtExprMutator {
     return store;
   }
 
-  Expr VisitExpr_(const BufferLoadNode* _load) final {
-    BufferLoad load = StmtExprMutator::VisitExpr_(_load).as_or_throw<BufferLoad>();
-    if (load->buffer.same_as(src_)) {
-      ffi::ObjectPtr<BufferLoadNode> new_load = ffi::make_object<BufferLoadNode>(*load.get());
-      new_load->buffer = dst_;
-      return BufferLoad(new_load);
+  Expr VisitExpr_(const TensorLoadNode* _load) final {
+    TensorLoad load = StmtExprMutator::VisitExpr_(_load).as_or_throw<TensorLoad>();
+    if (load->source.as_or_throw<tvm::tirx::BufferVar>().same_as(src_)) {
+      return BufferLoad(dst_, load->indices, load->span);
     }
     return load;
   }

--- a/src/s_tir/schedule/primitive/reduction.cc
+++ b/src/s_tir/schedule/primitive/reduction.cc
@@ -1049,14 +1049,15 @@ class WriteBackBlockCreator : public BaseBlockCreator {
   void CreateRegion(const ffi::Array<PrimExpr>& buf_loads, bool is_read) {
     ffi::Array<BufferRegion>& buf_regions = is_read ? read_regions_ : write_regions_;
     for (const PrimExpr& expr : buf_loads) {
-      const auto* buf_load = expr.as<BufferLoadNode>();
+      const auto* buf_load = expr.as<TensorLoadNode>();
       TVM_FFI_ICHECK(buf_load != nullptr);
       ffi::Array<Range> region;
       region.reserve(buf_load->indices.size());
       for (const PrimExpr& index : buf_load->indices) {
         region.push_back(Range::FromMinExtent(index, MakeConst(index.ty(), 1)));
       }
-      buf_regions.push_back(BufferRegion(buf_load->buffer, std::move(region)));
+      buf_regions.push_back(
+          BufferRegion(buf_load->source.as_or_throw<tvm::tirx::BufferVar>(), std::move(region)));
     }
   }
 

--- a/src/s_tir/schedule/primitive/rolling_buffer.cc
+++ b/src/s_tir/schedule/primitive/rolling_buffer.cc
@@ -375,11 +375,13 @@ class RollingBufferRewriter : public StmtExprMutator {
     return stmt;
   }
 
-  Expr VisitExpr_(const BufferLoadNode* op) final {
-    BufferLoad stmt = StmtExprMutator::VisitExpr_(op).as_or_throw<BufferLoad>();
-    if (stmt->buffer.same_as(info_->old_buffer)) {
-      BufferLoadNode* n = stmt.CopyOnWrite();
-      RewriteBufferAccess(&n->buffer, &n->indices);
+  Expr VisitExpr_(const TensorLoadNode* op) final {
+    TensorLoad stmt = StmtExprMutator::VisitExpr_(op).as_or_throw<TensorLoad>();
+    if (stmt->source.as_or_throw<tvm::tirx::BufferVar>().same_as(info_->old_buffer)) {
+      BufferVar buffer = stmt->source.as_or_throw<tvm::tirx::BufferVar>();
+      ffi::Array<PrimExpr> indices = stmt->indices;
+      RewriteBufferAccess(&buffer, &indices);
+      return BufferLoad(buffer, indices, stmt->span);
     }
     return stmt;
   }

--- a/src/s_tir/schedule/transform.cc
+++ b/src/s_tir/schedule/transform.cc
@@ -147,8 +147,8 @@ Stmt ReplaceBufferMutator::VisitStmt_(const BufferStoreNode* op) {
   return VisitBufferAccess(std::move(node));
 }
 
-Expr ReplaceBufferMutator::VisitExpr_(const BufferLoadNode* op) {
-  auto node = StmtExprMutator::VisitExpr_(op).as_or_throw<BufferLoad>();
+Expr ReplaceBufferMutator::VisitExpr_(const TensorLoadNode* op) {
+  auto node = StmtExprMutator::VisitExpr_(op).as_or_throw<TensorLoad>();
   return VisitBufferAccess(std::move(node));
 }
 
@@ -470,8 +470,8 @@ Stmt BlockBufferAccessSimplifier::VisitStmt_(const BufferStoreNode* op) {
   return node;
 }
 
-Expr BlockBufferAccessSimplifier::VisitExpr_(const BufferLoadNode* op) {
-  BufferLoad node = arith::IRMutatorWithAnalyzer::VisitExpr_(op).as_or_throw<BufferLoad>();
+Expr BlockBufferAccessSimplifier::VisitExpr_(const TensorLoadNode* op) {
+  TensorLoad node = arith::IRMutatorWithAnalyzer::VisitExpr_(op).as_or_throw<TensorLoad>();
   SimplifyBufferIndices(&node.CopyOnWrite()->indices);
   return node;
 }

--- a/src/s_tir/schedule/transform.h
+++ b/src/s_tir/schedule/transform.h
@@ -152,9 +152,15 @@ class ReplaceBufferMutator : public StmtExprMutator {
     return node;
   }
 
+  TensorLoad VisitBufferAccess(TensorLoad node) {
+    BufferVar buffer = node->source.as_or_throw<tvm::tirx::BufferVar>();
+    auto it = buffer_var_map_.find(buffer.get());
+    return it != buffer_var_map_.end() ? BufferLoad(it->second, node->indices, node->span) : node;
+  }
+
   Stmt VisitStmt_(const BufferStoreNode* op) override;
 
-  Expr VisitExpr_(const BufferLoadNode* op) override;
+  Expr VisitExpr_(const TensorLoadNode* op) override;
 
   virtual MatchBufferRegion VisitMatchBufferRegion(const MatchBufferRegion& match_buffer);
 
@@ -253,7 +259,7 @@ class BlockBufferAccessSimplifier : public arith::IRMutatorWithAnalyzer {
 
   Stmt VisitStmt_(const SBlockNode* op) final;
   Stmt VisitStmt_(const BufferStoreNode* op) final;
-  Expr VisitExpr_(const BufferLoadNode* op) final;
+  Expr VisitExpr_(const TensorLoadNode* op) final;
 };
 
 }  // namespace s_tir

--- a/src/s_tir/transform/bound_checker.cc
+++ b/src/s_tir/transform/bound_checker.cc
@@ -108,9 +108,9 @@ class BoundChecker : public StmtExprMutator {
     return ffi::GetRef<Stmt>(op);
   }
 
-  Expr VisitExpr_(const BufferLoadNode* op) final {
-    if (CanInstrument(op->indices, op->buffer.var())) {
-      Collect(op->indices, op->buffer.var());
+  Expr VisitExpr_(const TensorLoadNode* op) final {
+    if (CanInstrument(op->indices, op->source.as_or_throw<tvm::tirx::BufferVar>().var())) {
+      Collect(op->indices, op->source.as_or_throw<tvm::tirx::BufferVar>().var());
     }
     return StmtExprMutator::VisitExpr_(op);
   }

--- a/src/s_tir/transform/compact_buffer_region.cc
+++ b/src/s_tir/transform/compact_buffer_region.cc
@@ -79,8 +79,9 @@ class Var2BufferCollector : public StmtExprVisitor {
     StmtExprVisitor::VisitStmt_(op);
   }
 
-  void VisitExpr_(const BufferLoadNode* op) final {
-    var2buffer_[op->buffer.var()].insert(op->buffer);
+  void VisitExpr_(const TensorLoadNode* op) final {
+    var2buffer_[op->source.as_or_throw<tvm::tirx::BufferVar>().var()].insert(
+        op->source.as_or_throw<tvm::tirx::BufferVar>());
     StmtExprVisitor::VisitExpr_(op);
   }
 
@@ -150,12 +151,14 @@ class BufferAccessRegionCollector : public StmtExprVisitor {
     VisitExpr(op->value);
   }
 
-  void VisitExpr_(const BufferLoadNode* op) final {
-    auto explicit_it = explicit_access_annotations_.find(op->buffer);
+  void VisitExpr_(const TensorLoadNode* op) final {
+    auto explicit_it =
+        explicit_access_annotations_.find(op->source.as_or_throw<tvm::tirx::BufferVar>());
     if (explicit_it != explicit_access_annotations_.end()) {
       VisitBufferAccess(explicit_it->second);
     } else {
-      VisitBufferAccess(BufferRegion::FromPoint(op->buffer, op->indices));
+      VisitBufferAccess(
+          BufferRegion::FromPoint(op->source.as_or_throw<tvm::tirx::BufferVar>(), op->indices));
     }
     StmtExprVisitor::VisitExpr_(op);
   }
@@ -579,11 +582,12 @@ class BufferCompactor : public StmtExprMutator {
     return store;
   }
 
-  Expr VisitExpr_(const BufferLoadNode* _op) final {
-    BufferLoad load = StmtExprMutator::VisitExpr_(_op).as_or_throw<BufferLoad>();
-    BufferLoadNode* op = load.CopyOnWrite();
-    RewriteBufferAccess(_op->buffer, &op->buffer, &op->indices);
-    return load;
+  Expr VisitExpr_(const TensorLoadNode* _op) final {
+    TensorLoad load = StmtExprMutator::VisitExpr_(_op).as_or_throw<TensorLoad>();
+    BufferVar buffer = load->source.as_or_throw<tvm::tirx::BufferVar>();
+    ffi::Array<PrimExpr> indices = load->indices;
+    RewriteBufferAccess(_op->source.as_or_throw<tvm::tirx::BufferVar>(), &buffer, &indices);
+    return BufferLoad(buffer, indices, load->span);
   }
 
   Stmt VisitStmt_(const SBlockNode* op) final {

--- a/src/s_tir/transform/compact_buffer_region.cc
+++ b/src/s_tir/transform/compact_buffer_region.cc
@@ -80,8 +80,8 @@ class Var2BufferCollector : public StmtExprVisitor {
   }
 
   void VisitExpr_(const TensorLoadNode* op) final {
-    var2buffer_[op->source.as_or_throw<tvm::tirx::BufferVar>().var()].insert(
-        op->source.as_or_throw<tvm::tirx::BufferVar>());
+    BufferVar buffer = op->source.as_or_throw<tvm::tirx::BufferVar>();
+    var2buffer_[buffer.var()].insert(buffer);
     StmtExprVisitor::VisitExpr_(op);
   }
 
@@ -152,13 +152,12 @@ class BufferAccessRegionCollector : public StmtExprVisitor {
   }
 
   void VisitExpr_(const TensorLoadNode* op) final {
-    auto explicit_it =
-        explicit_access_annotations_.find(op->source.as_or_throw<tvm::tirx::BufferVar>());
+    BufferVar buffer = op->source.as_or_throw<tvm::tirx::BufferVar>();
+    auto explicit_it = explicit_access_annotations_.find(buffer);
     if (explicit_it != explicit_access_annotations_.end()) {
       VisitBufferAccess(explicit_it->second);
     } else {
-      VisitBufferAccess(
-          BufferRegion::FromPoint(op->source.as_or_throw<tvm::tirx::BufferVar>(), op->indices));
+      VisitBufferAccess(BufferRegion::FromPoint(buffer, op->indices));
     }
     StmtExprVisitor::VisitExpr_(op);
   }
@@ -584,9 +583,10 @@ class BufferCompactor : public StmtExprMutator {
 
   Expr VisitExpr_(const TensorLoadNode* _op) final {
     TensorLoad load = StmtExprMutator::VisitExpr_(_op).as_or_throw<TensorLoad>();
+    BufferVar original_buffer = _op->source.as_or_throw<tvm::tirx::BufferVar>();
     BufferVar buffer = load->source.as_or_throw<tvm::tirx::BufferVar>();
     ffi::Array<PrimExpr> indices = load->indices;
-    RewriteBufferAccess(_op->source.as_or_throw<tvm::tirx::BufferVar>(), &buffer, &indices);
+    RewriteBufferAccess(original_buffer, &buffer, &indices);
     return BufferLoad(buffer, indices, load->span);
   }
 

--- a/src/s_tir/transform/inject_double_buffer.cc
+++ b/src/s_tir/transform/inject_double_buffer.cc
@@ -235,10 +235,11 @@ class DoubleBufferInjector : public StmtExprMutator {
     return node;
   }
 
-  Expr VisitExpr_(const BufferLoadNode* op) final {
-    auto node = StmtExprMutator::VisitExpr_(op).as_or_throw<BufferLoad>();
+  Expr VisitExpr_(const TensorLoadNode* op) final {
+    auto node = StmtExprMutator::VisitExpr_(op).as_or_throw<TensorLoad>();
+    BufferVar buffer = node->source.as_or_throw<tvm::tirx::BufferVar>();
 
-    auto it = dbuffer_info_.find(node->buffer.get());
+    auto it = dbuffer_info_.find(buffer.get());
     if (it != dbuffer_info_.end()) {
       const StorageEntry& e = it->second;
       TVM_FFI_ICHECK(e.switch_read_var.defined());
@@ -246,9 +247,8 @@ class DoubleBufferInjector : public StmtExprMutator {
       TVM_FFI_ICHECK_EQ(node->indices.size(), 1) << "InjectDoubleBuffer expects flat 1-d buffers.  "
                                                  << "Has FlattenBuffer been run?";
 
-      auto writer = node.CopyOnWrite();
-      writer->buffer = GetRemappedBuffer(node->buffer, e.stride);
-      writer->indices = {e.switch_read_var * e.stride + node->indices[0]};
+      return BufferLoad(GetRemappedBuffer(buffer, e.stride),
+                        {e.switch_read_var * e.stride + node->indices[0]}, node->span);
     }
 
     return node;

--- a/src/s_tir/transform/inject_permuted_layout.cc
+++ b/src/s_tir/transform/inject_permuted_layout.cc
@@ -220,22 +220,23 @@ class PermutedLayoutInjector : private IRMutatorWithAnalyzer {
     return store;
   }
 
-  Expr VisitExpr_(const BufferLoadNode* op) final {
+  Expr VisitExpr_(const TensorLoadNode* op) final {
     // Rewrite load from shared or shared.dyn to global
-    auto load = IRMutatorWithAnalyzer::VisitExpr_(op).as_or_throw<BufferLoad>();
+    auto load = IRMutatorWithAnalyzer::VisitExpr_(op).as_or_throw<TensorLoad>();
 
-    if (!permute_ || load->buffer->shape.size() < 2) {
+    if (!permute_ || load->source.as_or_throw<tvm::tirx::BufferVar>()->shape.size() < 2) {
       return load;
     }
 
-    auto scope = StorageScope::Create(load->buffer.scope());
+    auto scope = StorageScope::Create(load->source.as_or_throw<tvm::tirx::BufferVar>().scope());
     if (scope.rank != StorageRank::kShared) {
       return load;
     }
 
-    auto load_node = load.CopyOnWrite();
-    load_node->indices = HandleBufferIndices(load_node->buffer, load_node->indices);
-    return load;
+    return BufferLoad(
+        load->source.as_or_throw<tvm::tirx::BufferVar>(),
+        HandleBufferIndices(load->source.as_or_throw<tvm::tirx::BufferVar>(), load->indices),
+        load->span);
   }
 
   Expr HandleAccessPtrAndOffset(Expr access_ptr, ffi::Optional<PrimExpr> offset = std::nullopt) {

--- a/src/s_tir/transform/inject_ptx_async_copy.cc
+++ b/src/s_tir/transform/inject_ptx_async_copy.cc
@@ -52,18 +52,21 @@ class PTXAsyncCopyInjector : public StmtMutator {
     return StmtMutator::VisitStmt_(attr);
   }
 
-  Stmt InjectPTX(const BufferLoadNode* load, const BufferStoreNode* store, bool predicated = false,
+  Stmt InjectPTX(const TensorLoadNode* load, const BufferStoreNode* store, bool predicated = false,
                  PrimExpr predicate_value = PrimExpr()) {
-    if (load->buffer.scope() == "global") {
+    if (load->source.as_or_throw<tvm::tirx::BufferVar>().scope() == "global") {
       TVM_FFI_ICHECK(load->indices.size() == 1 && store->indices.size() == 1);
       TVM_FFI_ICHECK(load->indices[0].ty().lanes() == store->indices[0].ty().lanes());
 
       const int indices_lanes = load->indices[0].ty().lanes();
-      const int bytes = indices_lanes * static_cast<int>(load->buffer->dtype.StorageBytes());
+      const int bytes =
+          indices_lanes *
+          static_cast<int>(load->source.as_or_throw<tvm::tirx::BufferVar>()->dtype.StorageBytes());
 
       if (bytes == 4 || bytes == 8 || bytes == 16) {
         auto dst_elem_type = GetPointerType(store->buffer.DataPointerType());
-        auto src_elem_type = GetPointerType(load->buffer.DataPointerType());
+        auto src_elem_type =
+            GetPointerType(load->source.as_or_throw<tvm::tirx::BufferVar>().DataPointerType());
         TVM_FFI_ICHECK(dst_elem_type.has_value() && src_elem_type.has_value())
             << "Both store and load buffer should have a pointer type annotation.";
 
@@ -85,7 +88,8 @@ class PTXAsyncCopyInjector : public StmtMutator {
           auto src_offset = load->indices[0];
           auto dst_offset = store->indices[0];
           ffi::Array<Expr> args = {store->buffer.data(), mul(dst_offset, PrimExpr(index_factor)),
-                                   load->buffer.data(), src_offset, PrimExpr(bytes)};
+                                   load->source.as_or_throw<tvm::tirx::BufferVar>().data(),
+                                   src_offset, PrimExpr(bytes)};
           // use arguments size to indicate whether or not to use predicated cp.async
           if (predicated) {
             args.push_back(predicate_value);
@@ -123,7 +127,8 @@ class PTXAsyncCopyInjector : public StmtMutator {
             static const Op& ptx_cp_async_op = Op::Get("tirx.s_tir.cp_async_raw");
             return Evaluate(Call(store->buffer->dtype, ptx_cp_async_op,
                                  {store->buffer.data(), mul(dst_offset, PrimExpr(index_factor)),
-                                  load->buffer.data(), src_offset, PrimExpr(bytes)})
+                                  load->source.as_or_throw<tvm::tirx::BufferVar>().data(),
+                                  src_offset, PrimExpr(bytes)})
                                 .as_or_throw<PrimExpr>());
           }
         } else {
@@ -152,11 +157,11 @@ class PTXAsyncCopyInjector : public StmtMutator {
 
           if (src_offset.defined() && dst_offset.defined()) {
             static const Op& ptx_cp_async_op = Op::Get("tirx.s_tir.cp_async_raw");
-            return Evaluate(
-                Call(store->buffer->dtype, ptx_cp_async_op,
-                     {store->buffer.data(), mul(dst_offset, PrimExpr(index_factor)),
-                      load->buffer.data(), src_offset, PrimExpr(bytes), predicate_value})
-                    .as_or_throw<PrimExpr>());
+            return Evaluate(Call(store->buffer->dtype, ptx_cp_async_op,
+                                 {store->buffer.data(), mul(dst_offset, PrimExpr(index_factor)),
+                                  load->source.as_or_throw<tvm::tirx::BufferVar>().data(),
+                                  src_offset, PrimExpr(bytes), predicate_value})
+                                .as_or_throw<PrimExpr>());
           }
         }
       }
@@ -166,12 +171,12 @@ class PTXAsyncCopyInjector : public StmtMutator {
 
   Stmt VisitStmt_(const BufferStoreNode* store) {
     if (in_async && (store->buffer.scope() == "shared" || store->buffer.scope() == "shared.dyn")) {
-      if (auto* load = store->value.as<BufferLoadNode>()) {
+      if (auto* load = store->value.as<TensorLoadNode>()) {
         return InjectPTX(load, store);
       } else if (auto* call = store->value.as<CallNode>()) {
         // tirx.if_then_else is a call to tirx::builtin::if_then_else()
         if (call->op.same_as(builtin::if_then_else()) && call->args.size() == 3) {
-          if (auto* load = call->args[1].as<BufferLoadNode>()) {
+          if (auto* load = call->args[1].as<TensorLoadNode>()) {
             // Only default value of 0 is supported since 0 is the default value used by cp.async
             // ptx. @see section 9.7.8.22.3. of
             // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#asynchronous-memory-operations

--- a/src/s_tir/transform/inject_ptx_ldg32.cc
+++ b/src/s_tir/transform/inject_ptx_ldg32.cc
@@ -61,7 +61,7 @@ class PTXRewriter : public StmtMutator {
     Stmt result = StmtMutator::VisitStmt_(store);
     BufferVar load_buffer = store->buffer;
     PrimExpr load_value = store->value;
-    // const BufferLoadNode* gload = load_value.as<BufferLoadNode>(); // take
+    // const TensorLoadNode* gload = load_value.as<TensorLoadNode>(); // take
     // the place of instance of
     const CallNode* call = load_value.as<CallNode>();
     if (call != nullptr) {
@@ -71,10 +71,10 @@ class PTXRewriter : public StmtMutator {
         PrimExpr lhs = call->args[1].as_or_throw<PrimExpr>();
         PrimExpr rhs = call->args[2].as_or_throw<PrimExpr>();
         PrimExpr global_addr, local_addr;
-        const BufferLoadNode* load = lhs.as<BufferLoadNode>();
+        const TensorLoadNode* load = lhs.as<TensorLoadNode>();
         PrimExpr imm_value = rhs;
         if (load == nullptr) {
-          load = rhs.as<BufferLoadNode>();
+          load = rhs.as<TensorLoadNode>();
           imm_value = lhs;
           if (load == nullptr) {
             return result;
@@ -92,7 +92,8 @@ class PTXRewriter : public StmtMutator {
         BufferStore local_addr_store(addr_buffer, local_addr, {IntImm::Int32(1)});
         BufferStore predicate_store(predicate_buffer, predicate, {IntImm::Int32(0)});
         PrimExpr new_lhs, new_rhs, new_predicate, new_indice;
-        new_lhs = BufferLoad(load->buffer, {BufferLoad(addr_buffer, {IntImm::Int32(0)})});
+        new_lhs = BufferLoad(load->source.as_or_throw<tvm::tirx::BufferVar>(),
+                             {BufferLoad(addr_buffer, {IntImm::Int32(0)})});
         new_rhs = IntImm::Int32(0);
         new_predicate = BufferLoad(predicate_buffer, {IntImm::Int32(0)});
         new_indice = BufferLoad(addr_buffer, {IntImm::Int32(1)});

--- a/src/s_tir/transform/inject_software_pipeline.cc
+++ b/src/s_tir/transform/inject_software_pipeline.cc
@@ -311,19 +311,18 @@ class PipelineBodyRewriter : public StmtExprMutator {
     return store;
   }
 
-  Expr VisitExpr_(const BufferLoadNode* op) final {
-    BufferLoad load = StmtExprMutator::VisitExpr_(op).as_or_throw<BufferLoad>();
-    auto it = buffer_remap_.find(load->buffer);
+  Expr VisitExpr_(const TensorLoadNode* op) final {
+    TensorLoad load = StmtExprMutator::VisitExpr_(op).as_or_throw<TensorLoad>();
+    auto it = buffer_remap_.find(load->source.as_or_throw<tvm::tirx::BufferVar>());
     if (it == buffer_remap_.end()) {
       return load;
     }
     const BufferVar& new_buffer = (*it).second;
-    auto* n = load.CopyOnWrite();
-    n->buffer = new_buffer;
     PrimExpr version =
         floormod((pipeline_loop_->loop_var - pipeline_loop_->min), new_buffer->shape[0]);
-    n->indices.insert(n->indices.begin(), version);
-    return load;
+    ffi::Array<PrimExpr> indices = load->indices;
+    indices.insert(indices.begin(), version);
+    return BufferLoad(new_buffer, indices, load->span);
   }
 
   Expr VisitExpr_(const CallNode* op) final {

--- a/src/s_tir/transform/inject_virtual_thread.cc
+++ b/src/s_tir/transform/inject_virtual_thread.cc
@@ -69,8 +69,8 @@ class ExprTouched final : public StmtExprVisitor {
     if (expr_touched_ && !check_write_) return;
     StmtExprVisitor::VisitStmt(n);
   }
-  void VisitExpr_(const BufferLoadNode* op) final {
-    HandleUseVar(op->buffer.get());
+  void VisitExpr_(const TensorLoadNode* op) final {
+    HandleUseVar(op->source.as_or_throw<tvm::tirx::BufferVar>().get());
     StmtExprVisitor::VisitExpr_(op);
   }
   void VisitExpr_(const VarNode* op) final { HandleUseVar(op); }
@@ -262,8 +262,8 @@ class VTInjector : public arith::IRMutatorWithAnalyzer {
       }
       PrimExpr predicate = this->VisitPrimExpr(op->args.back().as_or_throw<PrimExpr>());
       if (is_load) {
-        BufferLoad access = VisitBufferAccess(BufferLoad(buffer, indices, op->span));
-        ffi::Array<Expr> args{access->buffer.var()};
+        TensorLoad access = VisitBufferAccess(BufferLoad(buffer, indices, op->span));
+        ffi::Array<Expr> args{access->source.as_or_throw<tvm::tirx::BufferVar>().var()};
         for (const PrimExpr& index : access->indices) args.push_back(index);
         args.push_back(predicate);
         return Call(op->ty, op->op, args, op->attrs, op->ty_args, op->span);
@@ -311,8 +311,8 @@ class VTInjector : public arith::IRMutatorWithAnalyzer {
     return StmtExprMutator::VisitStmt_(op);
   }
   // BufferLoad
-  Expr VisitExpr_(const BufferLoadNode* op) final {
-    auto node = StmtExprMutator::VisitExpr_(op).as_or_throw<BufferLoad>();
+  Expr VisitExpr_(const TensorLoadNode* op) final {
+    auto node = StmtExprMutator::VisitExpr_(op).as_or_throw<TensorLoad>();
     return VisitBufferAccess(std::move(node));
   }
   // BufferStore
@@ -338,6 +338,19 @@ class VTInjector : public arith::IRMutatorWithAnalyzer {
     }
 
     return node;
+  }
+
+  TensorLoad VisitBufferAccess(TensorLoad node) {
+    BufferVar buffer = node->source.as_or_throw<tvm::tirx::BufferVar>();
+    if (touched_var_.count(buffer.get())) {
+      visit_touched_var_ = true;
+    }
+    auto it = alloc_remap_.find(buffer.get());
+    if (it == alloc_remap_.end()) return node;
+    TVM_FFI_ICHECK_EQ(node->indices.size(), 1)
+        << "InjectVirtualThread expects rewritten allocations to be flat memory.";
+    return BufferLoad(GetRemappedBuffer(buffer, it->second),
+                      {RewriteIndex(node->indices[0], it->second)}, node->span);
   }
 
   BufferVar GetRemappedBuffer(BufferVar buf, PrimExpr alloc_extent) {

--- a/src/s_tir/transform/lower_cross_thread_reduction.cc
+++ b/src/s_tir/transform/lower_cross_thread_reduction.cc
@@ -178,9 +178,9 @@ class BufferReplacer : private StmtExprMutator {
   explicit BufferReplacer(ffi::Map<BufferVar, BufferVar> buffer_map)
       : buffer_map_(std::move(buffer_map)) {}
 
-  Expr VisitExpr_(const BufferLoadNode* load) final {
-    auto it = buffer_map_.find(load->buffer);
-    return it != buffer_map_.end() ? BufferLoad((*it).second, {0}) : ffi::GetRef<BufferLoad>(load);
+  Expr VisitExpr_(const TensorLoadNode* load) final {
+    auto it = buffer_map_.find(load->source.as_or_throw<tvm::tirx::BufferVar>());
+    return it != buffer_map_.end() ? BufferLoad((*it).second, {0}) : ffi::GetRef<TensorLoad>(load);
   }
 
   Stmt VisitStmt_(const BufferStoreNode* store) final {

--- a/src/s_tir/transform/lower_match_buffer.cc
+++ b/src/s_tir/transform/lower_match_buffer.cc
@@ -149,11 +149,11 @@ class MatchBufferLower : public StmtExprMutator {
     }
   }
 
-  Expr VisitExpr_(const BufferLoadNode* op) final {
+  Expr VisitExpr_(const TensorLoadNode* op) final {
     // Save the original buffer before base class mutation may remap it
-    BufferVar orig_buffer = op->buffer;
+    BufferVar orig_buffer = op->source.as_or_throw<tvm::tirx::BufferVar>();
     PrimExpr expr = StmtExprMutator::VisitExpr_(op).as_or_throw<PrimExpr>();
-    op = expr.as<BufferLoadNode>();
+    op = expr.as<TensorLoadNode>();
     TVM_FFI_ICHECK(op != nullptr);
 
     auto it = match_buffers_.find(orig_buffer);

--- a/src/s_tir/transform/lower_thread_allreduce.cc
+++ b/src/s_tir/transform/lower_thread_allreduce.cc
@@ -147,8 +147,9 @@ class ThreadAllreduceBuilder final : public StmtExprMutator {
     return StmtExprMutator::VisitStmt_(op);
   }
 
-  Expr VisitExpr_(const BufferLoadNode* op) final {
-    const VarNode* allocation = GetAllocationKey(op->buffer.get());
+  Expr VisitExpr_(const TensorLoadNode* op) final {
+    const VarNode* allocation =
+        GetAllocationKey(op->source.as_or_throw<tvm::tirx::BufferVar>().get());
     if (auto it = load_remap_.find(allocation); it != load_remap_.end()) {
       for (const auto& index : op->indices) {
         TVM_FFI_ICHECK(is_zero(index));
@@ -156,11 +157,11 @@ class ThreadAllreduceBuilder final : public StmtExprMutator {
       return it->second;
     }
 
-    BufferLoad load = StmtExprMutator::VisitExpr_(op).as_or_throw<BufferLoad>();
+    TensorLoad load = StmtExprMutator::VisitExpr_(op).as_or_throw<TensorLoad>();
     op = load.get();
 
-    if (auto opt = GetRemappedBuffer(load->buffer)) {
-      load.CopyOnWrite()->buffer = opt.value();
+    if (auto opt = GetRemappedBuffer(load->source.as_or_throw<tvm::tirx::BufferVar>())) {
+      return BufferLoad(opt.value(), load->indices, load->span);
     }
     return load;
   }
@@ -170,13 +171,13 @@ class ThreadAllreduceBuilder final : public StmtExprMutator {
     BufferStore store = StmtExprMutator::VisitStmt_(op).as_or_throw<BufferStore>();
 
     if (auto it = load_remap_.find(allocation); it != load_remap_.end()) {
-      const auto* replacement = it->second.as<BufferLoadNode>();
+      const auto* replacement = it->second.as<TensorLoadNode>();
       TVM_FFI_ICHECK(replacement);
       for (const auto& index : store->indices) {
         TVM_FFI_ICHECK(is_zero(index));
       }
       auto* writer = store.CopyOnWrite();
-      writer->buffer = replacement->buffer;
+      writer->buffer = replacement->source.as_or_throw<tvm::tirx::BufferVar>();
       writer->indices = replacement->indices;
     } else if (auto opt = GetRemappedBuffer(store->buffer)) {
       store.CopyOnWrite()->buffer = opt.value();
@@ -225,7 +226,7 @@ class ThreadAllreduceBuilder final : public StmtExprMutator {
       if (auto cast = arg.as<CastNode>()) {
         arg = cast->value;
       }
-      buffers[idx] = arg.as_or_throw<BufferLoad>()->buffer;
+      buffers[idx] = arg.as_or_throw<TensorLoad>()->source.as_or_throw<tvm::tirx::BufferVar>();
     }
 
     std::unordered_set<const VarNode*> reduce_set;
@@ -349,7 +350,9 @@ class ThreadAllreduceBuilder final : public StmtExprMutator {
         // This avoids to emit predicated stores, as all threads are
         // uniformly writing the same result.
         for (size_t i = 0; i < size; ++i) {
-          BufferVar buf = reduce_results[i].as_or_throw<BufferLoad>()->buffer;
+          BufferVar buf = reduce_results[i]
+                              .as_or_throw<TensorLoad>()
+                              ->source.as_or_throw<tvm::tirx::BufferVar>();
           PrimExpr val = BufferLoad(buf, {zero_index});
           TVM_FFI_ICHECK_EQ(val.ty(), dtypes[i]);
           PrimExpr splat = WarpShuffle(builtin::tvm_warp_shuffle(), new_alloc_bufs.back(), val,
@@ -381,7 +384,9 @@ class ThreadAllreduceBuilder final : public StmtExprMutator {
         std::vector<Stmt> write_staging_buf;
         write_staging_buf.reserve(size);
         for (size_t i = 0; i < size; ++i) {
-          new_alloc_bufs.push_back(reduce_results[i].as_or_throw<BufferLoad>()->buffer);
+          new_alloc_bufs.push_back(reduce_results[i]
+                                       .as_or_throw<TensorLoad>()
+                                       ->source.as_or_throw<tvm::tirx::BufferVar>());
           write_staging_buf.push_back(BufferStore(
               /*buffer=*/staging_shared_bufs[i],
               /*value=*/reduce_results[i],
@@ -407,7 +412,9 @@ class ThreadAllreduceBuilder final : public StmtExprMutator {
         std::vector<Stmt> write_result;
         write_result.reserve(size);
         for (size_t i = 0; i < size; ++i) {
-          new_alloc_bufs.push_back(reduce_results[i].as_or_throw<BufferLoad>()->buffer);
+          new_alloc_bufs.push_back(reduce_results[i]
+                                       .as_or_throw<TensorLoad>()
+                                       ->source.as_or_throw<tvm::tirx::BufferVar>());
           BufferVar broadcast_shared_buf = decl_buffer(
               /*shape=*/{IntImm(reduce_index.ty(), group_extent)},
               /*dtype=*/buffers[i]->dtype, /*name=*/"red_result", /*storage_scope=*/"shared");
@@ -424,7 +431,8 @@ class ThreadAllreduceBuilder final : public StmtExprMutator {
       for (size_t i = 0; i < size; ++i) {
         const VarNode* alloc_key = GetAllocationKey(buffers[i].get());
         TVM_FFI_ICHECK(!load_remap_.count(alloc_key));
-        BufferVar buf = reduce_results[i].as_or_throw<BufferLoad>()->buffer;
+        BufferVar buf =
+            reduce_results[i].as_or_throw<TensorLoad>()->source.as_or_throw<tvm::tirx::BufferVar>();
         TVM_FFI_ICHECK_EQ(reduce_results[i].ty(), dtypes[i]);
         load_remap_[alloc_key] = reduce_results[i];
 
@@ -460,8 +468,8 @@ class ThreadAllreduceBuilder final : public StmtExprMutator {
         const VarNode* alloc_key = GetAllocationKey(buffers[idx].get());
         TVM_FFI_ICHECK(!load_remap_.count(alloc_key));
         PrimExpr pred = MakeConst(PrimType::Bool(static_cast<int16_t>(dtypes[idx].lanes())), true);
-        BufferLoad load(shared_bufs[idx],
-                        {BufIndex(IntImm(reduce_index.ty(), 0), group_index, reduce_extent)});
+        TensorLoad load = BufferLoad(
+            shared_bufs[idx], {BufIndex(IntImm(reduce_index.ty(), 0), group_index, reduce_extent)});
         TVM_FFI_ICHECK_EQ(load.ty(), dtypes[idx]);
         load_remap_[alloc_key] = load;
         alloc_remap_[alloc_key] = shared_bufs[idx];
@@ -544,7 +552,7 @@ class ThreadAllreduceBuilder final : public StmtExprMutator {
       ffi::Array<PrimExpr> a, b;
       for (int i = 0; i < n_buffers; ++i) {
         BufferVar shared_buf = shared_bufs[i];
-        BufferLoad val(shared_buf, zero_indices);
+        TensorLoad val = BufferLoad(shared_buf, zero_indices);
         TVM_FFI_ICHECK_EQ(val.ty(), dtypes[i]);
         a.push_back(val);
 
@@ -565,7 +573,7 @@ class ThreadAllreduceBuilder final : public StmtExprMutator {
         Stmt s = BufferStore(local_buf, other, zero_indices);
         seq->push_back(s);
 
-        BufferLoad load = BufferLoad(local_buf, zero_indices);
+        TensorLoad load = BufferLoad(local_buf, zero_indices);
         TVM_FFI_ICHECK_EQ(load.ty(), dtypes[i]);
         b.push_back(load);
       }
@@ -623,12 +631,12 @@ class ThreadAllreduceBuilder final : public StmtExprMutator {
     auto fload = [&](int offset) {
       ffi::Array<PrimExpr> a, b;
       for (size_t i = 0; i < size; ++i) {
-        BufferLoad b_load(shared_bufs[i],
-                          {BufIndex(reduce_index + offset, group_index, reduce_extent)});
+        TensorLoad b_load = BufferLoad(
+            shared_bufs[i], {BufIndex(reduce_index + offset, group_index, reduce_extent)});
         TVM_FFI_ICHECK_EQ(b_load.ty(), dtypes[i]);
         b.push_back(b_load);
 
-        BufferLoad a_load(shared_bufs[i], {buf_index});
+        TensorLoad a_load = BufferLoad(shared_bufs[i], {buf_index});
         TVM_FFI_ICHECK_EQ(a_load.ty(), dtypes[i]);
         a.push_back(a_load);
       }
@@ -889,7 +897,7 @@ namespace transform {
  *
  * In flat IR, AllocBuffer nodes may be visited before the alloc_remap_ is populated
  * (since MakeAllreduce runs when Evaluate is visited, which is later in the flat sequence).
- * Handles AllocBuffer, DeclBuffer, and BufferLoad nodes whose remappings
+ * Handles AllocBuffer, DeclBuffer, and TensorLoad nodes whose remappings
  * were not available during the main traversal.
  */
 class DeferredRemapper : public StmtExprMutator {

--- a/src/s_tir/transform/manifest_shared_memory_local_stage.cc
+++ b/src/s_tir/transform/manifest_shared_memory_local_stage.cc
@@ -71,8 +71,8 @@ class IntermediateStageRewriter {
     // Step 2: Create the local stage block
     Stmt local_stage = MakeLocalStage(block, new_buffer, buffer_indices, relaxed_loops, store);
 
-    // Step 3: Create BufferLoad from the intermediate buffer
-    BufferLoad new_buffer_load = BufferLoad(new_buffer, buffer_indices);
+    // Step 3: Create TensorLoad from the intermediate buffer
+    TensorLoad new_buffer_load = BufferLoad(new_buffer, buffer_indices);
     BufferStore new_buffer_store = block->body.as_or_throw<BufferStore>();
     new_buffer_store.CopyOnWrite()->value = new_buffer_load;
     SBlock new_block = ffi::GetRef<SBlock>(block);

--- a/src/s_tir/transform/memhammer_coalesce.cc
+++ b/src/s_tir/transform/memhammer_coalesce.cc
@@ -229,7 +229,7 @@ Stmt InverseMapping::Rewrite(const Stmt& stmt, const ConstraintSet& constraints,
           Substitute(inverse_mapping[loop_vars[j++].as_or_throw<Var>()], substitute_map));
     }
   }
-  BufferLoad new_buf_load = BufferLoad(read_region->buffer, read_index);
+  TensorLoad new_buf_load = BufferLoad(read_region->buffer, read_index);
   BufferStore new_buf_store = BufferStore(write_region->buffer, new_buf_load, write_index);
   Stmt ret = new_buf_store;
   // Step 3.3 construct loop body

--- a/src/s_tir/transform/memhammer_intermediate_stage.cc
+++ b/src/s_tir/transform/memhammer_intermediate_stage.cc
@@ -202,11 +202,11 @@ class IndexPatternFinder : public ExprVisitor {
 
 class BufferLoadReplacer : public StmtExprMutator {
  public:
-  BufferLoadReplacer(const BufferVar& tgt_buffer, const BufferLoad& new_buffer_load)
+  BufferLoadReplacer(const BufferVar& tgt_buffer, const TensorLoad& new_buffer_load)
       : tgt_buffer_(tgt_buffer), new_buffer_load_(new_buffer_load) {}
 
-  Expr VisitExpr_(const BufferLoadNode* op) {
-    if (op->buffer.same_as(tgt_buffer_)) {
+  Expr VisitExpr_(const TensorLoadNode* op) {
+    if (op->source.as_or_throw<tvm::tirx::BufferVar>().same_as(tgt_buffer_)) {
       return new_buffer_load_;
     }
     return StmtExprMutator::VisitExpr_(op);
@@ -214,7 +214,7 @@ class BufferLoadReplacer : public StmtExprMutator {
 
  private:
   BufferVar tgt_buffer_;
-  BufferLoad new_buffer_load_;
+  TensorLoad new_buffer_load_;
 };
 
 /*!
@@ -279,16 +279,17 @@ std::pair<Stmt, SeqStmt> InsertCacheStage(Stmt stmt, bool is_write_cache, ffi::S
   }
 
   arith::Analyzer analyzer;
-  const BufferLoadNode* target_buffer_load = nullptr;
+  const TensorLoadNode* target_buffer_load = nullptr;
   if (is_write_cache) {
     tirx::PreOrderVisit(stmt, [&](const ffi::ObjectRef& obj) {
-      if (const auto* buffer_load = obj.as<BufferLoadNode>()) {
-        if (buffer_load->buffer.scope() == "wmma.accumulator" ||
-            buffer_load->buffer.scope() == "m16n8k8.matrixC") {
+      if (const auto* buffer_load = obj.as<TensorLoadNode>()) {
+        if (buffer_load->source.as_or_throw<tvm::tirx::BufferVar>().scope() == "wmma.accumulator" ||
+            buffer_load->source.as_or_throw<tvm::tirx::BufferVar>().scope() == "m16n8k8.matrixC") {
           if (target_buffer_load == nullptr) {
             target_buffer_load = buffer_load;
           } else {
-            TVM_FFI_ICHECK(target_buffer_load->buffer.same_as(buffer_load->buffer))
+            TVM_FFI_ICHECK(target_buffer_load->source.as_or_throw<tvm::tirx::BufferVar>().same_as(
+                buffer_load->source.as_or_throw<tvm::tirx::BufferVar>()))
                 << "More than one target buffer found";
             TVM_FFI_ICHECK(target_buffer_load->indices.size() == buffer_load->indices.size());
             for (size_t i = 0; i < target_buffer_load->indices.size(); i++) {
@@ -307,9 +308,9 @@ std::pair<Stmt, SeqStmt> InsertCacheStage(Stmt stmt, bool is_write_cache, ffi::S
   ffi::Array<PrimExpr> cache_indices;
   ffi::Array<PrimExpr> new_shape;
   bool use_rank_promotion = false;
-  if (!is_write_cache && buf_store->value.as<BufferLoadNode>()) {
+  if (!is_write_cache && buf_store->value.as<TensorLoadNode>()) {
     ffi::Array<PrimExpr> indices =
-        is_write_cache ? buf_store->indices : buf_store->value.as<BufferLoadNode>()->indices;
+        is_write_cache ? buf_store->indices : buf_store->value.as<TensorLoadNode>()->indices;
     new_shape = IndexPatternFinder::getRankPromotedShape(indices, var_range, &cache_indices);
     // write cache disabled for now
     // rank promotion for write cache cannot guarantee the shape fits wmma.accumulator
@@ -362,7 +363,8 @@ std::pair<Stmt, SeqStmt> InsertCacheStage(Stmt stmt, bool is_write_cache, ffi::S
   if (is_write_cache) {
     // this is needed for global <- cast(load(wmma))
     // shared stage should have the same dtype as wmma
-    new_buffer = WithScope(target_buffer_load->buffer, storage_scope);
+    new_buffer =
+        WithScope(target_buffer_load->source.as_or_throw<tvm::tirx::BufferVar>(), storage_scope);
   } else {
     new_buffer = WithScope(buf_store->buffer, storage_scope);
   }
@@ -374,9 +376,10 @@ std::pair<Stmt, SeqStmt> InsertCacheStage(Stmt stmt, bool is_write_cache, ffi::S
   Stmt generate_body;
   if (is_write_cache) {
     // copy from wmma to new cache buffer
-    BufferLoad new_buffer_load{new_buffer, cache_indices};
-    generate_body = BufferLoadReplacer(target_buffer_load->buffer,
-                                       new_buffer_load)(ffi::GetRef<Stmt>(buf_store));
+    TensorLoad new_buffer_load = BufferLoad(new_buffer, cache_indices);
+    generate_body =
+        BufferLoadReplacer(target_buffer_load->source.as_or_throw<tvm::tirx::BufferVar>(),
+                           new_buffer_load)(ffi::GetRef<Stmt>(buf_store));
     generate_body = Substitute(generate_body, subst_map);
   } else {
     generate_body =
@@ -410,9 +413,9 @@ std::pair<Stmt, SeqStmt> InsertCacheStage(Stmt stmt, bool is_write_cache, ffi::S
   }
   Stmt rewrite_body;
   if (is_write_cache) {
-    BufferLoad new_buffer_load{new_buffer, cache_indices};
+    TensorLoad new_buffer_load = BufferLoad(new_buffer, cache_indices);
     rewrite_body =
-        BufferStore(new_buffer, ffi::GetRef<BufferLoad>(target_buffer_load), cache_indices);
+        BufferStore(new_buffer, ffi::GetRef<TensorLoad>(target_buffer_load), cache_indices);
   } else {
     rewrite_body =
         BufferStore(buf_store->buffer, BufferLoad(new_buffer, cache_indices), buf_store->indices);

--- a/src/s_tir/transform/memhammer_lower_auto_copy.cc
+++ b/src/s_tir/transform/memhammer_lower_auto_copy.cc
@@ -198,11 +198,11 @@ class AutoPadder {
           : buffer_map_(buffer_map) {}
 
      private:
-      Expr VisitExpr_(const BufferLoadNode* _op) final {
-        BufferLoad load = StmtExprMutator::VisitExpr_(_op).as_or_throw<BufferLoad>();
-        BufferLoadNode* op = load.CopyOnWrite();
-        if (buffer_map_.count(op->buffer)) {
-          op->buffer = buffer_map_[op->buffer];
+      Expr VisitExpr_(const TensorLoadNode* _op) final {
+        TensorLoad load = StmtExprMutator::VisitExpr_(_op).as_or_throw<TensorLoad>();
+        BufferVar buffer = load->source.as_or_throw<tvm::tirx::BufferVar>();
+        if (buffer_map_.count(buffer)) {
+          return BufferLoad(buffer_map_[buffer], load->indices, load->span);
         }
         return load;
       }
@@ -537,8 +537,9 @@ class AutoPadder {
      * The iteration space would be {{0, 1}, {0, 4, ..., 60}}.
      * \param op the buffer load
      */
-    void VisitExpr_(const BufferLoadNode* op) final {
-      runtime::StorageScope scope = runtime::StorageScope::Create(op->buffer.scope());
+    void VisitExpr_(const TensorLoadNode* op) final {
+      runtime::StorageScope scope =
+          runtime::StorageScope::Create(op->source.as_or_throw<tvm::tirx::BufferVar>().scope());
       if (scope.rank == runtime::StorageRank::kShared) {
         ffi::Array<PrimExpr> substitued_indices;
         arith::Analyzer analyzer;
@@ -548,12 +549,15 @@ class AutoPadder {
         std::vector<std::vector<int>> iter_space =
             PatternCollector::CollectIterationSpace(substitued_indices, var_range_, data_bits_);
         if (!iter_space.empty()) {
-          self->iter_spaces_[op->buffer.get()].push_back(iter_space);
+          self->iter_spaces_[op->source.as_or_throw<tvm::tirx::BufferVar>().get()].push_back(
+              iter_space);
         }
         if (vector_length_ != -1 &&
             CheckVarContiguous(substitued_indices.back(), vector_var, substitute_map_)) {
-          int64_t m = self->padding_min_.Get(op->buffer).value_or(1);
-          self->padding_min_.Set(op->buffer, std::max(static_cast<int64_t>(vector_length_), m));
+          int64_t m =
+              self->padding_min_.Get(op->source.as_or_throw<tvm::tirx::BufferVar>()).value_or(1);
+          self->padding_min_.Set(op->source.as_or_throw<tvm::tirx::BufferVar>(),
+                                 std::max(static_cast<int64_t>(vector_length_), m));
         }
       }
       StmtExprVisitor::VisitExpr_(op);

--- a/src/s_tir/transform/memhammer_lower_auto_copy.cc
+++ b/src/s_tir/transform/memhammer_lower_auto_copy.cc
@@ -538,8 +538,8 @@ class AutoPadder {
      * \param op the buffer load
      */
     void VisitExpr_(const TensorLoadNode* op) final {
-      runtime::StorageScope scope =
-          runtime::StorageScope::Create(op->source.as_or_throw<tvm::tirx::BufferVar>().scope());
+      BufferVar buffer = op->source.as_or_throw<tvm::tirx::BufferVar>();
+      runtime::StorageScope scope = runtime::StorageScope::Create(buffer.scope());
       if (scope.rank == runtime::StorageRank::kShared) {
         ffi::Array<PrimExpr> substitued_indices;
         arith::Analyzer analyzer;
@@ -549,15 +549,12 @@ class AutoPadder {
         std::vector<std::vector<int>> iter_space =
             PatternCollector::CollectIterationSpace(substitued_indices, var_range_, data_bits_);
         if (!iter_space.empty()) {
-          self->iter_spaces_[op->source.as_or_throw<tvm::tirx::BufferVar>().get()].push_back(
-              iter_space);
+          self->iter_spaces_[buffer.get()].push_back(iter_space);
         }
         if (vector_length_ != -1 &&
             CheckVarContiguous(substitued_indices.back(), vector_var, substitute_map_)) {
-          int64_t m =
-              self->padding_min_.Get(op->source.as_or_throw<tvm::tirx::BufferVar>()).value_or(1);
-          self->padding_min_.Set(op->source.as_or_throw<tvm::tirx::BufferVar>(),
-                                 std::max(static_cast<int64_t>(vector_length_), m));
+          int64_t m = self->padding_min_.Get(buffer).value_or(1);
+          self->padding_min_.Set(buffer, std::max(static_cast<int64_t>(vector_length_), m));
         }
       }
       StmtExprVisitor::VisitExpr_(op);

--- a/src/s_tir/transform/memhammer_tensorcore_rewrite.cc
+++ b/src/s_tir/transform/memhammer_tensorcore_rewrite.cc
@@ -127,11 +127,11 @@ Stmt RewriteWmmaLoad(Stmt stmt) {
       {loops[n - 1]->loop_var, IntSet::FromMinExtent(loops[n - 1]->min, loops[n - 1]->extent)},
       {loops[n - 2]->loop_var, IntSet::FromMinExtent(loops[n - 2]->min, loops[n - 2]->extent)},
   };
-  // TODO(tian): the assumption that the RHS of BufferStore is BufferLoad may not be accurate
+  // TODO(tian): the assumption that the RHS of BufferStore is TensorLoad may not be accurate
   const BufferStoreNode* buf_store = TVM_TYPE_AS(body, BufferStoreNode);
-  const BufferLoadNode* buf_load = TVM_TYPE_AS(buf_store->value, BufferLoadNode);
+  const TensorLoadNode* buf_load = TVM_TYPE_AS(buf_store->value, TensorLoadNode);
 
-  BufferVar src_buffer = buf_load->buffer;
+  BufferVar src_buffer = buf_load->source.as_or_throw<tvm::tirx::BufferVar>();
   BufferVar tgt_buffer = buf_store->buffer;
   std::string layout = tgt_buffer.scope() == "wmma.matrix_a" ? "row_major" : "col_major";
   BufferVar new_src_buffer(
@@ -224,19 +224,21 @@ Stmt RewriteWmmaStore(Stmt stmt) {
       {loops[n - 1]->loop_var, IntSet::FromMinExtent(loops[n - 1]->min, loops[n - 1]->extent)},
       {loops[n - 2]->loop_var, IntSet::FromMinExtent(loops[n - 2]->min, loops[n - 2]->extent)},
   };
-  // TODO(tian): the assumption that the RHS of BufferStore is BufferLoad may not be accurate
+  // TODO(tian): the assumption that the RHS of BufferStore is TensorLoad may not be accurate
   const BufferStoreNode* buf_store = TVM_TYPE_AS(body, BufferStoreNode);
-  const BufferLoadNode* buf_load = nullptr;
+  const TensorLoadNode* buf_load = nullptr;
   PostOrderVisit(buf_store->value, [&](const ffi::ObjectRef& obj) {
-    const BufferLoadNode* load = obj.as<BufferLoadNode>();
-    if (load && load->buffer.scope() == "wmma.accumulator") {
-      TVM_FFI_ICHECK(buf_load == nullptr || buf_load->buffer.same_as(load->buffer))
+    const TensorLoadNode* load = obj.as<TensorLoadNode>();
+    if (load && load->source.as_or_throw<tvm::tirx::BufferVar>().scope() == "wmma.accumulator") {
+      TVM_FFI_ICHECK(buf_load == nullptr ||
+                     buf_load->source.as_or_throw<tvm::tirx::BufferVar>().same_as(
+                         load->source.as_or_throw<tvm::tirx::BufferVar>()))
           << "More than one source buffer of wmma accumulator found";
       buf_load = load;
     }
     return true;
   });
-  BufferVar src_buffer = buf_load->buffer;
+  BufferVar src_buffer = buf_load->source.as_or_throw<tvm::tirx::BufferVar>();
   BufferVar tgt_buffer = buf_store->buffer;
 
   PrimType dtype_ty = src_buffer->dtype;
@@ -435,11 +437,13 @@ Stmt RewriteMmaStore(Stmt stmt) {
 
   // Step 2. Find matrixC buffer
   const BufferStoreNode* buf_store = TVM_TYPE_AS(body, BufferStoreNode);
-  const BufferLoadNode* buf_load = nullptr;
+  const TensorLoadNode* buf_load = nullptr;
   PostOrderVisit(buf_store->value, [&](const ffi::ObjectRef& obj) {
-    const BufferLoadNode* load = obj.as<BufferLoadNode>();
-    if (load && load->buffer.scope() == "m16n8k8.matrixC") {
-      TVM_FFI_ICHECK(buf_load == nullptr || buf_load->buffer.same_as(load->buffer))
+    const TensorLoadNode* load = obj.as<TensorLoadNode>();
+    if (load && load->source.as_or_throw<tvm::tirx::BufferVar>().scope() == "m16n8k8.matrixC") {
+      TVM_FFI_ICHECK(buf_load == nullptr ||
+                     buf_load->source.as_or_throw<tvm::tirx::BufferVar>().same_as(
+                         load->source.as_or_throw<tvm::tirx::BufferVar>()))
           << "More than one source buffer of mma accumulator found";
       buf_load = load;
     }
@@ -455,7 +459,7 @@ Stmt RewriteMmaStore(Stmt stmt) {
   // https://docs.nvidia.com/cuda/archive/11.1.0/pdf/ptx_isa_7.1.pdf
 
   // Step 3.1. Generate new buffer
-  BufferVar src_buffer = buf_load->buffer;
+  BufferVar src_buffer = buf_load->source.as_or_throw<tvm::tirx::BufferVar>();
   BufferVar tgt_buffer = buf_store->buffer;
   PrimType dtype_ty = src_buffer->dtype;
   const PrimType& dtype = dtype_ty;

--- a/src/s_tir/transform/merge_shared_memory_allocations.cc
+++ b/src/s_tir/transform/merge_shared_memory_allocations.cc
@@ -213,10 +213,10 @@ class SharedMemLinearAccessPatternFinder final : public StmtExprVisitor {
     StmtExprVisitor::VisitStmt_(op);
   }
 
-  void VisitExpr_(const BufferLoadNode* op) final {
+  void VisitExpr_(const TensorLoadNode* op) final {
     // Add read access.
     StmtExprVisitor::VisitExpr_(op);
-    const VarNode* buf = ResolveAlias(op->buffer.get());
+    const VarNode* buf = ResolveAlias(op->source.as_or_throw<tvm::tirx::BufferVar>().get());
     auto it = alloc_info_.find(buf);
     if (it != alloc_info_.end() && it->second.buffer.defined()) {
       TVM_FFI_ICHECK_LT(it->second.level, scope_.size())
@@ -229,7 +229,7 @@ class SharedMemLinearAccessPatternFinder final : public StmtExprVisitor {
 
   void VisitExpr_(const CallNode* op) final {
     if (op->op.same_as(builtin::address_of())) {
-      if (const auto* load = op->args[0].as<BufferLoadNode>()) {
+      if (const auto* load = op->args[0].as<TensorLoadNode>()) {
         for (const auto& index : load->indices) {
           this->VisitExpr(index);
         }
@@ -498,8 +498,8 @@ class SharedMemoryRewriter : public StmtExprMutator {
     return node;
   }
 
-  Expr VisitExpr_(const BufferLoadNode* op) final {
-    auto node = StmtExprMutator::VisitExpr_(op).as_or_throw<BufferLoad>();
+  Expr VisitExpr_(const TensorLoadNode* op) final {
+    auto node = StmtExprMutator::VisitExpr_(op).as_or_throw<TensorLoad>();
     return VisitBufferAccess(std::move(node));
   }
 
@@ -525,6 +525,20 @@ class SharedMemoryRewriter : public StmtExprMutator {
     }
 
     return node;
+  }
+
+  TensorLoad VisitBufferAccess(TensorLoad node) {
+    BufferVar buffer = node->source.as_or_throw<tvm::tirx::BufferVar>();
+    if (!IsAppropriateSharedMemory(buffer) || scope_stack_.empty() ||
+        !ResolveAllocation(buffer.get(), scope_stack_.back())) {
+      return node;
+    }
+    TVM_FFI_ICHECK_EQ(node->indices.size(), 1)
+        << "MergeSharedMemoryAllocations expects flat memory buffers, and is to be run after "
+           "FlattenBuffer";
+    ffi::Array<PrimExpr> indices = {node->indices[0] +
+                                    this->GetBufferOffset(buffer.var(), buffer->dtype->dtype)};
+    return BufferLoad(GetUpdatedBuffer(buffer), indices, node->span);
   }
 
   BufferVar GetUpdatedBuffer(BufferVar buffer) {

--- a/src/s_tir/transform/plan_update_buffer_allocation_location.cc
+++ b/src/s_tir/transform/plan_update_buffer_allocation_location.cc
@@ -86,9 +86,9 @@ class BufferAllocateOrderCollector : public StmtExprVisitor {
     StmtExprVisitor::VisitStmt_(op);
   }
 
-  void VisitExpr_(const BufferLoadNode* op) final {
-    if (!find(op->buffer)) {
-      buffer_alloc_recorder_.push_back(op->buffer);
+  void VisitExpr_(const TensorLoadNode* op) final {
+    if (!find(op->source.as_or_throw<tvm::tirx::BufferVar>())) {
+      buffer_alloc_recorder_.push_back(op->source.as_or_throw<tvm::tirx::BufferVar>());
     }
     StmtExprVisitor::VisitExpr_(op);
   }

--- a/src/s_tir/transform/remove_store_undef.cc
+++ b/src/s_tir/transform/remove_store_undef.cc
@@ -77,7 +77,7 @@ class StoreUndefLocator : public StmtExprVisitor {
     TVM_FFI_ICHECK(!idx_undef) << "Error: T.undef() may not be used in buffer indices";
   }
 
-  void VisitExpr_(const BufferLoadNode* op) final {
+  void VisitExpr_(const TensorLoadNode* op) final {
     // Check indices for undef.  Undef in buffer indices is always an error.
     bool idx_undef = false;
     std::swap(has_undef_, idx_undef);

--- a/src/s_tir/transform/remove_weight_layout_rewrite_block.cc
+++ b/src/s_tir/transform/remove_weight_layout_rewrite_block.cc
@@ -81,11 +81,11 @@ class RemoveLayoutRewriteBlock : public StmtMutator {
     TVM_FFI_ICHECK(store);
 
     // Step 2. Checking the rhs of buffer store is a BufferLoad
-    const auto* load = store->value.as<BufferLoadNode>();
+    const auto* load = store->value.as<TensorLoadNode>();
     TVM_FFI_ICHECK(load);
 
     // Step 3. Update BufferVar
-    buf_map_.Set(load->buffer, store->buffer);
+    buf_map_.Set(load->source.as_or_throw<tvm::tirx::BufferVar>(), store->buffer);
     rewritten_buffers_.insert(store->buffer);
 
     // Step 4. Set block body as no_op
@@ -99,9 +99,11 @@ class RemoveLayoutRewriteBlock : public StmtMutator {
       TVM_FFI_ICHECK(ind.as<PrimVar>());
       load_indices.push_back(ind.as_or_throw<PrimVar>());
     }
-    buffer_var_to_index_map_[load->buffer.get()] = IndexMap(load_indices, store->indices);
+    buffer_var_to_index_map_[load->source.as_or_throw<tvm::tirx::BufferVar>().get()] =
+        IndexMap(load_indices, store->indices);
 
-    buffer_var_to_rewritten_shape_[load->buffer.get()] = store->buffer->shape;
+    buffer_var_to_rewritten_shape_[load->source.as_or_throw<tvm::tirx::BufferVar>().get()] =
+        store->buffer->shape;
 
     return Stmt(n);
   }

--- a/src/s_tir/transform/renew_defs.cc
+++ b/src/s_tir/transform/renew_defs.cc
@@ -171,7 +171,7 @@ class RenewDefMutator : public StmtExprMutator {
   BufferVar DefineBuffer(const BufferVar& buffer) {
     auto it = remap_.find(buffer);
     if (it != remap_.end()) {
-      return (*it).second.as_or_throw<BufferVar>();
+      return (*it).second.as_or_throw<tvm::tirx::BufferVar>();
     }
 
     auto redefine_if_is_var = [this](const Expr& expr) -> Expr {
@@ -209,7 +209,7 @@ class RenewDefMutator : public StmtExprMutator {
     // remap it without creating new var definitions.
     auto it = remap_.find(buffer);
     if (it != remap_.end()) {
-      return (*it).second.as_or_throw<BufferVar>();
+      return (*it).second.as_or_throw<tvm::tirx::BufferVar>();
     }
     auto visit_expr = [this](const PrimExpr& e) -> PrimExpr { return this->VisitPrimExpr(e); };
     ffi::Array<PrimExpr> shape = buffer->shape.Map(visit_expr);

--- a/src/s_tir/transform/rewrite_unsafe_select.cc
+++ b/src/s_tir/transform/rewrite_unsafe_select.cc
@@ -44,7 +44,7 @@ class UnsafeExprDetector : public ExprFunctor<bool(const Expr& n)> {
     if (op->op.same_as(builtin::if_then_else())) {
       return VisitExpr(op->args[0].as_or_throw<PrimExpr>());
     } else if (op->op.same_as(builtin::address_of())) {
-      if (const auto* load = op->args[0].as<BufferLoadNode>()) {
+      if (const auto* load = op->args[0].as<TensorLoadNode>()) {
         for (const auto& index : load->indices) {
           if (VisitExpr(index)) {
             return true;
@@ -67,7 +67,7 @@ class UnsafeExprDetector : public ExprFunctor<bool(const Expr& n)> {
       return true;
     }
   }
-  bool VisitExpr_(const BufferLoadNode* op) {
+  bool VisitExpr_(const TensorLoadNode* op) {
     // Load is considered unsafe.
     return true;
   }

--- a/src/s_tir/transform/storage_access.cc
+++ b/src/s_tir/transform/storage_access.cc
@@ -50,9 +50,9 @@ ffi::Optional<Var> GetBufferDataVar(const ffi::Any& data) {
 
 }  // namespace
 
-void StorageAccessVisitor::VisitExpr_(const BufferLoadNode* op) {
-  Var buf = ResolveBuffer(op->buffer.var());
-  StorageScope scope = StorageScope::Create(op->buffer.scope());
+void StorageAccessVisitor::VisitExpr_(const TensorLoadNode* op) {
+  Var buf = ResolveBuffer(op->source.as_or_throw<tvm::tirx::BufferVar>().var());
+  StorageScope scope = StorageScope::Create(op->source.as_or_throw<tvm::tirx::BufferVar>().scope());
   if (Enabled(buf.get(), scope)) {
     TVM_FFI_ICHECK(allow_append_) << op << " " << scope.to_string();
     AccessEntry e;
@@ -283,7 +283,7 @@ void StorageAccessVisitor::VisitExpr_(const CallNode* op) {
     }
     StmtExprVisitor::VisitExpr_(op);
   } else if (op->op.same_as(builtin::address_of())) {
-    if (const auto* load = op->args[0].as<BufferLoadNode>()) {
+    if (const auto* load = op->args[0].as<TensorLoadNode>()) {
       // Taking an address does not read the buffer value.  Visit only the
       // load's children so index expressions still contribute accesses.
       StmtExprVisitor::VisitExpr_(load);

--- a/src/s_tir/transform/storage_access.h
+++ b/src/s_tir/transform/storage_access.h
@@ -82,7 +82,7 @@ class StorageAccessVisitor : public StmtExprVisitor {
     std::vector<AccessEntry> access;
   };
   // override visitor pattern
-  void VisitExpr_(const BufferLoadNode* op) final;
+  void VisitExpr_(const TensorLoadNode* op) final;
   void VisitStmt_(const BufferStoreNode* op) final;
   void VisitStmt_(const DeclBufferNode* op) final;
   void VisitStmt_(const EvaluateNode* op) final;

--- a/src/s_tir/transform/transform_mma_buffer_layout.cc
+++ b/src/s_tir/transform/transform_mma_buffer_layout.cc
@@ -140,7 +140,10 @@ class MmaBufferLayoutTransformer : public StmtExprMutator {
         n->indices = std::move(new_indices);
       } else if (store->buffer.scope() == "m16n8k8.matrixA" ||
                  store->buffer.scope() == "m16n8k8.matrixB") {
-        n->buffer = buffer_map_[store->buffer];
+        TVM_FFI_ICHECK(false)
+            << "TransformMmaBufferLayout requires " << store->buffer.scope()
+            << " buffers to be accessed through opaque ldmatrix/mma_sync operations, but found "
+               "an explicit BufferStore.";
       }
     }
     return store;
@@ -148,16 +151,21 @@ class MmaBufferLayoutTransformer : public StmtExprMutator {
 
   Expr VisitExpr_(const TensorLoadNode* op) {
     TensorLoad load = StmtExprMutator::VisitExpr_(op).as_or_throw<TensorLoad>();
-    if (buffer_map_.count(load->source.as_or_throw<tvm::tirx::BufferVar>())) {
+    BufferVar buffer = load->source.as_or_throw<tvm::tirx::BufferVar>();
+    if (buffer_map_.count(buffer)) {
       ffi::Array<PrimExpr> indices = load->indices;
-      if (load->source.as_or_throw<tvm::tirx::BufferVar>().scope() == "m16n8k8.matrixC") {
+      if (buffer.scope() == "m16n8k8.matrixC") {
         const auto index_map_func = tvm::ffi::Function::GetGlobal("tirx.index_map_m16n8k8.matrixC");
         TVM_FFI_ICHECK(index_map_func.has_value());
         auto index_map = IndexMap::FromFunc(2, *index_map_func);
         indices = index_map->MapIndices(load->indices, analyzer);
+      } else {
+        TVM_FFI_ICHECK(false)
+            << "TransformMmaBufferLayout requires " << buffer.scope()
+            << " buffers to be accessed through opaque ldmatrix/mma_sync operations, but found "
+               "an explicit TensorLoad.";
       }
-      return BufferLoad(buffer_map_[load->source.as_or_throw<tvm::tirx::BufferVar>()], indices,
-                        load->span);
+      return BufferLoad(buffer_map_[buffer], indices, load->span);
     }
     return load;
   }

--- a/src/s_tir/transform/transform_mma_buffer_layout.cc
+++ b/src/s_tir/transform/transform_mma_buffer_layout.cc
@@ -146,21 +146,18 @@ class MmaBufferLayoutTransformer : public StmtExprMutator {
     return store;
   }
 
-  Expr VisitExpr_(const BufferLoadNode* op) {
-    BufferLoad load = StmtExprMutator::VisitExpr_(op).as_or_throw<BufferLoad>();
-    if (buffer_map_.count(load->buffer)) {
-      auto* n = load.CopyOnWrite();
-      if (load->buffer.scope() == "m16n8k8.matrixC") {
+  Expr VisitExpr_(const TensorLoadNode* op) {
+    TensorLoad load = StmtExprMutator::VisitExpr_(op).as_or_throw<TensorLoad>();
+    if (buffer_map_.count(load->source.as_or_throw<tvm::tirx::BufferVar>())) {
+      ffi::Array<PrimExpr> indices = load->indices;
+      if (load->source.as_or_throw<tvm::tirx::BufferVar>().scope() == "m16n8k8.matrixC") {
         const auto index_map_func = tvm::ffi::Function::GetGlobal("tirx.index_map_m16n8k8.matrixC");
         TVM_FFI_ICHECK(index_map_func.has_value());
         auto index_map = IndexMap::FromFunc(2, *index_map_func);
-        auto new_indices = index_map->MapIndices(load->indices, analyzer);
-        n->buffer = buffer_map_[load->buffer];
-        n->indices = std::move(new_indices);
-      } else if (load->buffer.scope() == "m16n8k8.matrixA" ||
-                 load->buffer.scope() == "m16n8k8.matrixB") {
-        n->buffer = buffer_map_[load->buffer];
+        indices = index_map->MapIndices(load->indices, analyzer);
       }
+      return BufferLoad(buffer_map_[load->source.as_or_throw<tvm::tirx::BufferVar>()], indices,
+                        load->span);
     }
     return load;
   }

--- a/src/s_tir/transform/using_assume_to_reduce_branches.cc
+++ b/src/s_tir/transform/using_assume_to_reduce_branches.cc
@@ -123,12 +123,12 @@ class ParseAssumeAndOvercompute : public IRMutatorWithAnalyzer {
   using Parent::VisitStmt_;
 
   // This struct stores all the relevant data related to asssume statement
-  struct assume_struct {           // Consider the example : T.assume(i < 14 or A[i] == 0)
-    PrimExpr buffer_context;       // The context of the assume statement (the bound on the axis)
-    PrimExpr buffer_predicate;     // The condition inside assume statement (i < 14) excluding
-                                   // bufferload expression (A[i] == 0)
-    tirx::BufferLoad buffer_load;  // Storing the buffer load Eg: A[i] in A[i] == 0
-    PrimExpr buffer_value;         // Storing the value for the buffer Eg : 0 in A[i] == 0
+  struct assume_struct {        // Consider the example : T.assume(i < 14 or A[i] == 0)
+    PrimExpr buffer_context;    // The context of the assume statement (the bound on the axis)
+    PrimExpr buffer_predicate;  // The condition inside assume statement (i < 14) excluding
+                                // bufferload expression (A[i] == 0)
+    TensorLoad buffer_load;     // Storing the buffer load Eg: A[i] in A[i] == 0
+    PrimExpr buffer_value;      // Storing the value for the buffer Eg : 0 in A[i] == 0
     ffi::Array<PrimExpr> buffer_indices;  // Storing the indices of the buffer Eg : i
   };
   // List of conditions in a scope
@@ -196,14 +196,16 @@ class ParseAssumeAndOvercompute : public IRMutatorWithAnalyzer {
     return Parent::VisitStmt_(op);
   }
 
-  Expr VisitExpr_(const BufferLoadNode* op) override {
-    if (map_buffer_assumption.find(op->buffer) != map_buffer_assumption.end()) {
+  Expr VisitExpr_(const TensorLoadNode* op) override {
+    if (map_buffer_assumption.find(op->source.as_or_throw<tvm::tirx::BufferVar>()) !=
+        map_buffer_assumption.end()) {
       PrimExpr buf_value;
       /* If the cuurent context where the buffer load is present is same as
       the context of the buffer assumption then, return the buffer value present in the assumption.
       This will eventually replace the bufferload value in the complete expresison */
 
-      auto buffer_assumption = map_buffer_assumption[op->buffer];
+      auto buffer_assumption =
+          map_buffer_assumption[op->source.as_or_throw<tvm::tirx::BufferVar>()];
       PrimExpr current_predicate_and_context = CurrentScopePredicate();
       PrimExpr buffer_predicate_and_context =
           buffer_assumption.buffer_context && buffer_assumption.buffer_predicate;
@@ -324,12 +326,12 @@ class ParseAssumeAndOvercompute : public IRMutatorWithAnalyzer {
 
     // Parse the statement and store the desired values
     // Ex: A[i]==0, load = A[i], value = 0
-    tirx::BufferLoad load;
+    TensorLoad load;
     PrimExpr value;
-    if (auto opt = as_equal_node->a.as<tirx::BufferLoad>()) {
+    if (auto opt = as_equal_node->a.as<TensorLoad>()) {
       load = opt.value();
       value = as_equal_node->b;
-    } else if (auto opt = as_equal_node->b.as<tirx::BufferLoad>()) {
+    } else if (auto opt = as_equal_node->b.as<TensorLoad>()) {
       load = opt.value();
       value = as_equal_node->a;
     } else {
@@ -347,7 +349,8 @@ class ParseAssumeAndOvercompute : public IRMutatorWithAnalyzer {
     for (size_t i = 0; i < load->indices.size(); i++) {
       buf_data.buffer_indices.push_back(analyzer_->Simplify(load->indices[i]));
     }
-    map_buffer_assumption[buf_data.buffer_load->buffer] = buf_data;
+    map_buffer_assumption[buf_data.buffer_load->source.as_or_throw<tvm::tirx::BufferVar>()] =
+        buf_data;
 
     auto has_side_effect = tirx::SideEffect(value) > tirx::CallEffectKind::kPure;
     TVM_FFI_ICHECK(!has_side_effect)

--- a/src/target/llvm/codegen_llvm.cc
+++ b/src/target/llvm/codegen_llvm.cc
@@ -1408,7 +1408,7 @@ llvm::Value* CodeGenLLVM::CreateIntrinsic(const CallNode* op) {
   } else if (op->op.same_as(builtin::tvm_storage_sync())) {
     return CreateStorageSync(op);
   } else if (op->op.same_as(builtin::address_of())) {
-    const BufferLoadNode* load = args[0].as<BufferLoadNode>();
+    const TensorLoadNode* load = args[0].as<TensorLoadNode>();
     TVM_FFI_ICHECK(args.size() == 1 && load);
 
     ffi::Array<PrimExpr> indices = load->indices;
@@ -1422,7 +1422,8 @@ llvm::Value* CodeGenLLVM::CreateIntrinsic(const CallNode* op) {
     }
 
     TypedPointer buffer_ptr =
-        CreateBufferPtr(MakeValue(load->buffer.var()), load->buffer->dtype, indices_val,
+        CreateBufferPtr(MakeValue(load->source.as_or_throw<tvm::tirx::BufferVar>().var()),
+                        load->source.as_or_throw<tvm::tirx::BufferVar>()->dtype, indices_val,
                         PrimType(load->ty.as_or_throw<PrimType>()->dtype));
     return buffer_ptr.addr;
   } else if (op->op.same_as(builtin::reinterpret()) && args[0].as<PrimExpr>() &&
@@ -1845,7 +1846,7 @@ void CodeGenLLVM::BufferAccessHelper(
   }
 }
 
-llvm::Value* CodeGenLLVM::VisitExpr_(const BufferLoadNode* op) {
+llvm::Value* CodeGenLLVM::VisitExpr_(const TensorLoadNode* op) {
   PrimType value_dtype = op->ty.as_or_throw<PrimType>();
   PrimType access_dtype = BufferAccessType(value_dtype);
 
@@ -1871,7 +1872,8 @@ llvm::Value* CodeGenLLVM::VisitExpr_(const BufferLoadNode* op) {
   // Pass all indices into BufferAccessHelper.  In CodeGenLLVM,
   // non-flat indices will result in an error in CreateBufferPtr, but
   // a subclass may override CreateBufferPtr.
-  BufferAccessHelper(op->buffer, op->indices, std::nullopt, access_dtype, make_load);
+  BufferAccessHelper(op->source.as_or_throw<tvm::tirx::BufferVar>(), op->indices, std::nullopt,
+                     access_dtype, make_load);
 
   llvm::Value* ret;
   if (loads.size() == 1) {

--- a/src/target/llvm/codegen_llvm.h
+++ b/src/target/llvm/codegen_llvm.h
@@ -221,7 +221,7 @@ class CodeGenLLVM : public ExprFunctor<llvm::Value*(const Expr&)>,
   llvm::Value* VisitExpr_(const NotNode* op) override;
   llvm::Value* VisitExpr_(const SelectNode* op) override;
   llvm::Value* VisitExpr_(const LetNode* op) override;
-  llvm::Value* VisitExpr_(const BufferLoadNode* op) override;
+  llvm::Value* VisitExpr_(const TensorLoadNode* op) override;
   llvm::Value* VisitExpr_(const CallNode* op) override;
   llvm::Value* VisitExpr_(const RampNode* op) override;
   llvm::Value* VisitExpr_(const ShuffleNode* op) override;

--- a/src/target/source/codegen_c.cc
+++ b/src/target/source/codegen_c.cc
@@ -288,7 +288,7 @@ std::string CodeGenC::GetBufferRef(const PrimType& t, const VarNode* buffer, Pri
     // float4_e2m1fn: sizeof(__nv_fp4_e2m1) = 1 byte, but data is packed
     // 2 elements per byte.  Divide element index by 2 to get byte offset.
     // This returns an lvalue so it works for address_of() and stores.
-    // Nibble extraction (for loads) is handled in VisitExpr_(BufferLoadNode*).
+    // Nibble extraction (for loads) is handled in VisitExpr_(TensorLoadNode*).
     os << "*(" << ptr_cast(t) << "(" << vid << " + " << index_str << " / 2))";
   } else if (t == buffer_element_dtype) {
     os << buffer_str << "[" << index_str << "]";
@@ -764,31 +764,34 @@ void CodeGenC::VisitExpr_(const CallNode* op, std::ostream& os) {  // NOLINT(*)
       }
       os << result;
     } else if (op->op.same_as(builtin::address_of())) {
-      const BufferLoadNode* load = op->args[0].as<BufferLoadNode>();
+      const TensorLoadNode* load = op->args[0].as<TensorLoadNode>();
       TVM_FFI_ICHECK(op->args.size() == 1);
       if (load) {
         TVM_FFI_ICHECK_EQ(load->indices.size(), 1)
             << "CodeGenC only supports flat memory allocations.";
         PrimExpr index = load->indices[0];
-        // A vector BufferLoad uses a Ramp to describe its lane indices.  The
+        // A vector TensorLoad uses a Ramp to describe its lane indices.  The
         // address of that load is the address of its first lane.
         if (const RampNode* ramp = index.as<RampNode>()) {
           index = ramp->base;
         }
-        const VarNode* data = load->buffer.get();
-        if (pointer_offset_vars_.count(data) && HandleTypeMatch(data, load->buffer->dtype) &&
+        const VarNode* data = load->source.as_or_throw<tvm::tirx::BufferVar>().get();
+        if (pointer_offset_vars_.count(data) &&
+            HandleTypeMatch(data, load->source.as_or_throw<tvm::tirx::BufferVar>()->dtype) &&
             !IsVolatile(data)) {
           os << "(" << GetVarID(data) << " + ";
           this->PrintExpr(index, os);
           os << ")";
         } else {
-          os << "(&(" << GetBufferRef(load->ty.as_or_throw<PrimType>(), load->buffer.get(), index)
+          os << "(&("
+             << GetBufferRef(load->ty.as_or_throw<PrimType>(),
+                             load->source.as_or_throw<tvm::tirx::BufferVar>().get(), index)
              << "))";
         }
       } else {
         auto* var = op->args[0].as<tirx::VarNode>();
         TVM_FFI_ICHECK(var)
-            << "Builtin address_of() expects the argument to be a BufferLoad or Var, but "
+            << "Builtin address_of() expects the argument to be a TensorLoad or Var, but "
             << "received argument " << op->args[0];
         if (auto* ptr = var->ty.as<PointerTypeNode>()) {
           if (ptr->element_type.as<TensorMapTypeNode>()) {
@@ -953,18 +956,19 @@ void CodeGenC::VisitStmt_(const DeclBufferNode* op) {
   RegisterHandleType(op->buffer.get(), op->buffer->dtype);
 }
 
-void CodeGenC::VisitExpr_(const BufferLoadNode* op, std::ostream& os) {  // NOLINT(*)
+void CodeGenC::VisitExpr_(const TensorLoadNode* op, std::ostream& os) {  // NOLINT(*)
   TVM_FFI_ICHECK_EQ(op->indices.size(), 1) << "Load from non-flat memory not supported.";
 
   PrimType value_ty = op->ty.as_or_throw<PrimType>();
   PrimExpr index = op->indices[0];
-  Var buffer_var = op->buffer.var();
-  const PrimType& element_ty = op->buffer->dtype;
+  Var buffer_var = op->source.as_or_throw<tvm::tirx::BufferVar>().var();
+  const PrimType& element_ty = op->source.as_or_throw<tvm::tirx::BufferVar>()->dtype;
 
   int lanes = value_ty.lanes();
   // delcare type.
   if (value_ty.lanes() == element_ty.lanes()) {
-    std::string ref = GetBufferRef(op->ty.as_or_throw<PrimType>(), op->buffer.get(), index);
+    std::string ref = GetBufferRef(op->ty.as_or_throw<PrimType>(),
+                                   op->source.as_or_throw<tvm::tirx::BufferVar>().get(), index);
     if (value_ty.MatchesCode(DLDataTypeCode::kDLFloat4_e2m1fn) && value_ty.lanes() == 1) {
       // GetBufferRef returns an lvalue: *(ptr + index/2), which reads the
       // full byte.  Extract the correct nibble (low for even, high for odd).
@@ -995,7 +999,9 @@ void CodeGenC::VisitExpr_(const BufferLoadNode* op, std::ostream& os) {  // NOLI
       can_vector_load = false;
     }
     if (can_vector_load) {
-      std::string ref = GetVecLoad(op->ty.as_or_throw<PrimType>(), op->buffer.get(), base.Eval());
+      std::string ref =
+          GetVecLoad(op->ty.as_or_throw<PrimType>(),
+                     op->source.as_or_throw<tvm::tirx::BufferVar>().get(), base.Eval());
       HandleVolatileLoads(ref, op, os);
     } else {
       std::ostringstream svalue_expr;

--- a/src/target/source/codegen_c.h
+++ b/src/target/source/codegen_c.h
@@ -165,7 +165,7 @@ class CodeGenC : public ExprFunctor<void(const Expr&, std::ostream&)>,
   virtual void InitFuncState(const PrimFunc& f);
   // expression
   void VisitExpr_(const VarNode* op, std::ostream& os) override;         // NOLINT(*)
-  void VisitExpr_(const BufferLoadNode* op, std::ostream& os) override;  // NOLINT(*)
+  void VisitExpr_(const TensorLoadNode* op, std::ostream& os) override;  // NOLINT(*)
   void VisitExpr_(const LetNode* op, std::ostream& os) override;         // NOLINT(*)
   void VisitExpr_(const CallNode* op, std::ostream& os) override;        // NOLINT(*)
   void VisitExpr_(const AddNode* op, std::ostream& os) override;         // NOLINT(*)
@@ -260,7 +260,7 @@ class CodeGenC : public ExprFunctor<void(const Expr&, std::ostream&)>,
    * does not implement volatile member functions. CUDA codegen will cast
    * away volatile qualifier from CUDA __half types.
    */
-  virtual void HandleVolatileLoads(const std::string& value, const BufferLoadNode* op,
+  virtual void HandleVolatileLoads(const std::string& value, const TensorLoadNode* op,
                                    std::ostream& os) {
     // By default, do nothing but print the loaded value.
     os << value;

--- a/src/te/operation/create_primfunc.cc
+++ b/src/te/operation/create_primfunc.cc
@@ -107,9 +107,9 @@ class BufferSubstituter : public StmtExprMutator {
     return StmtExprMutator::VisitExpr_(op);
   }
 
-  Expr VisitExpr_(const BufferLoadNode* op) final {
-    auto load = StmtExprMutator::VisitExpr_(op).as_or_throw<BufferLoad>();
-    auto it = buffer_map_.find(load->buffer.get());
+  Expr VisitExpr_(const TensorLoadNode* op) final {
+    auto load = StmtExprMutator::VisitExpr_(op).as_or_throw<TensorLoad>();
+    auto it = buffer_map_.find(load->source.as_or_throw<tvm::tirx::BufferVar>().get());
     if (it != buffer_map_.end()) {
       return BufferLoad(it->second, load->indices, load->span);
     }

--- a/src/tirx/analysis/deep_equal.cc
+++ b/src/tirx/analysis/deep_equal.cc
@@ -138,11 +138,13 @@ class ExprDeepEqualChecker : private ExprFunctor<bool(const Expr&, const PrimExp
     return plhs == rhs.get();
   }
 
-  bool VisitExpr_(const BufferLoadNode* plhs, const PrimExpr& rhs) final {
-    const auto* prhs = rhs.as<BufferLoadNode>();
+  bool VisitExpr_(const TensorLoadNode* plhs, const PrimExpr& rhs) final {
+    const auto* prhs = rhs.as<TensorLoadNode>();
     // we run pointer comparison of the buffer
     return plhs->ty.as_or_throw<PrimType>() == prhs->ty.as_or_throw<PrimType>() &&
-           plhs->buffer.same_as(prhs->buffer) && ArrayDeepEqual(plhs->indices, prhs->indices);
+           plhs->source.as_or_throw<tvm::tirx::BufferVar>().same_as(
+               prhs->source.as_or_throw<tvm::tirx::BufferVar>()) &&
+           ArrayDeepEqual(plhs->indices, prhs->indices);
   }
 
   bool VisitExpr_(const LetNode* plhs, const PrimExpr& rhs) final {

--- a/src/tirx/analysis/side_effect.cc
+++ b/src/tirx/analysis/side_effect.cc
@@ -38,7 +38,7 @@ class ExprSideEffect : public ExprVisitor {
     ExprVisitor::VisitExpr(e);
   }
 
-  void VisitExpr_(const BufferLoadNode* op) final {
+  void VisitExpr_(const TensorLoadNode* op) final {
     this->UpdateEffect(CallEffectKind::kReadState);
     ExprVisitor::VisitExpr_(op);
   }

--- a/src/tirx/analysis/var_touch.cc
+++ b/src/tirx/analysis/var_touch.cc
@@ -49,8 +49,8 @@ class VarTouchVisitor : public StmtExprVisitor {
     StmtVisitor::VisitStmt_(op);
   }
 
-  void VisitExpr_(const BufferLoadNode* op) final {
-    Handle(op->buffer.get());
+  void VisitExpr_(const TensorLoadNode* op) final {
+    Handle(op->source.as_or_throw<tvm::tirx::BufferVar>().get());
     ExprVisitor::VisitExpr_(op);
   }
 

--- a/src/tirx/analysis/verify_memory.cc
+++ b/src/tirx/analysis/verify_memory.cc
@@ -89,8 +89,8 @@ class MemoryAccessVerifier final : protected StmtExprVisitor {
     }
   }
 
-  void VisitExpr_(const BufferLoadNode* op) final {
-    HandleLoadStoreToVariable(op->buffer.var());
+  void VisitExpr_(const TensorLoadNode* op) final {
+    HandleLoadStoreToVariable(op->source.as_or_throw<tvm::tirx::BufferVar>().var());
     return StmtExprVisitor::VisitExpr_(op);
   }
 

--- a/src/tirx/analysis/verify_well_formed.cc
+++ b/src/tirx/analysis/verify_well_formed.cc
@@ -247,7 +247,7 @@ class UndefinedVarVerifier : public Verifier<UndefinedVarVerifier> {
  * it must not appear in a BufferLoad, BufferStore, or BufferRegion outside that declaration's
  * scope.
  *
- * All buffers that appear in BufferLoad or BufferStore must have a prior declaration.
+ * All buffers that appear in TensorLoad or BufferStore must have a prior declaration.
  */
 class UndefinedBufferVerifier : public Verifier<UndefinedBufferVerifier> {
  public:
@@ -304,6 +304,30 @@ class UndefinedBufferVerifier : public Verifier<UndefinedBufferVerifier> {
       previously_defined_;
 };
 
+/*! \brief Verify the asserted type of each tirx buffer load. */
+class TensorLoadTypeVerifier : public Verifier<TensorLoadTypeVerifier> {
+ public:
+  using Verifier::Verifier;
+
+ private:
+  void VisitExpr_(const TensorLoadNode* op, AccessPath path) override {
+    auto buffer = op->source.as<BufferVar>();
+    auto valid_source = Verify(buffer.has_value());
+    valid_source << "TypeError: TIR TensorLoad source at " << path->Attr("source")
+                 << " must be a BufferVar.";
+    if (!buffer.has_value()) {
+      Visit(op->indices, path->Attr("indices"));
+      return;
+    }
+
+    TensorLoad expected = BufferLoad(buffer.value(), op->indices, op->span);
+    auto valid_type = Verify(op->ty == expected->ty);
+    valid_type << "TypeError: TIR TensorLoad at " << path << " asserts result type " << op->ty
+               << ", but its source and indices imply " << expected->ty << ".";
+    TIRVisitorWithPath::VisitExpr_(op, path);
+  }
+};
+
 /* \brief Verify unique tirx::Var for each environment thread
  *
  * Environment threads, such as CUDA's `threadIdx.x`, are defined in
@@ -354,6 +378,8 @@ bool VerifyWellFormed(const PrimFunc& func, bool assert_mode) {
 
   if (!UndefinedBufferVerifier::Verify(func, assert_mode)) return false;
 
+  if (!TensorLoadTypeVerifier::Verify(func, assert_mode)) return false;
+
   // TODO(Siyuan): add more checks here.
   return true;
 }
@@ -371,6 +397,8 @@ bool VerifyWellFormed(const IRModule& mod, bool assert_mode) {
   if (!UndefinedVarVerifier::Verify(mod, assert_mode)) return false;
 
   if (!UndefinedBufferVerifier::Verify(mod, assert_mode)) return false;
+
+  if (!TensorLoadTypeVerifier::Verify(mod, assert_mode)) return false;
 
   return true;
 }

--- a/src/tirx/analysis/verify_well_formed.cc
+++ b/src/tirx/analysis/verify_well_formed.cc
@@ -320,8 +320,58 @@ class TensorLoadTypeVerifier : public Verifier<TensorLoadTypeVerifier> {
       return;
     }
 
+    bool valid_indices = buffer.value()->shape.size() == op->indices.size();
+    auto valid_rank = Verify(valid_indices);
+    valid_rank << "ValueError: TIR TensorLoad at " << path << " indexes "
+               << buffer.value()->shape.size() << "-dimensional buffer " << buffer.value().name()
+               << " with " << op->indices.size() << " indices.";
+    if (!valid_indices) {
+      Visit(op->indices, path->Attr("indices"));
+      return;
+    }
+
+    for (size_t i = 0; i + 1 < op->indices.size(); ++i) {
+      bool is_scalar = op->indices[i].ty().IsScalar();
+      auto valid_index = Verify(is_scalar);
+      valid_index << "TypeError: TIR TensorLoad index " << i << " at "
+                  << path->Attr("indices")->ArrayItem(i)
+                  << " must be scalar because only the final index may be vector-valued.";
+      valid_indices = valid_indices && is_scalar;
+    }
+    if (!valid_indices) {
+      Visit(op->indices, path->Attr("indices"));
+      return;
+    }
+
+    ffi::Optional<PrimType> index_ty = op->indices.empty()
+                                           ? ffi::Optional<PrimType>(buffer.value()->dtype)
+                                           : op->indices.back().ty().as<PrimType>();
+    AccessPath final_index_path = op->indices.empty()
+                                      ? path->Attr("indices")
+                                      : path->Attr("indices")->ArrayItem(op->indices.size() - 1);
+    auto valid_index_type = Verify(index_ty.has_value());
+    valid_index_type << "TypeError: TIR TensorLoad final index at " << final_index_path
+                     << " must have a primitive type.";
+    if (!index_ty.has_value()) {
+      Visit(op->indices, path->Attr("indices"));
+      return;
+    }
+
+    bool scalable_compatible = op->indices.empty() || !(buffer.value()->dtype.IsScalableVector() &&
+                                                        index_ty.value().IsScalableVector());
+    auto valid_scalability = Verify(scalable_compatible);
+    valid_scalability << "TypeError: TIR TensorLoad at " << path
+                      << " cannot combine a scalable buffer dtype with a scalable index.";
+    if (!scalable_compatible) {
+      Visit(op->indices, path->Attr("indices"));
+      return;
+    }
+
     TensorLoad expected = BufferLoad(buffer.value(), op->indices, op->span);
-    auto valid_type = Verify(op->ty == expected->ty);
+    ffi::Optional<PrimType> asserted_ty = op->ty.as<PrimType>();
+    ffi::Optional<PrimType> expected_ty = expected->ty.as<PrimType>();
+    auto valid_type = Verify(asserted_ty.has_value() && expected_ty.has_value() &&
+                             asserted_ty.value() == expected_ty.value());
     valid_type << "TypeError: TIR TensorLoad at " << path << " asserts result type " << op->ty
                << ", but its source and indices imply " << expected->ty << ".";
     TIRVisitorWithPath::VisitExpr_(op, path);

--- a/src/tirx/ir/data_type_rewriter.cc
+++ b/src/tirx/ir/data_type_rewriter.cc
@@ -498,16 +498,15 @@ Stmt IndexDataTypeRewriter::VisitStmt_(const BufferStoreNode* op) {
   return store;
 }
 
-Expr IndexDataTypeRewriter::VisitExpr_(const BufferLoadNode* op) {
-  BufferLoad load = ffi::GetRef<BufferLoad>(op);
+Expr IndexDataTypeRewriter::VisitExpr_(const TensorLoadNode* op) {
+  TensorLoad load = ffi::GetRef<TensorLoad>(op);
 
-  BufferVar new_buffer = VisitBufferUse(op->buffer);
+  BufferVar new_buffer = VisitBufferUse(op->source.as_or_throw<tvm::tirx::BufferVar>());
   auto indices = VisitIndices(op->indices);
 
-  if (!new_buffer.same_as(op->buffer) || !indices.same_as(op->indices)) {
-    auto writer = load.CopyOnWrite();
-    writer->indices = indices;
-    writer->buffer = new_buffer;
+  if (!new_buffer.same_as(op->source.as_or_throw<tvm::tirx::BufferVar>()) ||
+      !indices.same_as(op->indices)) {
+    return BufferLoad(new_buffer, indices, op->span);
   }
 
   return load;

--- a/src/tirx/ir/data_type_rewriter.h
+++ b/src/tirx/ir/data_type_rewriter.h
@@ -110,7 +110,7 @@ class IndexDataTypeRewriter : public DataTypeLegalizer {
   Stmt VisitStmt_(const SBlockNode* op) override;
   Stmt VisitStmt_(const BufferStoreNode* op) override;
   Stmt VisitStmt_(const AttrStmtNode* op) override;
-  Expr VisitExpr_(const BufferLoadNode* op) override;
+  Expr VisitExpr_(const TensorLoadNode* op) override;
   ffi::Array<PrimExpr> VisitIndices(ffi::Array<PrimExpr> indices);
   Stmt VisitStmt_(const IfThenElseNode* op) override;
   Stmt VisitStmt_(const BindNode* op) override;

--- a/src/tirx/ir/expr.cc
+++ b/src/tirx/ir/expr.cc
@@ -95,7 +95,6 @@ TVM_FFI_STATIC_INIT_BLOCK() {
   OrNode::RegisterReflection();
   NotNode::RegisterReflection();
   SelectNode::RegisterReflection();
-  BufferLoadNode::RegisterReflection();
   RampNode::RegisterReflection();
   BroadcastNode::RegisterReflection();
   LetNode::RegisterReflection();
@@ -718,15 +717,19 @@ TVM_FFI_STATIC_INIT_BLOCK() {
 }
 
 // BufferLoad
-void BufferLoadNode::LegalizeDType() {
+TensorLoad BufferLoad(BufferVar buffer, ffi::Array<PrimExpr> indices, Span span) {
+  TVM_FFI_ICHECK_EQ(buffer->shape.size(), indices.size())
+      << "BufferVar " << buffer.name() << " is " << buffer->shape.size()
+      << "-dimensional, cannot be indexed with the " << indices.size()
+      << "-dimensional indices provided.";
+
   for (int i = 0; i < static_cast<int>(indices.size()) - 1; i++) {
     TVM_FFI_ICHECK(indices[i].ty().IsScalar())
         << "Only the last index of a buffer access may be a vector type.";
   }
 
-  if (indices.empty()) {
-    this->ExprNode::ty = buffer->dtype;
-  } else {
+  PrimType result_ty = buffer->dtype;
+  if (!indices.empty()) {
     PrimType index_ty = indices.back().ty();
     int16_t buffer_encoded_lanes = static_cast<int16_t>(buffer->dtype->dtype.lanes);
     bool is_buffer_dtype_scalable = buffer_encoded_lanes < -1;
@@ -736,30 +739,17 @@ void BufferLoadNode::LegalizeDType() {
         << "Index dtype and buffer dtype can't both be scalable.";
 
     if (is_index_scalable) {
-      this->ExprNode::ty =
-          PrimType::ScalableVector(buffer->dtype.code(), buffer->dtype.bits(),
-                                   index_ty.VScaleFactor() * buffer->dtype.lanes());
+      result_ty = PrimType::ScalableVector(buffer->dtype.code(), buffer->dtype.bits(),
+                                           index_ty.VScaleFactor() * buffer->dtype.lanes());
     } else if (is_buffer_dtype_scalable) {
-      this->ExprNode::ty = PrimType::ScalableVector(buffer->dtype.code(), buffer->dtype.bits(),
-                                                    -buffer_encoded_lanes * index_ty.lanes());
+      result_ty = PrimType::ScalableVector(buffer->dtype.code(), buffer->dtype.bits(),
+                                           -buffer_encoded_lanes * index_ty.lanes());
     } else {
-      this->ExprNode::ty = buffer->dtype.WithLanes(index_ty.lanes() * buffer->dtype.lanes());
+      result_ty = buffer->dtype.WithLanes(index_ty.lanes() * buffer->dtype.lanes());
     }
   }
-}
 
-BufferLoad::BufferLoad(BufferVar buffer, ffi::Array<PrimExpr> indices, Span span) {
-  TVM_FFI_ICHECK_EQ(buffer->shape.size(), indices.size())
-      << "BufferVar " << buffer.name() << " is " << buffer->shape.size()
-      << "-dimensional, cannot be indexed with the " << indices.size()
-      << "-dimensional indices provided.";
-
-  ffi::ObjectPtr<BufferLoadNode> node = ffi::make_object<BufferLoadNode>();
-  node->buffer = std::move(buffer);
-  node->indices = std::move(indices);
-  node->span = std::move(span);
-  node->LegalizeDType();
-  data_ = std::move(node);
+  return TensorLoad(std::move(result_ty), std::move(buffer), std::move(indices), std::move(span));
 }
 
 TVM_FFI_STATIC_INIT_BLOCK() {

--- a/src/tirx/ir/expr.cc
+++ b/src/tirx/ir/expr.cc
@@ -749,7 +749,12 @@ TensorLoad BufferLoad(BufferVar buffer, ffi::Array<PrimExpr> indices, Span span)
     }
   }
 
-  return TensorLoad(std::move(result_ty), std::move(buffer), std::move(indices), std::move(span));
+  ffi::ObjectPtr<TensorLoadNode> node = ffi::make_object<TensorLoadNode>();
+  node->ty = std::move(result_ty);
+  node->source = std::move(buffer);
+  node->indices = std::move(indices);
+  node->span = std::move(span);
+  return TensorLoad(std::move(node));
 }
 
 TVM_FFI_STATIC_INIT_BLOCK() {

--- a/src/tirx/ir/expr_functor.cc
+++ b/src/tirx/ir/expr_functor.cc
@@ -30,7 +30,7 @@ namespace tirx {
 
 void ExprVisitor::VisitExpr_(const VarNode* op) {}
 
-void ExprVisitor::VisitExpr_(const BufferLoadNode* op) {
+void ExprVisitor::VisitExpr_(const TensorLoadNode* op) {
   VisitArray(op->indices, [this](const PrimExpr& e) { this->VisitExpr(e); });
 }
 
@@ -118,13 +118,13 @@ void ExprVisitor::VisitExpr_(const BroadcastNode* op) { this->VisitExpr(op->valu
 
 Expr ExprMutator::VisitExpr_(const VarNode* op) { return ffi::GetRef<Var>(op); }
 
-Expr ExprMutator::VisitExpr_(const BufferLoadNode* op) {
+Expr ExprMutator::VisitExpr_(const TensorLoadNode* op) {
   auto fmutate = [this](const PrimExpr& e) { return this->VisitPrimExpr(e); };
   ffi::Array<PrimExpr> indices = op->indices.Map(fmutate);
   if (indices.same_as(op->indices)) {
     return ffi::GetRef<PrimExpr>(op);
   } else {
-    return BufferLoad(op->buffer, indices);
+    return BufferLoad(op->source.as_or_throw<tvm::tirx::BufferVar>(), indices, op->span);
   }
 }
 

--- a/src/tirx/ir/py_functor.cc
+++ b/src/tirx/ir/py_functor.cc
@@ -102,7 +102,7 @@ class PyStmtExprVisitorNode : public ffi::Object, public StmtExprVisitor {
   ffi::Function f_visit_expr{nullptr};
   /*! \brief The packed function to the `VisitExpr_(const VarNode* op)` function. */
   ffi::Function f_visit_var{nullptr};
-  /*! \brief The packed function to the `VisitExpr_(const BufferLoadNode* op)` function. */
+  /*! \brief The packed function to the `VisitExpr_(const TensorLoadNode* op)` function. */
   ffi::Function f_visit_buffer_load{nullptr};
   /*! \brief The packed function to the `VisitExpr_(const LetNode* op)` function. */
   ffi::Function f_visit_let{nullptr};
@@ -231,7 +231,7 @@ class PyStmtExprVisitorNode : public ffi::Object, public StmtExprVisitor {
   PY_STMT_VISITOR_DISPATCH(SBlockRealizeNode, f_visit_sblock_realize);
   // Expression functions
   PY_EXPR_VISITOR_DISPATCH(VarNode, f_visit_var);
-  PY_EXPR_VISITOR_DISPATCH(BufferLoadNode, f_visit_buffer_load);
+  PY_EXPR_VISITOR_DISPATCH(TensorLoadNode, f_visit_buffer_load);
   PY_EXPR_VISITOR_DISPATCH(LetNode, f_visit_let);
   PY_EXPR_VISITOR_DISPATCH(CallNode, f_visit_call);
   PY_EXPR_VISITOR_DISPATCH(AddNode, f_visit_add);
@@ -267,7 +267,7 @@ class PyStmtExprVisitorNode : public ffi::Object, public StmtExprVisitor {
     FExprType vtable;
     // Set dispatch
     IR_EXPR_VISITOR_DEFAULT_DISPATCH(VarNode);
-    IR_EXPR_VISITOR_DEFAULT_DISPATCH(BufferLoadNode);
+    IR_EXPR_VISITOR_DEFAULT_DISPATCH(TensorLoadNode);
     IR_EXPR_VISITOR_DEFAULT_DISPATCH(TupleNode);
     IR_EXPR_VISITOR_DEFAULT_DISPATCH(TupleGetItemNode);
     IR_EXPR_VISITOR_DEFAULT_DISPATCH(LetNode);
@@ -447,7 +447,7 @@ class PyStmtExprMutatorNode : public ffi::Object, public StmtExprMutator {
   ffi::Function f_visit_expr{nullptr};
   /*! \brief The packed function to the `VisitExpr_(const VarNode* op)` function. */
   ffi::Function f_visit_var{nullptr};
-  /*! \brief The packed function to the `VisitExpr_(const BufferLoadNode* op)` function. */
+  /*! \brief The packed function to the `VisitExpr_(const TensorLoadNode* op)` function. */
   ffi::Function f_visit_buffer_load{nullptr};
   /*! \brief The packed function to the `VisitExpr_(const LetNode* op)` function. */
   ffi::Function f_visit_let{nullptr};
@@ -576,7 +576,7 @@ class PyStmtExprMutatorNode : public ffi::Object, public StmtExprMutator {
   PY_STMT_MUTATOR_DISPATCH(SBlockRealizeNode, f_visit_sblock_realize);
   // Expression functions
   PY_EXPR_MUTATOR_DISPATCH(VarNode, f_visit_var);
-  PY_EXPR_MUTATOR_DISPATCH(BufferLoadNode, f_visit_buffer_load);
+  PY_EXPR_MUTATOR_DISPATCH(TensorLoadNode, f_visit_buffer_load);
   PY_EXPR_MUTATOR_DISPATCH(LetNode, f_visit_let);
   PY_EXPR_MUTATOR_DISPATCH(CallNode, f_visit_call);
   PY_EXPR_MUTATOR_DISPATCH(AddNode, f_visit_add);
@@ -612,7 +612,7 @@ class PyStmtExprMutatorNode : public ffi::Object, public StmtExprMutator {
     FExprType vtable;
     // Set dispatch
     PY_EXPR_MUTATOR_DEFAULT_DISPATCH(VarNode);
-    PY_EXPR_MUTATOR_DEFAULT_DISPATCH(BufferLoadNode);
+    PY_EXPR_MUTATOR_DEFAULT_DISPATCH(TensorLoadNode);
     PY_EXPR_MUTATOR_DEFAULT_DISPATCH(TupleNode);
     PY_EXPR_MUTATOR_DEFAULT_DISPATCH(TupleGetItemNode);
     PY_EXPR_MUTATOR_DEFAULT_DISPATCH(LetNode);

--- a/src/tirx/ir/stmt_functor.cc
+++ b/src/tirx/ir/stmt_functor.cc
@@ -90,8 +90,8 @@ void StmtVisitor::VisitBufferDef(const BufferVar& buffer, bool alloc_data) {
 // where the buffer's shape variables are not defined.
 void StmtVisitor::VisitBufferUse(const BufferVar& buffer) {}
 
-void StmtExprVisitor::VisitExpr_(const BufferLoadNode* op) {
-  this->VisitBufferUse(op->buffer);
+void StmtExprVisitor::VisitExpr_(const TensorLoadNode* op) {
+  this->VisitBufferUse(op->source.as_or_throw<tvm::tirx::BufferVar>());
   ExprVisitor::VisitExpr_(op);
 }
 
@@ -451,15 +451,14 @@ Expr StmtExprMutator::VisitExpr_(const VarNode* op) {
   return var;
 }
 
-Expr StmtExprMutator::VisitExpr_(const BufferLoadNode* op) {
-  BufferVar new_buf = this->VisitBufferUse(op->buffer);
+Expr StmtExprMutator::VisitExpr_(const TensorLoadNode* op) {
+  BufferVar old_buf = op->source.as_or_throw<tvm::tirx::BufferVar>();
+  BufferVar new_buf = this->VisitBufferUse(old_buf);
   PrimExpr expr = ExprMutator::VisitExpr_(op).as_or_throw<PrimExpr>();
-  op = expr.as<BufferLoadNode>();
+  op = expr.as<TensorLoadNode>();
   TVM_FFI_ICHECK(op != nullptr);
-  if (!new_buf.same_as(op->buffer)) {
-    auto n = ffi::make_object<BufferLoadNode>(*op);
-    n->buffer = std::move(new_buf);
-    return PrimExpr(n);
+  if (!new_buf.same_as(old_buf)) {
+    return BufferLoad(std::move(new_buf), op->indices, op->span);
   }
   return expr;
 }

--- a/src/tirx/ir/tir_visitor_with_path.cc
+++ b/src/tirx/ir/tir_visitor_with_path.cc
@@ -352,8 +352,8 @@ void TIRVisitorWithPath::VisitStmt_(const ScopeIdDefStmtNode* op, AccessPath pat
 
 void TIRVisitorWithPath::VisitExpr_(const VarNode* op, AccessPath path) {}
 
-void TIRVisitorWithPath::VisitExpr_(const BufferLoadNode* op, AccessPath path) {
-  VisitBufferUse(op->buffer, path->Attr("buffer"));
+void TIRVisitorWithPath::VisitExpr_(const TensorLoadNode* op, AccessPath path) {
+  VisitBufferUse(op->source.as_or_throw<tvm::tirx::BufferVar>(), path->Attr("source"));
   Visit(op->indices, path->Attr("indices"));
 }
 

--- a/src/tirx/ir/tir_visitor_with_path.h
+++ b/src/tirx/ir/tir_visitor_with_path.h
@@ -151,7 +151,7 @@ class TIRVisitorWithPath : protected ExprFunctor<void(const Expr&, ffi::reflecti
 
   using ExprFunctor::VisitExpr;
   void VisitExpr_(const VarNode* op, ffi::reflection::AccessPath path) override;
-  void VisitExpr_(const BufferLoadNode* op, ffi::reflection::AccessPath path) override;
+  void VisitExpr_(const TensorLoadNode* op, ffi::reflection::AccessPath path) override;
   void VisitExpr_(const OpaqueExprNode* op, ffi::reflection::AccessPath path) override;
   void VisitExpr_(const TupleNode* op, ffi::reflection::AccessPath path) override;
   void VisitExpr_(const TupleGetItemNode* op, ffi::reflection::AccessPath path) override;

--- a/src/tirx/op/op.cc
+++ b/src/tirx/op/op.cc
@@ -132,7 +132,7 @@ Type GetType(const PrimExpr& expr) {
       TVM_FFI_ICHECK_EQ(address_of->args.size(), 1)
           << "Builtin address_of() expects a single argument, but received arguments "
           << address_of->args;
-      auto* address = address_of->args[0].as<BufferLoadNode>();
+      auto* address = address_of->args[0].as<TensorLoadNode>();
       if (address) {
         return PointerType(address->ty.as_or_throw<PrimType>());
       }
@@ -147,7 +147,7 @@ Type GetType(const PrimExpr& expr) {
       }
 
       TVM_FFI_ICHECK(false)
-          << "Builtin address_of() expects the argument to be a BufferLoad or Var, but "
+          << "Builtin address_of() expects the argument to be a TensorLoad or Var, but "
           << "received argument " << address_of->args[0];
     }
   }

--- a/src/tirx/script/builder/ir.cc
+++ b/src/tirx/script/builder/ir.cc
@@ -152,10 +152,10 @@ BufferVar MatchBuffer(ffi::ObjectRef param, ffi::Array<PrimExpr> shape, PrimType
       }
     }
     TVM_FFI_THROW(InternalError) << "ValueError: Can not bind non-input param to buffer.";
-  } else if (const auto* buffer_load = param.as<tvm::tirx::BufferLoadNode>()) {
+  } else if (const auto* buffer_load = param.as<TensorLoadNode>()) {
     SBlockFrame frame = FindSBlockFrame("T.match_buffer");
     frame->match_buffers.push_back(tvm::tirx::MatchBufferRegion(
-        buffer, BufferRegionFromLoad(ffi::GetRef<tvm::tirx::BufferLoad>(buffer_load))));
+        buffer, BufferRegionFromLoad(ffi::GetRef<tvm::TensorLoad>(buffer_load))));
   } else if (const auto* buffer_region = param.as<tvm::tirx::BufferRegionNode>()) {
     SBlockFrame frame = FindSBlockFrame("T.match_buffer");
     frame->match_buffers.push_back(
@@ -293,7 +293,7 @@ void Reads(ffi::Array<ffi::ObjectRef> buffer_slices) {
   for (const ffi::ObjectRef& obj : buffer_slices) {
     if (auto buffer_region = obj.as<BufferRegion>()) {
       reads.push_back(buffer_region.value());
-    } else if (auto buffer_load = obj.as<BufferLoad>()) {
+    } else if (auto buffer_load = obj.as<TensorLoad>()) {
       reads.push_back(BufferRegionFromLoad(buffer_load.value()));
     } else {
       TVM_FFI_THROW(InternalError) << "Invalid type for buffer reads.";
@@ -313,7 +313,7 @@ void Writes(ffi::Array<ffi::ObjectRef> buffer_slices) {
   for (const ffi::ObjectRef& obj : buffer_slices) {
     if (auto buffer_region = obj.as<BufferRegion>()) {
       writes.push_back(buffer_region.value());
-    } else if (auto buffer_load = obj.as<BufferLoad>()) {
+    } else if (auto buffer_load = obj.as<TensorLoad>()) {
       writes.push_back(BufferRegionFromLoad(buffer_load.value()));
     } else {
       TVM_FFI_THROW(InternalError) << "Invalid type for buffer writes.";
@@ -921,11 +921,10 @@ Var Ptr(PrimType dtype, ffi::String storage_scope = "global") {
 using tvm::script::ir_builder::details::Namer;
 
 TVM_STATIC_IR_FUNCTOR(Namer, vtable)
-    .set_dispatch<tvm::tirx::BufferLoadNode>([](const ffi::ObjectRef& node,
-                                                ffi::String name) -> void {
+    .set_dispatch<TensorLoadNode>([](const ffi::ObjectRef& node, ffi::String name) -> void {
       using namespace tvm::tirx;
-      BufferLoadNode* buffer = const_cast<BufferLoadNode*>(node.as<BufferLoadNode>());
-      Namer::Name(buffer->buffer, name);
+      TensorLoadNode* buffer = const_cast<TensorLoadNode*>(node.as<TensorLoadNode>());
+      Namer::Name(buffer->source.as_or_throw<tvm::tirx::BufferVar>(), name);
     });
 
 TVM_STATIC_IR_FUNCTOR(Namer, vtable)

--- a/src/tirx/script/builder/utils.h
+++ b/src/tirx/script/builder/utils.h
@@ -127,16 +127,16 @@ inline IfFrame FindIfFrame(const ffi::String& method) {
 }
 
 /*!
- * \brief Convert BufferLoad to BufferRegion.
+ * \brief Convert TensorLoad to BufferRegion.
  * \param buffer_load The BufferLoad.
  * \return The converted BufferRegion.
  */
-inline tvm::tirx::BufferRegion BufferRegionFromLoad(tvm::tirx::BufferLoad buffer_load) {
+inline tvm::tirx::BufferRegion BufferRegionFromLoad(tvm::TensorLoad buffer_load) {
   ffi::Array<Range> ranges;
   for (const PrimExpr& index : buffer_load->indices) {
     ranges.push_back(Range::FromMinExtent(index, IntImm(index.ty(), 1)));
   }
-  return tvm::tirx::BufferRegion(buffer_load->buffer, ranges);
+  return tvm::tirx::BufferRegion(buffer_load->source.as_or_throw<tvm::tirx::BufferVar>(), ranges);
 }
 
 }  // namespace tirx

--- a/src/tirx/script/printer/buffer.cc
+++ b/src/tirx/script/printer/buffer.cc
@@ -231,18 +231,19 @@ ffi::Map<ffi::String, ExprDoc> BufferAttrs(
   if (!buffer->allocated_addr.empty()) {
     if (buffer->allocated_addr.size() == 1) {
       // Unwrap single-element array: DeclBuffer expects Optional<PrimExpr>, not Array.
-      // For BufferLoad from scalar buffers, we must explicitly print buf[idx] because
+      // For TensorLoad from scalar buffers, we must explicitly print buf[idx] because
       // the scalar shorthand (which drops the index) produces just the variable name,
       // and the parser resolves that to a BufferVar object rather than a PrimExpr value.
       PrimExpr addr = buffer->allocated_addr[0];
       AccessPath addr_p = buffer_p->Attr("allocated_addr")->ArrayItem(0);
-      if (const auto* bl = addr.as<tirx::BufferLoadNode>()) {
+      if (const auto* bl = addr.as<TensorLoadNode>()) {
+        tirx::BufferVar source = bl->source.as_or_throw<tirx::BufferVar>();
         // Ensure the buffer variable is defined (may emit a T.Buffer(...) statement).
-        d->AsDoc<ExprDoc>(bl->buffer, addr_p->Attr("buffer"));
+        d->AsDoc<ExprDoc>(source, addr_p->Attr("source"));
         // Get the variable name bound to this buffer.
-        ffi::Optional<ExprDoc> buf_var = d->GetVarDoc(bl->buffer);
+        ffi::Optional<ExprDoc> buf_var = d->GetVarDoc(source);
         TVM_FFI_ICHECK(buf_var.has_value())
-            << "BufferVar in allocated_addr is not defined: " << bl->buffer;
+            << "BufferVar in allocated_addr is not defined: " << source;
         // Build var[indices] explicitly instead of going through the default BufferLoad
         // printer, which would use the scalar shorthand and drop the index.
         int n_idx = bl->indices.size();
@@ -429,17 +430,18 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
         });
 
 TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<tirx::BufferLoad>(  //
-        "", [](tirx::BufferLoad load, AccessPath p, IRDocsifier d) -> Doc {
-          ExprDoc buffer = d->AsDoc<ExprDoc>(load->buffer, p->Attr("buffer"));
+    .set_dispatch<TensorLoad>(  //
+        "", [](TensorLoad load, AccessPath p, IRDocsifier d) -> Doc {
+          tvm::tirx::BufferVar source = load->source.as_or_throw<tvm::tirx::BufferVar>();
+          ExprDoc buffer = d->AsDoc<ExprDoc>(source, p->Attr("source"));
 
           // special case for scalar
-          if (load->buffer.IsScalar(true) || load->buffer.IsScalar(false)) {
+          if (source.IsScalar(true) || source.IsScalar(false)) {
             // TVM_FFI_ICHECK(load->indices.size() == 1 && tirx::is_zero(load->indices[0]))
             //     << "Scalar buffer load with indices other than [0] is not supported";
-            ffi::Optional<ExprDoc> doc = d->GetVarDoc(load->buffer);
+            ffi::Optional<ExprDoc> doc = d->GetVarDoc(source);
             TVM_FFI_ICHECK(doc.has_value())
-                << "Scalar buffer is not defined in the environment: " << load->buffer;
+                << "Scalar buffer is not defined in the environment: " << source;
             return doc.value();
           }
 
@@ -580,7 +582,7 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
         });
 
 TVM_SCRIPT_REPR(tirx::BufferRegionNode, ReprPrintTIR);
-TVM_SCRIPT_REPR(tirx::BufferLoadNode, ReprPrintTIR);
+TVM_SCRIPT_REPR(TensorLoadNode, ReprPrintTIR);
 TVM_SCRIPT_REPR(tirx::BufferStoreNode, ReprPrintTIR);
 TVM_SCRIPT_REPR(tirx::BufferTypeNode, ReprPrintTIR);
 TVM_SCRIPT_REPR(tirx::IterNode, ReprPrintTIR);

--- a/src/tirx/script/printer/expr.cc
+++ b/src/tirx/script/printer/expr.cc
@@ -112,7 +112,7 @@ TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)  //
         if (ffi::Optional<ExprDoc> doc = d->GetVarDoc(buffer)) {
           // special case for scalar buffer
           if (buffer.IsScalar()) {
-            return doc.value()->Attr("buffer");
+            return doc.value()->Attr("source");
           }
           return doc.value();
         }

--- a/src/tirx/script/printer/utils.h
+++ b/src/tirx/script/printer/utils.h
@@ -119,8 +119,8 @@ inline void AsDocBody(const tirx::Stmt& stmt, AccessPath p, TIRFrameNode* f, con
     auto value_refs_buffer = [](const PrimExpr& value, const tirx::BufferVar& buffer) {
       bool found = false;
       tirx::PostOrderVisit(value, [&](const ffi::ObjectRef& node) {
-        if (const auto* load = node.as<tirx::BufferLoadNode>()) {
-          if (load->buffer.same_as(buffer)) {
+        if (const auto* load = node.as<TensorLoadNode>()) {
+          if (load->source.as_or_throw<tvm::tirx::BufferVar>().same_as(buffer)) {
             found = true;
           }
         } else if (const auto* call = node.as<CallNode>()) {

--- a/src/tirx/transform/common_subexpr_elim.cc
+++ b/src/tirx/transform/common_subexpr_elim.cc
@@ -259,14 +259,14 @@ class CSEPlanner : public StmtExprVisitor {
   /*!
    * \brief Check if an expression node type is forbidden for CSE.
    *
-   * Call nodes may have side effects. BufferLoad nodes depend on memory
+   * Call nodes may have side effects. TensorLoad nodes depend on memory
    * state and cannot be safely hoisted or deduplicated.
    *
    * \param expr The expression to check.
    * \return true if the expression is a Call or BufferLoad.
    */
   static bool IsForbiddenNode(const PrimExpr& expr) {
-    return (expr.as<CallNode>() != nullptr || expr.as<BufferLoadNode>() != nullptr);
+    return (expr.as<CallNode>() != nullptr || expr.as<TensorLoadNode>() != nullptr);
   }
 
   /*!

--- a/src/tirx/transform/flatten_buffer.cc
+++ b/src/tirx/transform/flatten_buffer.cc
@@ -240,9 +240,12 @@ class BufferFlattener : public arith::IRMutatorWithAnalyzer {
     return store;
   }
 
-  Expr VisitExpr_(const BufferLoadNode* op) final {
-    BufferVar original_buffer = op->buffer;
-    BufferLoad load = StmtExprMutator::VisitExpr_(op).as_or_throw<BufferLoad>();
+  Expr VisitExpr_(const TensorLoadNode* op) final {
+    BufferVar original_buffer = op->source.as_or_throw<tvm::tirx::BufferVar>();
+    // Mutate the indices while keeping the original source opaque.  The base
+    // statement mutator remaps buffer sources immediately, but this pass also
+    // changes their rank, so reconstruction must wait until after FoldIndices.
+    TensorLoad load = ExprMutator::VisitExpr_(op).as_or_throw<TensorLoad>();
     load = VisitBufferAccess(load, original_buffer);
     return load;
   }
@@ -291,6 +294,12 @@ class BufferFlattener : public arith::IRMutatorWithAnalyzer {
     writer->buffer = info.flattened;
     writer->indices = flattened_indices;
     return node;
+  }
+
+  TensorLoad VisitBufferAccess(TensorLoad node, const BufferVar& original_buffer) {
+    buffers_used_.insert(original_buffer);
+    const FlatInfo& info = Lookup(original_buffer);
+    return BufferLoad(info.flattened, FoldIndices(info, node->indices), node->span);
   }
 
   BufferRegion MutateBufferRegion(BufferRegion region) {

--- a/src/tirx/transform/ir_utils.cc
+++ b/src/tirx/transform/ir_utils.cc
@@ -216,8 +216,8 @@ class IRConvertSSA final : public StmtExprMutator {
     }
   }
 
-  Expr VisitExpr_(const BufferLoadNode* op) final {
-    auto node = StmtExprMutator::VisitExpr_(op).as_or_throw<BufferLoad>();
+  Expr VisitExpr_(const TensorLoadNode* op) final {
+    auto node = StmtExprMutator::VisitExpr_(op).as_or_throw<TensorLoad>();
     auto output = VisitBufferAccess(std::move(node));
     return output;
   }
@@ -287,6 +287,15 @@ class IRConvertSSA final : public StmtExprMutator {
     }
 
     return node;
+  }
+
+  TensorLoad VisitBufferAccess(TensorLoad node) {
+    BufferVar buffer = node->source.as_or_throw<BufferVar>();
+    BufferVar new_buf = GetRemappedBuffer(buffer);
+    if (new_buf.same_as(buffer)) {
+      return node;
+    }
+    return BufferLoad(new_buf, node->indices, node->span);
   }
 
   Var GetRemappedVar(Var var) {
@@ -455,7 +464,7 @@ class IRConvertSSA final : public StmtExprMutator {
     Stmt stmt = StmtExprMutator::VisitStmt_(op);
     op = stmt.as<AllocBufferNode>();
     // Use GetRemappedBuffer so that the AllocBuffer's buffer is the same
-    // object as the one used by BufferStore/BufferLoad in subsequent siblings.
+    // object as the one used by BufferStore/TensorLoad in subsequent siblings.
     BufferVar new_buf = GetRemappedBuffer(op->buffer);
     if (!new_buf.same_as(op->buffer)) {
       auto node = stmt.as_or_throw<AllocBuffer>();

--- a/src/tirx/transform/ir_utils.h
+++ b/src/tirx/transform/ir_utils.h
@@ -118,7 +118,7 @@ inline Call AddressOffset(Var handle, PrimType dtype, int offset) {
   auto pointer_type = handle->ty.as_or_throw<PointerType>();
   BufferVar dummy_buf(handle->name,
                       BufferType(pointer_type->storage_scope, dtype, shape, {}, 0, 0, 0));
-  BufferLoad buf_load(dummy_buf, {offset_expr});
+  TensorLoad buf_load = BufferLoad(dummy_buf, {offset_expr});
 
   return Call(handle->ty, builtin::address_of(), {buf_load});
 }
@@ -140,7 +140,7 @@ inline Call AddressOffset(Var handle, PrimType dtype, PrimExpr offset) {
   auto pointer_type = handle->ty.as_or_throw<PointerType>();
   BufferVar dummy_buf(handle->name, BufferType(pointer_type->storage_scope, dtype.WithLanes(1),
                                                shape, {}, 0, 0, 0));
-  BufferLoad buf_load(dummy_buf, {offset});
+  TensorLoad buf_load = BufferLoad(dummy_buf, {offset});
 
   return Call(handle->ty, builtin::address_of(), {buf_load});
 }

--- a/src/tirx/transform/lower_intrin.cc
+++ b/src/tirx/transform/lower_intrin.cc
@@ -56,7 +56,7 @@ static Expr LowerAccessPtr(const CallNode* call,
 
   // An access pointer may itself be used as the base of another access
   // pointer.  Fold those offsets before constructing the synthetic
-  // BufferLoad so lowering never assumes that args[1] is immediately a Var.
+  // TensorLoad so lowering never assumes that args[1] is immediately a Var.
   Expr buffer = call->args[1];
   while (const auto* inner = buffer.as<CallNode>()) {
     if (!inner->op.same_as(builtin::tvm_access_ptr())) break;
@@ -119,7 +119,7 @@ static Expr LowerAccessPtr(const CallNode* call,
                   BufferType(storage_scope, scalar_dtype, {scalar_extent}, {}, 0, 0, 0));
     buffer_aliases->push_back({access_buffer, access_data});
   }
-  BufferLoad buf_load(access_buffer, {offset});
+  TensorLoad buf_load = BufferLoad(access_buffer, {offset});
   return Call(call->ty, builtin::address_of(), {buf_load});
 }
 

--- a/src/tirx/transform/lower_tirx_cleanup.cc
+++ b/src/tirx/transform/lower_tirx_cleanup.cc
@@ -230,8 +230,8 @@ class LayoutApplier : public arith::IRMutatorWithAnalyzer {
     return std::move(store);
   }
 
-  Expr VisitExpr_(const BufferLoadNode* op) final {
-    BufferLoad load = StmtExprMutator::VisitExpr_(op).as_or_throw<BufferLoad>();
+  Expr VisitExpr_(const TensorLoadNode* op) final {
+    TensorLoad load = StmtExprMutator::VisitExpr_(op).as_or_throw<TensorLoad>();
     load = VisitBufferAccess(load);
     return std::move(load);
   }
@@ -295,6 +295,14 @@ class LayoutApplier : public arith::IRMutatorWithAnalyzer {
     return node;
   }
 
+  TensorLoad VisitBufferAccess(TensorLoad node) {
+    BufferVar buffer = node->source.as_or_throw<tvm::tirx::BufferVar>();
+    TVM_FFI_ICHECK(buffer.defined());
+    if (target_->kind->name == "trn" && !buffer->layout.has_value()) return node;
+    return BufferLoad(GetFlattenedBuffer(buffer), GetSimplifiedElemOffset(buffer, node->indices),
+                      node->span);
+  }
+
   /*! \brief Map of variables being remapped, including buffer variables. */
   std::unordered_map<Var, Var, ffi::ObjectPtrHash, ffi::ObjectPtrEqual> var_remap_;
 
@@ -335,7 +343,7 @@ class BufferOffsetRemover : public StmtExprMutator {
 
   Expr VisitExpr_(const CallNode* call) final {
     if (call->op.same_as(tirx::builtin::buffer_offset())) {
-      auto buffer_load = call->args[0].as_or_throw<BufferLoad>();
+      auto buffer_load = call->args[0].as_or_throw<TensorLoad>();
       TVM_FFI_ICHECK_EQ(buffer_load->indices.size(), 1) << "Expected a single index";
       return buffer_load->indices[0];
     }
@@ -367,8 +375,8 @@ class BufferOffsetRemover : public StmtExprMutator {
     return std::move(store);
   }
 
-  Expr VisitExpr_(const BufferLoadNode* op) final {
-    BufferLoad load = StmtExprMutator::VisitExpr_(op).as_or_throw<BufferLoad>();
+  Expr VisitExpr_(const TensorLoadNode* op) final {
+    TensorLoad load = StmtExprMutator::VisitExpr_(op).as_or_throw<TensorLoad>();
     load = VisitBufferAccess(load);
     return std::move(load);
   }
@@ -383,6 +391,14 @@ class BufferOffsetRemover : public StmtExprMutator {
       return node;
     }
     return node;
+  }
+
+  TensorLoad VisitBufferAccess(TensorLoad node) {
+    BufferVar buffer = node->source.as_or_throw<tvm::tirx::BufferVar>();
+    TVM_FFI_ICHECK(buffer.defined());
+    auto it = var_remap_.find(buffer.var());
+    return it == var_remap_.end() ? node
+                                  : BufferLoad(BufferVar(it->second), node->indices, node->span);
   }
 
   std::unordered_map<Var, Var, ffi::ObjectPtrHash, ffi::ObjectPtrEqual> var_remap_;

--- a/src/tirx/transform/lower_tvm_builtin.cc
+++ b/src/tirx/transform/lower_tvm_builtin.cc
@@ -489,7 +489,7 @@ class BuiltinLower : public StmtExprMutator {
           {ConstInt32(stack_begin + i)}));
     }
     PrimExpr offset = ConstInt32(stack_begin);
-    BufferLoad load(scope.stack_shape, {offset});
+    TensorLoad load = BufferLoad(scope.stack_shape, {offset});
     return Call(scope.stack_shape.DataPointerType(), builtin::address_of(), {load});
   }
   // make array

--- a/src/tirx/transform/lower_warp_memory.cc
+++ b/src/tirx/transform/lower_warp_memory.cc
@@ -371,10 +371,10 @@ class WarpAccessRewriter : protected StmtExprMutator {
     return store;
   }
 
-  Expr VisitExpr_(const BufferLoadNode* op) override {
-    auto load = StmtExprMutator::VisitExpr_(op).as_or_throw<BufferLoad>();
+  Expr VisitExpr_(const TensorLoadNode* op) override {
+    auto load = StmtExprMutator::VisitExpr_(op).as_or_throw<TensorLoad>();
 
-    if (load->buffer.get() != buffer_) {
+    if (load->source.as_or_throw<tvm::tirx::BufferVar>().get() != buffer_) {
       return load;
     }
 
@@ -388,9 +388,7 @@ class WarpAccessRewriter : protected StmtExprMutator {
         << "LowerWarpMemory failed to rewrite load to shuffle for index " << op->indices[0]
         << " local_index=" << local_index;
 
-    auto writer = load.CopyOnWrite();
-    writer->buffer = new_buffer_;
-    writer->indices = {local_index};
+    load = BufferLoad(new_buffer_, {local_index}, load->span);
 
     if (analyzer_->CanProveEqual(group, warp_index_.as_or_throw<PrimExpr>())) {
       return load;

--- a/src/tirx/transform/narrow_datatype.cc
+++ b/src/tirx/transform/narrow_datatype.cc
@@ -107,7 +107,7 @@ class DataTypeVisitor final : public StmtExprVisitor {
     }
   }
 
-  void VisitExpr_(const BufferLoadNode* op) {
+  void VisitExpr_(const TensorLoadNode* op) {
     int tmp = bits_;
     bits_ = target_bits_;
     StmtExprVisitor::VisitExpr_(op);

--- a/src/tirx/transform/remove_no_op.cc
+++ b/src/tirx/transform/remove_no_op.cc
@@ -202,13 +202,11 @@ class NoOpRemover : public arith::IRMutatorWithAnalyzer {
     // If the stored value is a load from the same location, the
     // statement is a no-op, regardless of contextual information.
     if (const TensorLoadNode* load = store->value.as<TensorLoadNode>()) {
-      if (load->source.as_or_throw<tvm::tirx::BufferVar>().same_as(store->buffer) &&
-          analyzer_->CanProveEqual(load->source.as_or_throw<tvm::tirx::BufferVar>()->elem_offset,
-                                   store->buffer->elem_offset) &&
-          ArrayValueEqual(load->source.as_or_throw<tvm::tirx::BufferVar>()->shape,
-                          store->buffer->shape) &&
-          ArrayValueEqual(load->source.as_or_throw<tvm::tirx::BufferVar>()->strides,
-                          store->buffer->strides) &&
+      BufferVar buffer = load->source.as_or_throw<tvm::tirx::BufferVar>();
+      if (buffer.same_as(store->buffer) &&
+          analyzer_->CanProveEqual(buffer->elem_offset, store->buffer->elem_offset) &&
+          ArrayValueEqual(buffer->shape, store->buffer->shape) &&
+          ArrayValueEqual(buffer->strides, store->buffer->strides) &&
           ArrayValueEqual(load->indices, store->indices)) {
         return only_side_effects();
       }

--- a/src/tirx/transform/remove_no_op.cc
+++ b/src/tirx/transform/remove_no_op.cc
@@ -201,11 +201,14 @@ class NoOpRemover : public arith::IRMutatorWithAnalyzer {
 
     // If the stored value is a load from the same location, the
     // statement is a no-op, regardless of contextual information.
-    if (const BufferLoadNode* load = store->value.as<BufferLoadNode>()) {
-      if (load->buffer.same_as(store->buffer) &&
-          analyzer_->CanProveEqual(load->buffer->elem_offset, store->buffer->elem_offset) &&
-          ArrayValueEqual(load->buffer->shape, store->buffer->shape) &&
-          ArrayValueEqual(load->buffer->strides, store->buffer->strides) &&
+    if (const TensorLoadNode* load = store->value.as<TensorLoadNode>()) {
+      if (load->source.as_or_throw<tvm::tirx::BufferVar>().same_as(store->buffer) &&
+          analyzer_->CanProveEqual(load->source.as_or_throw<tvm::tirx::BufferVar>()->elem_offset,
+                                   store->buffer->elem_offset) &&
+          ArrayValueEqual(load->source.as_or_throw<tvm::tirx::BufferVar>()->shape,
+                          store->buffer->shape) &&
+          ArrayValueEqual(load->source.as_or_throw<tvm::tirx::BufferVar>()->strides,
+                          store->buffer->strides) &&
           ArrayValueEqual(load->indices, store->indices)) {
         return only_side_effects();
       }

--- a/src/tirx/transform/split_host_device.cc
+++ b/src/tirx/transform/split_host_device.cc
@@ -206,7 +206,7 @@ class HostDeviceSplitter : public StmtMutator {
       } else {
         std::unordered_map<Var, int, ffi::ObjectPtrHash, ffi::ObjectPtrEqual> param_order;
         for (size_t i = 0; i < cur_func_->params.size(); ++i) {
-          param_order[cur_func_->params[i].as_or_throw<BufferVar>().var()] = i;
+          param_order[cur_func_->params[i].as_or_throw<tvm::tirx::BufferVar>().var()] = i;
         }
         // sort by original order
         std::sort(params.begin(), params.end(),

--- a/src/tirx/transform/stmt_simplify.cc
+++ b/src/tirx/transform/stmt_simplify.cc
@@ -121,10 +121,10 @@ class StmtSimplifier : public IRMutatorWithAnalyzer {
   // Do not simplify buffer definition fields (shape, strides, elem_offset).
   //
   // The simplifier's VisitExpr override calls analyzer_->Simplify() directly,
-  // bypassing the normal ExprMutator dispatch. This means BufferLoad expressions
-  // inside values (e.g., BufferStore value) skip VisitExpr_(BufferLoadNode*) and
+  // bypassing the normal ExprMutator dispatch. This means TensorLoad expressions
+  // inside values (e.g., BufferStore value) skip VisitExpr_(TensorLoadNode*) and
   // thus skip VisitBufferUse. If VisitBufferDef remaps buffers at DeclBuffer sites,
-  // the BufferLoad use sites won't pick up the remap, causing DeclBuffer/BufferLoad
+  // the TensorLoad use sites won't pick up the remap, causing DeclBuffer/BufferLoad
   // buffer identity divergence and well-formedness violations.
   //
   // Instead, we keep buffer definitions unchanged and rely on used_in_buffer_def_
@@ -205,16 +205,20 @@ class StmtSimplifier : public IRMutatorWithAnalyzer {
     return Parent::VisitExpr_(op);
   }
 
-  Expr VisitExpr_(const BufferLoadNode* op) override { return Parent::VisitExpr_(op); }
+  Expr VisitExpr_(const TensorLoadNode* op) override { return Parent::VisitExpr_(op); }
 
   // eliminate useless stores
   Stmt VisitStmt_(const BufferStoreNode* op) override {
     BufferStore store = Parent::VisitStmt_(op).as_or_throw<BufferStore>();
-    if (const BufferLoadNode* load = store->value.as<BufferLoadNode>()) {
-      if (load->buffer.same_as(store->buffer) && ArrayDeepEqual(load->indices, store->indices) &&
-          tirx::ExprDeepEqual()(load->buffer->elem_offset, store->buffer->elem_offset) &&
-          ArrayDeepEqual(load->buffer->shape, store->buffer->shape) &&
-          ArrayDeepEqual(load->buffer->strides, store->buffer->strides)) {
+    if (const TensorLoadNode* load = store->value.as<TensorLoadNode>()) {
+      if (load->source.as_or_throw<tvm::tirx::BufferVar>().same_as(store->buffer) &&
+          ArrayDeepEqual(load->indices, store->indices) &&
+          tirx::ExprDeepEqual()(load->source.as_or_throw<tvm::tirx::BufferVar>()->elem_offset,
+                                store->buffer->elem_offset) &&
+          ArrayDeepEqual(load->source.as_or_throw<tvm::tirx::BufferVar>()->shape,
+                         store->buffer->shape) &&
+          ArrayDeepEqual(load->source.as_or_throw<tvm::tirx::BufferVar>()->strides,
+                         store->buffer->strides)) {
         return Evaluate(0);
       }
     }

--- a/src/tirx/transform/stmt_simplify.cc
+++ b/src/tirx/transform/stmt_simplify.cc
@@ -211,14 +211,11 @@ class StmtSimplifier : public IRMutatorWithAnalyzer {
   Stmt VisitStmt_(const BufferStoreNode* op) override {
     BufferStore store = Parent::VisitStmt_(op).as_or_throw<BufferStore>();
     if (const TensorLoadNode* load = store->value.as<TensorLoadNode>()) {
-      if (load->source.as_or_throw<tvm::tirx::BufferVar>().same_as(store->buffer) &&
-          ArrayDeepEqual(load->indices, store->indices) &&
-          tirx::ExprDeepEqual()(load->source.as_or_throw<tvm::tirx::BufferVar>()->elem_offset,
-                                store->buffer->elem_offset) &&
-          ArrayDeepEqual(load->source.as_or_throw<tvm::tirx::BufferVar>()->shape,
-                         store->buffer->shape) &&
-          ArrayDeepEqual(load->source.as_or_throw<tvm::tirx::BufferVar>()->strides,
-                         store->buffer->strides)) {
+      BufferVar buffer = load->source.as_or_throw<tvm::tirx::BufferVar>();
+      if (buffer.same_as(store->buffer) && ArrayDeepEqual(load->indices, store->indices) &&
+          tirx::ExprDeepEqual()(buffer->elem_offset, store->buffer->elem_offset) &&
+          ArrayDeepEqual(buffer->shape, store->buffer->shape) &&
+          ArrayDeepEqual(buffer->strides, store->buffer->strides)) {
         return Evaluate(0);
       }
     }

--- a/src/tirx/transform/storage_rewrite.cc
+++ b/src/tirx/transform/storage_rewrite.cc
@@ -154,9 +154,9 @@ class LinearAccessPatternFinder final : public StmtExprVisitor {
     }
   }
 
-  void VisitExpr_(const BufferLoadNode* op) final {
+  void VisitExpr_(const TensorLoadNode* op) final {
     StmtExprVisitor::VisitExpr_(op);
-    RecordAccess(op->buffer);
+    RecordAccess(op->source.as_or_throw<tvm::tirx::BufferVar>());
   }
 
   void VisitStmt_(const EvaluateNode* op) final {
@@ -390,8 +390,8 @@ class InplaceOpVerifier : public StmtExprVisitor {
     StmtExprVisitor::VisitStmt_(op);
   }
 
-  void VisitExpr_(const BufferLoadNode* op) final {
-    const VarNode* buf = op->buffer.get();
+  void VisitExpr_(const TensorLoadNode* op) final {
+    const VarNode* buf = op->source.as_or_throw<tvm::tirx::BufferVar>().get();
     // cannot read from dst_ (no reduction)
     if (buf == dst_) {
       result_ = false;
@@ -487,6 +487,20 @@ class StoragePlanRewriter : public StmtExprMutator {
     return node;
   }
 
+  TensorLoad VisitBufferAccess(TensorLoad node) {
+    BufferVar buffer = node->source.as_or_throw<BufferVar>();
+    const VarNode* root = buffer_aliases_.Get(buffer.var()).value_or(buffer.var()).get();
+    auto it = alloc_map_.find(root);
+    if (it == alloc_map_.end()) {
+      return node;
+    }
+
+    BufferVar remapped = RemapBuffer(buffer, it->second->alloc_var);
+    ffi::Array<PrimExpr> indices = node->indices;
+    indices.Set(indices.size() - 1, RemapIndex(buffer->dtype, indices.back(), it->second));
+    return BufferLoad(remapped, indices, node->span);
+  }
+
   BufferVar RemapBuffer(BufferVar buf, Var new_backing_array) {
     auto key = buf.get();
     auto it = buffer_remap_.find(key);
@@ -512,8 +526,8 @@ class StoragePlanRewriter : public StmtExprMutator {
     return VisitBufferAccess(std::move(node));
   }
 
-  Expr VisitExpr_(const BufferLoadNode* op) final {
-    auto node = StmtExprMutator::VisitExpr_(op).as_or_throw<BufferLoad>();
+  Expr VisitExpr_(const TensorLoadNode* op) final {
+    auto node = StmtExprMutator::VisitExpr_(op).as_or_throw<TensorLoad>();
     return VisitBufferAccess(std::move(node));
   }
 
@@ -544,9 +558,9 @@ class StoragePlanRewriter : public StmtExprMutator {
         indices.push_back(this->VisitPrimExpr(op->args[i].as_or_throw<PrimExpr>()));
       }
       if (is_load) {
-        BufferLoad access(buffer, indices, op->span);
+        TensorLoad access = BufferLoad(buffer, indices, op->span);
         access = VisitBufferAccess(std::move(access));
-        ffi::Array<Expr> args{access->buffer.var()};
+        ffi::Array<Expr> args{access->source.as_or_throw<BufferVar>().var()};
         for (const PrimExpr& index : access->indices) args.push_back(index);
         args.push_back(this->VisitExpr(op->args.back()));
         return Call(access->ty, op->op, args, op->attrs, op->ty_args, op->span);
@@ -1308,8 +1322,9 @@ class VectorTypeAccessChecker : public StmtExprVisitor {
     }
   }
 
-  void VisitExpr_(const BufferLoadNode* op) final {
-    OnArrayAccess(op->ty.as_or_throw<PrimType>(), op->buffer.get(), op->indices,
+  void VisitExpr_(const TensorLoadNode* op) final {
+    OnArrayAccess(op->ty.as_or_throw<PrimType>(),
+                  op->source.as_or_throw<tvm::tirx::BufferVar>().get(), op->indices,
                   /*is_buffer_load=*/true);
     StmtExprVisitor::VisitExpr_(op);
   }
@@ -1341,8 +1356,9 @@ class VectorTypeAccessChecker : public StmtExprVisitor {
         OnArrayAccess(dtype, buffer_var.value().get(), {index}, false);
       }
     } else if (op->op.same_as(builtin::address_of())) {
-      if (const auto* load = op->args[0].as<BufferLoadNode>()) {
-        OnArrayAccess(load->ty.as_or_throw<PrimType>(), load->buffer.get(), load->indices,
+      if (const auto* load = op->args[0].as<TensorLoadNode>()) {
+        OnArrayAccess(load->ty.as_or_throw<PrimType>(),
+                      load->source.as_or_throw<tvm::tirx::BufferVar>().get(), load->indices,
                       /*is_buffer_load=*/false);
       }
     }
@@ -1641,7 +1657,7 @@ class VectorTypeRewriter : public StmtExprMutator {
   }
 
   /*!
-   * \brief Mutator for BufferLoad or BufferStore.
+   * \brief Mutator for TensorLoad or BufferStore.
    * \return The rewritten node and the shuffle index. (Only for BufferLoad) When the shuffle index
    * is non-negative, the caller should generate Shuffle to extract the element from the vector.
    */
@@ -1692,8 +1708,49 @@ class VectorTypeRewriter : public StmtExprMutator {
     return {node, shuffle_index};
   }
 
-  Expr VisitExpr_(const BufferLoadNode* op) final {
-    auto node = StmtExprMutator::VisitExpr_(op).as_or_throw<BufferLoad>();
+  std::pair<TensorLoad, int> VisitBufferAccess(TensorLoad node) {
+    int shuffle_index = -1;
+    if (!rewrite_indices_) {
+      return {node, shuffle_index};
+    }
+
+    BufferVar buffer = node->source.as_or_throw<BufferVar>();
+    Var root = buffer_aliases_.Get(buffer.var()).value_or(buffer.var());
+    auto it = rewrite_map_.find(root.get());
+    if (it == rewrite_map_.end()) {
+      return {node, shuffle_index};
+    }
+    const auto& info = it->second;
+
+    ffi::Array<PrimExpr> indices = node->indices;
+    const PrimExpr& last_dim_index = indices.back();
+    const RampNode* ramp_index = last_dim_index.as<RampNode>();
+    if (buffer->dtype.IsScalableVector() || last_dim_index.ty().IsScalableVector()) {
+      return {node, shuffle_index};
+    }
+
+    if (ramp_index && is_one(ramp_index->stride) && ramp_index->lanes->IsInstance<IntImmNode>()) {
+      int lanes = static_cast<int>(ramp_index->lanes.as_or_throw<IntImm>()->value);
+      PrimExpr new_index = ramp_index->base / MakeConst(ramp_index->base.ty(), lanes);
+      if (lanes != info.factor()) {
+        TVM_FFI_ICHECK(info.factor() && lanes % info.factor() == 0);
+        int new_lanes = lanes / info.factor();
+        new_index = Ramp(new_index * new_lanes, ramp_index->stride, new_lanes, ramp_index->span);
+      }
+      indices.Set(indices.size() - 1, new_index);
+    } else if (last_dim_index.ty().lanes() == 1 && info.factor() > 1) {
+      arith::ModularSet me = analyzer_->modular_set(last_dim_index);
+      TVM_FFI_ICHECK(me->coeff == 0 || info.factor() % me->coeff == 0);
+      PrimExpr new_index = last_dim_index / MakeConst(last_dim_index.ty(), info.factor());
+      shuffle_index = me->base % info.factor();
+      indices.Set(indices.size() - 1, new_index);
+    }
+
+    return {BufferLoad(RemapBuffer(buffer), indices, node->span), shuffle_index};
+  }
+
+  Expr VisitExpr_(const TensorLoadNode* op) final {
+    auto node = StmtExprMutator::VisitExpr_(op).as_or_throw<TensorLoad>();
     auto [modified, shuffle_index] = VisitBufferAccess(node);
 
     // Not needed for BufferStoreNode, so we can't just call
@@ -1702,8 +1759,6 @@ class VectorTypeRewriter : public StmtExprMutator {
       return node;
 
     } else {
-      auto writer = modified.CopyOnWrite();
-      writer->LegalizeDType();
       if (shuffle_index >= 0) {
         return Shuffle::ExtractElement(std::move(modified), shuffle_index);
       }
@@ -1725,12 +1780,11 @@ class VectorTypeRewriter : public StmtExprMutator {
       for (size_t i = 1; i + 1 < op->args.size(); ++i) {
         indices.push_back(this->VisitPrimExpr(op->args[i].as_or_throw<PrimExpr>()));
       }
-      BufferLoad access(buffer, indices, op->span);
+      TensorLoad access = BufferLoad(buffer, indices, op->span);
       auto [modified, shuffle_index] = VisitBufferAccess(access);
       TVM_FFI_ICHECK_LT(shuffle_index, 0)
           << "A masked vector load cannot be rewritten into a scalar shuffle.";
-      if (!modified.same_as(access)) modified.CopyOnWrite()->LegalizeDType();
-      ffi::Array<Expr> args{modified->buffer.var()};
+      ffi::Array<Expr> args{modified->source.as_or_throw<BufferVar>().var()};
       for (const PrimExpr& index : modified->indices) args.push_back(index);
       args.push_back(this->VisitExpr(op->args.back()));
       return Call(modified->ty, op->op, args, op->attrs, op->ty_args, op->span);

--- a/src/tirx/transform/unroll_loop.cc
+++ b/src/tirx/transform/unroll_loop.cc
@@ -165,9 +165,10 @@ class LoopUnroller : public StmtExprMutator {
     }
   }
 
-  Expr VisitExpr_(const BufferLoadNode* op) final {
+  Expr VisitExpr_(const TensorLoadNode* op) final {
     if (unroll_local_access_) {
-      auto storage_scope = runtime::StorageScope::Create(op->buffer.scope());
+      auto storage_scope =
+          runtime::StorageScope::Create(op->source.as_or_throw<tvm::tirx::BufferVar>().scope());
       if (storage_scope.rank == runtime::StorageRank::kLocal ||
           storage_scope.rank == runtime::StorageRank::kWarp) {
         VarLocalAccessMarker marker(&var_touched_local_);

--- a/src/tirx/transform/unsupported_dtype_legalize.cc
+++ b/src/tirx/transform/unsupported_dtype_legalize.cc
@@ -106,9 +106,9 @@ class ComputeLegalizePlanner : public StmtExprVisitor {
     this->PopulateBufferRemap(op->buffer);
   }
 
-  void VisitExpr_(const BufferLoadNode* op) final {
+  void VisitExpr_(const TensorLoadNode* op) final {
     StmtExprVisitor::VisitExpr_(op);
-    this->PopulateBufferRemap(op->buffer);
+    this->PopulateBufferRemap(op->source.as_or_throw<tvm::tirx::BufferVar>());
   }
 
   void VisitStmt_(const AllocBufferNode* op) final {
@@ -496,12 +496,12 @@ class ComputeLegalizer : public StmtExprMutator {
     }
   }
 
-  Expr VisitExpr_(const BufferLoadNode* op) final {
+  Expr VisitExpr_(const TensorLoadNode* op) final {
     PrimExpr ret = StmtExprMutator::VisitExpr_(op).as_or_throw<PrimExpr>();
-    op = ret.as<BufferLoadNode>();
+    op = ret.as<TensorLoadNode>();
 
-    BufferVar new_buf = GetRemappedBuffer(op->buffer);
-    if (new_buf.same_as(op->buffer)) {
+    BufferVar new_buf = GetRemappedBuffer(op->source.as_or_throw<tvm::tirx::BufferVar>());
+    if (new_buf.same_as(op->source.as_or_throw<tvm::tirx::BufferVar>())) {
       return ret;
     } else {
       return BufferLoad(new_buf, op->indices);
@@ -703,11 +703,11 @@ class StorageLegalizer : public StmtExprMutator {
     return ret;
   }
 
-  Expr VisitExpr_(const BufferLoadNode* op) final {
+  Expr VisitExpr_(const TensorLoadNode* op) final {
     PrimExpr ret = StmtExprMutator::VisitExpr_(op).as_or_throw<PrimExpr>();
-    op = ret.as<BufferLoadNode>();
-    BufferVar new_buf = GetRemappedBuffer(op->buffer);
-    if (new_buf.same_as(op->buffer)) {
+    op = ret.as<TensorLoadNode>();
+    BufferVar new_buf = GetRemappedBuffer(op->source.as_or_throw<tvm::tirx::BufferVar>());
+    if (new_buf.same_as(op->source.as_or_throw<tvm::tirx::BufferVar>())) {
       return ret;
     } else {
       return BufferLoad(new_buf, op->indices);

--- a/src/tirx/transform/update_pointer_storage_scope.cc
+++ b/src/tirx/transform/update_pointer_storage_scope.cc
@@ -78,6 +78,13 @@ Node UpdatePointerStorageScope::UpdateBufferAccess(Node node) {
   return node;
 }
 
+template <>
+TensorLoad UpdatePointerStorageScope::UpdateBufferAccess(TensorLoad node) {
+  BufferVar buffer = node->source.as_or_throw<tvm::tirx::BufferVar>();
+  BufferVar new_buffer = GetUpdatedBuffer(buffer);
+  return new_buffer.same_as(buffer) ? node : BufferLoad(new_buffer, node->indices, node->span);
+}
+
 BufferVar UpdatePointerStorageScope::GetUpdatedBuffer(BufferVar buf) {
   auto it = new_var_remap_.find(buf.get());
   if (it != new_var_remap_.end()) {
@@ -96,8 +103,8 @@ Stmt UpdatePointerStorageScope::VisitStmt_(const DeclBufferNode* op) {
   return UpdateBufferAccess(node);
 }
 
-Expr UpdatePointerStorageScope::VisitExpr_(const BufferLoadNode* op) {
-  auto node = StmtExprMutator::VisitExpr_(op).as_or_throw<BufferLoad>();
+Expr UpdatePointerStorageScope::VisitExpr_(const TensorLoadNode* op) {
+  auto node = StmtExprMutator::VisitExpr_(op).as_or_throw<TensorLoad>();
   return UpdateBufferAccess(node);
 }
 

--- a/src/tirx/transform/update_pointer_storage_scope.h
+++ b/src/tirx/transform/update_pointer_storage_scope.h
@@ -39,7 +39,7 @@ class UpdatePointerStorageScope : public StmtExprMutator {
       const std::unordered_map<const VarNode*, ffi::String>& new_storage_scopes);
 
   virtual Expr VisitExpr_(const VarNode*);
-  virtual Expr VisitExpr_(const BufferLoadNode*);
+  virtual Expr VisitExpr_(const TensorLoadNode*);
   virtual Stmt VisitStmt_(const AllocBufferNode*);
   virtual Stmt VisitStmt_(const DeclBufferNode*);
   virtual Stmt VisitStmt_(const BufferStoreNode*);

--- a/src/tirx/transform/vectorize_loop.cc
+++ b/src/tirx/transform/vectorize_loop.cc
@@ -206,8 +206,8 @@ class TryPredicateBufferAccesses : public StmtExprMutator {
   }
 
  private:
-  Expr VisitExpr_(const BufferLoadNode* op) final {
-    auto load = StmtExprMutator::VisitExpr_(op).as_or_throw<BufferLoad>();
+  Expr VisitExpr_(const TensorLoadNode* op) final {
+    auto load = StmtExprMutator::VisitExpr_(op).as_or_throw<TensorLoad>();
     return TryPredicateBufferAccess(load);
   }
 
@@ -273,9 +273,9 @@ class TryPredicateBufferAccesses : public StmtExprMutator {
     return lane_mask;
   }
 
-  Expr TryPredicateBufferAccess(BufferLoad load) {
+  Expr TryPredicateBufferAccess(TensorLoad load) {
     if (auto mask = GetLaneMask(load->indices)) {
-      ffi::Array<Expr> args{load->buffer.var()};
+      ffi::Array<Expr> args{load->source.as_or_throw<tvm::tirx::BufferVar>().var()};
       for (const PrimExpr& index : load->indices) args.push_back(index);
       args.push_back(mask.value());
       return Call(load->ty, builtin::masked_load(), args, {}, {}, load->span);
@@ -324,8 +324,8 @@ class VecAllocAccess : public StmtExprMutator {
   VecAllocAccess(const VarNode* buf, Var var, PrimExpr var_lanes)
       : buf_(buf), var_(var), var_lanes_(var_lanes) {}
 
-  Expr VisitExpr_(const BufferLoadNode* op) final {
-    auto load = StmtExprMutator::VisitExpr_(op).as_or_throw<BufferLoad>();
+  Expr VisitExpr_(const TensorLoadNode* op) final {
+    auto load = StmtExprMutator::VisitExpr_(op).as_or_throw<TensorLoad>();
     return UpdateBufferAccess(load);
   }
 
@@ -388,6 +388,34 @@ class VecAllocAccess : public StmtExprMutator {
     writer->buffer = buf;
     writer->indices = indices;
     return node;
+  }
+
+  TensorLoad UpdateBufferAccess(TensorLoad node) {
+    BufferVar buffer = node->source.as_or_throw<tvm::tirx::BufferVar>();
+    if (buffer.get() != buf_) return node;
+    BufferVar buf;
+    auto it = buffer_map_.find(buffer.get());
+    if (it != buffer_map_.end()) {
+      buf = it->second;
+    } else {
+      ffi::Array<PrimExpr> shape = buffer->shape;
+      shape.Set(shape.size() - 1, analyzer_->Simplify(shape.back() * var_lanes_));
+      ffi::Array<PrimExpr> strides = buffer->strides;
+      for (size_t i = 0; i < strides.size(); ++i) {
+        PrimExpr stride = strides[i];
+        if (i + 1 != strides.size()) stride *= var_lanes_;
+        strides.Set(i, analyzer_->Simplify(stride));
+      }
+      auto type = CopyBufferType(buffer);
+      type->shape = shape;
+      type->strides = strides;
+      buf = RebuildBufferVar(buffer, std::move(type));
+      buffer_map_[buffer.get()] = buf;
+    }
+    ffi::Array<PrimExpr> indices = node->indices;
+    indices.Set(indices.size() - 1,
+                analyzer_->Simplify(indices.back() * var_lanes_ + var_.as_or_throw<PrimExpr>()));
+    return BufferLoad(buf, indices, node->span);
   }
 
   // buffer var
@@ -751,16 +779,14 @@ class Vectorizer : public StmtMutator, public ExprFunctor<Expr(const Expr&)> {
     }
   }
   // BufferLoad
-  Expr VisitExpr_(const BufferLoadNode* op) final {
-    auto load = ffi::GetRef<BufferLoad>(op);
+  Expr VisitExpr_(const TensorLoadNode* op) final {
+    auto load = ffi::GetRef<TensorLoad>(op);
 
     auto fmutate = [this](const PrimExpr& index) { return this->VisitPrimExpr(index); };
     ffi::Array<PrimExpr> indices = op->indices.Map(fmutate);
 
     if (!indices.same_as(op->indices)) {
-      auto writer = load.CopyOnWrite();
-      writer->indices = indices;
-      writer->LegalizeDType();
+      return BufferLoad(op->source.as_or_throw<tvm::tirx::BufferVar>(), indices, op->span);
     }
 
     return load;

--- a/tests/python/s_tir/transform/test_s_tir_transform_mma_buffer_layout.py
+++ b/tests/python/s_tir/transform/test_s_tir_transform_mma_buffer_layout.py
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest
+
+import tvm
+import tvm.testing
+from tvm import s_tir, tirx
+
+
+@pytest.mark.parametrize(
+    "scope,shape", [("m16n8k8.matrixA", (32, 8)), ("m16n8k8.matrixB", (8, 32))]
+)
+@pytest.mark.parametrize("access_kind", ["load", "store"])
+def test_explicit_matrix_ab_access_is_rejected(scope, shape, access_kind):
+    buffer = tirx.decl_buffer(shape, "float32", scope=scope)
+    if access_kind == "load":
+        body = tirx.Evaluate(tirx.BufferLoad(buffer, [0, 0]))
+    else:
+        body = tirx.BufferStore(buffer, 0.0, [0, 0])
+    block = tirx.SBlock([], [], [], "root", body, alloc_buffers=[buffer])
+    func = tirx.PrimFunc([], tirx.SBlockRealize([], True, block))
+
+    with pytest.raises(tvm.error.InternalError, match=f"{scope}.*explicit"):
+        s_tir.transform.TransformMmaBufferLayout()(tvm.IRModule.from_expr(func))
+
+
+if __name__ == "__main__":
+    tvm.testing.main()

--- a/tests/python/tirx-analysis/test_tir_analysis_verify_well_formed.py
+++ b/tests/python/tirx-analysis/test_tir_analysis_verify_well_formed.py
@@ -17,6 +17,7 @@
 # ruff: noqa: F841
 
 import json
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -485,7 +486,13 @@ def test_tensor_load_asserted_type_matches_source_and_indices():
         buffer = T.alloc_buffer((4,), "float32")
         T.evaluate(buffer[0])
 
-    graph = json.loads(tvm.ir.save_json(func))
+    serialized = tvm.ir.save_json(func)
+    round_tripped = tvm.ir.load_json(serialized)
+    assert tvm.tirx.analysis.verify_well_formed(round_tripped, assert_mode=False)
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        assert executor.submit(tvm.tirx.analysis.verify_well_formed, func, False).result()
+
+    graph = json.loads(serialized)
     load = next(node for node in graph["nodes"] if node["type"] == "ir.TensorLoad")
     int32_type_index = next(
         index
@@ -498,6 +505,31 @@ def test_tensor_load_asserted_type_matches_source_and_indices():
     assert not tvm.tirx.analysis.verify_well_formed(malformed, assert_mode=False)
     with pytest.raises(tvm.error.InternalError, match="asserts result type"):
         tvm.tirx.analysis.verify_well_formed(malformed)
+
+
+def test_tensor_load_malformed_indices_return_false_without_asserting():
+    buffer = tvm.tirx.decl_buffer((4, 4), "float32")
+    vector_index = tvm.tirx.Ramp(0, 1, 4)
+    load = tvm.tirx.BufferLoad(buffer, [0, vector_index])
+    func = tvm.tirx.PrimFunc([buffer], tvm.tirx.Evaluate(load))
+
+    graph = json.loads(tvm.ir.save_json(func))
+    load_node = next(node for node in graph["nodes"] if node["type"] == "ir.TensorLoad")
+    indices = graph["nodes"][load_node["data"]["indices"]]["data"]
+
+    rank_mismatch_graph = json.loads(json.dumps(graph))
+    rank_mismatch_indices = rank_mismatch_graph["nodes"][load_node["data"]["indices"]]["data"]
+    rank_mismatch_indices.pop()
+    rank_mismatch = tvm.ir.load_json(json.dumps(rank_mismatch_graph))
+    assert not tvm.tirx.analysis.verify_well_formed(rank_mismatch, assert_mode=False)
+    with pytest.raises(tvm.error.InternalError, match="indexes 2-dimensional buffer"):
+        tvm.tirx.analysis.verify_well_formed(rank_mismatch)
+
+    indices[0], indices[1] = indices[1], indices[0]
+    non_final_vector = tvm.ir.load_json(json.dumps(graph))
+    assert not tvm.tirx.analysis.verify_well_formed(non_final_vector, assert_mode=False)
+    with pytest.raises(tvm.error.InternalError, match="only the final index"):
+        tvm.tirx.analysis.verify_well_formed(non_final_vector)
 
 
 if __name__ == "__main__":

--- a/tests/python/tirx-analysis/test_tir_analysis_verify_well_formed.py
+++ b/tests/python/tirx-analysis/test_tir_analysis_verify_well_formed.py
@@ -16,6 +16,8 @@
 # under the License.
 # ruff: noqa: F841
 
+import json
+
 import pytest
 
 import tvm
@@ -475,6 +477,27 @@ def test_error_undeclared_buffer_in_schedulable_tir():
         (ValueError, tvm.error.InternalError), match="buffer B.*without a prior DeclBuffer"
     ):
         tvm.tirx.analysis.verify_well_formed(prim_func)
+
+
+def test_tensor_load_asserted_type_matches_source_and_indices():
+    @T.prim_func
+    def func():
+        buffer = T.alloc_buffer((4,), "float32")
+        T.evaluate(buffer[0])
+
+    graph = json.loads(tvm.ir.save_json(func))
+    load = next(node for node in graph["nodes"] if node["type"] == "ir.TensorLoad")
+    int32_type_index = next(
+        index
+        for index, node in enumerate(graph["nodes"])
+        if node["type"] == "ir.PrimType" and node["data"]["dtype"] == "int32"
+    )
+    load["data"]["ty"] = int32_type_index
+    malformed = tvm.ir.load_json(json.dumps(graph))
+
+    assert not tvm.tirx.analysis.verify_well_formed(malformed, assert_mode=False)
+    with pytest.raises(tvm.error.InternalError, match="asserts result type"):
+        tvm.tirx.analysis.verify_well_formed(malformed)
 
 
 if __name__ == "__main__":

--- a/tests/python/tirx-base/test_tir_constructor.py
+++ b/tests/python/tirx-base/test_tir_constructor.py
@@ -108,11 +108,11 @@ def test_expr_constructor():
     buffer_var = tvm.tirx.Var("buf", tvm.ir.PointerType(tvm.ir.PrimType("float32")))
     buffer = tvm.tirx.decl_buffer([16], "float32", data=buffer_var)
     x = tvm.tirx.BufferLoad(buffer, [1])
-    assert isinstance(x, tvm.tirx.BufferLoad)
+    assert isinstance(x, tvm.ir.TensorLoad)
     assert x.ty == tvm.ir.PrimType("float32")
-    assert x.buffer == buffer
-    assert x.buffer.data.args[0].same_as(buffer)
-    assert x.buffer.data.ty == tvm.tirx.buffer_data_pointer_type(buffer)
+    assert x.source == buffer
+    assert x.source.data.args[0].same_as(buffer)
+    assert x.source.data.ty == tvm.tirx.buffer_data_pointer_type(buffer)
     assert list(x.indices) == [1]
 
     x = tvm.tirx.Ramp(1, 2, 10)

--- a/tests/python/tirx-base/test_tir_expr_functor.py
+++ b/tests/python/tirx-base/test_tir_expr_functor.py
@@ -18,7 +18,7 @@
 import tvm
 import tvm.testing
 from tvm import tirx as tir
-from tvm.ir import Call, Op, OpaqueExpr, Tuple, TupleGetItem
+from tvm.ir import Call, Op, OpaqueExpr, TensorLoad, Tuple, TupleGetItem
 from tvm.ir.base import assert_structural_equal
 from tvm.tirx.expr import (
     EQ,
@@ -30,7 +30,6 @@ from tvm.tirx.expr import (
     Add,
     And,
     Broadcast,
-    BufferLoad,
     Cast,
     Div,
     FloatImm,
@@ -96,7 +95,7 @@ class ASTPrinter(ExprVisitor):
     def visit_var_(self, op: Var) -> None:
         self.log.add("Var")
 
-    def visit_buffer_load_(self, op: BufferLoad) -> None:
+    def visit_buffer_load_(self, op: TensorLoad) -> None:
         self.log.add("BufferLoad")
         self.log.push_scope()
         for idx in op.indices:
@@ -337,7 +336,7 @@ class ASTPostPrinterMutator(ExprMutator):
         self.log.add("Var")
         return result
 
-    def visit_buffer_load_(self, op: BufferLoad) -> tir.Expr:
+    def visit_buffer_load_(self, op: TensorLoad) -> tir.Expr:
         result = super().visit_buffer_load_(op)
         self.log.add("BufferLoad")
         return result

--- a/tests/python/tirx-base/test_tir_nodes.py
+++ b/tests/python/tirx-base/test_tir_nodes.py
@@ -341,9 +341,13 @@ def test_scoped_storage_vars():
 def test_buffer_load_store():
     b = tvm.tirx.decl_buffer((10,), "float32")
     x = tvm.tirx.BufferLoad(b, [0])
-    assert isinstance(x, tvm.tirx.BufferLoad)
+    assert isinstance(x, tvm.ir.TensorLoad)
+    assert callable(tvm.tirx.BufferLoad)
     assert x.ty.dtype == "float32"
-    assert x.buffer == b
+    assert x.source == b
+    assert not hasattr(x, "buffer")
+    with pytest.raises(TypeError, match="cannot be constructed directly"):
+        tvm.ir.TensorLoad(b, [0])
     s = tvm.tirx.BufferStore(b, 0.1, [0])
     assert isinstance(s, tvm.tirx.BufferStore)
 
@@ -413,7 +417,7 @@ def test_buffer_load_scalable_vec():
     index = tvm.tirx.expr.Ramp(1, 1, 8 * tvm.tirx.vscale())
     load = tvm.tirx.BufferLoad(buf, [index])
 
-    assert isinstance(load, tvm.tirx.BufferLoad)
+    assert isinstance(load, tvm.ir.TensorLoad)
     assert load.ty.dtype == "float32xvscalex8"
 
 

--- a/tests/python/tirx-transform/test_tir_transform_lower_intrin.py
+++ b/tests/python/tirx-transform/test_tir_transform_lower_intrin.py
@@ -110,7 +110,7 @@ def test_lower_nested_access_ptr():
     assert not access_ptr_calls
     assert len(address_calls) == 1
     load = address_calls[0].args[0]
-    assert isinstance(load, tvm.tirx.BufferLoad)
+    assert isinstance(load, tvm.ir.TensorLoad)
     assert int(tvm.arith.Analyzer().simplify(load.indices[0])) == 5
 
     targets = ["c"]
@@ -152,10 +152,10 @@ def test_lower_vector_access_ptr():
     assert lowered.ty == access_ptr.ty
 
     load = lowered.args[0]
-    assert isinstance(load, tvm.tirx.BufferLoad)
-    assert load.buffer.same_as(alias.buffer)
-    assert not load.buffer.same_as(buffer)
-    assert load.buffer.ty.dtype == tvm.ir.PrimType("float32")
+    assert isinstance(load, tvm.ir.TensorLoad)
+    assert load.source.same_as(alias.buffer)
+    assert not load.source.same_as(buffer)
+    assert load.source.ty.dtype == tvm.ir.PrimType("float32")
     assert len(load.indices) == 1
     ramp = load.indices[0]
     assert isinstance(ramp, tvm.tirx.Ramp)
@@ -185,8 +185,8 @@ def test_lower_buffer_data_access_ptr_preserves_buffer_identity():
     assert isinstance(lowered, tvm.ir.Call)
     assert lowered.op.name == "tirx.address_of"
     load = lowered.args[0]
-    assert isinstance(load, tvm.tirx.BufferLoad)
-    assert load.buffer.same_as(buffer)
+    assert isinstance(load, tvm.ir.TensorLoad)
+    assert load.source.same_as(buffer)
     assert int(load.indices[0]) == 3
 
 
@@ -204,8 +204,8 @@ def test_lower_access_ptr_uses_flat_alias_for_non_1d_buffer(shape):
     assert isinstance(alias, tvm.tirx.DeclBuffer)
     assert len(alias.buffer.ty.shape) == 1
     load = lowered.seq[1].value.args[0]
-    assert isinstance(load, tvm.tirx.BufferLoad)
-    assert load.buffer.same_as(alias.buffer)
+    assert isinstance(load, tvm.ir.TensorLoad)
+    assert load.source.same_as(alias.buffer)
     assert len(load.indices) == 1
 
 

--- a/tests/python/tirx/codegen/test_codegen_blackwell.py
+++ b/tests/python/tirx/codegen/test_codegen_blackwell.py
@@ -71,7 +71,7 @@ def _assert_remote_mbarrier_ir(func, arrive_op_name, n_arrives=1):
     # instruction has no remote operand of its own, it just takes the mapped
     # address.
     mapped_dst, mapped_ptr, _rank = mapa_calls[0].args[:3]
-    assert isinstance(mapped_dst, tvm.tirx.BufferLoad)
+    assert isinstance(mapped_dst, tvm.ir.TensorLoad)
     assert mapped_ptr is not None
     assert len(arrive_calls) == n_arrives
 

--- a/tests/python/tirx/codegen/test_codegen_dsmem.py
+++ b/tests/python/tirx/codegen/test_codegen_dsmem.py
@@ -120,7 +120,7 @@ def test_mapa_pointer_bind_codegen():
             binds.append(node)
         elif isinstance(node, tvm.tirx.DeclBuffer):
             decl_buffers.append(node)
-        elif isinstance(node, tvm.tirx.BufferLoad):
+        elif isinstance(node, tvm.ir.TensorLoad):
             loads.append(node)
 
     tvm.tirx.stmt_functor.post_order_visit(main.body, collect)
@@ -131,7 +131,7 @@ def test_mapa_pointer_bind_codegen():
     assert_structural_equal(binds[0].var.ty, binds[0].value.ty)
     assert len(decl_buffers) == 1
     assert decl_buffers[0].data.same_as(binds[0].var)
-    assert any(load.buffer.same_as(decl_buffers[0].buffer) for load in loads)
+    assert any(load.source.same_as(decl_buffers[0].buffer) for load in loads)
 
     assert_structural_equal(main, tvm.script.from_source(main.script()))
     src = _get_source(main)

--- a/tests/python/tirx/test_parser_printer.py
+++ b/tests/python/tirx/test_parser_printer.py
@@ -743,7 +743,7 @@ def test_alloc_apis():
         def init(self):
             self.Ta = self.Ta + T.float16(1)
             self.Tb = self.Tb + T.float16(2)
-            self.idx.buffer[0] = T.int32(0)
+            self.idx.source[0] = T.int32(0)
             self.idx = self.idx + T.int32(1)
             self.inner_pool2 = self.inner_pool2 + T.float16(1)
             T.evaluate(T.address_of(self.Ta))
@@ -773,7 +773,7 @@ def test_alloc_apis():
         A[0] = C
         A[0] = C + D  # noqa: F821
         A[1] = B[0] * C
-        D.buffer[0] = D + T.float16(1)  # noqa: F821
+        D.source[0] = D + T.float16(1)  # noqa: F821
         D = D + T.float16(1)  # noqa: F821
         C = D
         T.evaluate(E)
@@ -784,14 +784,15 @@ def test_alloc_apis():
         C += D
         D += E + C + D
         T.evaluate(T.address_of(C))
-        T.evaluate(C.buffer.access_ptr("rw", offset=0))
-        T.evaluate(C.buffer.data)
+        T.evaluate(C.source.access_ptr("rw", offset=0))
+        T.evaluate(C.source.data)
         T.evaluate(D)
         T.evaluate(T.address_of(D))
         # fmt: on
 
     code = test.script()
     print(code)
+    assert ".buffer" not in code
     assert from_source(code).script() == code
 
 
@@ -2685,7 +2686,7 @@ def test_vector_annotation_with_python_variable_size():
 def test_roundtrip_tmem_decl_buffer():
     """DeclBuffer with tmem scope: data kwarg must be suppressed, allocated_addr
     must print as Expr (not Array), and scalar buffer index must not get
-    a .buffer suffix."""
+    a .source suffix."""
 
     # fmt: off
     @T.prim_func

--- a/tests/python/tirx/transform/test_stmt_functor.py
+++ b/tests/python/tirx/transform/test_stmt_functor.py
@@ -1204,7 +1204,7 @@ def test_op_call_pointer_config_visited_and_mutated():
             self.buffers = []
 
         def visit_buffer_load_(self, op):
-            self.buffers.append(op.buffer)
+            self.buffers.append(op.source)
             return super().visit_buffer_load_(op)
 
     collector = LoadCollector()
@@ -1216,14 +1216,14 @@ def test_op_call_pointer_config_visited_and_mutated():
     class ReplaceMbarLoad(StmtExprMutator):
         def visit_buffer_load_(self, op):
             new_op = super().visit_buffer_load_(op)
-            if op.buffer.same_as(mbar_buffer):
+            if op.source.same_as(mbar_buffer):
                 return tir.BufferLoad(replacement, new_op.indices)
             return new_op
 
     updated = ReplaceMbarLoad().visit_stmt(op_call)
     mbar_load = updated.config["mbar"].args[0]
-    assert isinstance(mbar_load, tir.BufferLoad)
-    assert mbar_load.buffer.same_as(replacement)
+    assert isinstance(mbar_load, tvm.ir.TensorLoad)
+    assert mbar_load.source.same_as(replacement)
 
 
 def test_op_call_nested_config_visited_and_substituted():

--- a/tests/python/tirx/transform/test_tirx_expr_functor.py
+++ b/tests/python/tirx/transform/test_tirx_expr_functor.py
@@ -18,7 +18,7 @@
 import tvm
 import tvm.testing
 from tvm import tirx as tir
-from tvm.ir import Call, Op, OpaqueExpr
+from tvm.ir import Call, Op, OpaqueExpr, TensorLoad
 from tvm.ir.base import assert_structural_equal
 from tvm.tirx.expr import (
     EQ,
@@ -30,7 +30,6 @@ from tvm.tirx.expr import (
     Add,
     And,
     Broadcast,
-    BufferLoad,
     Cast,
     Div,
     FloatImm,
@@ -96,7 +95,7 @@ class ASTPrinter(ExprVisitor):
     def visit_var_(self, op: Var) -> None:
         self.log.add("Var")
 
-    def visit_buffer_load_(self, op: BufferLoad) -> None:
+    def visit_buffer_load_(self, op: TensorLoad) -> None:
         self.log.add("BufferLoad")
         self.log.push_scope()
         for idx in op.indices:
@@ -324,7 +323,7 @@ class ASTPostPrinterMutator(ExprMutator):
         self.log.add("Var")
         return result
 
-    def visit_buffer_load_(self, op: BufferLoad) -> tir.Expr:
+    def visit_buffer_load_(self, op: TensorLoad) -> tir.Expr:
         result = super().visit_buffer_load_(op)
         self.log.add("BufferLoad")
         return result

--- a/tests/python/tirx/transform/test_transform_flatten_buffer.py
+++ b/tests/python/tirx/transform/test_transform_flatten_buffer.py
@@ -53,17 +53,18 @@ def _assert_loads_reference_defined_buffers(func):
 
     def check_expr(expr, where):
         def visit(node):
-            if isinstance(node, tvm.tirx.BufferLoad) and not is_defined(node.buffer):
-                stale.append(f"{where}: load of {node.buffer.name}")
+            if isinstance(node, tvm.ir.TensorLoad) and not is_defined(node.source):
+                stale.append(f"{where}: load of {node.source.name}")
 
         tvm.tirx.stmt_functor.post_order_visit(expr, visit)
 
     def visit(node):
-        if isinstance(node, tvm.tirx.BufferLoad | tvm.tirx.BufferStore):
-            if not is_defined(node.buffer):
-                stale.append(f"access of {node.buffer.name}")
+        if isinstance(node, tvm.ir.TensorLoad | tvm.tirx.BufferStore):
+            buffer = node.source if isinstance(node, tvm.ir.TensorLoad) else node.buffer
+            if not is_defined(buffer):
+                stale.append(f"access of {buffer.name}")
             for index in node.indices:
-                check_expr(index, f"index of {node.buffer.name}")
+                check_expr(index, f"index of {buffer.name}")
         if isinstance(node, tvm.tirx.AllocBuffer | tvm.tirx.DeclBuffer):
             for extent in node.buffer.shape:
                 check_expr(extent, f"shape of {node.buffer.name}")
@@ -118,7 +119,7 @@ def test_flatten_remaps_loads_in_folded_elem_offset():
         if isinstance(node, tvm.tirx.BufferStore) and node.buffer.name.startswith("mbar"):
 
             def inner(sub):
-                if isinstance(sub, tvm.tirx.BufferLoad):
+                if isinstance(sub, tvm.ir.TensorLoad):
                     found.append(sub)
 
             tvm.tirx.stmt_functor.post_order_visit(node.indices[0], inner)

--- a/tests/python/tirx/transform/test_transform_lower_tirx.py
+++ b/tests/python/tirx/transform/test_transform_lower_tirx.py
@@ -1462,7 +1462,7 @@ def test_lower_alloc_decl_buffer_outside_of_parser():
     def int_var1(val):
         buf = T.local_scalar("int32")
         if val is not None:
-            T.buffer_store(buf.buffer, val, 0)
+            T.buffer_store(buf.source, val, 0)
         return buf
 
     def int_var2(val):


### PR DESCRIPTION
Move indexed-load representation into core IR as `TensorLoad`, while keeping TIRx-specific type derivation and validation in the checked `BufferLoad` factory. Update visitors, rewriters, code generation, script printing, and consumers to use the generic source field with explicit buffer checks. Add verifier and regression coverage for asserted load types, source invariants, traversal, serialization, and rank-changing rewrites.