### PR TITLE
[CI] Restore ruff-format on test_target_codegen_c_host.py

### DIFF
--- a/tests/python/codegen/test_target_codegen_c_host.py
+++ b/tests/python/codegen/test_target_codegen_c_host.py
@@ -197,9 +197,7 @@ def test_round():
         # semantics every other backend and the constant folder use) differs
         # from ties-away-from-zero. np.random.rand never produces them, so the
         # random tail alone cannot exercise the tie rule.
-        midpoints = np.array(
-            [0.5, 1.5, 2.5, 3.5, -0.5, -1.5, -2.5, -3.5], dtype="float32"
-        )
+        midpoints = np.array([0.5, 1.5, 2.5, 3.5, -0.5, -1.5, -2.5, -3.5], dtype="float32")
         a_np = np.concatenate(
             [midpoints, np.random.rand(n - len(midpoints)).astype("float32")]
         ).astype("float32")


### PR DESCRIPTION
#20131 left a 3-line wrapped call in `test_round` (tests/python/codegen/test_target_codegen_c_host.py:200) that ruff-format rejoins into a single line under `line-length = 100`, so `pre-commit run --all-files` fails on every open PR — the CI lint is currently red on main, and this PR is the one-line restore.

```
-        midpoints = np.array(
-            [0.5, 1.5, 2.5, 3.5, -0.5, -1.5, -2.5, -3.5], dtype="float32"
-        )
+        midpoints = np.array([0.5, 1.5, 2.5, 3.5, -0.5, -1.5, -2.5, -3.5], dtype="float32")
```

Reproduce with the CI-pinned hook:

```
uvx ruff@0.12.3 format --check tests/python/codegen/test_target_codegen_c_host.py
```

Formatting-only; no other change. Once merged, #20252 (which rebases on this) goes green.