### PR TITLE
[CUDA][TIRx] PTX ISA 9.4 / CUDA 13.4 support for SM103a and SM107a (Rubin)

### DIFF
--- a/.agents/skills/tir-test/SKILL.md
+++ b/.agents/skills/tir-test/SKILL.md
@@ -113,7 +113,7 @@ Run all commands below in the same Bash shell from the TVM repository root.
 
 3. Full kernel import gate for correctness-suite coverage:
    ```bash
-   "$PYTHON_BIN" -m tirx_kernels.registry --cc 10 --strict
+   "$PYTHON_BIN" -m tirx_kernels.registry --strict
    ```
 
 4. Run the full test suite with xdist parallelism:

--- a/.agents/skills/tirx-ptx-dialect/SKILL.md
+++ b/.agents/skills/tirx-ptx-dialect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tirx-ptx-dialect
-description: Register, extend, or audit instructions in the table-driven T.ptx dialect (python/tvm/backend/cuda/ptx/table.py), and move the table to a newer PTX ISA version (9.3, 9.4, ...). Use when adding a PTX instruction or qualifier, widening an operand domain, fixing a ptxas certification failure, or checking the table's comments against the PTX ISA document.
+description: Register, extend, or audit instructions in the table-driven T.ptx dialect (python/tvm/backend/cuda/ptx/table.py), and move the table to a newer PTX ISA version. Use when adding a PTX instruction or qualifier, widening an operand domain, fixing a ptxas certification failure, or checking the table's comments against the PTX ISA document.
 ---
 
 # TIRx PTX dialect (`T.ptx`)
@@ -74,7 +74,8 @@ the suite. The last one (what the comments claim) is audited by hand, §4.
   note with the reason for every syntax line or token deliberately left out.
   A fact that comes from ptxas rather than the document is marked `MEASURED`
   and quotes the ptxas message. Section and table numbers follow the ISA
-  version named in the module docstring (currently **PTX ISA 9.2**, see §5).
+  version named in the module docstring (currently **PTX ISA 9.4**, the CUDA
+  13.4 developer-preview document, see §5).
 
 ## 2. Designing the entry
 
@@ -130,7 +131,7 @@ Worked example — the whole registration of `movmatrix` (commit a29a5e97ba,
 4 files, 40 lines):
 
 ```python
-    # movmatrix per PTX ISA 9.7.14.5.17 -- transpose one distributed m8n8
+    # movmatrix per PTX ISA 9.7.16.5.17 -- transpose one distributed m8n8
     # matrix whose 16-bit elements are carried by one b32 register per lane.
     #
     #   movmatrix.sync.aligned.m8n8.trans.b16 d, a;
@@ -196,8 +197,9 @@ Run from the TVM repo root with the workspace `PYTHONPATH` (see `tir-test`).
    gate that proves the domain. It assembles every closed variant of every
    entry, split into 32 shards; pick 8, 16 or 32 workers to taste (each one
    drives its own nvcc; `-n auto` on a many-core box mostly burns memory).
-   ~3.5 min at `-n 16`, ~6.5 min at `-n 8` on the current B200 host for the
-   ~800k-variant PTX ISA 9.2 table.
+   ~3.5 min at `-n 16`, ~6.5 min at `-n 8` on a B200-class host for the
+   ~760k-variant PTX ISA 9.4 table (`test_ptx_all_variants_render_unique`
+   pins the exact count).
    ```bash
    PTX_CERT=1 python -m pytest -n 16 -q \
      tests/python/tirx/codegen/test_ptx_dialect.py::test_ptx_all_helpers_certify
@@ -227,82 +229,107 @@ ISA versions.
 ## 5. Toolchain and ISA-version model
 
 - The dialect targets the **ptxas of the installed CUDA toolkit**, not the
-  latest ISA document. CUDA 13.2's ptxas implements PTX ISA 9.2. Establish
+  latest ISA document. CUDA 13.4's ptxas implements PTX ISA 9.4. Establish
   what yours implements from ptxas itself — `nvcc -ptx` only shows the
   version the front end chose to emit, and `-ptx` never validates inline
   asm:
   ```bash
   command -v nvcc ptxas && nvcc --version | tail -1 && ptxas --version | tail -1
-  printf '.version 9.3\n.target sm_90\n.address_size 64\n.visible .entry k() { ret; }\n' \
-    | ptxas -arch=sm_90 - -o /dev/null  # CUDA 13.2: "Unsupported .version 9.3; current version is '9.2'"
+  printf '.version 9.4\n.target sm_107a\n.address_size 64\n.visible .entry k() { ret; }\n' \
+    | ptxas -arch=sm_107a - -o /dev/null   # CUDA 13.4: accepted
   ```
-  Then let the certification suite (which compiles real inline-asm helpers
-  to cubin) be the final word.
+  A `.version` directive above what ptxas implements is refused outright
+  ("Unsupported .version ...; current version is '9.4'"), which is the
+  quickest way to read a toolkit's ceiling. Then let the certification suite
+  (which compiles real inline-asm helpers to cubin) be the final word.
 - The table's citations follow that same version (module docstring of
-  `table.py`: "Section and table numbers cite PTX ISA 9.2", archive URL
-  `docs.nvidia.com/cuda/archive/13.2.0/parallel-thread-execution/`). The
-  live `docs.nvidia.com/cuda/parallel-thread-execution/` page is the newest
-  version and its numbering differs; every ISA version stays available
-  under `docs.nvidia.com/cuda/archive/<cuda version>/`.
+  `table.py`: "Section and table numbers cite PTX ISA 9.4", URL
+  `docs.nvidia.com/cuda/developer-preview/13.4/parallel-thread-execution/`;
+  once CUDA 13.4 ships, the stable copy is
+  `docs.nvidia.com/cuda/archive/13.4.0/parallel-thread-execution/`). The
+  live `docs.nvidia.com/cuda/parallel-thread-execution/` page is whatever
+  version is newest and its numbering differs; every ISA version stays
+  available under `docs.nvidia.com/cuda/archive/<cuda version>/`.
+- Every `MEASURED` clause in `table.py` / `render.py` names the toolkit it
+  was taken on (currently CUDA 13.4). A toolkit bump re-measures all of them
+  (§6 step 5); a clause that names an older toolkit is a bug.
 - Certification needs only `nvcc`/`ptxas`; the on-GPU round-trip tests need
   a driver that can load a cubin from that toolkit. A newer toolkit with an
   older driver can therefore certify a table but not run it.
 - `PTX_ARCH` (env, default `sm_90`) is the certification arch for entries
   without `cert_arch`.
 
-## 6. Moving the table to PTX ISA 9.3 (and later)
+## 6. Moving the table to a newer PTX ISA
 
 Do this as one commit series, in this order:
 
 1. **Toolchain first.** Install the CUDA toolkit whose ptxas implements the
-   target ISA and confirm via `.version`. Until then, a 9.3 form cannot be
-   registered: certification would fail, and a `check()` written against an
-   older ptxas would silently delete the coverage later.
-2. **Retarget the citations.** Update the module docstring's version
-   statement and archive URL, then renumber. Between 9.2 and 9.3 the shifts
-   are: chapter `9.7.10 Fabric Instructions` inserted (everything from
-   Texture onward moves +1: sync `9.7.13→9.7.14`, mma `9.7.14→9.7.15`, wgmma
-   `9.7.15→9.7.16`, tcgen05 `9.7.16→9.7.17`, misc `9.7.19→9.7.20`);
-   `9.7.1.5 clmad` inserted (integer instructions from `mul24` on move +1);
-   `9.7.9.13 multimem.st.async` inserted (data movement from `st.bulk` on
-   move +1); `9.7.14.8 multimem.red.async` inserted (sync instructions from
-   `vote` on move +1); the mbarrier chapter gains three descriptive
-   subsections (Layouts, Tracking successful completion, Report-on), so its
-   instruction subsections move +3 (`mbarrier.arrive` `9.7.13.15.13 →
-   9.7.14.16.16`) and `mbarrier.check_layout` is appended; global table
-   numbers shift (the tcgen05.ld/st register-count tables are 49/50 in 9.2
-   and 52/53 in 9.3).
-   Renumber intra-chapter subsections too, not just chapters, and re-run the
-   audit of §4 afterwards — a chapter-only shift was the exact mistake made
-   the first time this table changed versions.
-3. **Register the newly legal forms.** Per the 9.3 release notes (ISA
-   chapter 13.1) and the per-section "introduced in PTX ISA version 9.3"
-   notes, the forms this table currently leaves out because they are 9.3 are:
-   - `ld.mmio` with `.acquire`, `st.mmio` with `.release` (`_check_ld` /
-     `_check_st`: "PTX ISA 9.2 spells only relaxed");
-   - `clmad` (new integer family, 9.7.1 banner note);
-   - `multimem.st.async`, `multimem.red.async` (new families, 9.7.9 / sync
-     chapter);
-   - `.sem`/`.scope` on `cp.async.bulk`, `cp.reduce.async.bulk`,
-     `multimem.cp.async.bulk`, `multimem.cp.reduce.async.bulk` (new slots
-     on the cp.async.bulk entries);
-   - mbarrier: `.phase_type::*` on `test_wait`/`try_wait`, the
-     `waitComplete|reportPredicate{, reportValue}` report forms (new
-     entries — a second destination is a new shape), the `.layout` qualifier
-     on `mbarrier.init`/`pending_count`, and `mbarrier.check_layout` (new
-     family);
-   - `fence.proxy.to_proxykind::from_proxykind_fabric.alias.sem_fabric.sys`
-     (two new slots on the fence family; sm_100);
-   - the `fabric.*` instructions (a whole new chapter; new families).
-   Each one: read the section, apply §2, then §3 including full
-   certification at the right `cert_arch`.
-4. **Do not widen operand carriers from the ISA's relaxed-typing tables
-   without certifying.** ISA §9.4.1 Tables 27/28 are an upper bound and say
-   so ("some combinations may still be invalid for a particular
-   instruction"); ptxas rejects, for example, any `cvt` that pairs a `.bf16`
-   operand with a wider register on the other side, and 128-bit carriers on
-   several `.ftz` conversions. The `_cvt_dst_dtypes` / `_cvt_src_dtypes`
-   docstrings in `table.py` record the measured gaps; a version bump must
-   re-run certification and re-measure them, because gaps can close.
-5. Regenerate the stub, update the variant count, run the full suite, and
-   run the §4 audit against the new document before merging.
+   target ISA and confirm via `.version` (§5). Until then, a new form cannot
+   be registered: certification would fail, and a `check()` written against
+   an older ptxas would silently delete the coverage later.
+2. **Build the section map structurally, from both TOCs.** Dump both HTML
+   documents to text, extract the two tables of contents (`<num> <title>`),
+   and derive a `rule(old) -> new` function from where the new version
+   inserted sections; cross-check it by asserting every old `9.7.*` entry
+   maps to an identically titled new entry. Never trust title matching
+   alone (duplicate titles such as "mov" x2 or "Async Proxy" x2 collide) and
+   never shift chapters only — a chapter-only shift was the exact mistake
+   made the first time this table changed versions.
+3. **Retarget the citations.** Update the module docstring's version
+   statement and URL, then run the renumbering over `table.py`,
+   `engine.py`, `render.py`, `tests/python/tirx/codegen/test_ptx_*.py` and
+   `test_codegen_cuda.py`, skipping any block that already carries the new
+   numbering (`_PTX_94_ENTRIES` was such a block for 9.3→9.4). Hand-fix the
+   forms a regex cannot: ranges that span an insertion (`9.7.x.a-b`), brace
+   groups (`9.7.4.{1,2,3}`), sibling shorthand (`.12`, `/ .17`), global
+   `Table NN` numbers, and `:line` offsets (re-derive against the new
+   section text from the quoted sentence, or drop the offset and keep the
+   quote). Then regenerate the stub (§3).
+4. **Register the newly legal forms.** Read the new version's release notes
+   (ISA chapter 13.1) and the per-section "introduced in PTX ISA version
+   X.Y" notes; each one: read the section, apply §2, then §3 including full
+   certification at the right `cert_arch`. Keep the new version's additions
+   grouped (the `_PTX_94_ENTRIES` list is the 9.4 group).
+5. **Re-measure every `MEASURED` clause on the new toolkit** and reword it
+   to name that toolkit. Registered forms are re-proven by full
+   certification; excluded forms need a targeted probe each (raw PTX through
+   `ptxas -arch=<a>` for grammar claims, an exact force-inlined kernel
+   through `nvcc` for crash claims — `test_ptx_dialect._certification_kernel`
+   builds that shape). Quote the diagnostic the new ptxas actually prints;
+   texts change between releases. If a gap has closed, either widen the
+   domain with certification or say so in the clause — never leave a
+   sentence that attributes the restriction to a toolkit you no longer use.
+   ISA §9.4.1 Tables 27/28 are an upper bound and say so ("some combinations
+   may still be invalid for a particular instruction"); the `_cvt_dst_dtypes`
+   / `_cvt_src_dtypes` docstrings record the measured gaps.
+6. Regenerate the stub, update the variant/address counts the tests pin,
+   run the full suite, and run the §4 audit against the new document before
+   merging.
+
+Worked example, PTX ISA 9.3 → 9.4:
+
+- 9.4 inserted chapter `9.7.6 Alternate Floating-Point Instructions`, so
+  every `9.7.N` with N ≥ 6 became `9.7.(N+1)` (comparison `9.7.6→9.7.7`,
+  data movement `9.7.9→9.7.10`, fabric `9.7.10→9.7.11`, sync
+  `9.7.14→9.7.15`, mma `9.7.15→9.7.16`, wgmma `9.7.16→9.7.17`, tcgen05
+  `9.7.17→9.7.18`, misc `9.7.20→9.7.21`).
+- Inside data movement, `applypriority.async.bulk[.tensor]` were inserted as
+  `9.7.10.18/19`, so `9.7.9.18..27 → 9.7.10.20..29` (+2), and "Overriding
+  tensor property value" as `9.7.10.28.5.2`, so
+  `9.7.9.26.5.2..4 → 9.7.10.28.5.3..5`.
+- Inside tcgen05, "Decompression of input matrices" became `9.7.18.10.8`,
+  so `9.7.17.10.8.x → 9.7.18.10.9.x` and `9.7.17.10.9.x → 9.7.18.10.10.x`.
+- Global tables: tcgen05.ld/st register-count tables `52/53 → 59/61`,
+  tensormap `new_val` validity `33 → 36`; the relaxed-typing tables `27/28`
+  kept their numbers.
+- Two files still carried 9.2 numbering (`test_ptx_cvt.py`, `render.py`:
+  cvt as `9.7.9.21`, which in 9.3 is cvta) — check every file's baseline
+  before mapping it.
+- Toolchain facts that changed on 13.4: the `.L2::cache_hint` diagnostics
+  on `.shared`/`.local`/`.volatile`, the bare
+  `clusterlaunchcontrol.query_cancel` diagnostic, `multimem.st.async`
+  accepting 16/32-bit sources for its byte forms, and the bf16 atom
+  bit-bucket forms compiling again (still withheld pending certification).
+- 9.4-only sections worth registering later: `9.7.6.1-4` (alternate FP
+  x4 arithmetic, sm_100a/sm_103a), `9.7.10.28.1.3` (report mechanisms),
+  `9.7.18.10.7.2.6 / .3.6` (block16 K=128/256 scale layouts).

--- a/docs/tirx/api/ptx.rst
+++ b/docs/tirx/api/ptx.rst
@@ -36,7 +36,7 @@ tile-primitive dispatch.
 
 Supported instruction families
 ------------------------------
-The current instruction table has 318 entries across the following 94
+The current instruction table has 506 entries across the following 101
 families.  These are the Python attribute names written after ``Tx.ptx``; each
 family accepts only the modifier and operand combinations declared by its table
 entries.
@@ -57,6 +57,7 @@ entries.
    * ``bfind``
    * ``bmsk``
    * ``brev``
+   * ``clmad``
    * ``clusterlaunchcontrol``
    * ``clz``
    * ``cnot``
@@ -73,6 +74,7 @@ entries.
    * ``dp4a``
    * ``elect_sync``
    * ``ex2``
+   * ``fabric``
    * ``fence``
    * ``fma``
    * ``fns``
@@ -96,9 +98,12 @@ entries.
    * ``movmatrix``
    * ``mul``
    * ``mul24``
+   * ``multimem_cp``
    * ``multimem_ld_reduce``
    * ``multimem_red``
+   * ``multimem_red_async``
    * ``multimem_st``
+   * ``multimem_st_async``
    * ``neg``
    * ``not_``
    * ``or_``
@@ -123,6 +128,8 @@ entries.
    * ``shr``
    * ``sin``
    * ``slct``
+   * ``spcompress``
+   * ``spdecompress``
    * ``sqrt``
    * ``st``
    * ``st_async``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,7 +167,10 @@ addopts = "-v --tb=short"
 python_files = ["test_*.py", "*_test.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
-markers = ["gpu: Mark a test as requiring a GPU"]
+markers = [
+  "gpu: Mark a test as requiring a GPU",
+  "cuda_arch(*arches, device='cuda0'): Require one of the exact CUDA runtime architectures",
+]
 
 [tool.ruff]
 include = [

--- a/python/tvm/backend/cuda/codegen/header.py
+++ b/python/tvm/backend/cuda/codegen/header.py
@@ -779,7 +779,7 @@ union InstrDescriptorBlockScaled
              scale_format_  : 1,  // bit [23,24) : 0=E4M3, 1=E8M0
              m_dim_         : 5,  // bit [24,29) : 4 LSBs not included. Valid values are: 4 (M=64), 8 (M=128), 16 (M=256)
              a_sf_id_       : 2,  // bit [29,31) : Matrix A Scale Factor ID
-                            : 1;  //
+             k_dim_         : 1;  // bit [31,32): K-dim low bit (Table 53): 1 = dense K=96, .kind::mxf4/.kind::mxf4nvf4 only (sm_103a, sm_107a)
   };
 
   // Decay to a uint32_t

--- a/python/tvm/backend/cuda/cpp/descriptors.py
+++ b/python/tvm/backend/cuda/cpp/descriptors.py
@@ -266,7 +266,19 @@ def _check_tcgen05_mma_matrix_shape(kind, cta_group, m, n, k, is_sparse):
         raise ValueError(err)
     k_dense, k_sparse = k_pair
     expected_k = k_sparse if is_sparse else k_dense
-    if k != expected_k:
+    # PTX ISA 9.4, 9.7.18.2.1 (shape table) and 9.7.18.2.1.1: the two MXF4
+    # block-scaled kinds also take dense K=96 -- at cta_group::1 with M=128
+    # (128xNxK, K = 64 / 96) and at cta_group::2 with M=256 (256xNxK1,
+    # K1 = 96 / 128) -- and "K = 96 is only supported for sm_103a, sm_107a".
+    # Table 53 encodes K in two bits, bit 31 (low) and bit 3 (high): K=64 -> 0,
+    # K=96 -> 1, K=128 -> 2, so dense K=96 is bit 31 alone.
+    is_k96 = (
+        not is_sparse
+        and kind in {"mxf4", "mxf4nvf4"}
+        and (cta_group, m) in {(1, 128), (2, 256)}
+        and k == 96
+    )
+    if k != expected_k and not is_k96:
         raise ValueError(err)
 
     return True
@@ -390,7 +402,7 @@ device_intrinsic(
     "_cuda_tcgen05_encode_instr_descriptor_block_scaled_impl",
     helper_name="ptx_tcgen05_encode_instr_descriptor_block_scaled",
     c_signature=(
-        "(uint32_t* desc, int M, int N, int a_format, int b_format, int s_format, "
+        "(uint32_t* desc, int M, int N, int K, int a_format, int b_format, int s_format, "
         "bool trans_a, bool trans_b, bool neg_a, bool neg_b, bool is_sparse)"
     ),
     body=(
@@ -407,6 +419,7 @@ device_intrinsic(
         "  _desc.m_dim_ = (M >> 4);\n"
         "  _desc.n_dim_ = (N >> 3);\n"
         "\n"
+        "  _desc.k_dim_ = static_cast<uint8_t>(K == 96);\n"
         "  _desc.a_major_ = static_cast<uint8_t>(trans_a);\n"
         "  _desc.b_major_ = static_cast<uint8_t>(trans_b);\n"
         "\n"
@@ -504,7 +517,20 @@ def codegen_cuda_tcgen05_encode_instr_descriptor_block_scaled(
         raise ValueError(f"Invalid b_dtype for transpose: {b_dtype}")
 
     return CODEGEN_REGISTRY["tirx._cuda_tcgen05_encode_instr_descriptor_block_scaled_impl"](
-        [desc, M, N, a_format, b_format, s_format, trans_a, trans_b, neg_a, neg_b, is_sparse]
+        [
+            desc,
+            M,
+            N,
+            K,
+            a_format,
+            b_format,
+            s_format,
+            trans_a,
+            trans_b,
+            neg_a,
+            neg_b,
+            is_sparse,
+        ]
     )
 
 
@@ -746,6 +772,9 @@ def encode_instr_descriptor_block_scaled_uint32(
         M, N, a_format, b_format, trans_a, trans_b, neg_a, neg_b, is_sparse
     )
     desc |= (_INSTR_DESC_SF_FORMAT_MAP[sf_name] & 0x1) << 23
+    # Table 53 K-dimension low bit (bit 31): 1 selects dense K=96 for
+    # .kind::mxf4 / .kind::mxf4nvf4 (sm_103a, sm_107a).
+    desc |= (int(K) == 96) << 31
     # `a_sf_id_` / `b_sf_id_` stay 0, as the runtime encoder leaves them:
     # callers that cycle scale-factor ids patch those bits per MMA.
     return desc & 0xFFFFFFFF

--- a/python/tvm/backend/cuda/ptx/engine.py
+++ b/python/tvm/backend/cuda/ptx/engine.py
@@ -98,7 +98,7 @@ def register_table(table: dict[str, InstructionEntry]) -> None:
         #
         # Escaped, because "a user can type it" is the whole requirement and
         # three PTX mnemonics are Python keywords: `and`, `or` and `not` (ISA
-        # 9.7.8) print as `T.ptx.and_` and are read back by `unescape_token` in
+        # 9.7.9) print as `T.ptx.and_` and are read back by `unescape_token` in
         # `PTXNamespace.__getattr__`. The escape is the identity for every
         # other family, and `gen_stubs` already spells the attribute this way.
         family = escape_token(entry.family)
@@ -630,6 +630,7 @@ def _coerce_imm(entry, slot, value, mod_map):
 
 
 def _coerce_pred(entry, pred):
+    pred = getattr(pred, "scalar", pred)
     # A Python bool names no dtype but is unambiguous, so type it here rather
     # than making every call site spell `T.bool(True)`.
     if isinstance(pred, bool):
@@ -682,7 +683,7 @@ def _emit(entry, filled, operands, pred=None, preserve_dst=False):
                 )
             sunk.add(i + lane)
         if lanes and all(i + lane in sunk for lane in range(lanes)):
-            # ISA 9.7.9.4 states it for mov ("provided that at least one
+            # ISA 9.7.10.4 states it for mov ("provided that at least one
             # element is a scalar register"). This API is deliberately the
             # partial-lane sink facility; whole-operand bit buckets such as
             # atom's `_` keep their memory side effect and are registered as

--- a/python/tvm/backend/cuda/ptx/render.py
+++ b/python/tvm/backend/cuda/ptx/render.py
@@ -126,11 +126,11 @@ BRIDGE = {
     "pred": Bridge(
         ".pred", "ps{n}", "pd{n}", "setp.ne.b32 {reg}, %{idx}, 0;", "selp.b32 %{idx}, 1, 0, {reg};"
     ),
-    # `.e2m1x2`: the ISA types this operand .b8 (9.7.9.21:92 for the
+    # `.e2m1x2`: the ISA types this operand .b8 (9.7.10.24:92 for the
     # destination, :101 for the source). Its general prose says a wider
     # register may be used and names no exception for e2m1x2 (:476-486), but
     # the toolchain disagrees, so the width here is measured, not read:
-    # ptxas 13.2 at -arch=sm_100a answers "Arguments mismatch for instruction
+    # ptxas 13.4 at -arch=sm_100a answers "Arguments mismatch for instruction
     # 'cvt'" for BOTH carrier widths ("h" and "r") in BOTH directions, across
     # cvt.rn.satfinite.e2m1x2.{f32,f16x2,bf16x2} and
     # cvt.rn.{f16x2,bf16x2}.e2m1x2 -- ten probes, ten rejections.
@@ -144,10 +144,33 @@ BRIDGE = {
     "e2m1x2": Bridge(
         ".b8", "raw_{slot}", "raw_{slot}", "cvt.u8.u16 {reg}, %{idx};", "cvt.u16.u8 %{idx}, {reg};"
     ),
+    # PTX ISA 9.4 types cvt.scaled::n1::ue8m0's scale-factor as .b8.  Keep
+    # this scoped to that private table token: inline asm still has no byte
+    # constraint, and widening the instruction operand itself is rejected.
+    "cvt_scale_ue8m0": Bridge(
+        ".b8", "raw_{slot}", "raw_{slot}", "cvt.u8.u16 {reg}, %{idx};", "cvt.u16.u8 %{idx}, {reg};"
+    ),
+    # PTX ISA 9.4 permits tensorSizeToOverride elements in .b8 registers.
+    # Inline asm has no byte constraint, so stage the uint8 API carrier through
+    # the exact register class named by the instruction operand.
+    "tma_size_b8": Bridge(
+        ".b8",
+        "raw_{slot}_{n}",
+        "raw_{slot}_{n}",
+        "cvt.u8.u16 {reg}, %{idx};",
+        "cvt.u16.u8 %{idx}, {reg};",
+    ),
     # st.async.release's b8/u8/s8 sources share one private .b8 staging
-    # register.  Stores preserve the low eight bits; the instruction suffix
+    # register. Stores preserve the low eight bits; the instruction suffix
     # still supplies the public signed/unsigned interpretation.
     "st_async_b8reg": Bridge(
+        ".b8", "raw_{slot}", "raw_{slot}", "cvt.u8.u16 {reg}, %{idx};", "cvt.u16.u8 %{idx}, {reg};"
+    ),
+    # MEASURED on CUDA 13.4 / sm_103a: mbarrier's reportValue destination
+    # rejects .b16/.b32/.b64 registers and accepts an actual local .b8.  Use a
+    # family-private key so ordinary `.b8` operands keep their established
+    # carrier behavior.
+    "mbarrier_report_b8reg": Bridge(
         ".b8", "raw_{slot}", "raw_{slot}", "cvt.u8.u16 {reg}, %{idx};", "cvt.u16.u8 %{idx}, {reg};"
     ),
 }
@@ -233,8 +256,8 @@ def _helper_name(
         else [C_BINDING[dtype].suffix for dtype, _ in present]
     )
     return "tvm_builtin_ptx_" + "_".join([*isa_name, *discriminator]).replace("::", "__").replace(
-        ".", "_"
-    ).replace("-", "m")
+        ":", "_"
+    ).replace(".", "_").replace("-", "m")
 
 
 def render_variant(

--- a/python/tvm/backend/cuda/ptx/table.py
+++ b/python/tvm/backend/cuda/ptx/table.py
@@ -20,11 +20,14 @@ Pure data + pure functions: this module deliberately imports nothing from
 ``tvm`` so the thin generators (``gen_stubs``, ``gen_coverage``,
 ``gen_helpers``) can load it standalone.
 
-Section and table numbers cite PTX ISA 9.2:
-``https://docs.nvidia.com/cuda/archive/13.2.0/parallel-thread-execution/index.html``.
-That is the version accepted by CUDA 13.2 ptxas. PTX ISA 9.3 added or
-reorganized several sections, including Fabric Instructions, ``clmad``,
-``multimem.st.async``, and ``multimem.red.async``, so its numbering differs.
+Section and table numbers cite PTX ISA 9.4, the version implemented by the
+CUDA 13.4 ptxas this table is certified against:
+``https://docs.nvidia.com/cuda/developer-preview/13.4/parallel-thread-execution/index.html``.
+Every ``MEASURED`` note records CUDA 13.4 ptxas behaviour.  ``_PTX_94_ENTRIES``
+groups the instructions and qualifiers PTX ISA 9.4 introduced (the SM107
+family additions) ahead of the long-standing families in ``_ENTRIES``; it is a
+grouping by ISA release, not a second document version -- every entry cites
+the same document.
 
 The converged :class:`InstructionEntry` design:
 
@@ -84,7 +87,7 @@ PTX_TYPE_DTYPES = {
     # with the floating carrier removed. ISA 5.2 says a `.bN` operand accepts
     # any fundamental type of that width, and for most instructions it does --
     # but a handful refuse a float register in one position while taking both
-    # integer signednesses. Measured on ptxas 13.2, at sm_90 unless noted:
+    # integer signednesses. MEASURED on ptxas 13.4, at sm_90 unless noted:
     # bmsk (all three operands), redux.sync's bitwise line (both), match.sync
     # and elect.sync's destination, mbarrier's phase-state token, and
     # tensormap.replace's dimension fields (sm_90a) -- each answers
@@ -109,7 +112,7 @@ PTX_TYPE_DTYPES = {
     # in one 64-bit register. It names a packed layout whose container happens
     # to be .b64, not a bit container, so it is not widened.
     "f32x2": ("uint64",),
-    # cvt's narrow packed formats, per ISA 9.7.9.21's operand table. Each names
+    # cvt's narrow packed formats, per ISA 9.7.10.24's operand table. Each names
     # a lane layout, not a container: two (or four) sub-byte or 8-bit elements
     # ride one integer register, exactly as `.f16x2` does. The carrier width is
     # what the register must be, so it is the dtype the operand binds.
@@ -118,6 +121,8 @@ PTX_TYPE_DTYPES = {
     "e2m3x2": ("uint16",),
     "e3m2x2": ("uint16",),
     "ue8m0x2": ("uint16",),
+    # PTX ISA 9.4's unsigned E5M3 pair is packed in one .b16 register.
+    "ue5m3x2": ("uint16",),
     "s2f6x2": ("uint16",),
     "e2m1x4": ("uint16",),
     "e4m3x4": ("uint32",),
@@ -133,11 +138,24 @@ PTX_TYPE_DTYPES = {
     # is here so those entries can name it; the uint8 is the C-boundary
     # contract, not the register the instruction sees.
     "e2m1x2": ("uint8",),
+    # Private .b8 carrier for TMA attribute-override tensor sizes. PTX also
+    # permits a .b16 register; that legal carrier is represented by a sibling
+    # entry whose operand uses the ordinary b16 token.
+    "tma_size_b8": ("uint8",),
+    # Private carrier for cvt.scaled::n1::ue8m0's scale-factor. The ISA
+    # types that operand .b8; render.BRIDGE stages this uint8 C-boundary value
+    # through a block-local byte register. It is not a general .b8 carrier.
+    "cvt_scale_ue8m0": ("uint8",),
     # Private carrier for st.async.release's byte source.  Inline asm has no
     # 8-bit constraint, so render.BRIDGE stages the C-boundary value through a
     # local .b8 register.  The entry's dtypes callback preserves the public
     # b8/u8/s8 domains; this token never reaches the opcode or another family.
     "st_async_b8reg": ("uint8", "int8"),
+    # Private carrier for PTX 9.3 mbarrier reportValue.  The ISA requires an
+    # actual .b8 destination register, while inline asm's narrowest constraint
+    # binds a 16-bit register.  render.BRIDGE materializes the result through a
+    # block-local .b8 register and exposes an ordinary uint8 at the boundary.
+    "mbarrier_report_b8reg": ("uint8",),
     # Mixed-precision sources live in a plain 16-bit register -- the ISA's own
     # example declares them `.reg .b16`.
     "f16": ("uint16",),
@@ -164,8 +182,8 @@ PTX_TYPE_DTYPES = {
 
 
 def escape_token(token: str) -> str:
-    """PTX token -> Python attribute name (``::`` -> ``__``, keyword -> trailing ``_``)."""
-    token = token.replace("::", "__")
+    """PTX token -> reversible Python attribute name."""
+    token = token.replace("::", "__").replace(":", "__colon__")
     if keyword.iskeyword(token):
         token += "_"
     return token
@@ -173,7 +191,8 @@ def escape_token(token: str) -> str:
 
 def unescape_token(token: str) -> str:
     """Python attribute name -> PTX token. Inverse of :func:`escape_token`."""
-    token = token.replace("__", "::")
+    colon = "\0"
+    token = token.replace("__colon__", colon).replace("__", "::").replace(colon, ":")
     if token.endswith("_"):
         token = token[:-1]
     return token
@@ -247,7 +266,7 @@ class OperandSlot:
     operands the ISA types by formula rather than by a token in the
     instruction text: ``mul.wide``'s destination ("d is twice as wide as a and
     b", 9.7.1.3) and ``dp4a``'s accumulator ("c has type .u32 if both .atype
-    and .btype are .u32 else .s32", 9.7.1.23). Neither type is spellable as a
+    and .btype are .u32 else .s32", 9.7.1.24). Neither type is spellable as a
     slot reference, because neither is written in the instruction -- and a
     slot could not hold it either: every written token is rendered into the
     opcode, so a `.s64` slot would emit `mul.wide.s32.s64`.
@@ -318,7 +337,7 @@ class OperandSlot:
     # A pipe-joined operand pair: adjacent slots naming the same `pipe` render
     # as one PTX operand written `p|q`, each keeping its own C parameter,
     # constraint and bridge. Same idea as `bracket` above, different separator
-    # and a different reason: `setp.lt.and.s32 p|q, a, b, r;` (ISA 9.7.6.2)
+    # and a different reason: `setp.lt.and.s32 p|q, a, b, r;` (ISA 9.7.7.2)
     # writes two predicates, the second one from the *complement* of the
     # compare result, so `q` is a second destination and not a restatement of
     # `p`. The ISA writes the pair in one operand position, so the table does
@@ -332,7 +351,7 @@ class OperandSlot:
     #   rw="w"   the element is not written   (ld's `d`, mov's unpack `d`)
     #   rw="rw"  neither read nor written     (clusterlaunchcontrol's `.v4`,
     #            whose own example is `{xctaid, _, _, _}`)
-    #   rw="r"   the element is not stored    (st's `b`, ISA 9.7.9.11)
+    #   rw="r"   the element is not stored    (st's `b`, ISA 9.7.10.11)
     # So this is a per-slot fact read off the syntax line, never derived from
     # the direction.
     #
@@ -593,7 +612,7 @@ def sink_combos(entry: InstructionEntry, tokens) -> tuple[frozenset, ...]:
     """Every legal assignment of the sink symbol ``_`` to this entry's lanes.
 
     A sink is spelled per element, so the domain is the subsets of the
-    sinkable lanes -- minus the all-sunk one. ISA 9.7.9.4 states that
+    sinkable lanes -- minus the all-sunk one. ISA 9.7.10.4 states that
     exclusion for `mov` ("provided that at least one element is a scalar
     register"), and this per-lane facility keeps the same conservative rule
     for every register group. A whole-operand bit bucket can still have a side
@@ -707,16 +726,18 @@ def variants(entry: InstructionEntry) -> tuple:
 
 def _check_cache_hint(m):
     """`{.level::cache_hint}` and its `{, cache_policy}` operand, per ISA
-    9.7.9.8/9.7.9.9/9.7.9.11/9.7.13.5/9.7.13.6 and MEASURED on ptxas 13.2
+    9.7.10.8/9.7.10.9/9.7.10.11/9.7.15.5/9.7.15.6 and MEASURED on ptxas 13.4
     at -arch=sm_90.
 
     The qualifier is an L2 policy, so it is spelled only on lines that can
-    reach L2: `.global` or generic addressing. `.local`, `.shared` and the
-    `.volatile` line (whose ISA syntax carries no `{.level::cache_hint}` at
-    all) are each answered with "Modifier '.L2::cache_hint' cannot be used
-    with ...". `.mmio` is excluded by its own "no cache qualifiers" rule, which
-    had to grow to name this qualifier: ptxas answers "Modifier
-    '.L2::cache_hint' cannot be combined with modifier '.mmio'".
+    reach L2: `.global` or generic addressing. `.local` and `.shared` are
+    answered with "Modifier '.L2::cache_hint' cannot be applied to '.shared'
+    space for instruction 'ld'" (resp. '.local'), and the `.volatile` line
+    (whose ISA syntax carries no `{.level::cache_hint}` at all) with "Modifier
+    '.L2::cache_hint' cannot be combined with modifier '.volatile'". `.mmio`
+    is excluded by its own "no cache qualifiers" rule, which had to grow to
+    name this qualifier: ptxas answers "Modifier '.L2::cache_hint' cannot be
+    combined with modifier '.mmio'".
     Accepted alongside .cop, .nc, both eviction priorities, .level::prefetch_size
     and the .acquire/.relaxed scoped lines -- probed, all OK.
     """
@@ -730,7 +751,7 @@ def _check_cache_hint(m):
 
 
 def _check_ld(m):
-    """Scalar ld grammar per PTX ISA 9.7.9.8 (ld) and 9.7.9.9 (ld.global.nc)."""
+    """Scalar ld grammar per PTX ISA 9.7.10.8 (ld) and 9.7.10.9 (ld.global.nc)."""
     hint = _check_cache_hint(m)
     if hint:
         return hint
@@ -752,9 +773,9 @@ def _check_ld(m):
         return "only ld.relaxed/ld.acquire take a scope"
     if mmio:
         # "ld.mmio.sem.sys{.global}": "Only .sys thread scope is valid";
-        # global or generic addressing only. PTX ISA 9.2 spells only relaxed.
-        if sem != "relaxed":
-            return "ld.mmio requires .relaxed"
+        # global or generic addressing only. PTX ISA 9.3 adds .acquire.
+        if sem not in ("relaxed", "acquire"):
+            return "ld.mmio requires .relaxed or .acquire"
         if scope != "sys":
             return "only the sys scope is valid for ld.mmio"
         if ss not in ("", "global"):
@@ -796,8 +817,8 @@ def _check_ld(m):
 
 
 # The vector entries declare no `mmio` slot -- it is the one qualifier with no
-# `{.vec}` position, since PTX ISA 9.7.9.8 spells it
-# `ld.mmio.sem.sys{.global}.type  d, [a];` and 9.7.9.11 spells it
+# `{.vec}` position, since PTX ISA 9.7.10.8 spells it
+# `ld.mmio.sem.sys{.global}.type  d, [a];` and 9.7.10.11 spells it
 # `st.mmio.sem.sys{.global}.type         [a], b;`, neither carrying a `{.vec}`.
 # `.l2ev` is declared only by the 256-bit entries. Both are read with a default
 # in the scalar checks, so a vector modifier map goes straight in.
@@ -818,7 +839,7 @@ def _check_st_vec(m):
 def _sink256(m):
     """Whether the 256-bit lines admit `_` under these modifiers.
 
-    ISA 9.7.9.8/9.7.9.11, verbatim: "sink symbol '_' can be used in vector
+    ISA 9.7.10.8/9.7.10.11, verbatim: "sink symbol '_' can be used in vector
     expression d when: .vec is .v8 and .type is .b32 or .s32 or .u32 or .f32
     OR .vec is .v4 and .type is .b64 or .s64 or .u64 or .f64" (and the same
     sentence for `b` on st). It is the same pairing that gates
@@ -826,7 +847,7 @@ def _sink256(m):
     properties of the 32-byte access, not of the qualifier.
 
     ptxas is looser than this: it also takes `_` on `.v4` with a 32-bit type
-    (measured, CUDA 13.2 at sm_100). The ISA is the law here -- toolchain
+    (MEASURED on CUDA 13.4 at sm_100). The ISA is the law here -- toolchain
     evidence narrows what the ISA permits, it never widens it -- so that
     spelling stays out.
     """
@@ -838,7 +859,7 @@ def _sink256(m):
 def _check_ld_vec256(m):
     """The 256-bit ld lines -- the only ld entry with a `.level2::eviction_priority`.
 
-    PTX ISA 9.7.9.8 spells the L2 priority only where the L1 priority already
+    PTX ISA 9.7.10.8 spells the L2 priority only where the L1 priority already
     is, and on no line that carries `.cop` or `.volatile`. The three lines that
     settle it, wrapped here but otherwise verbatim:
 
@@ -854,7 +875,7 @@ def _check_ld_vec256(m):
     with "The .weak, .volatile, .relaxed and .acquire qualifiers are mutually
     exclusive", so the third line is the only one `.volatile` can be on.
 
-    9.7.9.9 splits `ld.global.nc` the same way -- `ld.global{.cop}.nc{...}`
+    9.7.10.9 splits `ld.global.nc` the same way -- `ld.global{.cop}.nc{...}`
     against `ld.global.nc{.level1::eviction_priority}{.level2::eviction_priority}`
     -- so `.nc` with an L2 priority is on a syntax line while `.nc` with a
     `.cop` and one is not. The two priorities are grammatically joined: every
@@ -872,7 +893,7 @@ def _check_ld_vec256(m):
 def _check_st_vec256(m):
     """The 256-bit st lines -- the only st entry with a `.level2::eviction_priority`.
 
-    Same structure as `_check_ld_vec256`, from PTX ISA 9.7.9.11: the L2
+    Same structure as `_check_ld_vec256`, from PTX ISA 9.7.10.11: the L2
     priority shares its lines with the L1 one and appears on neither the `.cop`
     line nor the `.volatile` line, which spells no cache qualifier at all.
 
@@ -899,7 +920,7 @@ def _check_st_vec256(m):
 
 
 def _check_st(m):
-    """Scalar st grammar per PTX ISA 9.7.9.11 (the mirror of _check_ld)."""
+    """Scalar st grammar per PTX ISA 9.7.10.11 (the mirror of _check_ld)."""
     hint = _check_cache_hint(m)
     if hint:
         return hint
@@ -915,9 +936,9 @@ def _check_st(m):
         return "only st.relaxed/st.release take a scope"
     if mmio:
         # "st.mmio.sem.sys{.global}": "Only .sys thread scope is valid for the
-        # st.mmio operation." PTX ISA 9.2 spells only relaxed.
-        if sem != "relaxed":
-            return "st.mmio requires .relaxed"
+        # st.mmio operation." PTX ISA 9.3 adds .release.
+        if sem not in ("relaxed", "release"):
+            return "st.mmio requires .relaxed or .release"
         if scope != "sys":
             return "only the sys scope is valid for st.mmio"
         if ss not in ("", "global"):
@@ -1003,7 +1024,7 @@ def _check_div_f(m):
 
 
 # The .type line shared by most of PTX ISA 9.7.1: mul/mad (9.7.1.3/4), sad
-# (9.7.1.7), div (9.7.1.8) and rem (9.7.1.9) all spell exactly this set.
+# (9.7.1.8), div (9.7.1.9) and rem (9.7.1.10) all spell exactly this set.
 _INT_TYPES = ("u16", "u32", "u64", "s16", "s32", "s64")
 
 # `.wide`'s result type (ISA 9.7.1.3: "If .wide is specified, then d is twice
@@ -1020,7 +1041,8 @@ def _wide_dtype(m):
 
 
 _RELAXED_MEM_DTYPES = {
-    # PTX ISA 9.4.1, Tables 27/28.  `ld`, `st`, and `ldu` accept wider data
+    # ISA section 9.4.1 (Operand Size Exceeding Instruction-Type Size), Tables
+    # 27/28.  `ld`, `st`, and `ldu` accept wider data
     # registers.  Bit-size instructions accept any fundamental register class;
     # integer instructions accept bit/integer classes; floating instructions
     # accept their native class or a bit carrier.  Canonical dtypes stay first
@@ -1126,10 +1148,11 @@ def _relaxed_mem_dtypes(m):
 
 
 def _st_vec_dtypes(m):
-    """Relaxed carriers accepted by CUDA 13.2 for the <=128-bit vector ``st`` lines."""
+    """Relaxed carriers accepted by CUDA 13.4 ptxas for the <=128-bit vector ``st`` lines."""
     dtypes = _RELAXED_MEM_DTYPES[m["type"]]
-    # PTX ISA 9.2 section 9.4.1 permits a wider bit register, but CUDA 13.2
-    # ptxas reports C7907 for an otherwise minimal `st.v2.f64` whose source
+    # ISA section 9.4.1 permits a wider bit register, but CUDA 13.4 ptxas
+    # reports "(C7907) Internal compiler error" for an otherwise minimal
+    # `st.v2.f64` whose source
     # lanes use 128-bit carriers.  The same carriers assemble for scalar st,
     # ld/ldu and their <=128-bit vector forms, so keep the toolchain exception
     # local to this one source-operand shape.
@@ -1139,7 +1162,7 @@ def _st_vec_dtypes(m):
 
 
 def _dp_acc_dtype(m):
-    """dp4a/dp2a's accumulator type (ISA 9.7.1.23/9.7.1.24).
+    """dp4a/dp2a's accumulator type (ISA 9.7.1.24/9.7.1.25).
 
     "Operand c has type .u32 if both .atype and .btype are .u32 else operand c
     has type .s32" -- and d accumulates into the same type. It is a function of
@@ -1188,7 +1211,7 @@ def _check_int_mad(m):
     """`.sat` on the multiply-add lines: `.hi` mode, `.s32` type, nothing else.
 
     Both lines spell it as a syntax line of its own -- `mad.hi.sat.s32 d, a, b,
-    c;` (ISA 9.7.1.4) and `mad24.hi.sat.s32 d, a, b, c;` (9.7.1.6) -- with the
+    c;` (ISA 9.7.1.4) and `mad24.hi.sat.s32 d, a, b, c;` (9.7.1.7) -- with the
     Notes repeating "Applies only to .s32 type in .hi mode".
     """
     if m["sat"] and (m["mode"], m["type"]) != ("hi", "s32"):
@@ -1196,7 +1219,7 @@ def _check_int_mad(m):
     return None
 
 
-# The .type tokens of the integer min/max lines (PTX ISA 9.7.1.12/9.7.1.13).
+# The .type tokens of the integer min/max lines (PTX ISA 9.7.1.13/9.7.1.14).
 # `.relu` is only on the signed line (type2); the unsigned/other line takes none.
 # NOT REGISTERED: `.u8x4` and `{.relu}.s8x4`, which the ISA supports only on
 # "sm_120f or higher in the same family" -- outside the architectures this
@@ -1211,8 +1234,8 @@ def _check_mbarrier_sem_scope(m):
     """`.sem` and `.scope` are one qualifier pair: both or neither.
 
     Stated in so many words by every mbarrier section that has the pair --
-    "Qualifiers .sem and .scope must be specified together." (ISA 9.7.13.15.11
-    expect_tx, .12 complete_tx, .13 arrive, .14 arrive_drop, .16 test_wait /
+    "Qualifiers .sem and .scope must be specified together." (ISA 9.7.15.16.14
+    expect_tx, .15 complete_tx, .16 arrive, .17 arrive_drop, .19 test_wait /
     try_wait). The rule is what the sections say, not how they spell it: some
     lines write the pair as one `{.sem.scope}` group and others as two
     `{.sem}{.scope}` groups, and `mbarrier.arrive.noComplete` fixes it to
@@ -1227,7 +1250,7 @@ def _check_fence_proxy(m):
     """`.proxykind = { .alias, .async, .async.global, .async.shared::{cta,cluster} }`.
 
     Modelled as proxykind + an optional space so the surface can walk it one
-    attribute at a time; only `.async` carries a state space (ISA 9.7.13.4).
+    attribute at a time; only `.async` carries a state space (ISA 9.7.15.4).
     """
     if m["space"] and m["proxykind"] != "async":
         return f"fence.proxy.{m['proxykind']} takes no state space"
@@ -1259,23 +1282,101 @@ _CP_REDUCE_BULK_TYPES = {
 
 
 def _check_cp_reduce_async_bulk(m):
-    """Exact redOp/type grid of non-tensor cp.reduce.async.bulk (ISA 9.7.9.25.4.2)."""
+    """Exact redOp/type grid of non-tensor cp.reduce.async.bulk (ISA 9.7.10.28.4.2).
+
+    This is the pre-9.4 grid: `.noftz` is required on `.add.f16`/`.add.bf16`
+    into .global and legal nowhere else.  PTX ISA 9.4's `.add.noftz.f32` line
+    (requires sm_90) is owned by the `*_f32_noftz` siblings in
+    `_PTX_94_ENTRIES`, so these entries keep their pre-9.4 grid and floor.
+    """
     dst, op, ty = m["dst"], m["redop"], m["type"]
     if ty not in _CP_REDUCE_BULK_TYPES[dst][op]:
         allowed = " / ".join("." + item for item in _CP_REDUCE_BULK_TYPES[dst][op])
         return f".{op} to .{dst} takes {allowed}"
+    noftz = bool(m.get("noftz", ""))
     needs_noftz = dst == "global" and op == "add" and ty in ("f16", "bf16")
-    if bool(m.get("noftz", "")) != needs_noftz:
-        if needs_noftz:
-            return f"cp.reduce.async.bulk.add.{ty} requires .noftz"
-        return ".noftz applies only to .add.f16 and .add.bf16 into .global"
+    if needs_noftz and not noftz:
+        return f"cp.reduce.async.bulk.add.{ty} requires .noftz"
+    if noftz and not needs_noftz:
+        return (
+            ".noftz applies only to .add.f16/.bf16 into .global here "
+            "(.add.noftz.f32 is the PTX 9.4 sibling entry)"
+        )
     return None
+
+
+_FABRIC_RED_TYPES = {
+    "and": ("b32", "b64"),
+    "or": ("b32", "b64"),
+    "xor": ("b32", "b64"),
+    "min": ("u32", "s32", "u64", "s64", "f16", "bf16"),
+    "max": ("u32", "s32", "u64", "s64", "f16", "bf16"),
+    "add": ("u32", "u64", "f16", "bf16", "f32", "f64"),
+}
+
+
+def _check_fabric_red(m):
+    """Exact fabric.try_red reduction/type grid (PTX ISA 9.3, 9.7.11.5.3)."""
+    op, ty = m["redop"], m["type"]
+    if ty not in _FABRIC_RED_TYPES[op]:
+        allowed = " / ".join("." + item for item in _FABRIC_RED_TYPES[op])
+        return f".{op} fabric reduction takes {allowed}"
+    return None
+
+
+# PTX ISA 9.4 (9.7.11, fabric.try_pullred) lists the extra pull-reduction
+# forms -- `.add.acc::f16`/`.add.acc::f32` and `.min`/`.max` on e4m3/e5m2 --
+# under sm_120a/sm_121a and the sm_100f/sm_110f families.  MEASURED on CUDA
+# 13.4: ptxas also assembles them at .target sm_103a.  NOT REGISTERED all the
+# same: no call site uses them, and the `.acc::f16`/`.acc::f32` spellings put
+# a second qualifier inside the redOp token, which this grid's single `redop`
+# slot does not model.  The grid below is the ISA's base syntax lines.
+_FABRIC_PULLRED_TYPES = {
+    "and": ("b32", "b64"),
+    "or": ("b32", "b64"),
+    "xor": ("b32", "b64"),
+    "min": ("u32", "s32", "u64", "s64", "f16", "bf16"),
+    "max": ("u32", "s32", "u64", "s64", "f16", "bf16"),
+    "add": ("u32", "u64", "f16", "bf16", "f32"),
+}
+
+
+def _check_fabric_pullred(m):
+    """The fabric.try_pullred reduction/type grid registered here (ISA 9.7.11 base lines)."""
+    op, ty = m["redop"], m["type"]
+    if ty not in _FABRIC_PULLRED_TYPES[op]:
+        allowed = " / ".join("." + item for item in _FABRIC_PULLRED_TYPES[op])
+        return f".{op} pull-reduction takes {allowed}"
+    return None
+
+
+def _check_cp_async_bulk_sem(m):
+    """PTX 9.3 strong bulk-copy qualifiers are one complete syntax line.
+
+    The legacy/default and explicit ``.weak`` spellings carry neither scope
+    nor type.  ``.relaxed`` requires both ``.scope`` and the fixed ``.b128``
+    suffix (ISA 9.7.10.28.4.1).
+    """
+    sem, scope, ty = m.get("sem", ""), m.get("scope", ""), m.get("type", "")
+    if sem == "relaxed":
+        if not scope or ty != "b128":
+            return ".relaxed bulk-copy requires both .scope and .b128"
+        return None
+    if scope or ty:
+        return ".scope/.b128 belong only to the .relaxed bulk-copy line"
+    return None
+
+
+def _check_cp_reduce_async_bulk_93(m):
+    """Reduction grid plus PTX 9.3's optional paired ``.relaxed.scope``."""
+    error = _check_mbarrier_sem_scope(m)
+    return error or _check_cp_reduce_async_bulk(m)
 
 
 def _check_minmax(m):
     """Which qualifiers each min/max syntax line allows.
 
-    Integer lines (9.7.1.12/13):  op.type1 d,a,b   |  op{.relu}.type2 d,a,b
+    Integer lines (9.7.1.13/14):  op.type1 d,a,b   |  op{.relu}.type2 d,a,b
     Floating lines (9.7.3.11/12): op{.ftz}{.NaN}{.xorsign.abs}.f32 d,a,b
                                   op.f64 d,a,b
     Half lines (9.7.4.7/8):       op{.ftz}{.NaN}{.xorsign.abs}.f16{x2} d,a,b
@@ -1398,7 +1499,7 @@ def _check_half_ex2(m):
     return None
 
 
-# The comparison operators of set/setp (PTX ISA 9.7.6.1/9.7.6.2), grouped the
+# The comparison operators of set/setp (PTX ISA 9.7.7.1/9.7.7.2), grouped the
 # way the Integer Notes and Floating Point Notes group them.
 _CMP_ORDERED_OPS = ("eq", "ne", "lt", "le", "gt", "ge")
 # "For unsigned values, the comparison operators lo, ls, hi, and hs ... may be
@@ -1414,7 +1515,7 @@ _CMP_TYPES = ("b16", "b32", "b64", "u16", "u32", "u64", "s16", "s32", "s64", "f3
 
 
 def _check_cmp(m):
-    """Which comparison operators each source type accepts (ISA 9.7.6.1/9.7.6.2).
+    """Which comparison operators each source type accepts (ISA 9.7.7.1/9.7.7.2).
 
     The `.CmpOp` line in the Syntax block is the union over all types; the
     per-type rule is in the Notes, and it is three disjoint sets:
@@ -1451,12 +1552,12 @@ def _check_cmp(m):
     return None
 
 
-# The `.CmpOp` line of the half-precision comparisons (PTX ISA 9.7.7): the
+# The `.CmpOp` line of the half-precision comparisons (PTX ISA 9.7.8): the
 # ordered six and the unordered six plus num/nan. The unsigned alternates
-# lo/ls/hi/hs of 9.7.6 are absent from this section's line entirely.
+# lo/ls/hi/hs of 9.7.7 are absent from this section's line entirely.
 #
 # MEASURED, NOT REGISTERED: ptxas does accept them on an integer source with a
-# half destination (`set.lo.f16.u32` assembles at sm_90), but no 9.7.7 syntax
+# half destination (`set.lo.f16.u32` assembles at sm_90), but no 9.7.8 syntax
 # line spells them, so they stay out -- the table follows the ISA where ptxas
 # is the more permissive of the two.
 _HALF_CMP_OPS = (*_CMP_ORDERED_OPS, *_CMP_UNORDERED_OPS)
@@ -1466,24 +1567,24 @@ _HALF_CMP_OPS = (*_CMP_ORDERED_OPS, *_CMP_UNORDERED_OPS)
 _SET_HALF_STYPES = (
     "b16", "b32", "b64", "u16", "u32", "u64", "s16", "s32", "s64", "f16", "f32", "f64",
 )  # fmt: skip
-# The packed half types, which 9.7.7 treats as one pair of lanes per register.
+# The packed half types, which 9.7.8 treats as one pair of lanes per register.
 _HALF_X2 = ("f16x2", "bf16x2")
 # The bit-size widths the logic and shift instructions operate on (PTX ISA
-# 9.7.8): "fundamentally untyped ... provided the operands are of the same
+# 9.7.9): "fundamentally untyped ... provided the operands are of the same
 # size". `_LOGIC_TYPES` adds the predicate line that and/or/xor/not also carry.
 _BIT_TYPES = ("b16", "b32", "b64")
 _LOGIC_TYPES = ("pred", *_BIT_TYPES)
-# scalar mov's type line (PTX ISA 9.7.9.3): "Although only predicate and
+# scalar mov's type line (PTX ISA 9.7.10.3): "Although only predicate and
 # bit-size types are required, we include the arithmetic types for the
 # programmer's convenience".
 _MOV_TYPES = ("pred", "b16", "b32", "b64", "u16", "u32", "u64", "s16", "s32", "s64", "f32", "f64")
-# The state spaces cvta converts between and isspacep queries (ISA 9.7.9.20,
-# 9.7.9.19) -- the same eight, spelled the same way, in both instructions.
+# The state spaces cvta converts between and isspacep queries (ISA 9.7.10.23,
+# 9.7.10.22) -- the same eight, spelled the same way, in both instructions.
 _CVTA_SPACES = (
     "const", "global", "local", "shared", "shared::cta", "shared::cluster", "param", "param::entry",
 )  # fmt: skip
 # The source types `set` will take `.ftz` with. MEASURED: the ISA writes
-# `{.ftz}` across the whole `set.CmpOp{.ftz}.f16.stype` line, but ptxas 13.2
+# `{.ftz}` across the whole `set.CmpOp{.ftz}.f16.stype` line, but ptxas 13.4
 # answers "Illegal modifier '.ftz' for instruction 'set'" for every source
 # outside this set -- probed over all 8 destination x 15 source pairs at
 # sm_90. The rule that survives the probe is the one the modifier means:
@@ -1493,7 +1594,7 @@ _FTZ_SET_STYPES = ("f16", "f32", "f16x2")
 
 
 def _check_half_set(m):
-    """The six syntax-line groups of the half-precision `set` (ISA 9.7.7.1).
+    """The six syntax-line groups of the half-precision `set` (ISA 9.7.8.1).
 
         set.CmpOp{.ftz}.f16.stype     / set.CmpOp.bf16.stype      .stype = the 12 above
         set.CmpOp{.ftz}.dtype.f16     / set.CmpOp.dtype.bf16      .dtype = {u16,s16,u32,s32}
@@ -1507,7 +1608,7 @@ def _check_half_set(m):
       on exactly one side of every line. The integer destinations reach only
       half sources, and the packed destinations only their own packed source.
       The wide integer cells this leaves out -- (u32, b32) and friends -- are
-      not lost: they are the 9.7.6 `set` lines, which own that dtype already.
+      not lost: they are the 9.7.7 `set` lines, which own that dtype already.
     - `.ftz` follows the *source* precision, not the line it is written on:
       only a `.f16`/`.f32`/`.f16x2` source has subnormals to flush at this
       width, and no bf16 destination takes the modifier at all. See
@@ -1527,7 +1628,7 @@ def _check_half_set(m):
         or (dt == "bf16x2" and st == "bf16x2")
     )
     if not paired:
-        return f"no half-precision syntax line pairs .{dt} with .{st} (ISA 9.7.7.1)"
+        return f"no half-precision syntax line pairs .{dt} with .{st} (ISA 9.7.8.1)"
     if m["ftz"]:
         if dt.startswith("bf16"):
             return f"a .{dt} destination takes no .ftz"
@@ -1543,7 +1644,7 @@ def _check_half_set(m):
 
 
 def _check_half_setp(m):
-    """`.ftz` on the half-precision `setp` lines (ISA 9.7.7.2).
+    """`.ftz` on the half-precision `setp` lines (ISA 9.7.8.2).
 
     Spelled on `.f16`/`.f16x2`, on neither bf16 line -- the same split the half
     arithmetic lines make. The other half of this section's shape, single
@@ -1555,18 +1656,20 @@ def _check_half_setp(m):
     return None
 
 
-# --- PTX ISA 9.7.9.12 (st.async) and 9.7.9.14 (multimem) --------------------
+# --- PTX ISA 9.7.10.12 (st.async) and 9.7.10.15 (multimem) --------------------
 # The vector lines of st.async: "`.v2` is supported with .b32, .b64, .s32,
 # .s64, .u32, .u64, .f32 and .f64 types. `.v4` qualifier is supported with
 # .b32, .s32, .u32 and .f32 types."
 _ST_ASYNC_TYPES = ("b32", "b64", "b128", "u32", "u64", "s32", "s64", "f32", "f64")
 _ST_ASYNC_V2 = ("b32", "b64", "u32", "u64", "s32", "s64", "f32", "f64")
 _ST_ASYNC_V4 = ("b32", "u32", "s32", "f32")
-# The release line's complete type list (9.7.9.12, second syntax block), which
+# The release line's complete type list (9.7.10.12, second syntax block), which
 # reaches below the 32-bit floor of the mbarrier line.  The byte forms need an
 # exact local .b8 source register: inline asm has no 8-bit constraint,
 # and binding their C values directly through the usual 16-bit carrier makes
-# ptxas reject the instruction.  The private bridge is selected only here;
+# ptxas reject the instruction (MEASURED on CUDA 13.4 at sm_100: a .b16 source
+# is "Arguments mismatch for instruction 'st.async'"; a block-local .b8
+# assembles).  The private bridge is selected only here;
 # the separate dtypes callback retains each suffix's public type domain.
 _ST_ASYNC_REL_TYPES = (
     "b8", "b16", "b32", "b64", "u8", "u16", "u32", "u64",
@@ -1584,7 +1687,7 @@ def _st_async_rel_operand_dtypes(m):
     return PTX_TYPE_DTYPES[m["type"]]
 
 
-# createpolicy's `.level::primary_priority` line (ISA 9.7.9.18). Wider than
+# createpolicy's `.level::primary_priority` line (ISA 9.7.10.21). Wider than
 # the `_L2_EVICT` set the ld/st eviction hints use: this instruction is where
 # a priority is *created*, so it spells all four.
 _CACHE_PRIORITIES = (
@@ -1615,7 +1718,7 @@ _MM_VEC_TYPES = {
 
 
 def _check_multimem_sem(m):
-    """How `.sem` and `.scope` go together on every multimem line (ISA 9.7.9.14).
+    """How `.sem` and `.scope` go together on every multimem line (ISA 9.7.10.15).
 
     The ISA writes two syntax lines for `multimem.ld_reduce` and `multimem.st`:
     `{.sem}{.scope}` and a `.weak` line with no scope position. `multimem.red`
@@ -1632,7 +1735,7 @@ def _check_multimem_sem(m):
 
 
 def _check_multimem_int(m):
-    """op x type on the integer multimem lines (ISA 9.7.9.14).
+    """op x type on the integer multimem lines (ISA 9.7.10.15).
 
     The `.type` line in the Syntax block is the union over ops; the pairing is
     the "valid combinations of .op and base type" table, and `.add` is the row
@@ -1688,7 +1791,7 @@ def _check_multimem_f(m):
 
 
 def _check_st_async(m):
-    """st.async's mbarrier line (ISA 9.7.9.12), whose `.vec` narrows the types.
+    """st.async's mbarrier line (ISA 9.7.10.12), whose `.vec` narrows the types.
 
     `.v4` is the 32-bit four and `.v2` everything but `.b128`, which the ISA
     gives no vector form at all.
@@ -1702,18 +1805,28 @@ def _check_st_async(m):
 
 def _check_st_async_rel(m):
     """st.async's release line: "If .mmio is specified, .scope must be .sys"
-    (ISA 9.7.9.12), which ptxas enforces as an illegal-modifier error."""
+    (ISA 9.7.10.12), which ptxas enforces as an illegal-modifier error."""
     if m["mmio"] and m["scope"] != "sys":
         return ".mmio requires .sys scope"
     return None
 
 
-# --- PTX ISA 9.7.13 warp-level and async reductions -------------------------
-# red.async's four mbarrier lines (9.7.13.7), one op group each.
+def _multimem_async_operand_type(m):
+    """Use the measured byte-register bridge for 8-bit async stores."""
+    return "st_async_b8reg" if m["type"] in ("b8", "u8", "s8") else m["type"]
+
+
+def _multimem_async_operand_dtypes(m):
+    """Keep the public dtype domain named by the multimem async suffix."""
+    return PTX_TYPE_DTYPES[m["type"]]
+
+
+# --- PTX ISA 9.7.15 warp-level and async reductions -------------------------
+# red.async's four mbarrier lines (9.7.15.7), one op group each.
 _RED_ASYNC_OPS = {"inc": ("u32",), "dec": ("u32",), "min": ("u32", "s32"),
                   "max": ("u32", "s32"), "and": ("b32",), "or": ("b32",), "xor": ("b32",),
                   "add": ("u32", "s32", "u64")}  # fmt: skip
-# atom/red's three vector lines (9.7.13.5 / 9.7.13.6): `.f32`, a half-word,
+# atom/red's three vector lines (9.7.15.5 / 9.7.15.6): `.f32`, a half-word,
 # and a packed pair. The latter two share one table entry per mnemonic; a half
 # element rides `.v2`/`.v4`/`.v8`, while a packed pair stops at `.v4`.
 # `.f32` has only the `.add` line. Every cell probed.
@@ -1721,7 +1834,7 @@ _ATOM_VEC_HALF = ("f16", "bf16")
 
 
 def _check_red_async(m):
-    """op x type on red.async's mbarrier lines (ISA 9.7.13.7).
+    """op x type on red.async's mbarrier lines (ISA 9.7.15.7).
 
     The ISA writes one syntax line per op group rather than a table, so the
     grid is read off those four lines: increment/decrement on the unsigned
@@ -1735,7 +1848,7 @@ def _check_red_async(m):
 
 
 def _check_atomic_vec(m):
-    """`.vec` x type on atom/red's vector lines (ISA 9.7.13.5 / 9.7.13.6).
+    """`.vec` x type on atom/red's vector lines (ISA 9.7.15.5 / 9.7.15.6).
 
         atom{.sem}{.scope}{.global}.add{.cache}.vec_32_bit.f32               d, [a], b;
         atom{...}.op.noftz{.cache}.vec_16_bit.half_word_type                 d, [a], b;
@@ -1755,17 +1868,20 @@ def _check_atomic_vec(m):
 def _check_atom_bitbucket_bf16(m):
     """Withhold the documented bf16 atom bit-bucket forms from this backend.
 
-    PTX ISA 9.2 permits ``_`` as the destination of a simple ``atom``
-    reduction, including the scalar and vector bf16 lines.  CUDA 13.2 ptxas
-    does not compile those forms: an exact force-inlined kernel probe
-    containing ``atom...bf16 _`` terminates ptxas with a segmentation fault.
-    The corresponding returned-value bf16 form and f16 bit-bucket form both
-    compile, so this is deliberately limited to bf16/bf16x2 bit buckets.
+    The ISA permits ``_`` as the destination of a simple ``atom`` reduction,
+    including the scalar and vector bf16 lines.  They were withheld because an
+    earlier toolchain crashed on them (an exact force-inlined kernel probe
+    containing ``atom...bf16 _`` terminated ptxas with a segmentation fault).
+    MEASURED on CUDA 13.4: raw ptxas and the same force-inlined nvcc probe both
+    compile ``atom.global.add.noftz.bf16 _`` and
+    ``atom.global.add.noftz.v2.bf16x2 _``.  The forms stay withheld until they
+    are added with full certification (follow-up); the returned-value bf16
+    forms and the f16 bit buckets are registered.
     """
     if m["type"].startswith("bf16"):
         return (
-            "PTX ISA 9.2 supports a bf16 atom bit-bucket destination, but CUDA 13.2 "
-            "ptxas does not compile it"
+            "the ISA documents a bf16 atom bit-bucket destination, but this table "
+            "withholds it pending certification on CUDA 13.4"
         )
     return None
 
@@ -1779,7 +1895,7 @@ def _check_atom_vec_half_bitbucket(m):
 
 
 def _check_slct(m):
-    """slct's two lines (ISA 9.7.6.4), which differ only in the selector type.
+    """slct's two lines (ISA 9.7.7.4), which differ only in the selector type.
 
         slct.dtype.s32        d, a, b, c;
         slct{.ftz}.dtype.f32  d, a, b, c;
@@ -1796,7 +1912,8 @@ _SLCT_VALUE_DTYPES = {
     # d/a/b are bit values of the first instruction type's width, not numeric
     # operands of that type. Keep its native TVM dtype first so the canonical
     # helper names and signatures remain stable; the rest are the carrier
-    # classes accepted by ptxas 13.2 over the full independent d x a x b grid.
+    # classes accepted by ptxas 13.4 (re-certified) over the full independent
+    # d x a x b grid.
     "b16": ("uint16", "int16", "float16", "bfloat16"),
     "u16": ("uint16", "int16", "float16", "bfloat16"),
     "s16": ("int16", "uint16", "float16", "bfloat16"),
@@ -1853,7 +1970,7 @@ def _check_farith(m):
 
 
 def _check_prefetch(m):
-    """Each prefetch syntax line names exactly one target (PTX ISA 9.7.9.15).
+    """Each prefetch syntax line names exactly one target (PTX ISA 9.7.10.16).
 
     `.level::eviction_priority` stays bound to `.global` on purpose: its syntax
     line is `prefetch.global.level::eviction_priority`, with `.global` written
@@ -1886,7 +2003,7 @@ _ATOM_TYPES = ("b32", "b64", "u32", "u64", "s32", "s64", "f32", "f64")
 
 
 def _check_atomic(m):
-    """op x type pairings for atom/red (PTX ISA 9.7.13.5 / 9.7.13.6).
+    """op x type pairings for atom/red (PTX ISA 9.7.15.5 / 9.7.15.6).
 
     The op/type rules in those sections give the pairings cell by cell. The
     `.type = {...}` line in the Syntax block is only the union across ops,
@@ -1934,7 +2051,7 @@ _BITS64 = ("b64", "u64", "s64", "f64")
 
 
 def _vec_lanes(m):
-    # ISA 9.7.9.8/9.7.9.11: the destination/source is a brace-enclosed vector
+    # ISA 9.7.10.8/9.7.10.11: the destination/source is a brace-enclosed vector
     # of `.vec` registers.
     return int(m["vec"][1:])
 
@@ -1963,14 +2080,14 @@ _FRND = ("rn", "rz", "rm", "rp")  # .rnd on the floating-point arithmetic lines
 
 
 def _matrix_num_lanes(m):
-    # ISA 9.7.14.5.16 (stmatrix): "a brace-enclosed vector expression consisting
+    # ISA 9.7.16.5.16 (stmatrix): "a brace-enclosed vector expression consisting
     # of 1, 2, or 4 32-bit registers as per the value of .num" -- no shape term,
     # unlike ldmatrix's .m16n16 doubling.
     return int(m["num"][1:])
 
 
 def _ldmatrix_lanes(m):
-    # ISA 9.7.14.5.15: "a brace-enclosed vector expression consisting of 1, 2,
+    # ISA 9.7.16.5.15: "a brace-enclosed vector expression consisting of 1, 2,
     # or 4 32-bit registers as per the value of .num" -- and, for shape 16x16,
     # "two destination registers r0 and r1 of type .b32 must be specified" per
     # matrix, so .m16n16 doubles the count (ptxas: "Vector of size 2 is
@@ -1992,7 +2109,7 @@ def _check_ldmatrix_b8fmt(m):
 
 
 def _tcgen05_ldst_lanes(m):
-    # ISA 9.7.16.8.3 Table 49 / 9.7.16.8.4 Table 50: the register vector holds
+    # ISA 9.7.18.8.3 Table 59 / 9.7.18.8.4 Table 61: the register vector holds
     # `.num` x (rows x shape width / 1024b) registers -- 1 per `.num` for
     # .16x32bx2/.16x64b/.32x32b, 2 for .16x128b, and 4 for .16x256b -- capped
     # at 128.
@@ -2001,14 +2118,28 @@ def _tcgen05_ldst_lanes(m):
 
 
 def _check_tcgen05_ldst(m):
-    """The Table 49/50 rows marked NA -- the products that exceed 128 registers."""
+    """The Table 59/61 rows marked NA -- the products that exceed 128 registers."""
     if _tcgen05_ldst_lanes(m) > 128:
         return f"shape {m['shape']} caps .num where the vector would exceed 128 registers"
     return None
 
 
+def _check_tcgen05_ld_red(m):
+    """tcgen05.ld.red qualifier grid (PTX ISA 9.4, 9.7.18.8.3), MEASURED on CUDA 13.4.
+
+    ``.x1`` is rejected ("Illegal modifier '.x1'"; the ISA requires .num of at
+    least .x2), and ``.abs``/``.NaN`` belong to the ``.f32`` line only -- ptxas
+    answers "Illegal modifier '.abs'" on the integer lines in either position.
+    """
+    if m["num"] == "x1":
+        return "tcgen05.ld.red requires .num of .x2 or greater"
+    if m["type"] != "f32" and (m.get("abs", "") or m.get("nan", "")):
+        return ".abs and .NaN apply only to the .f32 reduction line"
+    return None
+
+
 def _check_tcgen05_cp(m):
-    """The shape <-> multicast pairings ISA 9.7.16.9.2 states, and the fmt pair.
+    """The shape <-> multicast pairings ISA 9.7.18.9.2 states, and the fmt pair.
 
     ".64x128b requires .warpx2::02_13 or .warpx2::01_23" and ".32x128b
     requires .warpx4"; the wider shapes copy to all warps and take no
@@ -2029,7 +2160,7 @@ def _check_tcgen05_cp(m):
     return None
 
 
-# mma fragment sizes, per the Matrix Fragments tables of ISA 9.7.14.5.1-13.
+# mma fragment sizes, per the Matrix Fragments tables of ISA 9.7.16.5.1-13.
 # Each is `rows * cols * bits / threads / 32`, the register count a thread holds
 # of an MxN (or MxK / KxN) tile -- the ISA states the tables, this states the
 # rule they follow. .m8n8k4 with .f16 multiplicands is the one shape a warp
@@ -2054,7 +2185,7 @@ def _mma_regs(dtype, rows, cols, threads, reg_bits=32):
 def _mma_threads(m):
     """Threads sharing one tile: 8 on the .f16 .m8n8k4 line, 32 everywhere else.
 
-    ISA 9.7.14.5.14: "A warp executing mma.sync.m8n8k4 instruction computes 4
+    ISA 9.7.16.5.14: "A warp executing mma.sync.m8n8k4 instruction computes 4
     matrix multiply and accumulate operations. Rest of the mma.sync operations
     compute a single matrix mutliply and accumulate operation per warp." Four
     operations to a warp is 8 threads each, so a thread's fragment of that line
@@ -2062,7 +2193,7 @@ def _mma_threads(m):
     (d=4, a=2, b=2 for .f16.f16.f16.f16; anything else is "Arguments mismatch").
 
     The division by 8 belongs to that line alone. The .f64 .m8n8k4 line has its
-    own fragment section, ISA 9.7.14.5.2, which opens "A warp executing
+    own fragment section, ISA 9.7.16.5.2, which opens "A warp executing
     mma.m8n8k4 with .f64 floating point type will compute an MMA operation of
     shape .m8n8k4" -- one operation, the whole warp -- and tabulates A and B as
     "A vector expression containing a single .f64 register" and C/D as "A
@@ -2101,7 +2232,7 @@ def _mma_lanes(which):
 def _mma_sp_lanes(which):
     """Like `_mma_lanes`, but A holds half of K -- the structured-sparse half.
 
-    ISA 9.7.14.6: "For an MxNxK sparse mma.sp{::ordered_metadata} operation,
+    ISA 9.7.16.6: "For an MxNxK sparse mma.sp{::ordered_metadata} operation,
     the MxK matrix A is packed into MxK/2 elements" -- 50% zeros per row at a
     shape- and kind-specific granularity: e2m1 is 2:4 in the
     f8f6f4/mxf8f6f4 lines and 4:8 only in mxf4/mxf4nvf4; the other forms have
@@ -2137,7 +2268,7 @@ _CVT_INT_BITS = {"u8": 8, "s8": 8, "u16": 16, "s16": 16, "u32": 32, "s32": 32, "
 _CVT_IRND = ("rni", "rzi", "rmi", "rpi")
 _CVT_FRND = ("rn", "rz", "rm", "rp")
 
-# The generic scalar cvt line follows ISA 9.4.1's relaxed type checking: an
+# The generic scalar cvt line follows ISA section 9.4.1's relaxed type checking: an
 # integer instruction type may use a same-width or wider integer/bit register,
 # while a floating instruction type may use its native register or a same-width
 # or wider bit register. These are the base TVM carrier spellings, canonical
@@ -2214,7 +2345,7 @@ _CVT_RELAXED_DTYPES = {
 
 # The same-width subset of each relaxed domain.  This is intentionally broader
 # than the canonical dtype: for example, a `.f16` operand may ride any 16-bit
-# register class.  CUDA 13.2 ptxas needs this subset for a few cvt-specific
+# register class.  CUDA 13.4 ptxas needs this subset for a few cvt-specific
 # gaps in the general relaxed type-checking rules, documented at the callbacks
 # below.  Packed/narrow cvt entries do not use this table.
 _CVT_SAME_WIDTH_DTYPES = {
@@ -2232,9 +2363,9 @@ _CVT_SAME_WIDTH_DTYPES = {
     "f64": ("float64", "uint64", "int64"),
 }
 
-# PTX ISA 9.2, 9.4.1 Table 27 and cvt's own notes permit a floating source
+# ISA section 9.4.1 Table 27 and cvt's own notes permit a floating source
 # operand to use a wider bit register, with the instruction consuming its low
-# bits.  CUDA 13.2 ptxas accepts `.version 9.2` and the exact-width form, but a
+# bits.  CUDA 13.4 ptxas accepts `.version 9.4` and the exact-width form, but a
 # direct probe such as
 #
 #   .reg .b16 d;
@@ -2255,11 +2386,13 @@ _CVT_FLOAT_SRC_DTYPES = {
 
 
 def _cvt_dst_dtypes(m):
-    """Destination carriers supported by CUDA 13.2 for scalar ``cvt``.
+    """Destination carriers supported by CUDA 13.4 ptxas for scalar ``cvt``.
 
-    PTX ISA 9.2 Tables 27/28 describe a relaxed upper bound, but also warn
-    that a particular instruction may reject combinations from that grid.
-    Exact force-inlined CUDA 13.2 probes expose three operand-local gaps:
+    ISA section 9.4.1 Tables 27/28 describe a relaxed upper bound, but also
+    warn that a particular instruction may reject combinations from that grid.
+    Exact force-inlined CUDA 13.4 probes expose three operand-local gaps (ptxas
+    names the rejected 64/128-bit destinations "Arguments mismatch for
+    instruction 'mov'"):
 
     - when the source instruction type is ``.bf16``, the destination carrier
       cannot be wider than its own instruction type;
@@ -2289,7 +2422,7 @@ def _cvt_src_dtypes(m):
     """Source carriers supported by ptxas for the generic scalar ``cvt`` line."""
     atype = m["atype"]
     dtypes = _CVT_FLOAT_SRC_DTYPES.get(atype, _CVT_RELAXED_DTYPES[atype])
-    # CUDA 13.2 rejects a wider carrier on the opposite operand whenever the
+    # CUDA 13.4 ptxas rejects a wider carrier on the opposite operand whenever the
     # destination instruction type is `.bf16`.  Same-width bit/integer carrier
     # spellings still assemble and remain exposed.
     if m["dtype"] == "bf16":
@@ -2301,7 +2434,7 @@ def _present_lanes(slot: str) -> LanesFn:
     """A bracketed-optional operand: one register when its qualifier is written.
 
     The ISA spells several of these `{, operand}` against a `{.qualifier}`, and
-    says so in the same words each time -- ISA 9.7.9.21:180-182 for cvt's
+    says so in the same words each time -- ISA 9.7.10.24:180-182 for cvt's
     scale-factor is typical: "Operand scale-factor and qualifier
     .scaled::n2::ue8m0 must be used together." `lanes=0` is what makes the
     operand vanish from the helper signature (see render.operand_layout), so
@@ -2311,21 +2444,28 @@ def _present_lanes(slot: str) -> LanesFn:
 
 
 # `{, scale-factor}` exists exactly when `.scaled::n2::ue8m0` is written. ISA
-# 9.7.9.21:180-182: "Optional qualifier .scaled::n2::ue8m0 specifies that the
+# 9.7.10.24:180-182: "Optional qualifier .scaled::n2::ue8m0 specifies that the
 # instruction uses packed scale-factor with 2 scale values of ue8m0 type.
 # Operand scale-factor and qualifier .scaled::n2::ue8m0 must be used together."
 _cvt_scale_lanes = _present_lanes("scaled")
 
 
+def _check_cvt_94_narrow(m):
+    """Keep only the PTX 9.4 additions to the pre-existing narrow cvt shapes."""
+    if m["rnd"] == "rn" and not m["pzo"] and not m["scaled"]:
+        return "the bare .rn spelling is owned by the pre-9.4 narrow cvt entry"
+    return None
+
+
 def _check_cvt_tf32(m):
-    """The two `.tf32` lines, ISA 9.7.9.21:18-19 --
+    """The two `.tf32` lines, ISA 9.7.10.24:18-19 --
 
         cvt.rna{.satfinite}.tf32.f32               d, a;
         cvt.frnd2{.satfinite}{.relu}.tf32.f32      d, a;
 
     One entry: same `d, a` shape, same types, and the only difference is which
     modifiers each spelling admits. `.rna` is written on the line that has no
-    `{.relu}`, so the two never meet. (ptxas 13.2 agrees -- it answers
+    `{.relu}`, so the two never meet. (ptxas 13.4 agrees -- it answers
     "Modifier '.relu' cannot be combined with modifier '.rna'" -- but the
     grammar above is the reason this is rejected.)
     """
@@ -2356,7 +2496,7 @@ def _cvt_int_covers(d: str, a: str) -> bool:
 
 
 def _check_cvt_same_type(t, rnd):
-    """The `.dtype == .atype` sub-grid of the generic scalar line, ISA 9.7.9.21.
+    """The `.dtype == .atype` sub-grid of the generic scalar line, ISA 9.7.10.24.
 
     A same-type cvt is a real instruction, not a move: an *integer* rounding
     mode may ride a float-to-float conversion here. The ISA licenses that for
@@ -2364,10 +2504,10 @@ def _check_cvt_same_type(t, rnd):
     six pairs, not four -- `.f16` and `.bf16` are both 16-bit. This toolchain
     assembles only the same-type four; see the third ptxas-only restriction in
     `_check_cvt_scalar`, which is where the cross-type pairs are ruled on. ISA
-    9.7.9.21:329-331 (Integer Notes): "Integer rounding is required for
+    9.7.10.24:329-331 (Integer Notes): "Integer rounding is required for
     float-to-integer conversions, and for same-size float-to-float conversions
     where the value is rounded to an integer. Integer rounding is illegal in
-    all other instances." And 9.7.9.21:424-426: "A floating-point value may be
+    all other instances." And 9.7.10.24:424-426: "A floating-point value may be
     rounded to an integral value using the integer rounding modifiers (see
     Integer Notes). The operands must be of the same size. The result is an
     integral value, stored in floating-point format." The section's Examples
@@ -2394,8 +2534,8 @@ def _check_cvt_same_type(t, rnd):
     -- and for `.bf16` it applies the ISA's destination-type exclusion.)
 
     Together with that tail this admits 53 of the 432 same-type spellings in this entry's slot grid,
-    which is exactly the set ptxas assembles (measured over the full grid, nvcc
-    13.2 -arch=sm_90; no spelling in either direction differs).
+    which is exactly the set ptxas assembles (MEASURED over the full 432-spelling
+    grid on ptxas 13.4 at sm_90; no spelling in either direction differs).
     """
     if rnd in _CVT_FRND:
         return f"{t} from {t} is exact, so a floating-point rounding mode is illegal"
@@ -2405,7 +2545,7 @@ def _check_cvt_same_type(t, rnd):
 
 
 def _check_cvt_frnd2_scalar(d, a, rnd, ftz, sat):
-    """The frnd2 *scalar* lines' sub-grid, ISA 9.7.9.21:10 and :14 --
+    """The frnd2 *scalar* lines' sub-grid, ISA 9.7.10.24:10 and :14 --
 
         cvt.frnd2{.relu}{.satfinite}.f16.f32       d, a;
         cvt.frnd2{.relu}{.satfinite}.bf16.f32      d, a;
@@ -2445,7 +2585,7 @@ def _check_cvt_frnd2_scalar(d, a, rnd, ftz, sat):
 
 
 def _check_cvt_scalar(m):
-    """The generic scalar line's rules, quoting ISA 9.7.9.21.
+    """The generic scalar line's rules, quoting ISA 9.7.10.24.
 
     Rounding: "Integer rounding is required for float-to-integer conversions,
     and for same-size float-to-float conversions where the value is rounded to
@@ -2473,7 +2613,7 @@ def _check_cvt_scalar(m):
     8-bit integer, takes no `.sat` when .bf16 is the source, and refuses an
     integer rounding mode on the two same-size cross-type float pairs -- `cvt.rni.bf16.f16`
     and `cvt.rni.f16.bf16` are "Illegal rounding modifier for instruction 'cvt'"
-    at ptxas 13.2 / sm_90 even though the Integer Notes clause quoted above
+    at ptxas 13.4 / sm_90 even though the Integer Notes clause quoted above
     requires integer rounding for exactly those conversions. The `.dtype !=
     .atype` branch below therefore rejects them, which is a toolchain verdict,
     not the ISA's.
@@ -2528,7 +2668,7 @@ def _check_cvt_scalar(m):
 
 # Which multiplicand-type *set* each mma / mma.sp syntax line draws BOTH of its
 # type positions from. A line never pairs a type from one set with a type from
-# another -- ISA 9.7.14.5.14 spells the integer lines as
+# another -- ISA 9.7.16.5.14 spells the integer lines as
 #
 #     mma.sync.aligned.shape.row.col{.satfinite}.s32.atype.btype.s32 d, a, b, c;
 #     .atype   = {.u8, .s8};
@@ -2546,7 +2686,7 @@ _MMA_INT_LINE = {"u8": "i8", "s8": "i8", "u4": "i4", "s4": "i4", "b1": "b1"}
 # The one floating-point line registered here that quantifies its two
 # multiplicand positions independently is
 # "mma.sync.aligned.shape.row.col.dtype.f8type.f8type.ctype", with
-# ".f8type = {.e4m3, .e5m2};" (ISA 9.7.14.5.14:23,28). The unregistered
+# ".f8type = {.e4m3, .e5m2};" (ISA 9.7.16.5.14:23,28). The unregistered
 # `.kind::f8f6f4` and `.block_scale` lines do the same over
 # `.f8f6f4type = {.e4m3, .e5m2, .e3m2, .e2m3, .e2m1}`. Every other fp line
 # registered here writes a literal token in both positions (.f16.f16,
@@ -2565,7 +2705,7 @@ def _check_mma_fp_pair(a: str, b: str) -> str | None:
 
 def _check_mma_sp_fp_types(m):
     """The sparse floating-point lines spell one literal token in both
-    multiplicand positions, per ISA 9.7.14.6.3:8-21 --
+    multiplicand positions, per ISA 9.7.16.6.3:8-21 --
 
         mma.spvariant.sync.aligned.m16n8k16.row.col.dtype.f16.f16.ctype  d, a, b, c, e, f;
         mma.spvariant.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32     d, a, b, c, e, f;
@@ -2579,12 +2719,12 @@ def _check_mma_sp_fp_types(m):
     data-type of the elements in the matrices scale_A and scale_B. In case of
     shapes .m16n8k16, .m16n8k32 and .m16n8k64, .dtype must be the same as
     .ctype." -- .dtype/.ctype only; grepping "must be the same" over the whole
-    9.7.14.6.3 slice returns that line and nothing else, so the section states
+    9.7.16.6.3 slice returns that line and nothing else, so the section states
     no .atype/.btype equality rule.
 
     The blanket "the multiplicand types must match" this check used to apply to
     every sparse entry came from the **wmma.mma** section, a different
-    instruction: ISA 9.7.14.4.5:77-78, "For integer wmma, .ctype and .dtype must
+    instruction: ISA 9.7.16.4.5:77-78, "For integer wmma, .ctype and .dtype must
     be specified as .s32. Also, the values for .atype and .btype must be the
     same, i.e., either both are .s8 or both are .u8." The sparse lines that do
     name two independent type variables -- ".s32.atype.btype.s32" and
@@ -2601,7 +2741,7 @@ def _check_mma_sp_fp_types(m):
 
 
 def _check_mma_sp_int_types(m):
-    """The sparse integer lines pair by width class, per ISA 9.7.14.6.3:60-71 --
+    """The sparse integer lines pair by width class, per ISA 9.7.16.6.3:60-71 --
 
         mma.spvariant.sync.aligned.shape.row.col{.satfinite}.s32.atype.btype.s32 d, a, b, c, e, f;
         .atype     = {.u8, .s8};
@@ -2612,9 +2752,9 @@ def _check_mma_sp_int_types(m):
     mixed signedness (.u8 x .s8, .u4 x .s4) is in the grammar; only crossing
     the 8-bit and 4-bit lines is not.
 
-    9.7.14.6.3 states no .atype/.btype equality rule (see
+    9.7.16.6.3 states no .atype/.btype equality rule (see
     `_check_mma_sp_fp_types` for the section's one type-equality sentence);
-    the equality this check used to apply is wmma.mma's, ISA 9.7.14.4.5:77-78.
+    the equality this check used to apply is wmma.mma's, ISA 9.7.16.4.5:77-78.
     """
     a, b = m["atype"], m["btype"]
     if _MMA_INT_LINE[a] != _MMA_INT_LINE[b]:
@@ -2625,7 +2765,7 @@ def _check_mma_sp_int_types(m):
 def _check_mma_sp_fp_thread(m):
     """The floating-point lines whose selector names one thread of four.
 
-    ISA 9.7.14.6.1: .f16/.bf16 at .m16n8k16 and .tf32 at .m16n8k8. Sparse
+    ISA 9.7.16.6.1: .f16/.bf16 at .m16n8k16 and .tf32 at .m16n8k8. Sparse
     doubles K against the dense line it mirrors, so these shape lists differ
     from the dense `_check_mma_fp_f32`'s.
     """
@@ -2670,7 +2810,7 @@ def _check_mma_sp_int_all(m):
 def _check_mma_fp_f16(m):
     """The .f16-accumulator forms: the ISA's f16 and f8 lines.
 
-    The half-precision lines (ISA 9.7.14.5.14:8-10, with ".ctype   = {.f16,
+    The half-precision lines (ISA 9.7.16.5.14:8-10, with ".ctype   = {.f16,
     .f32};" / ".dtype   = {.f16, .f32};" at :14-15) spell the token literally in
     both multiplicand positions --
 
@@ -2678,7 +2818,7 @@ def _check_mma_fp_f16(m):
         mma.sync.aligned.m16n8k8.row.col.dtype.f16.f16.ctype  d, a, b, c;
         mma.sync.aligned.m16n8k16.row.col.dtype.f16.f16.ctype d, a, b, c;
 
-    -- while the f8 line, ISA 9.7.14.5.14:23 with ".f8type     = {.e4m3,
+    -- while the f8 line, ISA 9.7.16.5.14:23 with ".f8type     = {.e4m3,
     .e5m2};" (:28) and ".shape      = {.m16n8k16, .m16n8k32};" (:32),
 
         mma.sync.aligned.shape.row.col.dtype.f8type.f8type.ctype  d, a, b, c;
@@ -2690,10 +2830,10 @@ def _check_mma_fp_f16(m):
 
     This check used to reject every `.atype != .btype`. That blanket rule is a
     sentence from the **wmma.mma** section, a different instruction: ISA
-    9.7.14.4.5:77-78, "For integer wmma, .ctype and .dtype must be specified as
+    9.7.16.4.5:77-78, "For integer wmma, .ctype and .dtype must be specified as
     .s32. Also, the values for .atype and .btype must be the same, i.e., either
     both are .s8 or both are .u8." mma's own restriction block
-    (9.7.14.5.14:122-135) scopes ".atype must be the same as .btype." to
+    (9.7.16.5.14:122-135) scopes ".atype must be the same as .btype." to
     .m16n8k8 alone, and this entry reaches .m16n8k8 only through the .f16.f16
     line above -- the f8 line's shapes are .m16n8k16 / .m16n8k32 -- so that rule
     holds by construction here.
@@ -2715,7 +2855,7 @@ def _check_mma_fp_f16(m):
 
 
 def _check_mma_fp_f32(m):
-    """One check per floating-point syntax line of ISA 9.7.14.5.14.
+    """One check per floating-point syntax line of ISA 9.7.16.5.14.
 
     The lines differ in which shapes pair with which operand types, and only
     the .m8n8k4 line leaves the layouts free -- every other line spells
@@ -2723,10 +2863,10 @@ def _check_mma_fp_f32(m):
 
     Multiplicand types are NOT equal in general. This check used to reject
     every `.atype != .btype`; that blanket rule is a sentence from the
-    **wmma.mma** section, a different instruction -- ISA 9.7.14.4.5:77-78, "For
+    **wmma.mma** section, a different instruction -- ISA 9.7.16.4.5:77-78, "For
     integer wmma, .ctype and .dtype must be specified as .s32. Also, the values
     for .atype and .btype must be the same, i.e., either both are .s8 or both
-    are .u8." mma's own restriction block, ISA 9.7.14.5.14:122-135, reads:
+    are .u8." mma's own restriction block, ISA 9.7.16.5.14:122-135, reads:
 
         Specific shapes have type restrictions :
         .m8n8k4 : When .ctype is .f32, .dtype must also be .f32.
@@ -2738,7 +2878,7 @@ def _check_mma_fp_f32(m):
 
     so `.atype == .btype` binds at .m16n8k8 alone. That is exactly the one
     alternate-fp line whose two type positions are separate variables over one
-    set (9.7.14.5.14:21,26-27):
+    set (9.7.16.5.14:21,26-27):
 
         mma.sync.aligned.m16n8k8.row.col.f32.atype.btype.f32      d, a, b, c;
         .atype      = {.bf16, .tf32};
@@ -2786,18 +2926,18 @@ def _check_mma_fp_f32(m):
 
 
 def _check_mma_int(m):
-    """The integer / sub-byte / single-bit lines of ISA 9.7.14.5.14.
+    """The integer / sub-byte / single-bit lines of ISA 9.7.16.5.14.
 
     Mixed signedness is legal. This check used to reject every `.atype !=
     .btype` under the comment "the values for .atype and .btype must be the
     same" -- that sentence is the **wmma.mma** section's, a different
-    instruction: ISA 9.7.14.4.5:77-78, "For integer wmma, .ctype and .dtype
+    instruction: ISA 9.7.16.4.5:77-78, "For integer wmma, .ctype and .dtype
     must be specified as .s32. Also, the values for .atype and .btype must be
     the same, i.e., either both are .s8 or both are .u8." mma's own restriction
-    block (9.7.14.5.14:122-135) states no rule for the integer lines at all,
+    block (9.7.16.5.14:122-135) states no rule for the integer lines at all,
     and scopes ".atype must be the same as .btype." to .m16n8k8 -- a shape no
     integer or single-bit line lists. The integer lines quantify their two
-    positions independently (9.7.14.5.14:67-77):
+    positions independently (9.7.16.5.14:67-77):
 
         mma.sync.aligned.shape.row.col{.satfinite}.s32.atype.btype.s32 d, a, b, c;
         .shape   = {.m8n8k16, .m16n8k16, .m16n8k32}
@@ -2840,17 +2980,17 @@ def _check_mma_int(m):
     return None
 
 
-# wgmma.mma_async register fragments, per ISA 9.7.15.5.1.1.1-.4 (Matrix
+# wgmma.mma_async register fragments, per ISA 9.7.17.5.1.1.1-.4 (Matrix
 # Fragments): across the 128-thread warpgroup the accumulator D holds
 # M*N/128 = N/2 registers per thread (.f32 and .s32), and M*N/256 = N/4
 # when .dtype is .f16 (two halves per register). The A fragment of the rs
 # form works out to M*K/128/(32/bits) = 4 registers for every (K, type)
 # pairing the ISA defines, so it is a plain `lanes=4`, not a function.
 #
-# The N domains follow ISA 9.7.15.2 (Matrix Shape): the floating-point and
+# The N domains follow ISA 9.7.17.2 (Matrix Shape): the floating-point and
 # fp8 lines take every multiple of 8 up to 256; the integer and single-bit
 # lines drop 40, 56, ... (the odd multiples of 8 above 32). The integer
-# syntax enumeration in 9.7.15.5.2 stops at 224 even though the Matrix Shape
+# syntax enumeration in 9.7.17.5.2 stops at 224 even though the Matrix Shape
 # table includes 240 and 256.  The public surface follows the instruction's
 # concrete syntax line; the single-bit syntax separately includes both shapes.
 _WGMMA_N_FULL = tuple(str(8 * i) for i in range(1, 33))
@@ -2864,7 +3004,7 @@ def _wgmma_acc_lanes(m):
     return n // 4 if m["dtype"] == "f16" else n // 2
 
 
-# cp.async.bulk.tensor coordinate vectors, per ISA 9.7.9.25.5.2: "Vector of
+# cp.async.bulk.tensor coordinate vectors, per ISA 9.7.10.28.5.3: "Vector of
 # n elements where n = .dim" -- except the gather4/scatter4 load modes, whose
 # tensorCoords is a "fixed length vector of size 5" (one column index plus
 # four row indices) whatever the dimension.
@@ -2890,7 +3030,7 @@ def _check_tma_gather4(m):
     return None
 
 
-# tcgen05.mma disable-output-lane, per ISA 9.7.16.10.9.1: "The size of the
+# tcgen05.mma disable-output-lane, per ISA 9.7.18.10.10.1: "The size of the
 # vector is as follows: .cta_group::1 -> 4, .cta_group::2 -> 8".
 def _tcgen05_mma_mask_lanes(m):
     return 8 if m["cta_group"] == "cta_group::2" else 4
@@ -2932,22 +3072,2632 @@ _ignore_oob_lanes = _present_lanes("ignore_oob")
 
 
 def _check_lop3_imm(_m, operand, value):
-    """PTX ISA 9.7.8.6 constrains immLut to one unsigned byte."""
+    """PTX ISA 9.7.9.6 constrains immLut to one unsigned byte."""
     if operand == "immLut" and not 0 <= value <= 255:
         return f"operand 'immLut' must be in the inclusive range 0..255, got {value}"
     return None
 
 
+def _multicast_mask_dtype(m):
+    """PTX 9.4's explicit ::32b multicast token selects a 32-bit CTA mask."""
+    return "u32" if m["multicast"].endswith("::32b") else "u16"
+
+
+def _sp_num(m):
+    return int(m["num"][1:])
+
+
+def _sp_bits(token):
+    return int(token[1:])
+
+
+def _spcompress_lanes(role):
+    """Return a PTX 9.4 spcompress register-vector length for one operand."""
+
+    def lanes(m):
+        num = _sp_num(m)
+        if role == "data":
+            return 2 * num
+        if role == "cdata":
+            return num
+        return (num * _sp_bits(m["idxsize"]) + _sp_bits(m["elemsize"]) - 1) // _sp_bits(
+            m["elemsize"]
+        )
+
+    return lanes
+
+
+def _spdecompress_factor(m):
+    src, dst = m["spfactor"].removeprefix("sp::").split(":")
+    return int(src), int(dst)
+
+
+def _spdecompress_lanes(role):
+    """Return a PTX 9.4 spdecompress register-vector length for one operand."""
+
+    def lanes(m):
+        src, dst = _spdecompress_factor(m)
+        num = _sp_num(m)
+        elem = _sp_bits(m["elemsize"])
+        idx = _sp_bits(m["idxsize"])
+        bits = {
+            "mdata": src * idx * num,
+            "cdata": src * elem * num,
+            "data": dst * elem * num,
+        }[role]
+        return (bits + 31) // 32
+
+    return lanes
+
+
+def _check_spdecompress(m):
+    """Enforce PTX 9.4's five spdecompress vector-size constraints."""
+    src, dst = _spdecompress_factor(m)
+    num = _sp_num(m)
+    elem = _sp_bits(m["elemsize"])
+    idx = _sp_bits(m["idxsize"])
+    if src * elem > 32:
+        return "one compressed iteration must fit in one .b32 register"
+    if 2**idx < dst:
+        return f".{m['idxsize']} cannot index {dst} target elements"
+    data_bits = dst * elem * num
+    if data_bits < 32 or data_bits > 4096:
+        return "the dense data vector must occupy 1..128 .b32 registers"
+    sizes = (
+        _spdecompress_lanes("mdata")(m),
+        _spdecompress_lanes("cdata")(m),
+        _spdecompress_lanes("data")(m),
+    )
+    if sum(sizes) > 253:
+        return "the three register vectors may contain at most 253 registers total"
+    return None
+
+
+def _tcgen05_spcompress_lanes(role):
+    """Return a PTX 9.4 tcgen05.ld.spcompress output-vector length."""
+    return lambda m: (_sp_num(m) + 31) // 32 if role == "mdata" else _sp_num(m) // 2
+
+
+def _check_report_ignore_oob(m):
+    """With .ignore_oob, PTX 9.4 permits only the explicitly disabled report."""
+    if m.get("ignore_oob") and m["report"] != "mbarrier::report::disabled":
+        return ".ignore_oob requires .mbarrier::report::disabled"
+    return None
+
+
+def _check_cp_async_bulk_cta_report(m):
+    """Enforce non-tensor bulk-copy semantics and the CTA report/OOB pairing."""
+    return _check_cp_async_bulk_sem(m) or _check_report_ignore_oob(m)
+
+
+_PTX_94_REPORT_MECHANISMS = (
+    "mbarrier::report::disabled",
+    "mbarrier::report::validity::per_16bytes::80000000",
+    "mbarrier::report::validity::per_16bytes::8000",
+    "mbarrier::report::validity::per_16bytes::80",
+    "mbarrier::report::validity::per_16bytes::8",
+    "mbarrier::report::validity::per_element::ff",
+)
+
+
+def _tma_dim_lanes(m):
+    return int(m["dim"][0])
+
+
+def _tma_lower_stride_lanes(m):
+    return int(m["dim"][0]) - 1
+
+
+def _tma_im2col_lanes(m):
+    return int(m["dim"][0]) - 2 if m["load_mode"] == "im2col" else 2
+
+
+def _check_tma_im2col(m):
+    """PTX im2col and im2col_no_offs modes require at least three dimensions."""
+    if int(m["dim"][0]) < 3:
+        return f".{m['load_mode']} requires .3d, .4d, or .5d"
+    return None
+
+
+def _tma_im2col_dtype(m):
+    return "u16" if m["load_mode"] == "im2col" else "b16"
+
+
+def _tma_global_dim_operands(bracket, size_type):
+    return (
+        OperandSlot("tmap", kind="addr", space="global", bracket=bracket),
+        OperandSlot("global_address", dtype="u64", bracket=bracket),
+        OperandSlot("tensor_size", dtype=size_type, lanes=1, vector=True, bracket=bracket),
+        OperandSlot("coords", dtype="s32", lanes=1, vector=True, bracket=bracket),
+    )
+
+
+def _tma_global_dim_stride_operands(bracket, size_type):
+    return (
+        OperandSlot("tmap", kind="addr", space="global", bracket=bracket),
+        OperandSlot("global_address", dtype="u64", bracket=bracket),
+        OperandSlot(
+            "tensor_size",
+            dtype=size_type,
+            lanes=_tma_dim_lanes,
+            bracket=bracket,
+        ),
+        OperandSlot(
+            "lower_stride",
+            dtype="b32",
+            lanes=_tma_lower_stride_lanes,
+            bracket=bracket,
+        ),
+        OperandSlot("upper_stride", dtype="b16", bracket=bracket),
+        OperandSlot("coords", dtype="s32", lanes=_tma_coords_lanes, bracket=bracket),
+    )
+
+
+_TCGEN05_COLLECTOR_A = (
+    "collector::a::fill",
+    "collector::a::use",
+    "collector::a::lastuse",
+    "collector::a::discard",
+)
+_TCGEN05_COLLECTOR_B = (
+    "collector::b::fill",
+    "collector::b::use",
+    "collector::b::lastuse",
+    "collector::b::discard",
+)
+_TCGEN05_WS_COLLECTOR_B = tuple(
+    f"collector::b{buffer}::{op}"
+    for buffer in range(4)
+    for op in ("fill", "use", "lastuse", "discard")
+)
+
+
+def _check_tcgen05_collector_ashift(m):
+    """An A collector fill/use operation cannot be combined with .ashift."""
+    if m.get("ashift") and m["collector_a"] in (
+        "collector::a::fill",
+        "collector::a::use",
+    ):
+        return ".ashift cannot be combined with collector A fill/use"
+    return None
+
+
+def _check_set_packed(m):
+    """Unsigned aliases .lo/.ls/.hi/.hs are invalid for signed packed types."""
+    if m["type"].startswith("s") and m["cmp"] in ("lo", "ls", "hi", "hs"):
+        return "unsigned comparison qualifier requires an unsigned packed type"
+    return None
+
+
+_PTX_94_ENTRIES = [
+    # PTX ISA 9.4, 9.7.5.1/2 -- SM107 mixed packed add/sub.  Keep the
+    # three type positions independent: the syntax defines one up-conversion
+    # line and two fixed down-conversion lines, not their Cartesian product.
+    *[
+        InstructionEntry(
+            name=f"{name}_mixed_vec_up",
+            mnemonic=name,
+            slots=(
+                ModifierSlot("rnd", _FRND, optional=True),
+                ModifierSlot("dtype", ("f32x2",)),
+                ModifierSlot("atype", ("f16x2", "bf16x2")),
+                ModifierSlot("ctype", ("f32x2",)),
+            ),
+            cert_arch="sm_107f",
+            operands=(
+                OperandSlot("d", rw="w", dtype="dtype"),
+                OperandSlot("a", dtype="atype"),
+                OperandSlot("c", dtype="ctype"),
+            ),
+        )
+        for name in ("add", "sub")
+    ],
+    *[
+        InstructionEntry(
+            name=f"{name}_mixed_vec_down_f16",
+            mnemonic=name,
+            slots=(
+                ModifierSlot("rnd", ("rz",)),
+                ModifierSlot("ftz", ("ftz",)),
+                ModifierSlot("dtype", ("f16x2",)),
+                ModifierSlot("atype", ("f32x2",)),
+                ModifierSlot("ctype", ("f32x2",)),
+            ),
+            cert_arch="sm_107f",
+            operands=(
+                OperandSlot("d", rw="w", dtype="dtype"),
+                OperandSlot("a", dtype="atype"),
+                OperandSlot("c", dtype="ctype"),
+            ),
+        )
+        for name in ("add", "sub")
+    ],
+    *[
+        InstructionEntry(
+            name=f"{name}_mixed_vec_down_bf16",
+            mnemonic=name,
+            slots=(
+                ModifierSlot("rnd", ("rz",)),
+                ModifierSlot("dtype", ("bf16x2",)),
+                ModifierSlot("atype", ("f32x2",)),
+                ModifierSlot("ctype", ("f32x2",)),
+            ),
+            cert_arch="sm_107f",
+            operands=(
+                OperandSlot("d", rw="w", dtype="dtype"),
+                OperandSlot("a", dtype="atype"),
+                OperandSlot("c", dtype="ctype"),
+            ),
+        )
+        for name in ("add", "sub")
+    ],
+    # PTX ISA 9.4, 9.7.5.3 -- vector mixed-precision fused multiply-add.
+    InstructionEntry(
+        name="fma_mixed_vec",
+        mnemonic="fma",
+        slots=(
+            ModifierSlot("rnd", _FRND),
+            ModifierSlot("dtype", ("f32x2",)),
+            ModifierSlot("atype", ("f16x2", "bf16x2")),
+            ModifierSlot("btype", ("f32x2",)),
+            ModifierSlot("ctype", ("f32x2",)),
+        ),
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("d", rw="w", dtype="dtype"),
+            OperandSlot("a", dtype="atype"),
+            OperandSlot("b", dtype="btype"),
+            OperandSlot("c", dtype="ctype"),
+        ),
+    ),
+    # PTX ISA 9.4, 9.7.5.4 -- the four mixed vector multiply syntax lines.
+    InstructionEntry(
+        name="mul_mixed_vec_down_f16",
+        mnemonic="mul",
+        slots=(
+            ModifierSlot("ftz", ("ftz",)),
+            ModifierSlot("rnd", ("rz",)),
+            ModifierSlot("dtype", ("f16x2",)),
+            ModifierSlot("atype", ("f32x2",)),
+            ModifierSlot("ctype", ("f32x2",)),
+        ),
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("d", rw="w", dtype="dtype"),
+            OperandSlot("a", dtype="atype"),
+            OperandSlot("c", dtype="ctype"),
+        ),
+    ),
+    InstructionEntry(
+        name="mul_mixed_vec_down_bf16",
+        mnemonic="mul",
+        slots=(
+            ModifierSlot("rnd", ("rz",)),
+            ModifierSlot("dtype", ("bf16x2",)),
+            ModifierSlot("atype", ("f32x2",)),
+            ModifierSlot("ctype", ("f32x2",)),
+        ),
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("d", rw="w", dtype="dtype"),
+            OperandSlot("a", dtype="atype"),
+            OperandSlot("c", dtype="ctype"),
+        ),
+    ),
+    InstructionEntry(
+        name="mul_mixed_vec_bf16_f16",
+        mnemonic="mul",
+        slots=(
+            ModifierSlot("dtype", ("bf16x2",)),
+            ModifierSlot("atype", ("bf16x2",)),
+            ModifierSlot("ctype", ("f16x2",)),
+        ),
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("d", rw="w", dtype="dtype"),
+            OperandSlot("a", dtype="atype"),
+            OperandSlot("c", dtype="ctype"),
+        ),
+    ),
+    InstructionEntry(
+        name="mul_mixed_vec_f16_bf16",
+        mnemonic="mul",
+        slots=(
+            ModifierSlot("dtype", ("f16x2",)),
+            ModifierSlot("atype", ("f16x2",)),
+            ModifierSlot("ctype", ("bf16x2",)),
+        ),
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("d", rw="w", dtype="dtype"),
+            OperandSlot("a", dtype="atype"),
+            OperandSlot("c", dtype="ctype"),
+        ),
+    ),
+    # PTX ISA 9.4, 9.7.7.1 -- packed integer comparisons on SM107.
+    # All three operands ride ordinary .b32 registers; the instruction type
+    # selects two half-word or four byte comparisons and packed all-ones/zero
+    # results.
+    InstructionEntry(
+        name="set_packed",
+        mnemonic="set",
+        slots=(
+            ModifierSlot("cmp", ("eq", "ne", "lt", "le", "gt", "ge", "lo", "ls", "hi", "hs")),
+            ModifierSlot("type", ("u8x4", "s8x4", "u16x2", "s16x2")),
+        ),
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("d", rw="w", dtype="b32"),
+            OperandSlot("a", dtype="b32"),
+            OperandSlot("b", dtype="b32"),
+        ),
+        check=_check_set_packed,
+    ),
+    # PTX ISA 9.4, 9.7.10.8 -- readonly-proxy scalar load.
+    # The source is .global or a generic address pointing to global/const; this
+    # syntax line carries no memory-ordering or cache qualifiers.
+    # The ISA spells the qualifier in two places: the Syntax block prints it
+    # before .type (`ld.proxy::readonly{.ss}.type d, [a];`) and the Examples
+    # after it (`ld.global.u32.proxy::readonly %r0, [%rd0];`).  MEASURED on
+    # CUDA 13.4 ptxas (sm_90 and sm_107a): both orders assemble.  The Examples
+    # order is registered.
+    # MEASURED on CUDA 13.4: the shared grammar's .b128 production answers
+    # "Illegal modifier '.proxy::readonly' for instruction 'ld'" when the
+    # readonly proxy is present, so .b128 stays out of this entry's type slot.
+    InstructionEntry(
+        name="ld_proxy_readonly",
+        mnemonic="ld",
+        slots=(
+            ModifierSlot("space", ("global",), optional=True),
+            ModifierSlot("type", tuple(t for t in _LD_TYPES if t != "b128")),
+            ModifierSlot("proxy", ("proxy::readonly",)),
+        ),
+        cert_arch="sm_90",
+        operands=(
+            OperandSlot("d", rw="w", dtypes=_relaxed_mem_dtypes),
+            OperandSlot("addr", kind="addr", allow_imm_offset=True),
+        ),
+    ),
+    # PTX ISA 9.4, 9.7.10.16 -- validity-checked 32-byte L1 prefetch.
+    # .valid_addr is mandatory on this syntax line and the address is global
+    # or generic pointing to global.
+    InstructionEntry(
+        name="prefetch_valid_addr",
+        mnemonic="prefetch",
+        slots=(
+            ModifierSlot("space", ("global",), optional=True),
+            ModifierSlot("level", ("L1::32B",)),
+            ModifierSlot("valid_addr", ("valid_addr",)),
+        ),
+        cert_arch="sm_90",
+        operands=(OperandSlot("addr", kind="addr", allow_imm_offset=True),),
+    ),
+    # PTX ISA 9.4, 9.7.10.24 -- .pzo on the scalar/vector/tf32 frnd2
+    # conversion lines.  Written .pzo makes these siblings disjoint from the
+    # pre-9.4 entries with the same operand shapes.
+    # Target floor of the 9.4 cvt additions (.pzo, .rz on the narrow packed
+    # destinations, .scaled::n1::ue8m0, .ue5m3x2): the 9.4 Target ISA Notes
+    # carry no explicit entry for them.  MEASURED on CUDA 13.4: sm_107a and
+    # sm_107f assemble them; sm_103a answers "Feature '.pzo' not supported on
+    # .target 'sm_103a'".  Every such entry below certifies at sm_107f.
+    InstructionEntry(
+        name="cvt_pzo_scalar_f32",
+        mnemonic="cvt",
+        slots=(
+            ModifierSlot("rnd", ("rn", "rz")),
+            ModifierSlot("relu", ("relu",), optional=True),
+            ModifierSlot("satfinite", ("satfinite",), optional=True),
+            ModifierSlot("pzo", ("pzo",)),
+            ModifierSlot("dtype", ("f16", "bf16")),
+            ModifierSlot("atype", ("f32",)),
+        ),
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("d", rw="w", dtype="dtype"),
+            OperandSlot("a", dtype="f32"),
+        ),
+    ),
+    InstructionEntry(
+        name="cvt_pzo_fp16x2_f32",
+        mnemonic="cvt",
+        slots=(
+            ModifierSlot("rnd", ("rn", "rz")),
+            ModifierSlot("relu", ("relu",), optional=True),
+            ModifierSlot("satfinite", ("satfinite",), optional=True),
+            ModifierSlot("pzo", ("pzo",)),
+            ModifierSlot("dtype", ("f16x2", "bf16x2")),
+            ModifierSlot("atype", ("f32",)),
+        ),
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("d", rw="w", dtype="dtype"),
+            OperandSlot("a", dtype="f32"),
+            OperandSlot("b", dtype="f32"),
+        ),
+    ),
+    InstructionEntry(
+        name="cvt_pzo_tf32_f32",
+        mnemonic="cvt",
+        slots=(
+            ModifierSlot("rnd", ("rn", "rz")),
+            ModifierSlot("satfinite", ("satfinite",), optional=True),
+            ModifierSlot("relu", ("relu",), optional=True),
+            ModifierSlot("pzo", ("pzo",)),
+            ModifierSlot("dtype", ("tf32",)),
+            ModifierSlot("atype", ("f32",)),
+        ),
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("d", rw="w", dtype="tf32"),
+            OperandSlot("a", dtype="f32"),
+        ),
+    ),
+    # MEASURED on CUDA 13.4: PTX 9.4 also prints .pzo on the stochastic-rounding
+    # .rs lines, but ptxas rejects both the documented .rs.pzo order and .pzo.rs
+    # with "Illegal modifier '.pzo' for instruction 'cvt' with '.rs'"; do not
+    # expose uncertified helpers until the toolchain implements those lines.
+    # The five narrow packed destinations gain .rz, .pzo and n1 scaling.  The
+    # check removes only the already-owned bare .rn variant; every remaining
+    # combination contains at least one PTX 9.4 token.
+    InstructionEntry(
+        name="cvt_94_narrow_f32",
+        mnemonic="cvt",
+        slots=(
+            ModifierSlot("rnd", ("rn", "rz")),
+            ModifierSlot("satfinite", ("satfinite",)),
+            ModifierSlot("relu", ("relu",), optional=True),
+            ModifierSlot("pzo", ("pzo",), optional=True),
+            ModifierSlot("scaled", ("scaled::n1::ue8m0",), optional=True),
+            ModifierSlot("dtype", ("e4m3x2", "e5m2x2", "e2m1x2", "e2m3x2", "e3m2x2")),
+            ModifierSlot("atype", ("f32",)),
+        ),
+        check=_check_cvt_94_narrow,
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("d", rw="w", dtype="dtype"),
+            OperandSlot("a", dtype="f32"),
+            OperandSlot("b", dtype="f32"),
+            OperandSlot(
+                "scale_factor",
+                dtype="cvt_scale_ue8m0",
+                lanes=_cvt_scale_lanes,
+                vector=False,
+            ),
+        ),
+    ),
+    InstructionEntry(
+        name="cvt_94_narrow_fp16x2",
+        mnemonic="cvt",
+        slots=(
+            ModifierSlot("rnd", ("rn", "rz")),
+            ModifierSlot("satfinite", ("satfinite",)),
+            ModifierSlot("relu", ("relu",), optional=True),
+            ModifierSlot("pzo", ("pzo",), optional=True),
+            ModifierSlot("scaled", ("scaled::n1::ue8m0",), optional=True),
+            ModifierSlot("dtype", ("e4m3x2", "e5m2x2", "e2m1x2", "e2m3x2", "e3m2x2")),
+            ModifierSlot("atype", ("f16x2", "bf16x2")),
+        ),
+        check=_check_cvt_94_narrow,
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("d", rw="w", dtype="dtype"),
+            OperandSlot("a", dtype="atype"),
+            OperandSlot(
+                "scale_factor",
+                dtype="cvt_scale_ue8m0",
+                lanes=_cvt_scale_lanes,
+                vector=False,
+            ),
+        ),
+    ),
+    # PTX ISA 9.4's UE5M3 conversion family.  .ue5m3x2 always rides .b16;
+    # n1 scale factors ride the scoped .b8 bridge and n2 factors stay packed
+    # in the existing .b16 ue8m0x2 carrier.
+    InstructionEntry(
+        name="cvt_ue5m3x2_f32",
+        mnemonic="cvt",
+        slots=(
+            ModifierSlot("rnd", ("rn", "rz", "rp")),
+            ModifierSlot("satfinite", ("satfinite",), optional=True),
+            ModifierSlot("dtype", ("ue5m3x2",)),
+            ModifierSlot("atype", ("f32",)),
+        ),
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("d", rw="w", dtype="ue5m3x2"),
+            OperandSlot("a", dtype="f32"),
+            OperandSlot("b", dtype="f32"),
+        ),
+    ),
+    InstructionEntry(
+        name="cvt_ue5m3x2_f32_scaled",
+        mnemonic="cvt",
+        slots=(
+            ModifierSlot("rnd", ("rn", "rz")),
+            ModifierSlot("satfinite", ("satfinite",), optional=True),
+            ModifierSlot("scaled", ("scaled::n1::ue8m0",)),
+            ModifierSlot("dtype", ("ue5m3x2",)),
+            ModifierSlot("atype", ("f32",)),
+        ),
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("d", rw="w", dtype="ue5m3x2"),
+            OperandSlot("a", dtype="f32"),
+            OperandSlot("b", dtype="f32"),
+            OperandSlot("scale_factor", dtype="cvt_scale_ue8m0"),
+        ),
+    ),
+    InstructionEntry(
+        name="cvt_ue5m3x2_fp16x2",
+        mnemonic="cvt",
+        slots=(
+            ModifierSlot("rnd", ("rn", "rz", "rp")),
+            ModifierSlot("satfinite", ("satfinite",), optional=True),
+            ModifierSlot("dtype", ("ue5m3x2",)),
+            ModifierSlot("atype", ("f16x2", "bf16x2")),
+        ),
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("d", rw="w", dtype="ue5m3x2"),
+            OperandSlot("a", dtype="atype"),
+        ),
+    ),
+    InstructionEntry(
+        name="cvt_ue5m3x2_fp16x2_scaled",
+        mnemonic="cvt",
+        slots=(
+            ModifierSlot("rnd", ("rn", "rz")),
+            ModifierSlot("satfinite", ("satfinite",), optional=True),
+            ModifierSlot("scaled", ("scaled::n1::ue8m0",)),
+            ModifierSlot("dtype", ("ue5m3x2",)),
+            ModifierSlot("atype", ("f16x2", "bf16x2")),
+        ),
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("d", rw="w", dtype="ue5m3x2"),
+            OperandSlot("a", dtype="atype"),
+            OperandSlot("scale_factor", dtype="cvt_scale_ue8m0"),
+        ),
+    ),
+    InstructionEntry(
+        name="cvt_f16x2_ue5m3x2",
+        mnemonic="cvt",
+        slots=(
+            ModifierSlot("rnd", ("rn",)),
+            ModifierSlot("dtype", ("f16x2",)),
+            ModifierSlot("atype", ("ue5m3x2",)),
+        ),
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("d", rw="w", dtype="f16x2"),
+            OperandSlot("a", dtype="ue5m3x2"),
+        ),
+    ),
+    InstructionEntry(
+        name="cvt_bf16x2_ue5m3x2",
+        mnemonic="cvt",
+        slots=(
+            ModifierSlot("rnd", ("rn",)),
+            ModifierSlot("satfinite", ("satfinite",), optional=True),
+            ModifierSlot("scaled", ("scaled::n2::ue8m0",), optional=True),
+            ModifierSlot("dtype", ("bf16x2",)),
+            ModifierSlot("atype", ("ue5m3x2",)),
+        ),
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("d", rw="w", dtype="bf16x2"),
+            OperandSlot("a", dtype="ue5m3x2"),
+            OperandSlot(
+                "scale_factor",
+                dtype="ue8m0x2",
+                lanes=_cvt_scale_lanes,
+                vector=False,
+            ),
+        ),
+    ),
+    # PTX ISA 9.4, 9.7.10.28.4.1 and 9.7.10.28.5.3 -- 32-bit cluster
+    # multicast masks for non-tensor and tensor global-to-shared copies.
+    InstructionEntry(
+        name="cp_async_bulk_g2s_cluster_multicast32",
+        mnemonic="cp",
+        slots=(
+            ModifierSlot("api", ("async",)),
+            ModifierSlot("kind", ("bulk",)),
+            ModifierSlot("sem", ("weak", "relaxed"), optional=True),
+            ModifierSlot("scope", ("cta", "cluster", "gpu", "sys"), optional=True),
+            ModifierSlot("dst", ("shared::cluster",)),
+            ModifierSlot("src", ("global",)),
+            ModifierSlot("completion", ("mbarrier::complete_tx::bytes",)),
+            ModifierSlot("multicast", ("multicast::cluster::32b",)),
+            ModifierSlot("cache", ("L2::cache_hint",), optional=True),
+            ModifierSlot("type", ("b128",), optional=True),
+        ),
+        check=_check_cp_async_bulk_sem,
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("dst_mem", kind="addr", allow_imm_offset=True, space="shared::cluster"),
+            OperandSlot("src_mem", kind="addr", allow_imm_offset=True, space="global"),
+            OperandSlot("size", dtype="u32"),
+            OperandSlot("mbar", kind="addr", allow_imm_offset=True, space="shared"),
+            OperandSlot("cta_mask", dtype="u32"),
+            OperandSlot("cache_policy", dtype="u64", lanes=_tma_cache_lanes, vector=False),
+        ),
+    ),
+    InstructionEntry(
+        name="cp_async_bulk_tensor_g2s_cluster_multicast32",
+        mnemonic="cp",
+        slots=(
+            ModifierSlot("api", ("async",)),
+            ModifierSlot("kind", ("bulk",)),
+            ModifierSlot("unit", ("tensor",)),
+            ModifierSlot("dim", ("1d", "2d", "3d", "4d", "5d")),
+            ModifierSlot("dst", ("shared::cluster",)),
+            ModifierSlot("src", ("global",)),
+            ModifierSlot("load_mode", ("tile", "tile::gather4"), optional=True),
+            ModifierSlot("completion", ("mbarrier::complete_tx::bytes",)),
+            ModifierSlot("multicast", ("multicast::cluster::32b",)),
+            ModifierSlot("cta_group", ("cta_group::1", "cta_group::2"), optional=True),
+            ModifierSlot("cache", ("L2::cache_hint",), optional=True),
+        ),
+        cert_arch="sm_107f",
+        check=_check_tma_gather4,
+        operands=(
+            OperandSlot("dst_mem", kind="addr", allow_imm_offset=True, space="shared::cluster"),
+            OperandSlot("tmap", kind="addr", space="global", bracket="src"),
+            OperandSlot("coords", dtype="s32", lanes=_tma_coords_lanes, bracket="src"),
+            OperandSlot("mbar", kind="addr", allow_imm_offset=True, space="shared"),
+            OperandSlot("cta_mask", dtype="u32"),
+            OperandSlot("cache_policy", dtype="u64", lanes=_tma_cache_lanes, vector=False),
+        ),
+    ),
+    # PTX ISA 9.4, 9.7.15.16.14-17 -- 32-bit multicast mbarrier forms.
+    *[
+        InstructionEntry(
+            name=f"mbarrier_{action}_multicast32",
+            mnemonic="mbarrier",
+            slots=(
+                ModifierSlot("action", (action,)),
+                ModifierSlot("sem", ("relaxed",), optional=True),
+                ModifierSlot("scope", ("cta", "cluster"), optional=True),
+                ModifierSlot("space", ("shared::cluster",)),
+                ModifierSlot("multicast", ("multicast::cluster::32b",)),
+                ModifierSlot("type", ("b64",)),
+            ),
+            check=_check_mbarrier_sem_scope,
+            cert_arch="sm_107f",
+            operands=(
+                OperandSlot("addr", kind="addr", allow_imm_offset=True, space="shared::cluster"),
+                OperandSlot("tx_count", dtype="u32"),
+                OperandSlot("cta_mask", dtype="u32"),
+            ),
+        )
+        for action in ("expect_tx", "complete_tx")
+    ],
+    *[
+        InstructionEntry(
+            name=f"mbarrier_{action}_multicast32_nocount",
+            mnemonic="mbarrier",
+            slots=(
+                ModifierSlot("action", (action,)),
+                ModifierSlot("sem", ("release", "relaxed"), optional=True),
+                ModifierSlot("scope", ("cta", "cluster"), optional=True),
+                ModifierSlot("space", ("shared::cluster",)),
+                ModifierSlot("multicast", ("multicast::cluster::32b",)),
+                ModifierSlot("type", ("b64",)),
+            ),
+            check=_check_mbarrier_sem_scope,
+            cert_arch="sm_107f",
+            operands=(
+                OperandSlot("state", kind="imm", literal="_"),
+                OperandSlot("addr", kind="addr", allow_imm_offset=True, space="shared::cluster"),
+                OperandSlot("cta_mask", dtype="u32"),
+            ),
+        )
+        for action in ("arrive", "arrive_drop")
+    ],
+    *[
+        InstructionEntry(
+            name=f"mbarrier_{action}_multicast32",
+            mnemonic="mbarrier",
+            slots=(
+                ModifierSlot("action", (action,)),
+                ModifierSlot("sem", ("release", "relaxed"), optional=True),
+                ModifierSlot("scope", ("cta", "cluster"), optional=True),
+                ModifierSlot("space", ("shared::cluster",)),
+                ModifierSlot("multicast", ("multicast::cluster::32b",)),
+                ModifierSlot("type", ("b64",)),
+            ),
+            check=_check_mbarrier_sem_scope,
+            cert_arch="sm_107f",
+            operands=(
+                OperandSlot("state", kind="imm", literal="_"),
+                OperandSlot("addr", kind="addr", allow_imm_offset=True, space="shared::cluster"),
+                OperandSlot("count", dtype="u32"),
+                OperandSlot("cta_mask", dtype="u32"),
+            ),
+        )
+        for action in ("arrive", "arrive_drop")
+    ],
+    *[
+        InstructionEntry(
+            name=f"mbarrier_{action}_expect_tx_multicast32",
+            mnemonic="mbarrier",
+            slots=(
+                ModifierSlot("action", (action,)),
+                ModifierSlot("expect_tx", ("expect_tx",)),
+                ModifierSlot("sem", ("release", "relaxed"), optional=True),
+                ModifierSlot("scope", ("cta", "cluster"), optional=True),
+                ModifierSlot("space", ("shared::cluster",)),
+                ModifierSlot("multicast", ("multicast::cluster::32b",)),
+                ModifierSlot("type", ("b64",)),
+            ),
+            check=_check_mbarrier_sem_scope,
+            cert_arch="sm_107f",
+            operands=(
+                OperandSlot("state", kind="imm", literal="_"),
+                OperandSlot("addr", kind="addr", allow_imm_offset=True, space="shared::cluster"),
+                OperandSlot("tx_count", dtype="u32"),
+                OperandSlot("cta_mask", dtype="u32"),
+            ),
+        )
+        for action in ("arrive", "arrive_drop")
+    ],
+    # PTX ISA 9.4, 9.7.18.7.1 -- exclusive Tensor Memory ownership.
+    *[
+        InstructionEntry(
+            name=f"tcgen05_{action}_exclusive",
+            mnemonic="tcgen05",
+            slots=(
+                ModifierSlot("action", (action,)),
+                ModifierSlot("exclusive", ("exclusive",)),
+                ModifierSlot("cta_group", ("cta_group::1", "cta_group::2")),
+                ModifierSlot("sync", ("sync",)),
+                ModifierSlot("aligned", ("aligned",)),
+                *(
+                    (ModifierSlot("space", ("shared::cta",), optional=True),)
+                    if action == "alloc"
+                    else ()
+                ),
+                ModifierSlot("type", ("b32",)),
+            ),
+            cert_arch="sm_107f",
+            orders_memory=True,
+            operands=(
+                *(
+                    (OperandSlot("dst", kind="addr", allow_imm_offset=True),)
+                    if action == "alloc"
+                    else (OperandSlot("taddr", dtype="u32"),)
+                ),
+                OperandSlot("ncols", dtype="u32"),
+            ),
+        )
+        for action in ("alloc", "dealloc")
+    ],
+    # PTX ISA 9.4, 9.7.18.12.1 -- explicit mask width and A-read completion.
+    InstructionEntry(
+        name="tcgen05_commit_multicast_width",
+        mnemonic="tcgen05",
+        slots=(
+            ModifierSlot("action", ("commit",)),
+            ModifierSlot("cta_group", ("cta_group::1", "cta_group::2")),
+            ModifierSlot("completion", ("mbarrier::arrive::one",)),
+            ModifierSlot("space", ("shared::cluster",), optional=True),
+            ModifierSlot(
+                "multicast",
+                ("multicast::cluster::16b", "multicast::cluster::32b"),
+            ),
+            ModifierSlot("type", ("b64",)),
+        ),
+        cert_arch="sm_107f",
+        orders_memory=True,
+        operands=(
+            OperandSlot("mbar", kind="addr", allow_imm_offset=True),
+            OperandSlot("cta_mask", dtype=_multicast_mask_dtype),
+        ),
+    ),
+    InstructionEntry(
+        name="tcgen05_commit_sync_restrict",
+        mnemonic="tcgen05",
+        slots=(
+            ModifierSlot("action", ("commit",)),
+            ModifierSlot("cta_group", ("cta_group::1", "cta_group::2")),
+            ModifierSlot("completion", ("mbarrier::arrive::one",)),
+            ModifierSlot("sync_restrict", ("sync_restrict::shared::read::mma::a",)),
+            ModifierSlot("space", ("shared::cluster",), optional=True),
+            ModifierSlot("type", ("b64",)),
+        ),
+        cert_arch="sm_107f",
+        orders_memory=True,
+        operands=(OperandSlot("mbar", kind="addr", allow_imm_offset=True),),
+    ),
+    InstructionEntry(
+        name="tcgen05_commit_sync_restrict_multicast",
+        mnemonic="tcgen05",
+        slots=(
+            ModifierSlot("action", ("commit",)),
+            ModifierSlot("cta_group", ("cta_group::1", "cta_group::2")),
+            ModifierSlot("completion", ("mbarrier::arrive::one",)),
+            ModifierSlot("sync_restrict", ("sync_restrict::shared::read::mma::a",)),
+            ModifierSlot("space", ("shared::cluster",), optional=True),
+            ModifierSlot(
+                "multicast",
+                (
+                    "multicast::cluster",
+                    "multicast::cluster::16b",
+                    "multicast::cluster::32b",
+                ),
+            ),
+            ModifierSlot("type", ("b64",)),
+        ),
+        cert_arch="sm_107f",
+        orders_memory=True,
+        operands=(
+            OperandSlot("mbar", kind="addr", allow_imm_offset=True),
+            OperandSlot("cta_mask", dtype=_multicast_mask_dtype),
+        ),
+    ),
+    # PTX ISA 9.4, 9.7.10.18/19 -- bulk and tensor cache-priority operations.
+    InstructionEntry(
+        name="applypriority_async_bulk",
+        mnemonic="applypriority",
+        slots=(
+            ModifierSlot("api", ("async",)),
+            ModifierSlot("kind", ("bulk",)),
+            ModifierSlot("src", ("global",), optional=True),
+            ModifierSlot("completion", ("bulk_group",)),
+            ModifierSlot("priority", ("L2::evict_normal",)),
+        ),
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("addr", kind="addr", allow_imm_offset=True, space="global"),
+            OperandSlot("size", dtype="u32"),
+        ),
+    ),
+    InstructionEntry(
+        name="applypriority_async_bulk_tensor",
+        mnemonic="applypriority",
+        slots=(
+            ModifierSlot("api", ("async",)),
+            ModifierSlot("kind", ("bulk",)),
+            ModifierSlot("unit", ("tensor",)),
+            ModifierSlot("dim", ("1d", "2d", "3d", "4d", "5d")),
+            ModifierSlot("src", ("global",), optional=True),
+            ModifierSlot("completion", ("bulk_group",)),
+            ModifierSlot("load_mode", ("tile", "tile::gather4"), optional=True),
+            ModifierSlot("priority", ("L2::evict_normal",)),
+        ),
+        check=_check_tma_gather4,
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("tmap", kind="addr", space="global", bracket="src"),
+            OperandSlot("coords", dtype="s32", lanes=_tma_coords_lanes, bracket="src"),
+        ),
+    ),
+    # PTX ISA 9.4, 9.7.10.30/31 -- register-vector sparse compression.
+    InstructionEntry(
+        name="spcompress",
+        slots=(
+            ModifierSlot("elemsize", ("b8", "b16")),
+            ModifierSlot("idxsize", ("b2", "b4")),
+            ModifierSlot("spfactor", ("sp::2:4",)),
+            ModifierSlot("num", ("x1", "x2", "x4", "x8", "x16", "x32", "x64")),
+        ),
+        cert_arch="sm_107a",
+        operands=(
+            OperandSlot("mdata", rw="w", dtype="b32", lanes=_spcompress_lanes("mdata")),
+            OperandSlot("cdata", rw="w", dtype="b32", lanes=_spcompress_lanes("cdata")),
+            OperandSlot("data", dtype="b32", lanes=_spcompress_lanes("data")),
+            OperandSlot("spdesc", dtype="u32"),
+        ),
+    ),
+    InstructionEntry(
+        name="spdecompress",
+        slots=(
+            ModifierSlot("elemsize", ("b8", "b16")),
+            ModifierSlot("idxsize", ("b2", "b4")),
+            ModifierSlot(
+                "spfactor",
+                (
+                    "sp::1:2",
+                    "sp::1:4",
+                    "sp::1:8",
+                    "sp::1:16",
+                    "sp::2:4",
+                    "sp::2:8",
+                    "sp::2:16",
+                    "sp::4:8",
+                    "sp::4:16",
+                ),
+            ),
+            ModifierSlot("num", ("x1", "x2", "x4", "x8", "x16", "x32", "x64")),
+        ),
+        check=_check_spdecompress,
+        cert_arch="sm_107a",
+        operands=(
+            OperandSlot("data", rw="w", dtype="b32", lanes=_spdecompress_lanes("data")),
+            OperandSlot("mdata", dtype="b32", lanes=_spdecompress_lanes("mdata")),
+            OperandSlot("cdata", dtype="b32", lanes=_spdecompress_lanes("cdata")),
+        ),
+    ),
+    # PTX ISA 9.4, 9.7.18.8.3 -- Tensor Memory load fused with 2:4 compression.
+    InstructionEntry(
+        name="tcgen05_ld_spcompress",
+        mnemonic="tcgen05",
+        slots=(
+            ModifierSlot("action", ("ld",)),
+            ModifierSlot("spcompress", ("spcompress",)),
+            ModifierSlot("sync", ("sync",)),
+            ModifierSlot("aligned", ("aligned",)),
+            ModifierSlot("shape", ("32x32b",)),
+            ModifierSlot("num", ("x4", "x8", "x16", "x32", "x64", "x128")),
+            ModifierSlot("rowop", ("min", "max")),
+            ModifierSlot("spfactor", ("sp::2:4",)),
+            ModifierSlot("abs", ("abs",), optional=True),
+            ModifierSlot("type", ("f32",)),
+            ModifierSlot("idxsize", ("b2",)),
+        ),
+        cert_arch="sm_107a",
+        operands=(
+            OperandSlot("mdata", rw="w", dtype="b32", lanes=_tcgen05_spcompress_lanes("mdata")),
+            OperandSlot("cdata", rw="w", dtype="b32", lanes=_tcgen05_spcompress_lanes("cdata")),
+            OperandSlot("taddr", kind="addr", space="tmem"),
+        ),
+    ),
+    InstructionEntry(
+        name="tcgen05_ld_red_spcompress",
+        mnemonic="tcgen05",
+        slots=(
+            ModifierSlot("action", ("ld",)),
+            ModifierSlot("red", ("red",)),
+            ModifierSlot("spcompress", ("spcompress",)),
+            ModifierSlot("sync", ("sync",)),
+            ModifierSlot("aligned", ("aligned",)),
+            ModifierSlot("shape", ("32x32b",)),
+            ModifierSlot("num", ("x4", "x8", "x16", "x32", "x64", "x128")),
+            ModifierSlot("rowop", ("min", "max")),
+            ModifierSlot("spfactor", ("sp::2:4",)),
+            ModifierSlot("abs", ("abs",), optional=True),
+            ModifierSlot("nan", ("NaN",), optional=True),
+            ModifierSlot("type", ("f32",)),
+            ModifierSlot("idxsize", ("b2",)),
+        ),
+        cert_arch="sm_107a",
+        operands=(
+            OperandSlot("mdata", rw="w", dtype="b32", lanes=_tcgen05_spcompress_lanes("mdata")),
+            OperandSlot("cdata", rw="w", dtype="b32", lanes=_tcgen05_spcompress_lanes("cdata")),
+            OperandSlot("redval", rw="w", dtype="f32"),
+            OperandSlot("taddr", kind="addr", space="tmem"),
+        ),
+    ),
+    # PTX ISA 9.4, 9.7.10.28.4.1 -- explicit 16-bit multicast spelling.
+    # (The tensor sibling is the corresponding 9.7.10.28.5.3 syntax line.)
+    InstructionEntry(
+        name="cp_async_bulk_g2s_cluster_multicast16",
+        mnemonic="cp",
+        slots=(
+            ModifierSlot("api", ("async",)),
+            ModifierSlot("kind", ("bulk",)),
+            ModifierSlot("sem", ("weak", "relaxed"), optional=True),
+            ModifierSlot("scope", ("cta", "cluster", "gpu", "sys"), optional=True),
+            ModifierSlot("dst", ("shared::cluster",)),
+            ModifierSlot("src", ("global",)),
+            ModifierSlot("completion", ("mbarrier::complete_tx::bytes",)),
+            ModifierSlot("multicast", ("multicast::cluster::16b",)),
+            ModifierSlot("cache", ("L2::cache_hint",), optional=True),
+            ModifierSlot("type", ("b128",), optional=True),
+        ),
+        check=_check_cp_async_bulk_sem,
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("dst_mem", kind="addr", allow_imm_offset=True, space="shared::cluster"),
+            OperandSlot("src_mem", kind="addr", allow_imm_offset=True, space="global"),
+            OperandSlot("size", dtype="u32"),
+            OperandSlot("mbar", kind="addr", allow_imm_offset=True, space="shared"),
+            OperandSlot("cta_mask", dtype="u16"),
+            OperandSlot("cache_policy", dtype="u64", lanes=_tma_cache_lanes, vector=False),
+        ),
+    ),
+    InstructionEntry(
+        name="cp_async_bulk_tensor_g2s_cluster_multicast16",
+        mnemonic="cp",
+        slots=(
+            ModifierSlot("api", ("async",)),
+            ModifierSlot("kind", ("bulk",)),
+            ModifierSlot("unit", ("tensor",)),
+            ModifierSlot("dim", ("1d", "2d", "3d", "4d", "5d")),
+            ModifierSlot("dst", ("shared::cluster",)),
+            ModifierSlot("src", ("global",)),
+            ModifierSlot("load_mode", ("tile", "tile::gather4"), optional=True),
+            ModifierSlot("completion", ("mbarrier::complete_tx::bytes",)),
+            ModifierSlot("multicast", ("multicast::cluster::16b",)),
+            ModifierSlot("cta_group", ("cta_group::1", "cta_group::2"), optional=True),
+            ModifierSlot("cache", ("L2::cache_hint",), optional=True),
+        ),
+        check=_check_tma_gather4,
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("dst_mem", kind="addr", allow_imm_offset=True, space="shared::cluster"),
+            OperandSlot("tmap", kind="addr", space="global", bracket="src"),
+            OperandSlot("coords", dtype="s32", lanes=_tma_coords_lanes, bracket="src"),
+            OperandSlot("mbar", kind="addr", allow_imm_offset=True, space="shared"),
+            OperandSlot("cta_mask", dtype="u16"),
+            OperandSlot("cache_policy", dtype="u64", lanes=_tma_cache_lanes, vector=False),
+        ),
+    ),
+    # PTX ISA 9.4, 9.7.10.28.4.1 and 9.7.10.28.5.3: explicit report tokens
+    # are siblings of the pre-9.4 default-disabled forms.
+    InstructionEntry(
+        name="cp_async_bulk_g2s_cta_report",
+        mnemonic="cp",
+        slots=(
+            ModifierSlot("api", ("async",)),
+            ModifierSlot("kind", ("bulk",)),
+            ModifierSlot("sem", ("weak", "relaxed"), optional=True),
+            ModifierSlot("scope", ("cta", "cluster", "gpu", "sys"), optional=True),
+            ModifierSlot("dst", ("shared::cta",)),
+            ModifierSlot("src", ("global",)),
+            ModifierSlot("completion", ("mbarrier::complete_tx::bytes",)),
+            ModifierSlot("report", _PTX_94_REPORT_MECHANISMS),
+            ModifierSlot("cache", ("L2::cache_hint",), optional=True),
+            ModifierSlot("ignore_oob", ("ignore_oob",), optional=True),
+            ModifierSlot("type", ("b128",), optional=True),
+        ),
+        check=_check_cp_async_bulk_cta_report,
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("dst_mem", kind="addr", allow_imm_offset=True, space="shared::cta"),
+            OperandSlot("src_mem", kind="addr", allow_imm_offset=True, space="global"),
+            OperandSlot("size", dtype="u32"),
+            OperandSlot(
+                "ignore_bytes_left",
+                dtype="u32",
+                lanes=_ignore_oob_lanes,
+                vector=False,
+            ),
+            OperandSlot(
+                "ignore_bytes_right",
+                dtype="u32",
+                lanes=_ignore_oob_lanes,
+                vector=False,
+            ),
+            OperandSlot("mbar", kind="addr", allow_imm_offset=True, space="shared"),
+            OperandSlot("cache_policy", dtype="u64", lanes=_tma_cache_lanes, vector=False),
+        ),
+    ),
+    InstructionEntry(
+        name="cp_async_bulk_g2s_cluster_report",
+        mnemonic="cp",
+        slots=(
+            ModifierSlot("api", ("async",)),
+            ModifierSlot("kind", ("bulk",)),
+            ModifierSlot("sem", ("weak", "relaxed"), optional=True),
+            ModifierSlot("scope", ("cta", "cluster", "gpu", "sys"), optional=True),
+            ModifierSlot("dst", ("shared::cluster",)),
+            ModifierSlot("src", ("global",)),
+            ModifierSlot("completion", ("mbarrier::complete_tx::bytes",)),
+            ModifierSlot("report", _PTX_94_REPORT_MECHANISMS),
+            ModifierSlot(
+                "multicast",
+                (
+                    "multicast::cluster",
+                    "multicast::cluster::16b",
+                    "multicast::cluster::32b",
+                ),
+                optional=True,
+            ),
+            ModifierSlot("cache", ("L2::cache_hint",), optional=True),
+            ModifierSlot("type", ("b128",), optional=True),
+        ),
+        check=_check_cp_async_bulk_sem,
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("dst_mem", kind="addr", allow_imm_offset=True, space="shared::cluster"),
+            OperandSlot("src_mem", kind="addr", allow_imm_offset=True, space="global"),
+            OperandSlot("size", dtype="u32"),
+            OperandSlot("mbar", kind="addr", allow_imm_offset=True, space="shared"),
+            OperandSlot(
+                "cta_mask",
+                dtype=_multicast_mask_dtype,
+                lanes=_tma_mask_lanes,
+                vector=False,
+            ),
+            OperandSlot("cache_policy", dtype="u64", lanes=_tma_cache_lanes, vector=False),
+        ),
+    ),
+    InstructionEntry(
+        name="cp_async_bulk_tensor_g2s_cta_report",
+        mnemonic="cp",
+        slots=(
+            ModifierSlot("api", ("async",)),
+            ModifierSlot("kind", ("bulk",)),
+            ModifierSlot("unit", ("tensor",)),
+            ModifierSlot("dim", ("1d", "2d", "3d", "4d", "5d")),
+            ModifierSlot("dst", ("shared::cta",)),
+            ModifierSlot("src", ("global",)),
+            ModifierSlot("load_mode", ("tile", "tile::gather4"), optional=True),
+            ModifierSlot("completion", ("mbarrier::complete_tx::bytes",)),
+            ModifierSlot("report", _PTX_94_REPORT_MECHANISMS),
+            ModifierSlot("cta_group", ("cta_group::1", "cta_group::2"), optional=True),
+            ModifierSlot("cache", ("L2::cache_hint",), optional=True),
+        ),
+        check=_check_tma_gather4,
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("dst_mem", kind="addr", allow_imm_offset=True, space="shared::cta"),
+            OperandSlot("tmap", kind="addr", space="global", bracket="src"),
+            OperandSlot("coords", dtype="s32", lanes=_tma_coords_lanes, bracket="src"),
+            OperandSlot("mbar", kind="addr", allow_imm_offset=True, space="shared"),
+            OperandSlot("cache_policy", dtype="u64", lanes=_tma_cache_lanes, vector=False),
+        ),
+    ),
+    InstructionEntry(
+        name="cp_async_bulk_tensor_g2s_cluster_report",
+        mnemonic="cp",
+        slots=(
+            ModifierSlot("api", ("async",)),
+            ModifierSlot("kind", ("bulk",)),
+            ModifierSlot("unit", ("tensor",)),
+            ModifierSlot("dim", ("1d", "2d", "3d", "4d", "5d")),
+            ModifierSlot("dst", ("shared::cluster",)),
+            ModifierSlot("src", ("global",)),
+            ModifierSlot("load_mode", ("tile", "tile::gather4"), optional=True),
+            ModifierSlot("completion", ("mbarrier::complete_tx::bytes",)),
+            ModifierSlot("report", _PTX_94_REPORT_MECHANISMS),
+            ModifierSlot(
+                "multicast",
+                (
+                    "multicast::cluster",
+                    "multicast::cluster::16b",
+                    "multicast::cluster::32b",
+                ),
+                optional=True,
+            ),
+            ModifierSlot("cta_group", ("cta_group::1", "cta_group::2"), optional=True),
+            ModifierSlot("cache", ("L2::cache_hint",), optional=True),
+        ),
+        check=_check_tma_gather4,
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("dst_mem", kind="addr", allow_imm_offset=True, space="shared::cluster"),
+            OperandSlot("tmap", kind="addr", space="global", bracket="src"),
+            OperandSlot("coords", dtype="s32", lanes=_tma_coords_lanes, bracket="src"),
+            OperandSlot("mbar", kind="addr", allow_imm_offset=True, space="shared"),
+            OperandSlot(
+                "cta_mask",
+                dtype=_multicast_mask_dtype,
+                lanes=_tma_mask_lanes,
+                vector=False,
+            ),
+            OperandSlot("cache_policy", dtype="u64", lanes=_tma_cache_lanes, vector=False),
+        ),
+    ),
+    # PTX ISA 9.4, 9.7.10.28.4.3/28.5.5: eviction-priority prefetch
+    # alternatives carry no cache-policy operand.
+    InstructionEntry(
+        name="cp_async_bulk_prefetch_evict_last",
+        mnemonic="cp",
+        slots=(
+            ModifierSlot("api", ("async",)),
+            ModifierSlot("kind", ("bulk",)),
+            ModifierSlot("op", ("prefetch",)),
+            ModifierSlot("level", ("L2",)),
+            ModifierSlot("src", ("global",)),
+            ModifierSlot("priority", ("L2::evict_last",)),
+        ),
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("src_mem", kind="addr", allow_imm_offset=True, space="global"),
+            OperandSlot("size", dtype="u32"),
+        ),
+    ),
+    InstructionEntry(
+        name="cp_async_bulk_tensor_prefetch_evict_last",
+        mnemonic="cp",
+        slots=(
+            ModifierSlot("api", ("async",)),
+            ModifierSlot("kind", ("bulk",)),
+            ModifierSlot("action", ("prefetch",)),
+            ModifierSlot("unit", ("tensor",)),
+            ModifierSlot("dim", ("1d", "2d", "3d", "4d", "5d")),
+            ModifierSlot("level", ("L2",)),
+            ModifierSlot("src", ("global",)),
+            ModifierSlot("load_mode", ("tile", "tile::gather4"), optional=True),
+            ModifierSlot("priority", ("L2::evict_last",)),
+        ),
+        check=_check_tma_gather4,
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("tmap", kind="addr", space="global", bracket="src"),
+            OperandSlot("coords", dtype="s32", lanes=_tma_coords_lanes, bracket="src"),
+        ),
+    ),
+    # TMA im2col load modes use a trailing vector outside the tensor address.
+    *[
+        InstructionEntry(
+            name=f"cp_async_bulk_tensor_g2s_{dst_name}_im2col",
+            mnemonic="cp",
+            slots=(
+                ModifierSlot("api", ("async",)),
+                ModifierSlot("kind", ("bulk",)),
+                ModifierSlot("unit", ("tensor",)),
+                ModifierSlot("dim", ("3d", "4d", "5d")),
+                ModifierSlot("dst", (dst,)),
+                ModifierSlot("src", ("global",)),
+                ModifierSlot("load_mode", ("im2col", "im2col::w", "im2col::w::128")),
+                ModifierSlot("completion", ("mbarrier::complete_tx::bytes",)),
+                ModifierSlot("report", _PTX_94_REPORT_MECHANISMS, optional=True),
+                *(
+                    (
+                        ModifierSlot(
+                            "multicast",
+                            (
+                                "multicast::cluster",
+                                "multicast::cluster::16b",
+                                "multicast::cluster::32b",
+                            ),
+                            optional=True,
+                        ),
+                    )
+                    if dst == "shared::cluster"
+                    else ()
+                ),
+                ModifierSlot("cta_group", ("cta_group::1", "cta_group::2"), optional=True),
+                ModifierSlot("cache", ("L2::cache_hint",), optional=True),
+            ),
+            check=_check_tma_im2col,
+            cert_arch="sm_107f",
+            operands=(
+                OperandSlot("dst_mem", kind="addr", allow_imm_offset=True, space=dst),
+                OperandSlot("tmap", kind="addr", space="global", bracket="src"),
+                OperandSlot("coords", dtype="s32", lanes=_tma_coords_lanes, bracket="src"),
+                OperandSlot("mbar", kind="addr", allow_imm_offset=True, space="shared"),
+                OperandSlot(
+                    "im2col_info",
+                    dtype=_tma_im2col_dtype,
+                    lanes=_tma_im2col_lanes,
+                ),
+                *(
+                    (
+                        OperandSlot(
+                            "cta_mask",
+                            dtype=_multicast_mask_dtype,
+                            lanes=_tma_mask_lanes,
+                            vector=False,
+                        ),
+                    )
+                    if dst == "shared::cluster"
+                    else ()
+                ),
+                OperandSlot("cache_policy", dtype="u64", lanes=_tma_cache_lanes, vector=False),
+            ),
+        )
+        for dst_name, dst in (("cta", "shared::cta"), ("cluster", "shared::cluster"))
+    ],
+    InstructionEntry(
+        name="cp_async_bulk_tensor_s2g_im2col_no_offs_w",
+        mnemonic="cp",
+        slots=(
+            ModifierSlot("api", ("async",)),
+            ModifierSlot("kind", ("bulk",)),
+            ModifierSlot("unit", ("tensor",)),
+            ModifierSlot("dim", ("3d", "4d", "5d")),
+            ModifierSlot("dst", ("global",)),
+            ModifierSlot("src", ("shared::cta",)),
+            ModifierSlot("load_mode", ("im2col_no_offs", "im2col_no_offs::w")),
+            ModifierSlot("completion", ("bulk_group",)),
+            ModifierSlot("cache", ("L2::cache_hint",), optional=True),
+        ),
+        check=_check_tma_im2col,
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("tmap", kind="addr", space="global", bracket="dst"),
+            OperandSlot("coords", dtype="s32", lanes=_tma_coords_lanes, bracket="dst"),
+            OperandSlot("src_mem", kind="addr", allow_imm_offset=True, space="shared::cta"),
+            OperandSlot("cache_policy", dtype="u64", lanes=_tma_cache_lanes, vector=False),
+        ),
+    ),
+    InstructionEntry(
+        name="cp_reduce_async_bulk_tensor_im2col_no_offs_w",
+        mnemonic="cp",
+        slots=(
+            ModifierSlot("op", ("reduce",)),
+            ModifierSlot("api", ("async",)),
+            ModifierSlot("kind", ("bulk",)),
+            ModifierSlot("unit", ("tensor",)),
+            ModifierSlot("dim", ("3d", "4d", "5d")),
+            ModifierSlot("dst", ("global",)),
+            ModifierSlot("src", ("shared::cta",)),
+            ModifierSlot("redop", ("add", "min", "max", "inc", "dec", "and", "or", "xor")),
+            ModifierSlot("load_mode", ("im2col_no_offs", "im2col_no_offs::w")),
+            ModifierSlot("completion", ("bulk_group",)),
+            ModifierSlot("cache", ("L2::cache_hint",), optional=True),
+        ),
+        check=_check_tma_im2col,
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("tmap", kind="addr", space="global", bracket="dst"),
+            OperandSlot("coords", dtype="s32", lanes=_tma_coords_lanes, bracket="dst"),
+            OperandSlot("src_mem", kind="addr", allow_imm_offset=True, space="shared::cta"),
+            OperandSlot("cache_policy", dtype="u64", lanes=_tma_cache_lanes, vector=False),
+        ),
+    ),
+    InstructionEntry(
+        name="cp_async_bulk_tensor_prefetch_im2col",
+        mnemonic="cp",
+        slots=(
+            ModifierSlot("api", ("async",)),
+            ModifierSlot("kind", ("bulk",)),
+            ModifierSlot("action", ("prefetch",)),
+            ModifierSlot("unit", ("tensor",)),
+            ModifierSlot("dim", ("3d", "4d", "5d")),
+            ModifierSlot("level", ("L2",)),
+            ModifierSlot("src", ("global",)),
+            ModifierSlot("load_mode", ("im2col", "im2col::w", "im2col::w::128")),
+            ModifierSlot("cache", ("L2::cache_hint",), optional=True),
+        ),
+        check=_check_tma_im2col,
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("tmap", kind="addr", space="global", bracket="src"),
+            OperandSlot("coords", dtype="s32", lanes=_tma_coords_lanes, bracket="src"),
+            OperandSlot(
+                "im2col_info",
+                dtype=_tma_im2col_dtype,
+                lanes=_tma_im2col_lanes,
+            ),
+            OperandSlot("cache_policy", dtype="u64", lanes=_tma_cache_lanes, vector=False),
+        ),
+    ),
+    InstructionEntry(
+        name="cp_async_bulk_tensor_prefetch_im2col_evict_last",
+        mnemonic="cp",
+        slots=(
+            ModifierSlot("api", ("async",)),
+            ModifierSlot("kind", ("bulk",)),
+            ModifierSlot("action", ("prefetch",)),
+            ModifierSlot("unit", ("tensor",)),
+            ModifierSlot("dim", ("3d", "4d", "5d")),
+            ModifierSlot("level", ("L2",)),
+            ModifierSlot("src", ("global",)),
+            ModifierSlot("load_mode", ("im2col", "im2col::w", "im2col::w::128")),
+            ModifierSlot("priority", ("L2::evict_last",)),
+        ),
+        check=_check_tma_im2col,
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("tmap", kind="addr", space="global", bracket="src"),
+            OperandSlot("coords", dtype="s32", lanes=_tma_coords_lanes, bracket="src"),
+            OperandSlot(
+                "im2col_info",
+                dtype=_tma_im2col_dtype,
+                lanes=_tma_im2col_lanes,
+            ),
+        ),
+    ),
+    InstructionEntry(
+        name="applypriority_async_bulk_tensor_im2col",
+        mnemonic="applypriority",
+        slots=(
+            ModifierSlot("api", ("async",)),
+            ModifierSlot("kind", ("bulk",)),
+            ModifierSlot("unit", ("tensor",)),
+            ModifierSlot("dim", ("3d", "4d", "5d")),
+            ModifierSlot("src", ("global",), optional=True),
+            ModifierSlot("completion", ("bulk_group",)),
+            ModifierSlot("load_mode", ("im2col", "im2col::w", "im2col::w::128")),
+            ModifierSlot("priority", ("L2::evict_normal",)),
+        ),
+        check=_check_tma_im2col,
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("tmap", kind="addr", space="global", bracket="src"),
+            OperandSlot("coords", dtype="s32", lanes=_tma_coords_lanes, bracket="src"),
+            OperandSlot(
+                "im2col_info",
+                dtype=_tma_im2col_dtype,
+                lanes=_tma_im2col_lanes,
+            ),
+        ),
+    ),
+    # PTX ISA 9.4, 9.7.10.28.5.2: the TMA base-address override is a u64
+    # inside the composite tensor address immediately after tensorMap.
+    *[
+        InstructionEntry(
+            name=f"cp_async_bulk_tensor_g2s_{dst_name}_override_address",
+            mnemonic="cp",
+            slots=(
+                ModifierSlot("api", ("async",)),
+                ModifierSlot("kind", ("bulk",)),
+                ModifierSlot("unit", ("tensor",)),
+                ModifierSlot("dim", ("1d", "2d", "3d", "4d", "5d")),
+                ModifierSlot("dst", (dst,)),
+                ModifierSlot("src", ("global",)),
+                ModifierSlot("load_mode", ("tile", "tile::gather4"), optional=True),
+                ModifierSlot("completion", ("mbarrier::complete_tx::bytes",)),
+                ModifierSlot("report", _PTX_94_REPORT_MECHANISMS, optional=True),
+                *(
+                    (
+                        ModifierSlot(
+                            "multicast",
+                            (
+                                "multicast::cluster",
+                                "multicast::cluster::16b",
+                                "multicast::cluster::32b",
+                            ),
+                            optional=True,
+                        ),
+                    )
+                    if dst == "shared::cluster"
+                    else ()
+                ),
+                ModifierSlot("cta_group", ("cta_group::1", "cta_group::2"), optional=True),
+                ModifierSlot("cache", ("L2::cache_hint",), optional=True),
+                ModifierSlot("override_address", ("override::global_address",)),
+            ),
+            check=_check_tma_gather4,
+            cert_arch="sm_107f",
+            operands=(
+                OperandSlot("dst_mem", kind="addr", allow_imm_offset=True, space=dst),
+                OperandSlot("tmap", kind="addr", space="global", bracket="src"),
+                OperandSlot("global_address", dtype="u64", bracket="src"),
+                OperandSlot("coords", dtype="s32", lanes=_tma_coords_lanes, bracket="src"),
+                OperandSlot("mbar", kind="addr", allow_imm_offset=True, space="shared"),
+                *(
+                    (
+                        OperandSlot(
+                            "cta_mask",
+                            dtype=_multicast_mask_dtype,
+                            lanes=_tma_mask_lanes,
+                            vector=False,
+                        ),
+                    )
+                    if dst == "shared::cluster"
+                    else ()
+                ),
+                OperandSlot("cache_policy", dtype="u64", lanes=_tma_cache_lanes, vector=False),
+            ),
+        )
+        for dst_name, dst in (("cta", "shared::cta"), ("cluster", "shared::cluster"))
+    ],
+    InstructionEntry(
+        name="cp_async_bulk_tensor_s2g_override_address",
+        mnemonic="cp",
+        slots=(
+            ModifierSlot("api", ("async",)),
+            ModifierSlot("kind", ("bulk",)),
+            ModifierSlot("unit", ("tensor",)),
+            ModifierSlot("dim", ("1d", "2d", "3d", "4d", "5d")),
+            ModifierSlot("dst", ("global",)),
+            ModifierSlot("src", ("shared::cta",)),
+            ModifierSlot("load_mode", ("tile", "tile::scatter4"), optional=True),
+            ModifierSlot("completion", ("bulk_group",)),
+            ModifierSlot("cache", ("L2::cache_hint",), optional=True),
+            ModifierSlot("override_address", ("override::global_address",)),
+        ),
+        check=_check_tma_gather4,
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("tmap", kind="addr", space="global", bracket="dst"),
+            OperandSlot("global_address", dtype="u64", bracket="dst"),
+            OperandSlot("coords", dtype="s32", lanes=_tma_coords_lanes, bracket="dst"),
+            OperandSlot("src_mem", kind="addr", allow_imm_offset=True, space="shared::cta"),
+            OperandSlot("cache_policy", dtype="u64", lanes=_tma_cache_lanes, vector=False),
+        ),
+    ),
+    InstructionEntry(
+        name="cp_reduce_async_bulk_tensor_override_address",
+        mnemonic="cp",
+        slots=(
+            ModifierSlot("op", ("reduce",)),
+            ModifierSlot("api", ("async",)),
+            ModifierSlot("kind", ("bulk",)),
+            ModifierSlot("unit", ("tensor",)),
+            ModifierSlot("dim", ("1d", "2d", "3d", "4d", "5d")),
+            ModifierSlot("dst", ("global",)),
+            ModifierSlot("src", ("shared::cta",)),
+            ModifierSlot("redop", ("add", "min", "max", "inc", "dec", "and", "or", "xor")),
+            ModifierSlot("load_mode", ("tile",), optional=True),
+            ModifierSlot("completion", ("bulk_group",)),
+            ModifierSlot("cache", ("L2::cache_hint",), optional=True),
+            ModifierSlot("override_address", ("override::global_address",)),
+        ),
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("tmap", kind="addr", space="global", bracket="dst"),
+            OperandSlot("global_address", dtype="u64", bracket="dst"),
+            OperandSlot("coords", dtype="s32", lanes=_tma_coords_lanes, bracket="dst"),
+            OperandSlot("src_mem", kind="addr", allow_imm_offset=True, space="shared::cta"),
+            OperandSlot("cache_policy", dtype="u64", lanes=_tma_cache_lanes, vector=False),
+        ),
+    ),
+    InstructionEntry(
+        name="cp_async_bulk_tensor_prefetch_override_address",
+        mnemonic="cp",
+        slots=(
+            ModifierSlot("api", ("async",)),
+            ModifierSlot("kind", ("bulk",)),
+            ModifierSlot("action", ("prefetch",)),
+            ModifierSlot("unit", ("tensor",)),
+            ModifierSlot("dim", ("1d", "2d", "3d", "4d", "5d")),
+            ModifierSlot("level", ("L2",)),
+            ModifierSlot("src", ("global",)),
+            ModifierSlot("load_mode", ("tile", "tile::gather4"), optional=True),
+            ModifierSlot("cache", ("L2::cache_hint",), optional=True),
+            ModifierSlot("override_address", ("override::global_address",)),
+        ),
+        check=_check_tma_gather4,
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("tmap", kind="addr", space="global", bracket="src"),
+            OperandSlot("global_address", dtype="u64", bracket="src"),
+            OperandSlot("coords", dtype="s32", lanes=_tma_coords_lanes, bracket="src"),
+            OperandSlot("cache_policy", dtype="u64", lanes=_tma_cache_lanes, vector=False),
+        ),
+    ),
+    InstructionEntry(
+        name="cp_async_bulk_tensor_prefetch_override_address_evict_last",
+        mnemonic="cp",
+        slots=(
+            ModifierSlot("api", ("async",)),
+            ModifierSlot("kind", ("bulk",)),
+            ModifierSlot("action", ("prefetch",)),
+            ModifierSlot("unit", ("tensor",)),
+            ModifierSlot("dim", ("1d", "2d", "3d", "4d", "5d")),
+            ModifierSlot("level", ("L2",)),
+            ModifierSlot("src", ("global",)),
+            ModifierSlot("load_mode", ("tile", "tile::gather4"), optional=True),
+            ModifierSlot("priority", ("L2::evict_last",)),
+            ModifierSlot("override_address", ("override::global_address",)),
+        ),
+        check=_check_tma_gather4,
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("tmap", kind="addr", space="global", bracket="src"),
+            OperandSlot("global_address", dtype="u64", bracket="src"),
+            OperandSlot("coords", dtype="s32", lanes=_tma_coords_lanes, bracket="src"),
+        ),
+    ),
+    InstructionEntry(
+        name="applypriority_async_bulk_tensor_override_address",
+        mnemonic="applypriority",
+        slots=(
+            ModifierSlot("api", ("async",)),
+            ModifierSlot("kind", ("bulk",)),
+            ModifierSlot("unit", ("tensor",)),
+            ModifierSlot("dim", ("1d", "2d", "3d", "4d", "5d")),
+            ModifierSlot("src", ("global",), optional=True),
+            ModifierSlot("completion", ("bulk_group",)),
+            ModifierSlot("load_mode", ("tile", "tile::gather4"), optional=True),
+            ModifierSlot("priority", ("L2::evict_normal",)),
+            ModifierSlot("override_address", ("override::global_address",)),
+        ),
+        check=_check_tma_gather4,
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("tmap", kind="addr", space="global", bracket="src"),
+            OperandSlot("global_address", dtype="u64", bracket="src"),
+            OperandSlot("coords", dtype="s32", lanes=_tma_coords_lanes, bracket="src"),
+        ),
+    ),
+    # Attribute override for 1D tensors: a singleton .b8/.b16 size vector.
+    *[
+        InstructionEntry(
+            name=f"cp_async_bulk_tensor_g2s_{dst_name}_override_global_dim_{size_name}",
+            mnemonic="cp",
+            slots=(
+                ModifierSlot("api", ("async",)),
+                ModifierSlot("kind", ("bulk",)),
+                ModifierSlot("unit", ("tensor",)),
+                ModifierSlot("dim", ("1d",)),
+                ModifierSlot("dst", (dst,)),
+                ModifierSlot("src", ("global",)),
+                ModifierSlot("load_mode", ("tile",), optional=True),
+                ModifierSlot("completion", ("mbarrier::complete_tx::bytes",)),
+                ModifierSlot("report", _PTX_94_REPORT_MECHANISMS, optional=True),
+                *(
+                    (
+                        ModifierSlot(
+                            "multicast",
+                            ("multicast::cluster::32b",),
+                            optional=True,
+                        ),
+                    )
+                    if dst == "shared::cluster"
+                    else ()
+                ),
+                ModifierSlot("cta_group", ("cta_group::1", "cta_group::2"), optional=True),
+                ModifierSlot("cache", ("L2::cache_hint",), optional=True),
+                ModifierSlot("override_address", ("override::global_address",)),
+                ModifierSlot("override_attribute", ("override::global_dim",)),
+            ),
+            cert_arch="sm_107f",
+            operands=(
+                OperandSlot("dst_mem", kind="addr", allow_imm_offset=True, space=dst),
+                *_tma_global_dim_operands("src", size_type),
+                OperandSlot("mbar", kind="addr", allow_imm_offset=True, space="shared"),
+                *(
+                    (
+                        OperandSlot(
+                            "cta_mask",
+                            dtype="u32",
+                            lanes=_tma_mask_lanes,
+                            vector=False,
+                        ),
+                    )
+                    if dst == "shared::cluster"
+                    else ()
+                ),
+                OperandSlot("cache_policy", dtype="u64", lanes=_tma_cache_lanes, vector=False),
+            ),
+        )
+        for dst_name, dst in (("cta", "shared::cta"), ("cluster", "shared::cluster"))
+        for size_name, size_type in (("b8", "tma_size_b8"), ("b16", "b16"))
+    ],
+    *[
+        InstructionEntry(
+            name=f"cp_async_bulk_tensor_s2g_override_global_dim_{size_name}",
+            mnemonic="cp",
+            slots=(
+                ModifierSlot("api", ("async",)),
+                ModifierSlot("kind", ("bulk",)),
+                ModifierSlot("unit", ("tensor",)),
+                ModifierSlot("dim", ("1d",)),
+                ModifierSlot("dst", ("global",)),
+                ModifierSlot("src", ("shared::cta",)),
+                ModifierSlot("load_mode", ("tile",), optional=True),
+                ModifierSlot("completion", ("bulk_group",)),
+                ModifierSlot("cache", ("L2::cache_hint",), optional=True),
+                ModifierSlot("override_address", ("override::global_address",)),
+                ModifierSlot("override_attribute", ("override::global_dim",)),
+            ),
+            cert_arch="sm_107f",
+            operands=(
+                *_tma_global_dim_operands("dst", size_type),
+                OperandSlot("src_mem", kind="addr", allow_imm_offset=True, space="shared::cta"),
+                OperandSlot("cache_policy", dtype="u64", lanes=_tma_cache_lanes, vector=False),
+            ),
+        )
+        for size_name, size_type in (("b8", "tma_size_b8"), ("b16", "b16"))
+    ],
+    *[
+        InstructionEntry(
+            name=f"cp_reduce_async_bulk_tensor_override_global_dim_{size_name}",
+            mnemonic="cp",
+            slots=(
+                ModifierSlot("op", ("reduce",)),
+                ModifierSlot("api", ("async",)),
+                ModifierSlot("kind", ("bulk",)),
+                ModifierSlot("unit", ("tensor",)),
+                ModifierSlot("dim", ("1d",)),
+                ModifierSlot("dst", ("global",)),
+                ModifierSlot("src", ("shared::cta",)),
+                ModifierSlot("redop", ("add", "min", "max", "inc", "dec", "and", "or", "xor")),
+                ModifierSlot("load_mode", ("tile",), optional=True),
+                ModifierSlot("completion", ("bulk_group",)),
+                ModifierSlot("cache", ("L2::cache_hint",), optional=True),
+                ModifierSlot("override_address", ("override::global_address",)),
+                ModifierSlot("override_attribute", ("override::global_dim",)),
+            ),
+            cert_arch="sm_107f",
+            operands=(
+                *_tma_global_dim_operands("dst", size_type),
+                OperandSlot("src_mem", kind="addr", allow_imm_offset=True, space="shared::cta"),
+                OperandSlot("cache_policy", dtype="u64", lanes=_tma_cache_lanes, vector=False),
+            ),
+        )
+        for size_name, size_type in (("b8", "tma_size_b8"), ("b16", "b16"))
+    ],
+    *[
+        InstructionEntry(
+            name=f"cp_async_bulk_tensor_prefetch_override_global_dim_{size_name}",
+            mnemonic="cp",
+            slots=(
+                ModifierSlot("api", ("async",)),
+                ModifierSlot("kind", ("bulk",)),
+                ModifierSlot("action", ("prefetch",)),
+                ModifierSlot("unit", ("tensor",)),
+                ModifierSlot("dim", ("1d",)),
+                ModifierSlot("level", ("L2",)),
+                ModifierSlot("src", ("global",)),
+                ModifierSlot("load_mode", ("tile",), optional=True),
+                ModifierSlot("cache", ("L2::cache_hint",), optional=True),
+                ModifierSlot("override_address", ("override::global_address",)),
+                ModifierSlot("override_attribute", ("override::global_dim",)),
+            ),
+            cert_arch="sm_107f",
+            operands=(
+                *_tma_global_dim_operands("src", size_type),
+                OperandSlot("cache_policy", dtype="u64", lanes=_tma_cache_lanes, vector=False),
+            ),
+        )
+        for size_name, size_type in (("b8", "tma_size_b8"), ("b16", "b16"))
+    ],
+    *[
+        InstructionEntry(
+            name=f"cp_async_bulk_tensor_prefetch_override_global_dim_evict_last_{size_name}",
+            mnemonic="cp",
+            slots=(
+                ModifierSlot("api", ("async",)),
+                ModifierSlot("kind", ("bulk",)),
+                ModifierSlot("action", ("prefetch",)),
+                ModifierSlot("unit", ("tensor",)),
+                ModifierSlot("dim", ("1d",)),
+                ModifierSlot("level", ("L2",)),
+                ModifierSlot("src", ("global",)),
+                ModifierSlot("load_mode", ("tile",), optional=True),
+                ModifierSlot("priority", ("L2::evict_last",)),
+                ModifierSlot("override_address", ("override::global_address",)),
+                ModifierSlot("override_attribute", ("override::global_dim",)),
+            ),
+            cert_arch="sm_107f",
+            operands=_tma_global_dim_operands("src", size_type),
+        )
+        for size_name, size_type in (("b8", "tma_size_b8"), ("b16", "b16"))
+    ],
+    *[
+        InstructionEntry(
+            name=f"applypriority_async_bulk_tensor_override_global_dim_{size_name}",
+            mnemonic="applypriority",
+            slots=(
+                ModifierSlot("api", ("async",)),
+                ModifierSlot("kind", ("bulk",)),
+                ModifierSlot("unit", ("tensor",)),
+                ModifierSlot("dim", ("1d",)),
+                ModifierSlot("src", ("global",), optional=True),
+                ModifierSlot("completion", ("bulk_group",)),
+                ModifierSlot("load_mode", ("tile",), optional=True),
+                ModifierSlot("priority", ("L2::evict_normal",)),
+                ModifierSlot("override_address", ("override::global_address",)),
+                ModifierSlot("override_attribute", ("override::global_dim",)),
+            ),
+            cert_arch="sm_107f",
+            operands=_tma_global_dim_operands("src", size_type),
+        )
+        for size_name, size_type in (("b8", "tma_size_b8"), ("b16", "b16"))
+    ],
+    # Attribute override for 2D-5D tensors: size, lower-stride, and packed
+    # upper-stride components inside the tensor address.
+    *[
+        InstructionEntry(
+            name=f"cp_async_bulk_tensor_g2s_{dst_name}_override_global_dim_stride_{size_name}",
+            mnemonic="cp",
+            slots=(
+                ModifierSlot("api", ("async",)),
+                ModifierSlot("kind", ("bulk",)),
+                ModifierSlot("unit", ("tensor",)),
+                ModifierSlot("dim", ("2d", "3d", "4d", "5d")),
+                ModifierSlot("dst", (dst,)),
+                ModifierSlot("src", ("global",)),
+                ModifierSlot("load_mode", ("tile",), optional=True),
+                ModifierSlot("completion", ("mbarrier::complete_tx::bytes",)),
+                ModifierSlot("report", _PTX_94_REPORT_MECHANISMS, optional=True),
+                *(
+                    (
+                        ModifierSlot(
+                            "multicast",
+                            ("multicast::cluster::32b",),
+                            optional=True,
+                        ),
+                    )
+                    if dst == "shared::cluster"
+                    else ()
+                ),
+                ModifierSlot("cta_group", ("cta_group::1", "cta_group::2"), optional=True),
+                ModifierSlot("cache", ("L2::cache_hint",), optional=True),
+                ModifierSlot("override_address", ("override::global_address",)),
+                ModifierSlot("override_attribute", ("override::global_dim_stride",)),
+            ),
+            cert_arch="sm_107f",
+            operands=(
+                OperandSlot("dst_mem", kind="addr", allow_imm_offset=True, space=dst),
+                *_tma_global_dim_stride_operands("src", size_type),
+                OperandSlot("mbar", kind="addr", allow_imm_offset=True, space="shared"),
+                *(
+                    (
+                        OperandSlot(
+                            "cta_mask",
+                            dtype="u32",
+                            lanes=_tma_mask_lanes,
+                            vector=False,
+                        ),
+                    )
+                    if dst == "shared::cluster"
+                    else ()
+                ),
+                OperandSlot("cache_policy", dtype="u64", lanes=_tma_cache_lanes, vector=False),
+            ),
+        )
+        for dst_name, dst in (("cta", "shared::cta"), ("cluster", "shared::cluster"))
+        for size_name, size_type in (("b8", "tma_size_b8"), ("b16", "b16"))
+    ],
+    *[
+        InstructionEntry(
+            name=f"cp_async_bulk_tensor_s2g_override_global_dim_stride_{size_name}",
+            mnemonic="cp",
+            slots=(
+                ModifierSlot("api", ("async",)),
+                ModifierSlot("kind", ("bulk",)),
+                ModifierSlot("unit", ("tensor",)),
+                ModifierSlot("dim", ("2d", "3d", "4d", "5d")),
+                ModifierSlot("dst", ("global",)),
+                ModifierSlot("src", ("shared::cta",)),
+                ModifierSlot("load_mode", ("tile",), optional=True),
+                ModifierSlot("completion", ("bulk_group",)),
+                ModifierSlot("cache", ("L2::cache_hint",), optional=True),
+                ModifierSlot("override_address", ("override::global_address",)),
+                ModifierSlot("override_attribute", ("override::global_dim_stride",)),
+            ),
+            cert_arch="sm_107f",
+            operands=(
+                *_tma_global_dim_stride_operands("dst", size_type),
+                OperandSlot("src_mem", kind="addr", allow_imm_offset=True, space="shared::cta"),
+                OperandSlot("cache_policy", dtype="u64", lanes=_tma_cache_lanes, vector=False),
+            ),
+        )
+        for size_name, size_type in (("b8", "tma_size_b8"), ("b16", "b16"))
+    ],
+    *[
+        InstructionEntry(
+            name=f"cp_reduce_async_bulk_tensor_override_global_dim_stride_{size_name}",
+            mnemonic="cp",
+            slots=(
+                ModifierSlot("op", ("reduce",)),
+                ModifierSlot("api", ("async",)),
+                ModifierSlot("kind", ("bulk",)),
+                ModifierSlot("unit", ("tensor",)),
+                ModifierSlot("dim", ("2d", "3d", "4d", "5d")),
+                ModifierSlot("dst", ("global",)),
+                ModifierSlot("src", ("shared::cta",)),
+                ModifierSlot("redop", ("add", "min", "max", "inc", "dec", "and", "or", "xor")),
+                ModifierSlot("load_mode", ("tile",), optional=True),
+                ModifierSlot("completion", ("bulk_group",)),
+                ModifierSlot("cache", ("L2::cache_hint",), optional=True),
+                ModifierSlot("override_address", ("override::global_address",)),
+                ModifierSlot("override_attribute", ("override::global_dim_stride",)),
+            ),
+            cert_arch="sm_107f",
+            operands=(
+                *_tma_global_dim_stride_operands("dst", size_type),
+                OperandSlot("src_mem", kind="addr", allow_imm_offset=True, space="shared::cta"),
+                OperandSlot("cache_policy", dtype="u64", lanes=_tma_cache_lanes, vector=False),
+            ),
+        )
+        for size_name, size_type in (("b8", "tma_size_b8"), ("b16", "b16"))
+    ],
+    *[
+        InstructionEntry(
+            name=f"cp_async_bulk_tensor_prefetch_override_global_dim_stride_{size_name}",
+            mnemonic="cp",
+            slots=(
+                ModifierSlot("api", ("async",)),
+                ModifierSlot("kind", ("bulk",)),
+                ModifierSlot("action", ("prefetch",)),
+                ModifierSlot("unit", ("tensor",)),
+                ModifierSlot("dim", ("2d", "3d", "4d", "5d")),
+                ModifierSlot("level", ("L2",)),
+                ModifierSlot("src", ("global",)),
+                ModifierSlot("load_mode", ("tile",), optional=True),
+                ModifierSlot("cache", ("L2::cache_hint",), optional=True),
+                ModifierSlot("override_address", ("override::global_address",)),
+                ModifierSlot("override_attribute", ("override::global_dim_stride",)),
+            ),
+            cert_arch="sm_107f",
+            operands=(
+                *_tma_global_dim_stride_operands("src", size_type),
+                OperandSlot("cache_policy", dtype="u64", lanes=_tma_cache_lanes, vector=False),
+            ),
+        )
+        for size_name, size_type in (("b8", "tma_size_b8"), ("b16", "b16"))
+    ],
+    *[
+        InstructionEntry(
+            name=f"cp_async_bulk_tensor_prefetch_override_global_dim_stride_evict_last_{size_name}",
+            mnemonic="cp",
+            slots=(
+                ModifierSlot("api", ("async",)),
+                ModifierSlot("kind", ("bulk",)),
+                ModifierSlot("action", ("prefetch",)),
+                ModifierSlot("unit", ("tensor",)),
+                ModifierSlot("dim", ("2d", "3d", "4d", "5d")),
+                ModifierSlot("level", ("L2",)),
+                ModifierSlot("src", ("global",)),
+                ModifierSlot("load_mode", ("tile",), optional=True),
+                ModifierSlot("priority", ("L2::evict_last",)),
+                ModifierSlot("override_address", ("override::global_address",)),
+                ModifierSlot("override_attribute", ("override::global_dim_stride",)),
+            ),
+            cert_arch="sm_107f",
+            operands=_tma_global_dim_stride_operands("src", size_type),
+        )
+        for size_name, size_type in (("b8", "tma_size_b8"), ("b16", "b16"))
+    ],
+    *[
+        InstructionEntry(
+            name=f"applypriority_async_bulk_tensor_override_global_dim_stride_{size_name}",
+            mnemonic="applypriority",
+            slots=(
+                ModifierSlot("api", ("async",)),
+                ModifierSlot("kind", ("bulk",)),
+                ModifierSlot("unit", ("tensor",)),
+                ModifierSlot("dim", ("2d", "3d", "4d", "5d")),
+                ModifierSlot("src", ("global",), optional=True),
+                ModifierSlot("completion", ("bulk_group",)),
+                ModifierSlot("load_mode", ("tile",), optional=True),
+                ModifierSlot("priority", ("L2::evict_normal",)),
+                ModifierSlot("override_address", ("override::global_address",)),
+                ModifierSlot("override_attribute", ("override::global_dim_stride",)),
+            ),
+            cert_arch="sm_107f",
+            operands=_tma_global_dim_stride_operands("src", size_type),
+        )
+        for size_name, size_type in (("b8", "tma_size_b8"), ("b16", "b16"))
+    ],
+    # PTX ISA 9.4, 9.7.18.10.10 -- SM107 family TensorCore MMA.
+    # .kind::ti16 encodes 16-bit signed s1z4m11 multiplicands in the
+    # instruction descriptor. Dense, sparse, weight-stationary, and
+    # weight-stationary sparse forms are separate syntax shapes.
+    *[
+        InstructionEntry(
+            name=f"tcgen05_mma_ti16_{form}" + ("_collector_b" if collector else ""),
+            mnemonic="tcgen05",
+            slots=(
+                ModifierSlot("action", ("mma",)),
+                ModifierSlot("cta_group", ("cta_group::1", "cta_group::2")),
+                ModifierSlot("kind", ("kind::ti16",)),
+                *((ModifierSlot("collector_b", _TCGEN05_COLLECTOR_B),) if collector else ()),
+            ),
+            cert_arch="sm_107f",
+            operands=(
+                OperandSlot("d_tmem", kind="addr", space="tmem"),
+                *(
+                    (OperandSlot("a_desc", dtype="u64"),)
+                    if form == "ss"
+                    else (OperandSlot("a_tmem", kind="addr", space="tmem"),)
+                ),
+                OperandSlot("b_desc", dtype="u64"),
+                OperandSlot("idesc", dtype="u32"),
+                OperandSlot(
+                    "disable_output_lane",
+                    dtype="u32",
+                    lanes=_tcgen05_mma_mask_lanes,
+                ),
+                OperandSlot("enable_input_d", dtype="pred"),
+            ),
+        )
+        for form in ("ss", "ts")
+        for collector in (False, True)
+    ],
+    # The 9.4 syntax line `tcgen05.mma.sp.cta_group.kind::ti16.collector_b_usage`
+    # (9.7.18.10.10.2, block 5) omits `[sp-meta-tmem]`; the sparse metadata
+    # operand is present on every other tcgen05.mma.sp line.  MEASURED on CUDA
+    # 13.4 ptxas: the spelling without it is "Arguments mismatch", with it
+    # assembles, so `sp_meta_tmem` stays on every sparse ti16 shape.
+    *[
+        InstructionEntry(
+            name=f"tcgen05_mma_sp_ti16_{form}" + ("_collector_b" if collector else ""),
+            mnemonic="tcgen05",
+            slots=(
+                ModifierSlot("action", ("mma",)),
+                ModifierSlot("sp", ("sp",)),
+                ModifierSlot("cta_group", ("cta_group::1", "cta_group::2")),
+                ModifierSlot("kind", ("kind::ti16",)),
+                *((ModifierSlot("collector_b", _TCGEN05_COLLECTOR_B),) if collector else ()),
+            ),
+            cert_arch="sm_107f",
+            operands=(
+                OperandSlot("d_tmem", kind="addr", space="tmem"),
+                *(
+                    (OperandSlot("a_desc", dtype="u64"),)
+                    if form == "ss"
+                    else (OperandSlot("a_tmem", kind="addr", space="tmem"),)
+                ),
+                OperandSlot("b_desc", dtype="u64"),
+                OperandSlot("sp_meta_tmem", kind="addr", space="tmem"),
+                OperandSlot("idesc", dtype="u32"),
+                OperandSlot(
+                    "disable_output_lane",
+                    dtype="u32",
+                    lanes=_tcgen05_mma_mask_lanes,
+                ),
+                OperandSlot("enable_input_d", dtype="pred"),
+            ),
+        )
+        for form in ("ss", "ts")
+        for collector in (False, True)
+    ],
+    *[
+        InstructionEntry(
+            name=(
+                f"tcgen05_mma_ws{'_sp' if sparse else ''}_ti16_{form}" + ("_mask" if mask else "")
+            ),
+            mnemonic="tcgen05",
+            slots=(
+                ModifierSlot("action", ("mma",)),
+                ModifierSlot("ws", ("ws",)),
+                *((ModifierSlot("sp", ("sp",)),) if sparse else ()),
+                ModifierSlot("cta_group", ("cta_group::1",)),
+                ModifierSlot("kind", ("kind::ti16",)),
+                ModifierSlot("collector_b", _TCGEN05_WS_COLLECTOR_B, optional=True),
+            ),
+            cert_arch="sm_107f",
+            operands=(
+                OperandSlot("d_tmem", kind="addr", space="tmem"),
+                *(
+                    (OperandSlot("a_desc", dtype="u64"),)
+                    if form == "ss"
+                    else (OperandSlot("a_tmem", kind="addr", space="tmem"),)
+                ),
+                OperandSlot("b_desc", dtype="u64"),
+                *((OperandSlot("sp_meta_tmem", kind="addr", space="tmem"),) if sparse else ()),
+                OperandSlot("idesc", dtype="u32"),
+                OperandSlot("enable_input_d", dtype="pred"),
+                *((OperandSlot("zero_col_mask", dtype="u64"),) if mask else ()),
+            ),
+        )
+        for sparse in (False, True)
+        for form in ("ss", "ts")
+        for mask in (False, True)
+    ],
+    # PTX ISA 9.4 pre-compressed-B lookup-table decompression. The metadata
+    # and scale operands are Tensor Memory addresses. Collector A and B are
+    # independently optional exactly as the two syntax lines specify.
+    *[
+        InstructionEntry(
+            name=f"tcgen05_mma_lut_b_{form}",
+            mnemonic="tcgen05",
+            slots=(
+                ModifierSlot("action", ("mma",)),
+                ModifierSlot("cta_group", ("cta_group::1", "cta_group::2")),
+                ModifierSlot("kind", ("kind::f8f6f4",)),
+                ModifierSlot("decompress", ("decompress::lut::b",)),
+                ModifierSlot("collector_a", _TCGEN05_COLLECTOR_A, optional=True),
+                ModifierSlot("collector_b", _TCGEN05_COLLECTOR_B, optional=True),
+            ),
+            cert_arch="sm_107f",
+            operands=(
+                OperandSlot("d_tmem", kind="addr", space="tmem"),
+                *(
+                    (OperandSlot("a_desc", dtype="u64"),)
+                    if form == "ss"
+                    else (OperandSlot("a_tmem", kind="addr", space="tmem"),)
+                ),
+                OperandSlot("b_compressed_desc", dtype="u64"),
+                OperandSlot("b_decompress_metadata", kind="addr", space="tmem"),
+                OperandSlot("idesc", dtype="u32"),
+                OperandSlot(
+                    "disable_output_lane",
+                    dtype="u32",
+                    lanes=_tcgen05_mma_mask_lanes,
+                ),
+                OperandSlot("enable_input_d", dtype="pred"),
+            ),
+        )
+        for form in ("ss", "ts")
+    ],
+    *[
+        InstructionEntry(
+            name=f"tcgen05_mma_block_scale_lut_b_{form}",
+            mnemonic="tcgen05",
+            slots=(
+                ModifierSlot("action", ("mma",)),
+                ModifierSlot("cta_group", ("cta_group::1", "cta_group::2")),
+                ModifierSlot("kind", ("kind::mxf8f6f4",)),
+                ModifierSlot("block_scale", ("block_scale",)),
+                ModifierSlot("decompress", ("decompress::lut::b",)),
+                ModifierSlot("block_size", ("block32",), optional=True),
+                ModifierSlot("collector_a", _TCGEN05_COLLECTOR_A, optional=True),
+                ModifierSlot("collector_b", _TCGEN05_COLLECTOR_B, optional=True),
+            ),
+            cert_arch="sm_107f",
+            operands=(
+                OperandSlot("d_tmem", kind="addr", space="tmem"),
+                *(
+                    (OperandSlot("a_desc", dtype="u64"),)
+                    if form == "ss"
+                    else (OperandSlot("a_tmem", kind="addr", space="tmem"),)
+                ),
+                OperandSlot("b_compressed_desc", dtype="u64"),
+                OperandSlot("b_decompress_metadata", kind="addr", space="tmem"),
+                OperandSlot("idesc", dtype="u32"),
+                OperandSlot("sfa_tmem", kind="addr", space="tmem"),
+                OperandSlot("sfb_tmem", kind="addr", space="tmem"),
+                OperandSlot("enable_input_d", dtype="pred"),
+            ),
+        )
+        for form in ("ss", "ts")
+    ],
+    # PTX ISA 9.4 collector-B support on activation-stationary dense and
+    # sparse MMA.  The three entries partition the manual's overlapping
+    # shared-A, tmem-A+ashift, and tmem-A+collector-A syntax lines so a
+    # written opcode is owned by exactly one entry.
+    *[
+        InstructionEntry(
+            name=(f"tcgen05_mma{'_sp' if sparse else ''}_collector_ab_ss"),
+            mnemonic="tcgen05",
+            slots=(
+                ModifierSlot("action", ("mma",)),
+                *((ModifierSlot("sp", ("sp",)),) if sparse else ()),
+                ModifierSlot("cta_group", ("cta_group::1", "cta_group::2")),
+                ModifierSlot(
+                    "kind",
+                    ("kind::f16", "kind::tf32", "kind::f8f6f4", "kind::ti16"),
+                ),
+                ModifierSlot("collector_a", _TCGEN05_COLLECTOR_A),
+                ModifierSlot("collector_b", _TCGEN05_COLLECTOR_B),
+            ),
+            cert_arch="sm_107f",
+            operands=(
+                OperandSlot("d_tmem", kind="addr", space="tmem"),
+                OperandSlot("a_desc", dtype="u64"),
+                OperandSlot("b_desc", dtype="u64"),
+                *((OperandSlot("sp_meta_tmem", kind="addr", space="tmem"),) if sparse else ()),
+                OperandSlot("idesc", dtype="u32"),
+                OperandSlot(
+                    "disable_output_lane",
+                    dtype="u32",
+                    lanes=_tcgen05_mma_mask_lanes,
+                ),
+                OperandSlot("enable_input_d", dtype="pred"),
+            ),
+        )
+        for sparse in (False, True)
+    ],
+    *[
+        InstructionEntry(
+            name=(f"tcgen05_mma{'_sp' if sparse else ''}_ashift_collector_b_ts"),
+            mnemonic="tcgen05",
+            slots=(
+                ModifierSlot("action", ("mma",)),
+                *((ModifierSlot("sp", ("sp",)),) if sparse else ()),
+                ModifierSlot("cta_group", ("cta_group::1", "cta_group::2")),
+                ModifierSlot(
+                    "kind",
+                    ("kind::f16", "kind::tf32", "kind::f8f6f4", "kind::ti16"),
+                ),
+                ModifierSlot("ashift", ("ashift",)),
+                ModifierSlot("collector_b", _TCGEN05_COLLECTOR_B),
+            ),
+            cert_arch="sm_107f",
+            operands=(
+                OperandSlot("d_tmem", kind="addr", space="tmem"),
+                OperandSlot("a_tmem", kind="addr", space="tmem"),
+                OperandSlot("b_desc", dtype="u64"),
+                *((OperandSlot("sp_meta_tmem", kind="addr", space="tmem"),) if sparse else ()),
+                OperandSlot("idesc", dtype="u32"),
+                OperandSlot(
+                    "disable_output_lane",
+                    dtype="u32",
+                    lanes=_tcgen05_mma_mask_lanes,
+                ),
+                OperandSlot("enable_input_d", dtype="pred"),
+            ),
+        )
+        for sparse in (False, True)
+    ],
+    *[
+        InstructionEntry(
+            name=(f"tcgen05_mma{'_sp' if sparse else ''}_collector_ab_ts"),
+            mnemonic="tcgen05",
+            slots=(
+                ModifierSlot("action", ("mma",)),
+                *((ModifierSlot("sp", ("sp",)),) if sparse else ()),
+                ModifierSlot("cta_group", ("cta_group::1", "cta_group::2")),
+                ModifierSlot(
+                    "kind",
+                    ("kind::f16", "kind::tf32", "kind::f8f6f4", "kind::ti16"),
+                ),
+                ModifierSlot("ashift", ("ashift",), optional=True),
+                ModifierSlot("collector_a", _TCGEN05_COLLECTOR_A),
+                ModifierSlot("collector_b", _TCGEN05_COLLECTOR_B),
+            ),
+            check=_check_tcgen05_collector_ashift,
+            cert_arch="sm_107f",
+            operands=(
+                OperandSlot("d_tmem", kind="addr", space="tmem"),
+                OperandSlot("a_tmem", kind="addr", space="tmem"),
+                OperandSlot("b_desc", dtype="u64"),
+                *((OperandSlot("sp_meta_tmem", kind="addr", space="tmem"),) if sparse else ()),
+                OperandSlot("idesc", dtype="u32"),
+                OperandSlot(
+                    "disable_output_lane",
+                    dtype="u32",
+                    lanes=_tcgen05_mma_mask_lanes,
+                ),
+                OperandSlot("enable_input_d", dtype="pred"),
+            ),
+        )
+        for sparse in (False, True)
+    ],
+    # Activation-stationary block-scaled MMA requires collector A; PTX 9.4
+    # makes collector B independently available.  SM107 supports the omitted
+    # scale-vector spelling; explicit scale_vec/block qualifiers remain scoped
+    # to the SM100/SM110 families by the Target ISA notes.
+    *[
+        InstructionEntry(
+            name=(f"tcgen05_mma{'_sp' if sparse else ''}_block_scale_collector_ab_{form}"),
+            mnemonic="tcgen05",
+            slots=(
+                ModifierSlot("action", ("mma",)),
+                *((ModifierSlot("sp", ("sp",)),) if sparse else ()),
+                ModifierSlot("cta_group", ("cta_group::1", "cta_group::2")),
+                ModifierSlot(
+                    "kind",
+                    ("kind::mxf8f6f4",) if sparse else ("kind::mxf8f6f4", "kind::mxf4"),
+                ),
+                ModifierSlot("block_scale", ("block_scale",)),
+                ModifierSlot("collector_a", _TCGEN05_COLLECTOR_A),
+                ModifierSlot("collector_b", _TCGEN05_COLLECTOR_B),
+            ),
+            cert_arch="sm_107f",
+            operands=(
+                OperandSlot("d_tmem", kind="addr", space="tmem"),
+                *(
+                    (OperandSlot("a_desc", dtype="u64"),)
+                    if form == "ss"
+                    else (OperandSlot("a_tmem", kind="addr", space="tmem"),)
+                ),
+                OperandSlot("b_desc", dtype="u64"),
+                *((OperandSlot("sp_meta_tmem", kind="addr", space="tmem"),) if sparse else ()),
+                OperandSlot("idesc", dtype="u32"),
+                OperandSlot("sfa_tmem", kind="addr", space="tmem"),
+                OperandSlot("sfb_tmem", kind="addr", space="tmem"),
+                OperandSlot("enable_input_d", dtype="pred"),
+            ),
+        )
+        for sparse in (False, True)
+        for form in ("ss", "ts")
+    ],
+    # PTX ISA 9.4, 9.7.10.28.5.2/3: the address override composes with the
+    # im2col load modes and report mechanism.  These siblings preserve the
+    # trailing im2col operand while placing global_address inside the address.
+    *[
+        InstructionEntry(
+            name=f"cp_async_bulk_tensor_g2s_{dst_name}_override_address_im2col",
+            mnemonic="cp",
+            slots=(
+                ModifierSlot("api", ("async",)),
+                ModifierSlot("kind", ("bulk",)),
+                ModifierSlot("unit", ("tensor",)),
+                ModifierSlot("dim", ("3d", "4d", "5d")),
+                ModifierSlot("dst", (dst,)),
+                ModifierSlot("src", ("global",)),
+                ModifierSlot("load_mode", ("im2col", "im2col::w", "im2col::w::128")),
+                ModifierSlot("completion", ("mbarrier::complete_tx::bytes",)),
+                ModifierSlot("report", _PTX_94_REPORT_MECHANISMS, optional=True),
+                *(
+                    (
+                        ModifierSlot(
+                            "multicast",
+                            (
+                                "multicast::cluster",
+                                "multicast::cluster::16b",
+                                "multicast::cluster::32b",
+                            ),
+                            optional=True,
+                        ),
+                    )
+                    if dst == "shared::cluster"
+                    else ()
+                ),
+                ModifierSlot("cta_group", ("cta_group::1", "cta_group::2"), optional=True),
+                ModifierSlot("cache", ("L2::cache_hint",), optional=True),
+                ModifierSlot("override_address", ("override::global_address",)),
+            ),
+            check=_check_tma_im2col,
+            cert_arch="sm_107f",
+            operands=(
+                OperandSlot("dst_mem", kind="addr", allow_imm_offset=True, space=dst),
+                OperandSlot("tmap", kind="addr", space="global", bracket="src"),
+                OperandSlot("global_address", dtype="u64", bracket="src"),
+                OperandSlot("coords", dtype="s32", lanes=_tma_coords_lanes, bracket="src"),
+                OperandSlot("mbar", kind="addr", allow_imm_offset=True, space="shared"),
+                OperandSlot(
+                    "im2col_info",
+                    dtype=_tma_im2col_dtype,
+                    lanes=_tma_im2col_lanes,
+                ),
+                *(
+                    (
+                        OperandSlot(
+                            "cta_mask",
+                            dtype=_multicast_mask_dtype,
+                            lanes=_tma_mask_lanes,
+                            vector=False,
+                        ),
+                    )
+                    if dst == "shared::cluster"
+                    else ()
+                ),
+                OperandSlot("cache_policy", dtype="u64", lanes=_tma_cache_lanes, vector=False),
+            ),
+        )
+        for dst_name, dst in (("cta", "shared::cta"), ("cluster", "shared::cluster"))
+    ],
+    InstructionEntry(
+        name="cp_async_bulk_tensor_s2g_override_address_im2col_no_offs_w",
+        mnemonic="cp",
+        slots=(
+            ModifierSlot("api", ("async",)),
+            ModifierSlot("kind", ("bulk",)),
+            ModifierSlot("unit", ("tensor",)),
+            ModifierSlot("dim", ("3d", "4d", "5d")),
+            ModifierSlot("dst", ("global",)),
+            ModifierSlot("src", ("shared::cta",)),
+            ModifierSlot("load_mode", ("im2col_no_offs", "im2col_no_offs::w")),
+            ModifierSlot("completion", ("bulk_group",)),
+            ModifierSlot("cache", ("L2::cache_hint",), optional=True),
+            ModifierSlot("override_address", ("override::global_address",)),
+        ),
+        check=_check_tma_im2col,
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("tmap", kind="addr", space="global", bracket="dst"),
+            OperandSlot("global_address", dtype="u64", bracket="dst"),
+            OperandSlot("coords", dtype="s32", lanes=_tma_coords_lanes, bracket="dst"),
+            OperandSlot("src_mem", kind="addr", allow_imm_offset=True, space="shared::cta"),
+            OperandSlot("cache_policy", dtype="u64", lanes=_tma_cache_lanes, vector=False),
+        ),
+    ),
+    InstructionEntry(
+        name="cp_reduce_async_bulk_tensor_override_address_im2col_no_offs_w",
+        mnemonic="cp",
+        slots=(
+            ModifierSlot("op", ("reduce",)),
+            ModifierSlot("api", ("async",)),
+            ModifierSlot("kind", ("bulk",)),
+            ModifierSlot("unit", ("tensor",)),
+            ModifierSlot("dim", ("3d", "4d", "5d")),
+            ModifierSlot("dst", ("global",)),
+            ModifierSlot("src", ("shared::cta",)),
+            ModifierSlot("redop", ("add", "min", "max", "inc", "dec", "and", "or", "xor")),
+            ModifierSlot("load_mode", ("im2col_no_offs", "im2col_no_offs::w")),
+            ModifierSlot("completion", ("bulk_group",)),
+            ModifierSlot("cache", ("L2::cache_hint",), optional=True),
+            ModifierSlot("override_address", ("override::global_address",)),
+        ),
+        check=_check_tma_im2col,
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("tmap", kind="addr", space="global", bracket="dst"),
+            OperandSlot("global_address", dtype="u64", bracket="dst"),
+            OperandSlot("coords", dtype="s32", lanes=_tma_coords_lanes, bracket="dst"),
+            OperandSlot("src_mem", kind="addr", allow_imm_offset=True, space="shared::cta"),
+            OperandSlot("cache_policy", dtype="u64", lanes=_tma_cache_lanes, vector=False),
+        ),
+    ),
+    InstructionEntry(
+        name="cp_async_bulk_tensor_prefetch_override_address_im2col",
+        mnemonic="cp",
+        slots=(
+            ModifierSlot("api", ("async",)),
+            ModifierSlot("kind", ("bulk",)),
+            ModifierSlot("action", ("prefetch",)),
+            ModifierSlot("unit", ("tensor",)),
+            ModifierSlot("dim", ("3d", "4d", "5d")),
+            ModifierSlot("level", ("L2",)),
+            ModifierSlot("src", ("global",)),
+            ModifierSlot("load_mode", ("im2col", "im2col::w", "im2col::w::128")),
+            ModifierSlot("cache", ("L2::cache_hint",), optional=True),
+            ModifierSlot("override_address", ("override::global_address",)),
+        ),
+        check=_check_tma_im2col,
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("tmap", kind="addr", space="global", bracket="src"),
+            OperandSlot("global_address", dtype="u64", bracket="src"),
+            OperandSlot("coords", dtype="s32", lanes=_tma_coords_lanes, bracket="src"),
+            OperandSlot(
+                "im2col_info",
+                dtype=_tma_im2col_dtype,
+                lanes=_tma_im2col_lanes,
+            ),
+            OperandSlot("cache_policy", dtype="u64", lanes=_tma_cache_lanes, vector=False),
+        ),
+    ),
+    InstructionEntry(
+        name="cp_async_bulk_tensor_prefetch_override_address_im2col_evict_last",
+        mnemonic="cp",
+        slots=(
+            ModifierSlot("api", ("async",)),
+            ModifierSlot("kind", ("bulk",)),
+            ModifierSlot("action", ("prefetch",)),
+            ModifierSlot("unit", ("tensor",)),
+            ModifierSlot("dim", ("3d", "4d", "5d")),
+            ModifierSlot("level", ("L2",)),
+            ModifierSlot("src", ("global",)),
+            ModifierSlot("load_mode", ("im2col", "im2col::w", "im2col::w::128")),
+            ModifierSlot("priority", ("L2::evict_last",)),
+            ModifierSlot("override_address", ("override::global_address",)),
+        ),
+        check=_check_tma_im2col,
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("tmap", kind="addr", space="global", bracket="src"),
+            OperandSlot("global_address", dtype="u64", bracket="src"),
+            OperandSlot("coords", dtype="s32", lanes=_tma_coords_lanes, bracket="src"),
+            OperandSlot(
+                "im2col_info",
+                dtype=_tma_im2col_dtype,
+                lanes=_tma_im2col_lanes,
+            ),
+        ),
+    ),
+    InstructionEntry(
+        name="applypriority_async_bulk_tensor_override_address_im2col",
+        mnemonic="applypriority",
+        slots=(
+            ModifierSlot("api", ("async",)),
+            ModifierSlot("kind", ("bulk",)),
+            ModifierSlot("unit", ("tensor",)),
+            ModifierSlot("dim", ("3d", "4d", "5d")),
+            ModifierSlot("src", ("global",), optional=True),
+            ModifierSlot("completion", ("bulk_group",)),
+            ModifierSlot("load_mode", ("im2col", "im2col::w", "im2col::w::128")),
+            ModifierSlot("priority", ("L2::evict_normal",)),
+            ModifierSlot("override_address", ("override::global_address",)),
+        ),
+        check=_check_tma_im2col,
+        cert_arch="sm_107f",
+        operands=(
+            OperandSlot("tmap", kind="addr", space="global", bracket="src"),
+            OperandSlot("global_address", dtype="u64", bracket="src"),
+            OperandSlot("coords", dtype="s32", lanes=_tma_coords_lanes, bracket="src"),
+            OperandSlot(
+                "im2col_info",
+                dtype=_tma_im2col_dtype,
+                lanes=_tma_im2col_lanes,
+            ),
+        ),
+    ),
+    # PTX ISA 9.4, 9.7.15.5/6 -- .noftz is now legal on add.f32.
+    # Separate siblings keep the pre-9.4 bare forms and certification floor
+    # intact while the written qualifier makes dispatch unambiguous.
+    *[
+        InstructionEntry(
+            name=f"{mnem}_f32_noftz",
+            mnemonic=mnem,
+            slots=(
+                ModifierSlot("sem", _ATOM_SEM if mnem == "atom" else _RED_SEM, optional=True),
+                ModifierSlot("scope", _ATOM_SCOPES, optional=True),
+                ModifierSlot("space", _ATOM_SPACES, optional=True),
+                ModifierSlot("op", ("add",)),
+                ModifierSlot("noftz", ("noftz",)),
+                ModifierSlot("cache", ("L2::cache_hint",), optional=True),
+                ModifierSlot("type", ("f32",)),
+            ),
+            check=_check_cache_hint,
+            cert_arch="sm_90",
+            operands=(
+                *((OperandSlot("d", rw="w", dtype="f32"),) if mnem == "atom" else ()),
+                OperandSlot("addr", kind="addr", allow_imm_offset=True),
+                OperandSlot("value", dtype="f32"),
+                OperandSlot(
+                    "cache_policy", dtype="u64", lanes=_present_lanes("cache"), vector=False
+                ),
+            ),
+        )
+        for mnem in ("atom", "red")
+    ],
+    *[
+        InstructionEntry(
+            name=f"{mnem}_vec_f32_noftz",
+            mnemonic=mnem,
+            slots=(
+                ModifierSlot("sem", _ATOM_SEM if mnem == "atom" else _RED_SEM, optional=True),
+                ModifierSlot("scope", _ATOM_SCOPES, optional=True),
+                ModifierSlot("space", ("global",), optional=True),
+                ModifierSlot("op", ("add",)),
+                ModifierSlot("noftz", ("noftz",)),
+                ModifierSlot("cache", ("L2::cache_hint",), optional=True),
+                ModifierSlot("vec", ("v2", "v4")),
+                ModifierSlot("type", ("f32",)),
+            ),
+            check=_check_cache_hint,
+            cert_arch="sm_90",
+            operands=(
+                *(
+                    (OperandSlot("d", rw="w", dtype="f32", lanes=_vec_lanes),)
+                    if mnem == "atom"
+                    else ()
+                ),
+                OperandSlot("addr", kind="addr", allow_imm_offset=True),
+                OperandSlot("value", dtype="f32", lanes=_vec_lanes),
+                OperandSlot(
+                    "cache_policy", dtype="u64", lanes=_present_lanes("cache"), vector=False
+                ),
+            ),
+        )
+        for mnem in ("atom", "red")
+    ],
+    # PTX ISA 9.4, 9.7.10.28.4.2 / 9.7.10.28.4.5 -- `.noftz` is now legal with
+    # `.add.f32` on the non-tensor bulk reductions into .global (introduced in
+    # PTX ISA 9.4, requires sm_90).  Siblings, exactly as for atom/red above:
+    # the pre-9.4 entries keep their grid (noftz required for f16/bf16, illegal
+    # for f32) and their sm_103a floor, and the written `.noftz` + `.f32` pair
+    # makes dispatch unambiguous.  MEASURED on CUDA 13.4 ptxas: the bare and
+    # the `.relaxed.<scope>` spellings assemble at sm_90 and sm_103a.
+    InstructionEntry(
+        name="cp_reduce_async_bulk_s2g_f32_noftz",
+        mnemonic="cp",
+        slots=(
+            ModifierSlot("op", ("reduce",)),
+            ModifierSlot("api", ("async",)),
+            ModifierSlot("kind", ("bulk",)),
+            ModifierSlot("sem", ("relaxed",), optional=True),
+            ModifierSlot("scope", ("cta", "cluster", "gpu", "sys"), optional=True),
+            ModifierSlot("dst", ("global",)),
+            ModifierSlot("src", ("shared::cta",)),
+            ModifierSlot("completion", ("bulk_group",)),
+            ModifierSlot("cache", ("L2::cache_hint",), optional=True),
+            ModifierSlot("redop", ("add",)),
+            ModifierSlot("noftz", ("noftz",)),
+            ModifierSlot("type", ("f32",)),
+        ),
+        check=_check_mbarrier_sem_scope,
+        cert_arch="sm_90",
+        operands=(
+            OperandSlot("dst_mem", kind="addr", allow_imm_offset=True, space="global"),
+            OperandSlot("src_mem", kind="addr", allow_imm_offset=True, space="shared::cta"),
+            OperandSlot("size", dtype="u32"),
+            OperandSlot("cache_policy", dtype="u64", lanes=_tma_cache_lanes, vector=False),
+        ),
+    ),
+    InstructionEntry(
+        name="multimem_cp_reduce_async_bulk_f32_noftz",
+        mnemonic="multimem.cp",
+        slots=(
+            ModifierSlot("op", ("reduce",)),
+            ModifierSlot("api", ("async",)),
+            ModifierSlot("kind", ("bulk",)),
+            ModifierSlot("sem", ("relaxed",), optional=True),
+            ModifierSlot("scope", ("cta", "cluster", "gpu", "sys"), optional=True),
+            ModifierSlot("dst", ("global",)),
+            ModifierSlot("src", ("shared::cta",)),
+            ModifierSlot("completion", ("bulk_group",)),
+            ModifierSlot("redop", ("add",)),
+            ModifierSlot("noftz", ("noftz",)),
+            ModifierSlot("type", ("f32",)),
+        ),
+        check=_check_mbarrier_sem_scope,
+        cert_arch="sm_90",
+        operands=(
+            OperandSlot("dst_mem", kind="addr", allow_imm_offset=True, space="global"),
+            OperandSlot("src_mem", kind="addr", allow_imm_offset=True, space="shared::cta"),
+            OperandSlot("size", dtype="u32"),
+        ),
+    ),
+    # PTX ISA 9.4, 9.7.16.5.15 -- m8n16 signed-byte load from packed s4.
+    # The destination contains one .b32 register per matrix selected by .num.
+    InstructionEntry(
+        name="ldmatrix_s8_s4",
+        mnemonic="ldmatrix",
+        slots=(
+            ModifierSlot("sync", ("sync",)),
+            ModifierSlot("aligned", ("aligned",)),
+            ModifierSlot("shape", ("m8n16",)),
+            ModifierSlot("num", ("x1", "x2", "x4")),
+            ModifierSlot("space", ("shared", "shared::cta"), optional=True),
+            ModifierSlot("dtype", ("s8",)),
+            ModifierSlot("ctype", ("s4",)),
+        ),
+        cert_arch="sm_107a",
+        operands=(
+            OperandSlot("r", rw="w", dtype="b32", lanes=_ldmatrix_lanes),
+            OperandSlot("p", kind="addr", allow_imm_offset=True),
+        ),
+    ),
+]
+
 _ENTRIES = [
+    *_PTX_94_ENTRIES,
     # ------------------------------------------------------------------
     # PTX ISA 9.7.1 — Integer Arithmetic Instructions
     # ------------------------------------------------------------------
-    # The existing public families cover this section with two exceptions,
-    # each stated at the entry it belongs to: the packed `.u8x4`/`.s8x4` types
+    # The existing public families cover this section with one exception,
+    # stated at the entry it belongs to: the packed `.u8x4`/`.s8x4` types
     # (and the saturating forms that arrived with them), which the ISA gives
-    # only to "sm_120f or higher in the same family"; and the distinct `clmad`
-    # family, which was introduced in PTX ISA 9.3 and is not in the current
-    # PTX ISA 9.2 toolchain.
+    # only to "sm_120f or higher in the same family".  The distinct `clmad`
+    # family (9.7.1.5, introduced in PTX ISA 9.3) is registered below.
     #
     # Several mnemonics have a floating-point line further down the table. The
     # integer lines are separate entries because they share no qualifier with
@@ -2955,7 +5705,7 @@ _ENTRIES = [
     # dispatch resolves them apart on their type tokens, exactly as it already
     # does for `add`/`add_half`.
     #
-    # min / max per PTX ISA 9.7.1.12, 9.7.1.13 (integer), 9.7.3.11, 9.7.3.12
+    # min / max per PTX ISA 9.7.1.13, 9.7.1.14 (integer), 9.7.3.11, 9.7.3.12
     # (single/double), 9.7.4.7, 9.7.4.8 (half).
     # Each mnemonic gets two entries because the ISA gives it two operand
     # shapes: the usual `d, a, b` and the three-source `d, a, b, c` line.
@@ -3006,7 +5756,7 @@ _ENTRIES = [
         )
         for name in ("max", "min")
     ],
-    # fns per PTX ISA 9.7.1.17: `fns.b32 d, mask, base, offset;` — one form.
+    # fns per PTX ISA 9.7.1.18: `fns.b32 d, mask, base, offset;` — one form.
     # The operands carry three different types (mask .b32, base .b32/.u32/.s32,
     # offset .s32), so each declares its own dtype rather than sharing the
     # entry's type slot.
@@ -3138,7 +5888,23 @@ _ENTRIES = [
             OperandSlot("c", dtype=_wide_dtype),
         ),
     ),
-    # mul24 / mad24 per PTX ISA 9.7.1.5, 9.7.1.6: a 24x24-bit multiply held in
+    # clmad, introduced in PTX ISA 9.3 (9.7.1.5): carryless 64-bit multiply
+    # followed by carryless add.  All four operands are unsigned 64-bit.
+    InstructionEntry(
+        name="clmad",
+        slots=(
+            ModifierSlot("mode", ("hi", "lo")),
+            ModifierSlot("type", ("u64",)),
+        ),
+        cert_arch="sm_80",
+        operands=(
+            OperandSlot("d", rw="w"),
+            OperandSlot("a"),
+            OperandSlot("b"),
+            OperandSlot("c"),
+        ),
+    ),
+    # mul24 / mad24 per PTX ISA 9.7.1.6, 9.7.1.7: a 24x24-bit multiply held in
     # 32-bit registers, so there is no `.wide` and the type line is 32-bit only.
     #   mul24.mode.type d, a, b;     mad24.mode.type  d, a, b, c;
     #   .mode = {.hi, .lo}           mad24.hi.sat.s32 d, a, b, c;
@@ -3169,7 +5935,7 @@ _ENTRIES = [
             OperandSlot("c"),
         ),
     ),
-    # sad per PTX ISA 9.7.1.7: `sad.type d, a, b, c;` -- d = c + |a - b|.
+    # sad per PTX ISA 9.7.1.8: `sad.type d, a, b, c;` -- d = c + |a - b|.
     InstructionEntry(
         name="sad",
         slots=(ModifierSlot("type", _INT_TYPES),),
@@ -3180,7 +5946,7 @@ _ENTRIES = [
             OperandSlot("c"),
         ),
     ),
-    # div / rem per PTX ISA 9.7.1.8, 9.7.1.9: `div.type d, a, b;`. These are
+    # div / rem per PTX ISA 9.7.1.9, 9.7.1.10: `div.type d, a, b;`. These are
     # the integer lines; the floating-point `div` (9.7.3.8) is the `div_f`
     # entry below, sharing this mnemonic.
     *[
@@ -3195,7 +5961,7 @@ _ENTRIES = [
         )
         for name in ("div", "rem")
     ],
-    # abs / neg per PTX ISA 9.7.1.10, 9.7.1.11 -- signed integers only. Their
+    # abs / neg per PTX ISA 9.7.1.11, 9.7.1.12 -- signed integers only. Their
     # floating-point lines (9.7.3.9, 9.7.3.10) are the `abs_f` and `neg`
     # entries below; which of each pair carries a suffix is just which arrived
     # second. NOT REGISTERED: `neg.s8x4`, sm_120f-only as above.
@@ -3216,7 +5982,7 @@ _ENTRIES = [
             OperandSlot("a"),
         ),
     ),
-    # popc / clz per PTX ISA 9.7.1.14, 9.7.1.15: `popc.type d, a;`. Both count
+    # popc / clz per PTX ISA 9.7.1.15, 9.7.1.16: `popc.type d, a;`. Both count
     # bits of a `.b32`/`.b64` source into a `.u32` destination whatever the
     # source width -- "destination d has type .u32" -- so d is typed outright
     # while a takes the instruction type.
@@ -3231,7 +5997,7 @@ _ENTRIES = [
         )
         for name in ("popc", "clz")
     ],
-    # bfind per PTX ISA 9.7.1.16: `bfind{.shiftamt}.type d, a;`, d again .u32.
+    # bfind per PTX ISA 9.7.1.17: `bfind{.shiftamt}.type d, a;`, d again .u32.
     InstructionEntry(
         name="bfind",
         slots=(
@@ -3243,7 +6009,7 @@ _ENTRIES = [
             OperandSlot("a"),
         ),
     ),
-    # brev per PTX ISA 9.7.1.18: `brev.type d, a;`.
+    # brev per PTX ISA 9.7.1.19: `brev.type d, a;`.
     InstructionEntry(
         name="brev",
         slots=(ModifierSlot("type", ("b32", "b64")),),
@@ -3252,7 +6018,7 @@ _ENTRIES = [
             OperandSlot("a"),
         ),
     ),
-    # bfe / bfi per PTX ISA 9.7.1.19, 9.7.1.20. Both take their position and
+    # bfe / bfi per PTX ISA 9.7.1.20, 9.7.1.21. Both take their position and
     # length operands as `.u32` regardless of the instruction type ("Operands b
     # and c are type .u32, but are restricted to the 8-bit value range 0..255").
     #   bfe.type  d, a, b, c;    .type = {.u32, .u64, .s32, .s64}
@@ -3271,7 +6037,7 @@ _ENTRIES = [
         name="bfi",
         # The ISA's own operand names, kept as they are: the destination is `f`
         # and `d` is the *length input*, the one family where `d` is not the
-        # result. Renaming them would make the helper unreadable against 9.7.1.20.
+        # result. Renaming them would make the helper unreadable against 9.7.1.21.
         slots=(ModifierSlot("type", ("b32", "b64")),),
         operands=(
             OperandSlot("f", rw="w"),
@@ -3281,7 +6047,7 @@ _ENTRIES = [
             OperandSlot("d", dtype="u32"),  # field length
         ),
     ),
-    # szext / bmsk per PTX ISA 9.7.1.21, 9.7.1.22 -- both `.mode = {.clamp,
+    # szext / bmsk per PTX ISA 9.7.1.22, 9.7.1.23 -- both `.mode = {.clamp,
     # .wrap}`, and both take their width operand as an unsigned 32-bit value.
     #   szext.mode.type d, a, b;   .type = {.u32, .s32}
     #   bmsk.mode.b32   d, a, b;   -- a (position) and b (width) are .u32
@@ -3315,7 +6081,7 @@ _ENTRIES = [
             OperandSlot("b", dtype="b32i"),  # mask width
         ),
     ),
-    # dp4a / dp2a per PTX ISA 9.7.1.23, 9.7.1.24:
+    # dp4a / dp2a per PTX ISA 9.7.1.24, 9.7.1.25:
     #   dp4a.atype.btype       d, a, b, c;   .atype = .btype = {.u32, .s32}
     #   dp2a.mode.atype.btype  d, a, b, c;   .mode = {.lo, .hi}
     # The only families in the table with no `type` slot at all: every operand
@@ -3394,13 +6160,16 @@ _ENTRIES = [
         # `mul` is the one line with no mixed-precision form (ISA 9.7.5).
         for name, mixed in (("add", True), ("sub", True), ("mul", False))
     ],
-    # NOT REGISTERED: across this whole arithmetic group, only the
+    # NOT REGISTERED:
+    # - Across the PTX 9.2 arithmetic group, only the
     # extended-precision lines add.cc/addc/sub.cc/subc (9.7.2.{1,2,3,4}), whose
     # carry flag is a piece of state no other instruction here has. Everything
     # else is registered: the integer lines (9.7.1.{1,2,3}) as
     # `add_int`/`sub_int`/`mul_int`/`mul_wide` above, and the half lines
     # (9.7.4.{1,2,3,4}) as `add_half`/`sub_half`/`mul_half`/`fma_half` below.
     #
+    # - PTX 9.4's FP8/FP6/FP4 x4 arithmetic types: the Target ISA notes allow
+    #   them on sm_100a/sm_103a, not on the SM107 target of this delta.
     # fma differs in shape, so it is its own entry: three sources, and .rnd is
     # mandatory on every line (PTX ISA 9.7.3.6 / 9.7.5.3).
     #   fma.rnd{.ftz}{.sat}.f32  d, a, b, c;   fma.rnd{.ftz}.f32x2  d, a, b, c;
@@ -3474,7 +6243,7 @@ _ENTRIES = [
     ),
     # abs / neg per PTX ISA 9.7.3.9, 9.7.3.10 -- one shape, one check:
     #   op{.ftz}.f32 d, a;   op.f64 d, a;
-    # `abs_f` carries the suffix because the integer `abs` (9.7.1.10) took the
+    # `abs_f` carries the suffix because the integer `abs` (9.7.1.11) took the
     # bare name first; `neg` keeps it because the integer one came second.
     *[
         InstructionEntry(
@@ -3707,7 +6476,7 @@ _ENTRIES = [
         ),
     ),
     # ------------------------------------------------------------------
-    # PTX ISA 9.7.6 — Comparison and Selection Instructions
+    # PTX ISA 9.7.7 — Comparison and Selection Instructions
     # ------------------------------------------------------------------
     # The section is registered in full. Two spellings are deliberately absent,
     # neither of which is a syntax line:
@@ -3724,7 +6493,7 @@ _ENTRIES = [
     #   sink guard is per operand rather than per pipe group -- it would reject
     #   `p|_` as "every lane sunk" without surgery that buys nothing.
     #
-    # set / setp per PTX ISA 9.7.6.1, 9.7.6.2. Both compare a and b and
+    # set / setp per PTX ISA 9.7.7.1, 9.7.7.2. Both compare a and b and
     # optionally fold a third predicate in with a Boolean operator; they differ
     # in where the answer goes -- set writes a value of `.dtype` (0xffffffff or
     # 1.0f for true), setp writes predicates.
@@ -3785,7 +6554,7 @@ _ENTRIES = [
         for boolop in (False, True)
         for pq in (False, True)
     ],
-    # selp per PTX ISA 9.7.6.3: `selp.type d, a, b, c;` -- a if the predicate
+    # selp per PTX ISA 9.7.7.3: `selp.type d, a, b, c;` -- a if the predicate
     # is true, b otherwise. The one selection instruction whose selector is a
     # predicate rather than a number.
     InstructionEntry(
@@ -3798,7 +6567,7 @@ _ENTRIES = [
             OperandSlot("c", dtype="pred"),
         ),
     ),
-    # slct per PTX ISA 9.7.6.4: `slct{.ftz}.dtype.ctype d, a, b, c;` -- a if
+    # slct per PTX ISA 9.7.7.4: `slct{.ftz}.dtype.ctype d, a, b, c;` -- a if
     # c >= 0, else b. Two instruction types, because the value being selected
     # and the number whose sign selects it are independent: "operands d, a and
     # b are treated as a bitsize type of the same width as the first
@@ -3826,21 +6595,21 @@ _ENTRIES = [
         ),
     ),
     # ------------------------------------------------------------------
-    # PTX ISA 9.7.7 — Half Precision Comparison Instructions
+    # PTX ISA 9.7.8 — Half Precision Comparison Instructions
     # ------------------------------------------------------------------
-    # The section is registered in full: `set` (9.7.7.1) and `setp` (9.7.7.2)
-    # over the half types, beside the 9.7.6 entries of the same two mnemonics.
-    # They are separate entries because the type grids are disjoint -- no 9.7.6
+    # The section is registered in full: `set` (9.7.8.1) and `setp` (9.7.8.2)
+    # over the half types, beside the 9.7.7 entries of the same two mnemonics.
+    # They are separate entries because the type grids are disjoint -- no 9.7.7
     # slot holds a half token -- and because this section's `.CmpOp` line is a
     # different set (no unsigned alternates; see `_HALF_CMP_OPS`).
     #
-    # `{!}c` is left out here for the reason given at the 9.7.6 banner above.
+    # `{!}c` is left out here for the reason given at the 9.7.7 banner above.
     # Three forms ptxas accepts that no syntax line spells are also left out,
     # each noted where it belongs: lo/ls/hi/hs on an integer source
     # (`_HALF_CMP_OPS`), `set.bf16.bf16` (`_SET_HALF_STYPES`), and a lone `p`
     # on the packed setp lines (at the pq entries below).
     #
-    # set per PTX ISA 9.7.7.1. Its two type tokens are a grid rather than a
+    # set per PTX ISA 9.7.8.1. Its two type tokens are a grid rather than a
     # product -- `_check_half_set` holds the six line groups.
     *[
         InstructionEntry(
@@ -3864,7 +6633,7 @@ _ENTRIES = [
         )
         for boolop in (False, True)
     ],
-    # setp per PTX ISA 9.7.7.2. Unlike 9.7.6's setp, which offers both
+    # setp per PTX ISA 9.7.8.2. Unlike 9.7.7's setp, which offers both
     # destination shapes on every type, here the type *decides* the shape: the
     # scalar lines spell one predicate, the packed lines spell `p|q`, and there
     # q is the second half's comparison rather than the complement of the first
@@ -3898,7 +6667,7 @@ _ENTRIES = [
         for pq in (False, True)
     ],
     # ------------------------------------------------------------------
-    # PTX ISA 9.7.8 — Logic and Shift Instructions
+    # PTX ISA 9.7.9 — Logic and Shift Instructions
     # ------------------------------------------------------------------
     # The section is registered in full. It is the one group that needs no
     # check function anywhere: "fundamentally untyped, performing bit-wise
@@ -3910,8 +6679,8 @@ _ENTRIES = [
     # `escape_token`/`unescape_token` carry them across the boundary. The PTX
     # text is unaffected; only the attribute a program types is.
     #
-    # and / or / xor (PTX ISA 9.7.8.1-9.7.8.3): `op.type d, a, b;`, and not
-    # (9.7.8.4): `not.type d, a;` -- all four over `.pred` and the three bit
+    # and / or / xor (PTX ISA 9.7.9.1-9.7.9.3): `op.type d, a, b;`, and not
+    # (9.7.9.4): `not.type d, a;` -- all four over `.pred` and the three bit
     # widths. The predicate line is real here -- "Allowed types include
     # predicate registers" -- so with `.pred` the sources want `T.ptx.pred(x)`
     # (or a bool expression) and the destination a uint32 lvalue, and the
@@ -3936,7 +6705,7 @@ _ENTRIES = [
             OperandSlot("a"),
         ),
     ),
-    # cnot per PTX ISA 9.7.8.5: `d = (a==0) ? 1 : 0`, C's `!` rather than the
+    # cnot per PTX ISA 9.7.9.5: `d = (a==0) ? 1 : 0`, C's `!` rather than the
     # bitwise `not` above. Its type line stops at the bit widths -- ptxas
     # answers "Unexpected instruction types specified for 'cnot'" to `.pred`,
     # which is why this entry cannot share the domain of the four above.
@@ -3948,7 +6717,7 @@ _ENTRIES = [
             OperandSlot("a"),
         ),
     ),
-    # lop3 per PTX ISA 9.7.8.6: any of the 256 three-input logical functions,
+    # lop3 per PTX ISA 9.7.9.6: any of the 256 three-input logical functions,
     # named by a look-up table byte rather than by an opcode.
     #   lop3.b32          d,   a, b, c, immLut;
     #   lop3.BoolOp.b32   d|p, a, b, c, immLut, q;
@@ -4015,7 +6784,7 @@ _ENTRIES = [
             OperandSlot("q", dtype="pred"),
         ),
     ),
-    # shf per PTX ISA 9.7.8.7: the funnel shift. a and b are the low and high
+    # shf per PTX ISA 9.7.9.7: the funnel shift. a and b are the low and high
     # halves of one 64-bit source ("Operand b holds bits 63:32 and operand a
     # holds bits 31:0"), and the direction picks which 32 bits of the shifted
     # result land in d. `.mode` bounds the shift amount: 0..32 clamping, or
@@ -4034,7 +6803,7 @@ _ENTRIES = [
             OperandSlot("c", dtype="u32"),  # the shift amount
         ),
     ),
-    # shl / shr per PTX ISA 9.7.8.8, 9.7.8.9. They differ in their type line,
+    # shl / shr per PTX ISA 9.7.9.8, 9.7.9.9. They differ in their type line,
     # not their shape: shl is untyped because a left shift zero-fills whatever
     # the operand means, while shr has to know whether to fill with the sign
     # bit, so it carries the signed and unsigned lines too (and keeps the
@@ -4057,20 +6826,20 @@ _ENTRIES = [
         )
     ],
     # ------------------------------------------------------------------
-    # PTX ISA 9.7.9 — Data Movement and Conversion Instructions
+    # PTX ISA 9.7.10 — Data Movement and Conversion Instructions
     # ------------------------------------------------------------------
     # The largest section of the ISA, and registered across all 26 of its
     # subsections. What is left out is listed at the entry it belongs to;
     # the exclusions that are about the toolchain or the architecture rather
     # than about this table are:
-    #   - `shfl` without `.sync` (9.7.9.5), removed by the ISA for sm_70+;
-    #   - the FP8 multimem types and `.acc::f16` (9.7.9.14), and
-    #     `tensormap.replace.swizzle_atomicity` (9.7.9.26), all scoped to
+    #   - `shfl` without `.sync` (9.7.10.5), removed by the ISA for sm_70+;
+    #   - the FP8 multimem types and `.acc::f16` (9.7.10.15), and
+    #     `tensormap.replace.swizzle_atomicity` (9.7.10.29), all scoped to
     #     architectures above the one their instruction is certified at.
     # Everything else absent is an operand the helper ABI cannot carry -- a
     # symbol rather than a value -- and says so where it is excluded.
     #
-    # mov, vector pack/unpack form (PTX ISA 9.7.9.4)
+    # mov, vector pack/unpack form (PTX ISA 9.7.10.4)
     #
     #   mov.type  d, a;   .type = {.b16, .b32, .b64, .b128}
     #
@@ -4095,11 +6864,11 @@ _ENTRIES = [
     # a multi-instruction template, which this dialect forbids.
     #
     # The sink symbol `_` IS registered on the unpack destinations, per ISA
-    # 9.7.9.4: "When destination operand d is a vector register, the sink
+    # 9.7.10.4: "When destination operand d is a vector register, the sink
     # symbol '_' may be used for one or more elements provided that at least
     # one element is a scalar register." That proviso is `sink_combos`' rule.
     #
-    # Registered separately below: scalar mov (9.7.9.3), a different
+    # Registered separately below: scalar mov (9.7.10.3), a different
     # instruction that shares the mnemonic; dispatch tells them apart by
     # arity.
     *[
@@ -4140,7 +6909,7 @@ _ENTRIES = [
         )
         for direction, unpack in (("pack", False), ("unpack", True))
     ],
-    # Complete scalar `ld` per PTX ISA 9.7.9.8 + the 9.7.9.9 ld.global.nc forms.
+    # Complete scalar `ld` per PTX ISA 9.7.10.8 + the 9.7.10.9 ld.global.nc forms.
     # NOT REGISTERED: each is an operand the helper-function ABI cannot carry,
     # because it is a *symbol* rather than a value --
     # - .unified (asserts its address names a variable declared with that
@@ -4183,7 +6952,7 @@ _ENTRIES = [
             OperandSlot("cache_policy", dtype="u64", lanes=_present_lanes("cache"), vector=False),
         ),
     ),
-    # The `.vec` lines of ld / st (PTX ISA 9.7.9.8 / 9.7.9.11). Separate
+    # The `.vec` lines of ld / st (PTX ISA 9.7.10.8 / 9.7.10.11). Separate
     # entries rather than an optional slot on the scalar ones: a vector operand
     # is brace-enclosed even at one register, so vector-ness has to be a
     # property of the entry, and the .v8/.v4-64bit lines carry a
@@ -4191,14 +6960,14 @@ _ENTRIES = [
     #
     # The memory-synchronization lines carry `{.vec}` too, so `.relaxed` and
     # `.acquire`/`.release` are on every entry below, each with the `.scope`
-    # its line makes mandatory. PTX ISA 9.7.9.8, wrapped but otherwise verbatim:
+    # its line makes mandatory. PTX ISA 9.7.10.8, wrapped but otherwise verbatim:
     #
     #   ld.relaxed.scope{.ss}{.level1::eviction_priority}{.level2::eviction_priority}
     #      {.level::cache_hint}{.level::prefetch_size}{.vec}.type  d, [a]{, cache_policy};
     #   ld.acquire.scope{.ss}{.level1::eviction_priority}{.level2::eviction_priority}
     #      {.level::cache_hint}{.level::prefetch_size}{.vec}.type  d, [a]{, cache_policy};
     #
-    # and the 9.7.9.11 mirror with `.relaxed`/`.release` and no prefetch term.
+    # and the 9.7.10.11 mirror with `.relaxed`/`.release` and no prefetch term.
     # Note these lines carry *both* eviction priorities, which is why the
     # 256-bit entries let `.L2::*` ride them -- unlike `.volatile`, whose line
     # (`ld.volatile{.ss}{.level::prefetch_size}{.vec}.type  d, [a];`) spells no
@@ -4254,12 +7023,14 @@ _ENTRIES = [
         cert_arch="sm_100",
         check=_check_ld_vec256,
         operands=(
-            # PTX ISA 9.2 section 9.4.1 permits a data register wider than the
-            # instruction type, but CUDA 13.2 ptxas does not compile that
-            # carrier axis reliably on the 256-bit ld lines: exact inlined
-            # callers produce C7907, segfaults, or stack-smashing aborts. Keep
-            # these lanes at PTX_TYPE_DTYPES' exact width. Scalar and <=128-bit
-            # vector ld retain the documented relaxed carriers above.
+            # ISA section 9.4.1 permits a data register wider than the
+            # instruction type, but that carrier axis is not uniformly
+            # available on the 256-bit ld lines.  MEASURED on CUDA 13.4: an
+            # exact force-inlined `ld.global.v8.b32` with 64-bit lanes is a
+            # ptxas "(C7907) Internal compiler error" (the .v4.b64 spelling
+            # with 128-bit lanes assembles).  Keep these lanes at
+            # PTX_TYPE_DTYPES' exact width. Scalar and <=128-bit vector ld
+            # retain the documented relaxed carriers above.
             #
             # `_` means this element is not read from memory.
             OperandSlot("d", rw="w", lanes=_vec_lanes, sinkable=_sink256),
@@ -4267,7 +7038,7 @@ _ENTRIES = [
             OperandSlot("cache_policy", dtype="u64", lanes=_present_lanes("cache"), vector=False),
         ),
     ),
-    # Complete scalar `st` per PTX ISA 9.7.9.11, at parity with `ld`.
+    # Complete scalar `st` per PTX ISA 9.7.10.11, at parity with `ld`.
     # NOT REGISTERED: .param::func -- a device-function parameter address
     # cannot originate on the helper's CUDA-C boundary (see the note on `ld`
     # above). Bare `.param` has the same meaning here because it defaults to
@@ -4337,20 +7108,22 @@ _ENTRIES = [
         check=_check_st_vec256,
         operands=(
             OperandSlot("addr", kind="addr", allow_imm_offset=True),
-            # PTX ISA 9.2 section 9.4.1 permits wider data registers, but CUDA
-            # 13.2 ptxas does not compile that carrier axis reliably for these
-            # 256-bit st lines (C7907/segfault/stack-smashing on exact inlined
-            # callers). Register only exact-width carriers, matching ld_vec256.
-            # Scalar and <=128-bit vector st keep the relaxed domain.
+            # ISA section 9.4.1 permits wider data registers.  MEASURED on CUDA
+            # 13.4: the wide `st.v8.b32` (64-bit lanes) and `st.v4.b64`
+            # (128-bit lanes) spellings assemble through exact force-inlined
+            # callers, but their ld_vec256 counterparts do not (C7907), so both
+            # 256-bit families register only exact-width carriers and stay
+            # symmetric; widening st alone is a follow-up.  Scalar and
+            # <=128-bit vector st keep the relaxed domain.
             #
-            # ISA 9.7.9.11 puts the sink in "vector expression b" -- the data
+            # ISA 9.7.10.11 puts the sink in "vector expression b" -- the data
             # being stored -- so here `_` means this element is not written to
             # memory. Sink is not a destination-only spelling.
             OperandSlot("value", lanes=_vec_lanes, sinkable=_sink256),
             OperandSlot("cache_policy", dtype="u64", lanes=_present_lanes("cache"), vector=False),
         ),
     ),
-    # st.bulk per PTX ISA 9.7.9.13:
+    # st.bulk per PTX ISA 9.7.10.14:
     #   st.bulk{.weak}{.shared::cta} [a], size, initval;  // initval must be zero
     # `size` accepts the ISA's 32- or 64-bit integer register forms.  Its two
     # numeric conditions remain caller preconditions because they depend on a
@@ -4370,7 +7143,7 @@ _ENTRIES = [
             OperandSlot("initval", kind="imm", literal="0"),
         ),
     ),
-    # prefetch per PTX ISA 9.7.9.15, covering three of its four syntax lines:
+    # prefetch per PTX ISA 9.7.10.16, covering three of its four syntax lines:
     #   prefetch{.space}.level [a]
     #   prefetch.global.level::eviction_priority [a]
     #   prefetch{.tensormap_space}.tensormap [a]
@@ -4386,7 +7159,7 @@ _ENTRIES = [
         check=_check_prefetch,
         operands=(OperandSlot("addr", kind="addr", allow_imm_offset=True),),
     ),
-    # st.async per PTX ISA 9.7.9.12. Two syntax blocks that share nothing but
+    # st.async per PTX ISA 9.7.10.12. Two syntax blocks that share nothing but
     # the mnemonic: one signals completion through an mbarrier, the other is a
     # release store to global memory.
     #   st.async{.weak}{.ss}.completion_mechanism{.vec}.type  [a], b, [mbar];
@@ -4438,7 +7211,32 @@ _ENTRIES = [
             ),
         ),
     ),
-    # multimem per PTX ISA 9.7.9.14: operations on a multimem address, which
+    # multimem.st.async, introduced in PTX ISA 9.3 (9.7.10.13).  MEASURED on
+    # CUDA 13.4 at sm_100: unlike st.async.release, the 8-bit source forms
+    # assemble with a .b8, .b16 or .b32 source register.  The byte forms keep
+    # the `st_async_b8reg` bridge anyway: .b8 is the register class the ISA
+    # names for them, it keeps the two st.async families' helper bodies alike,
+    # and the C boundary (a uint8/int8 carrier) is identical either way.
+    InstructionEntry(
+        name="multimem_st_async",
+        mnemonic="multimem.st.async",
+        slots=(
+            ModifierSlot("sem", ("release",)),
+            ModifierSlot("scope", ("gpu", "sys")),
+            ModifierSlot("space", ("global",), optional=True),
+            ModifierSlot("type", _ST_ASYNC_REL_TYPES),
+        ),
+        cert_arch="sm_100",
+        operands=(
+            OperandSlot("addr", kind="addr", allow_imm_offset=True),
+            OperandSlot(
+                "b",
+                dtype=_multimem_async_operand_type,
+                dtypes=_multimem_async_operand_dtypes,
+            ),
+        ),
+    ),
+    # multimem per PTX ISA 9.7.10.15: operations on a multimem address, which
     # names one location on each of several GPUs at once. Three mnemonics --
     # ld_reduce reduces across the copies into a register, st writes all of
     # them, red reduces into all of them -- and each splits into an integer and
@@ -4554,7 +7352,7 @@ _ENTRIES = [
         )
         for vec in (False, True)
     ],
-    # createpolicy per PTX ISA 9.7.9.18: build the opaque 64-bit cache-eviction
+    # createpolicy per PTX ISA 9.7.10.21: build the opaque 64-bit cache-eviction
     # policy that the `.level::cache_hint` operand of ld/st/cp takes. Three
     # syntax lines, three shapes:
     #   createpolicy.range{.global}.pri{.sec}.b64  policy, [a], primary, total;
@@ -4609,7 +7407,7 @@ _ENTRIES = [
             OperandSlot("access_property", dtype="u64"),
         ),
     ),
-    # cp.async.bulk.prefetch per PTX ISA 9.7.9.25.4.3 -- the non-tensor bulk
+    # cp.async.bulk.prefetch per PTX ISA 9.7.10.28.4.3 -- the non-tensor bulk
     # prefetch, beside the tensor one further down:
     #   cp.async.bulk.prefetch.L2.src{.level::cache_hint} [srcMem], size{, policy};
     InstructionEntry(
@@ -4630,7 +7428,7 @@ _ENTRIES = [
             OperandSlot("cache_policy", dtype="u64", lanes=_present_lanes("cache"), vector=False),
         ),
     ),
-    # tensormap.replace per PTX ISA 9.7.9.26: overwrite one field of a 1024-bit
+    # tensormap.replace per PTX ISA 9.7.10.29: overwrite one field of a 1024-bit
     # tensor-map object in place. Three field groups, and they differ in shape
     # rather than in qualifier, so they are three entries:
     #   .field1 = {global_address, rank}                      [addr], new_val
@@ -4689,7 +7487,7 @@ _ENTRIES = [
         )
     ],
     # The field3 group, one entry per field because each names its own closed
-    # set of immediate values (ISA Table 33).
+    # set of immediate values (ISA Table 36).
     *[
         InstructionEntry(
             name=f"tensormap_replace_{field}",
@@ -4714,7 +7512,29 @@ _ENTRIES = [
             ("fill_mode", ("0", "1")),
         )
     ],
-    # mov, scalar form (PTX ISA 9.7.9.3): `mov.type d, a;`. A different
+    # Swizzle-mode immediate value 4 requires sm_103a (PTX ISA 9.4, 9.7.10.29
+    # Target ISA Notes; the value itself dates from PTX ISA 8.8).  MEASURED on
+    # CUDA 13.4: sm_90a rejects it ("value '4' expected to be in range
+    # [0..3]"), sm_103a assembles it.  Keep it in a sibling entry so the
+    # existing 0..3 helpers retain their sm_90a certification floor;
+    # immediate-domain validation disambiguates calls.
+    InstructionEntry(
+        name="tensormap_replace_swizzle_mode_sm103a",
+        mnemonic="tensormap.replace",
+        slots=(
+            ModifierSlot("mode", ("tile",)),
+            ModifierSlot("field", ("swizzle_mode",)),
+            ModifierSlot("space", ("global", "shared::cta"), optional=True),
+            ModifierSlot("width", ("b1024",)),
+            ModifierSlot("type", ("b32",)),
+        ),
+        cert_arch="sm_103a",
+        operands=(
+            OperandSlot("addr", kind="addr", allow_imm_offset=True),
+            OperandSlot("new_val", kind="imm", choices=("4",)),
+        ),
+    ),
+    # mov, scalar form (PTX ISA 9.7.10.3): `mov.type d, a;`. A different
     # instruction from the vector pack/unpack lines above that share the
     # mnemonic -- this one just copies a register -- and dispatch tells them
     # apart by arity, since every pack/unpack shape takes at least three.
@@ -4731,7 +7551,7 @@ _ENTRIES = [
         ),
         asm_volatile=False,  # a register copy: let nvcc common it up
     ),
-    # prmt per PTX ISA 9.7.9.7: pick four arbitrary bytes out of the eight in
+    # prmt per PTX ISA 9.7.10.7: pick four arbitrary bytes out of the eight in
     # {b, a} and reassemble them. Without `.mode`, operand c is four 4-bit
     # selectors; with one, its two low bits pick a row of the mode's table.
     # The mode comes *after* the type in the text (`prmt.b32{.mode}`), which is
@@ -4749,7 +7569,7 @@ _ENTRIES = [
             OperandSlot("c"),
         ),
     ),
-    # ldu per PTX ISA 9.7.9.10: a load whose address is uniform across the
+    # ldu per PTX ISA 9.7.10.10: a load whose address is uniform across the
     # warp. Two lines, scalar and vector, split the way ld's are.
     # Only `.global` or generic addressing: ptxas answers "State space
     # incorrect for instruction 'ldu'" to anything else, matching the ISA's
@@ -4783,7 +7603,7 @@ _ENTRIES = [
             OperandSlot("addr", kind="addr", allow_imm_offset=True),
         ),
     ),
-    # prefetchu per PTX ISA 9.7.9.15, the third syntax form of that subsection.
+    # prefetchu per PTX ISA 9.7.10.16, the third syntax form of that subsection.
     # It targets the uniform cache rather than the data cache, so it has a
     # different mnemonic and no state space (it "requires a generic address").
     InstructionEntry(
@@ -4791,7 +7611,7 @@ _ENTRIES = [
         slots=(ModifierSlot("level", ("L1",)),),
         operands=(OperandSlot("addr", kind="addr", allow_imm_offset=True),),
     ),
-    # applypriority / discard per PTX ISA 9.7.9.16, 9.7.9.17. Same shape: an
+    # applypriority / discard per PTX ISA 9.7.10.17, 9.7.10.20. Same shape: an
     # address range and a cache level, one hinting how to evict it and the
     # other saying it need not be written back at all.
     #   applypriority{.global}.L2::evict_normal  [a], size;
@@ -4813,7 +7633,7 @@ _ENTRIES = [
         )
         for name, level in (("applypriority", "L2::evict_normal"), ("discard", "L2"))
     ],
-    # isspacep per PTX ISA 9.7.9.19: does this generic address fall inside the
+    # isspacep per PTX ISA 9.7.10.22: does this generic address fall inside the
     # window of a given state space? A `.pred` result, so it rides the bridge.
     # The address is a plain pointer rather than an `addr` operand: the
     # instruction reads the value, it does not dereference it, so there is
@@ -4827,7 +7647,7 @@ _ENTRIES = [
         ),
         asm_volatile=False,  # a pure query of an address value
     ),
-    # getctarank per PTX ISA 9.7.9.24: which CTA of the cluster owns this
+    # getctarank per PTX ISA 9.7.10.27: which CTA of the cluster owns this
     # address. Two lines by whether the address is a shared one or a generic
     # one; `.type` describes the *source*, while "destination d is always a
     # 32-bit register".
@@ -4848,7 +7668,7 @@ _ENTRIES = [
         )
         for name, shared in (("getctarank", True), ("getctarank_generic", False))
     ],
-    # cvt.pack per PTX ISA 9.7.9.22: convert two .s32 values with saturation
+    # cvt.pack per PTX ISA 9.7.10.25: convert two .s32 values with saturation
     # and pack them into one register. Two syntax lines, and the operand count
     # is what separates them -- the sub-byte line needs `c` to supply the bits
     # the pair does not fill, and the 16-bit line has none left over.
@@ -4878,11 +7698,11 @@ _ENTRIES = [
             ("cvt_pack_c", ("u2", "s2", "u4", "s4", "u8", "s8"), True),
         )
     ],
-    # shfl.sync per PTX ISA 9.7.9.6: exchange a register between the lanes of a
+    # shfl.sync per PTX ISA 9.7.10.6: exchange a register between the lanes of a
     # warp. `d[|p]` is optional in the syntax and adds a destination, so the
     # two shapes are two entries; p reports whether the computed source lane
     # was in range.
-    # NOT REGISTERED: the non-sync `shfl` of 9.7.9.5, which the ISA removed for
+    # NOT REGISTERED: the non-sync `shfl` of 9.7.10.5, which the ISA removed for
     # sm_70 and higher in PTX ISA 6.4 -- ptxas agrees ("Instruction 'shfl'
     # without '.sync' is not supported on .target sm_70 and higher"), so it
     # assembles on no architecture this dialect targets.
@@ -4905,7 +7725,7 @@ _ENTRIES = [
         )
         for pq in (False, True)
     ],
-    # cvta per PTX ISA 9.7.9.20, both directions over all eight state spaces.
+    # cvta per PTX ISA 9.7.10.23, both directions over all eight state spaces.
     # The `.to` direction converts a generic address into a space-specific one
     # and the bare direction does the reverse; they are two entries because the
     # bare one takes a plain value where `.to` takes a pointer.
@@ -4940,7 +7760,7 @@ _ENTRIES = [
         ),
         asm_volatile=False,
     ),
-    # cvt per PTX ISA 9.7.9.21.
+    # cvt per PTX ISA 9.7.10.24.
     #
     # The generic scalar line first: `cvt{.irnd|.frnd}{.ftz}{.sat}.dtype.atype`
     # over the ISA's twelve-type dtype/atype product. The two spellings the ISA
@@ -5002,7 +7822,7 @@ _ENTRIES = [
     ),
     # The two frnd2 lines that pack *two* .f32 sources into one register are a
     # different shape (`d, a, b`), so they are their own entries. ISA
-    # 9.7.9.21:65-68: "For .f16x2 and .bf16x2 instruction type, two inputs a and
+    # 9.7.10.24:65-68: "For .f16x2 and .bf16x2 instruction type, two inputs a and
     # b of .f32 type are converted into .f16 or .bf16 type and the converted
     # values are packed in the destination register d, such that the value
     # converted from input a is stored in the upper half of d and the value
@@ -5190,7 +8010,7 @@ _ENTRIES = [
         ),
         # The .bf16x2 source is the PTX ISA 9.1 line: "cvt.rn.satfinite{.relu}
         # {.e5m2x2/.e4m3x2}{.bf16x2} is supported on following family-specific
-        # architectures:" (9.7.9.21), listing sm_100f, sm_110f and sm_120f.
+        # architectures:" (9.7.10.24), listing sm_100f, sm_110f and sm_120f.
         cert_arch="sm_100a",
         operands=(
             OperandSlot("d", rw="w", dtype="dtype"),
@@ -5238,7 +8058,7 @@ _ENTRIES = [
         # ISA:634-639 puts this line on "following family-specific
         # architectures": "sm_100f or higher in the same family", "sm_110f or
         # higher in the same family", "sm_120f or higher in the same family".
-        # The entry certifies at sm_100a, which ptxas 13.2 accepts for every
+        # The entry certifies at sm_100a, which ptxas 13.4 accepts for every
         # variant here -- a toolchain fact; the sentence above is the rule.
         cert_arch="sm_100a",
         operands=(
@@ -5324,7 +8144,7 @@ _ENTRIES = [
         # ISA:619-624 puts this line on "following family-specific
         # architectures": "sm_100f or higher in the same family", "sm_110f or
         # higher in the same family", "sm_120f or higher in the same family".
-        # Certified at sm_100a, which ptxas 13.2 accepts here (toolchain fact),
+        # Certified at sm_100a, which ptxas 13.4 accepts here (toolchain fact),
         # the same treatment cvt_f6x2_fp16x2 gets from the same sentence.
         cert_arch="sm_100a",
         operands=(
@@ -5440,7 +8260,7 @@ _ENTRIES = [
         # ISA:619-624 puts this line on "following family-specific
         # architectures": "sm_100f or higher in the same family", "sm_110f or
         # higher in the same family", "sm_120f or higher in the same family".
-        # Certified at sm_100a, which ptxas 13.2 accepts here (toolchain fact).
+        # Certified at sm_100a, which ptxas 13.4 accepts here (toolchain fact).
         cert_arch="sm_100a",
         operands=(
             OperandSlot("d", rw="w", dtype="dtype"),
@@ -5593,7 +8413,7 @@ _ENTRIES = [
             ),
         ),
     ),
-    # mapa per PTX ISA 9.7.9.23: map a shared address into another CTA of the
+    # mapa per PTX ISA 9.7.10.26: map a shared address into another CTA of the
     # cluster. Syntax lines that differ only in how `a` is spelled at the PTX
     # level (register / variable / variable+imm) collapse to a register operand
     # through the C helper, while generic versus shared carrier semantics stay
@@ -5673,7 +8493,7 @@ _ENTRIES = [
         )
         for bulk in (False, True)
     ],
-    # cp.async per PTX ISA 9.7.9.25.3.1: the non-bulk asynchronous copy.
+    # cp.async per PTX ISA 9.7.10.28.3.1: the non-bulk asynchronous copy.
     # cp-size is an integer constant the ISA closes to {4, 8, 16} (and to 16
     # alone under .cg) -- a choices immediate. The src-size arity zero-fills
     # the destination tail; it is a separate entry told apart by arity, the
@@ -5734,7 +8554,7 @@ _ENTRIES = [
         operands=(),
     ),
     InstructionEntry(  # cp.async.wait_all ;
-        # The ISA's second syntax line of 9.7.9.25.3.3, and the one with no
+        # The ISA's second syntax line of 9.7.10.28.3.3, and the one with no
         # operand: "cp.async.wait_all is equivalent to :
         #
         #     cp.async.commit_group;
@@ -5748,7 +8568,7 @@ _ENTRIES = [
         # it nvcc may hoist the loads of the copied data above the wait.
         # "Writes performed by cp.async operations are made visible to the
         # executing thread only after: The completion of cp.async.wait_all"
-        # (9.7.9.25.3.3) is exactly what that clobber has to protect.
+        # (9.7.10.28.3.3) is exactly what that clobber has to protect.
         name="cp_async_wait_all",
         mnemonic="cp",
         slots=(
@@ -5758,15 +8578,15 @@ _ENTRIES = [
         orders_memory=True,
         operands=(),
     ),
-    # cp.async.bulk (non-tensor), per PTX ISA 9.7.9.25.4.1: four directions.
+    # cp.async.bulk (non-tensor), per PTX ISA 9.7.10.28.4.1: four directions.
     #
     # `.ignore_oob` is registered, on the one entry below whose direction the
     # ISA gives it: "The qualifier .ignore_oob is only available for the global
-    # to .shared::cta copy direction." (9.7.9.25.4.1). It is a PTX ISA 9.2
-    # feature and ptxas 13.2 takes it at sm_90 and sm_100.
+    # to .shared::cta copy direction." (9.7.10.28.4.1). It is a PTX ISA 9.2
+    # feature and ptxas 13.4 takes it at sm_90 and sm_100.
     InstructionEntry(  # global -> shared::cta
         # The `{.ignore_oob}` position and its two operands, from the syntax
-        # line (9.7.9.25.4.1), wrapped but otherwise verbatim:
+        # line (9.7.10.28.4.1), wrapped but otherwise verbatim:
         #
         #   cp.async.bulk.dst.src.completion_mechanism{.level::cache_hint}
         #      {.ignore_oob}
@@ -5786,13 +8606,17 @@ _ENTRIES = [
         slots=(
             ModifierSlot("api", ("async",)),
             ModifierSlot("kind", ("bulk",)),
+            ModifierSlot("sem", ("weak", "relaxed"), optional=True),
+            ModifierSlot("scope", ("cta", "cluster", "gpu", "sys"), optional=True),
             ModifierSlot("dst", ("shared::cta",)),
             ModifierSlot("src", ("global",)),
             ModifierSlot("completion", ("mbarrier::complete_tx::bytes",)),
             ModifierSlot("cache", ("L2::cache_hint",), optional=True),
             ModifierSlot("ignore_oob", ("ignore_oob",), optional=True),
+            ModifierSlot("type", ("b128",), optional=True),
         ),
-        cert_arch="sm_90",
+        check=_check_cp_async_bulk_sem,
+        cert_arch="sm_103a",
         operands=(
             OperandSlot("dst_mem", kind="addr", allow_imm_offset=True, space="shared::cta"),
             OperandSlot("src_mem", kind="addr", allow_imm_offset=True, space="global"),
@@ -5819,13 +8643,17 @@ _ENTRIES = [
         slots=(
             ModifierSlot("api", ("async",)),
             ModifierSlot("kind", ("bulk",)),
+            ModifierSlot("sem", ("weak", "relaxed"), optional=True),
+            ModifierSlot("scope", ("cta", "cluster", "gpu", "sys"), optional=True),
             ModifierSlot("dst", ("shared::cluster",)),
             ModifierSlot("src", ("global",)),
             ModifierSlot("completion", ("mbarrier::complete_tx::bytes",)),
             ModifierSlot("multicast", ("multicast::cluster",), optional=True),
             ModifierSlot("cache", ("L2::cache_hint",), optional=True),
+            ModifierSlot("type", ("b128",), optional=True),
         ),
-        cert_arch="sm_90",
+        check=_check_cp_async_bulk_sem,
+        cert_arch="sm_103a",
         operands=(
             OperandSlot("dst_mem", kind="addr", allow_imm_offset=True, space="shared::cluster"),
             OperandSlot("src_mem", kind="addr", allow_imm_offset=True, space="global"),
@@ -5841,11 +8669,15 @@ _ENTRIES = [
         slots=(
             ModifierSlot("api", ("async",)),
             ModifierSlot("kind", ("bulk",)),
+            ModifierSlot("sem", ("weak", "relaxed"), optional=True),
+            ModifierSlot("scope", ("cta", "cluster"), optional=True),
             ModifierSlot("dst", ("shared::cluster",)),
             ModifierSlot("src", ("shared::cta",)),
             ModifierSlot("completion", ("mbarrier::complete_tx::bytes",)),
+            ModifierSlot("type", ("b128",), optional=True),
         ),
-        cert_arch="sm_90",
+        cert_arch="sm_103a",
+        check=_check_cp_async_bulk_sem,
         operands=(
             OperandSlot("dst_mem", kind="addr", allow_imm_offset=True, space="shared::cluster"),
             OperandSlot("src_mem", kind="addr", allow_imm_offset=True, space="shared::cta"),
@@ -5859,6 +8691,8 @@ _ENTRIES = [
         slots=(
             ModifierSlot("api", ("async",)),
             ModifierSlot("kind", ("bulk",)),
+            ModifierSlot("sem", ("weak", "relaxed"), optional=True),
+            ModifierSlot("scope", ("cta", "cluster", "gpu", "sys"), optional=True),
             ModifierSlot("dst", ("global",)),
             ModifierSlot("src", ("shared::cta",)),
             ModifierSlot("completion", ("bulk_group",)),
@@ -5866,7 +8700,7 @@ _ENTRIES = [
             # .cp_mask masks bytes within each 16-byte chunk: "The i-th bit in
             # the 16-bit wide byteMask operand specifies whether the i-th byte
             # of each 16-byte wide chunk of source data is copied to the
-            # destination." (ISA 9.7.9.25.4.1:181-182). It is independent of
+            # destination." (ISA 9.7.10.28.4.1:181-182). It is independent of
             # .L2::cache_hint -- the syntax line brace-marks the two separately
             # ("cp.async.bulk.dst.src.completion_mechanism{.level::cache_hint}{.cp_mask}",
             # :72) and the section's only couplings are ":173 When the optional
@@ -5875,15 +8709,17 @@ _ENTRIES = [
             # qualifier .cp_mask is specified, the argument byteMask is
             # required." -- both of which this entry's operand `lanes` already
             # encode. This entry used to reject bare .cp_mask on the claim that
-            # ptxas required the pairing; ptxas (CUDA 13.2) assembles
+            # ptxas required the pairing; ptxas (CUDA 13.4) assembles
             # `cp.async.bulk.global.shared::cta.bulk_group.cp_mask [%rd], [%r1],
             # %r2, %h;` at sm_100 and sm_100a, so the claim was false.
             # .cp_mask is a Blackwell feature -- below sm_100 ptxas reports
             # "Feature '.cp_mask' requires .target sm_100 or higher", which the
             # entry's cert_arch already covers.
             ModifierSlot("cp_mask", ("cp_mask",), optional=True),
+            ModifierSlot("type", ("b128",), optional=True),
         ),
-        cert_arch="sm_100a",
+        cert_arch="sm_103a",
+        check=_check_cp_async_bulk_sem,
         operands=(
             OperandSlot("dst_mem", kind="addr", allow_imm_offset=True, space="global"),
             OperandSlot("src_mem", kind="addr", allow_imm_offset=True, space="shared::cta"),
@@ -5895,7 +8731,7 @@ _ENTRIES = [
             OperandSlot("byte_mask", dtype="u16", lanes=_cp_mask_lanes, vector=False),
         ),
     ),
-    # cp.reduce.async.bulk (non-tensor), per PTX ISA 9.7.9.25.4.2.
+    # cp.reduce.async.bulk (non-tensor), per PTX ISA 9.7.10.28.4.2.
     # PTX 9.2 exposes the original forms without explicit sem/scope tokens.
     InstructionEntry(
         name="cp_reduce_async_bulk_s2c",
@@ -5904,14 +8740,16 @@ _ENTRIES = [
             ModifierSlot("op", ("reduce",)),
             ModifierSlot("api", ("async",)),
             ModifierSlot("kind", ("bulk",)),
+            ModifierSlot("sem", ("relaxed",), optional=True),
+            ModifierSlot("scope", ("cta", "cluster"), optional=True),
             ModifierSlot("dst", ("shared::cluster",)),
             ModifierSlot("src", ("shared::cta",)),
             ModifierSlot("completion", ("mbarrier::complete_tx::bytes",)),
             ModifierSlot("redop", tuple(_CP_REDUCE_BULK_TYPES["shared::cluster"])),
             ModifierSlot("type", ("b32", "u32", "s32", "u64")),
         ),
-        check=_check_cp_reduce_async_bulk,
-        cert_arch="sm_90",
+        check=_check_cp_reduce_async_bulk_93,
+        cert_arch="sm_103a",
         operands=(
             OperandSlot("dst_mem", kind="addr", allow_imm_offset=True, space="shared::cluster"),
             OperandSlot("src_mem", kind="addr", allow_imm_offset=True, space="shared::cta"),
@@ -5926,6 +8764,8 @@ _ENTRIES = [
             ModifierSlot("op", ("reduce",)),
             ModifierSlot("api", ("async",)),
             ModifierSlot("kind", ("bulk",)),
+            ModifierSlot("sem", ("relaxed",), optional=True),
+            ModifierSlot("scope", ("cta", "cluster", "gpu", "sys"), optional=True),
             ModifierSlot("dst", ("global",)),
             ModifierSlot("src", ("shared::cta",)),
             ModifierSlot("completion", ("bulk_group",)),
@@ -5936,8 +8776,8 @@ _ENTRIES = [
                 "type", ("f16", "bf16", "b32", "u32", "s32", "b64", "u64", "s64", "f32", "f64")
             ),
         ),
-        check=_check_cp_reduce_async_bulk,
-        cert_arch="sm_90",
+        check=_check_cp_reduce_async_bulk_93,
+        cert_arch="sm_103a",
         operands=(
             OperandSlot("dst_mem", kind="addr", allow_imm_offset=True, space="global"),
             OperandSlot("src_mem", kind="addr", allow_imm_offset=True, space="shared::cta"),
@@ -5945,7 +8785,59 @@ _ENTRIES = [
             OperandSlot("cache_policy", dtype="u64", lanes=_tma_cache_lanes, vector=False),
         ),
     ),
-    # cp.async.bulk.tensor (TMA), per ISA 9.7.9.25.5.2-4. The tensor address
+    # Multimem bulk-copy families were introduced in PTX 9.1; PTX 9.3 adds
+    # their explicit strong semantic/scope forms.  Register both the default
+    # weak spellings and the new paired `.relaxed.scope` spellings.
+    InstructionEntry(
+        name="multimem_cp_async_bulk",
+        mnemonic="multimem.cp",
+        slots=(
+            ModifierSlot("api", ("async",)),
+            ModifierSlot("kind", ("bulk",)),
+            ModifierSlot("sem", ("weak", "relaxed"), optional=True),
+            ModifierSlot("scope", ("cta", "cluster", "gpu", "sys"), optional=True),
+            ModifierSlot("dst", ("global",)),
+            ModifierSlot("src", ("shared::cta",)),
+            ModifierSlot("completion", ("bulk_group",)),
+            ModifierSlot("cp_mask", ("cp_mask",), optional=True),
+            ModifierSlot("type", ("b128",), optional=True),
+        ),
+        check=_check_cp_async_bulk_sem,
+        cert_arch="sm_103a",
+        operands=(
+            OperandSlot("dst_mem", kind="addr", allow_imm_offset=True, space="global"),
+            OperandSlot("src_mem", kind="addr", allow_imm_offset=True, space="shared::cta"),
+            OperandSlot("size", dtype="u32"),
+            OperandSlot("byte_mask", dtype="u16", lanes=_cp_mask_lanes, vector=False),
+        ),
+    ),
+    InstructionEntry(
+        name="multimem_cp_reduce_async_bulk",
+        mnemonic="multimem.cp",
+        slots=(
+            ModifierSlot("op", ("reduce",)),
+            ModifierSlot("api", ("async",)),
+            ModifierSlot("kind", ("bulk",)),
+            ModifierSlot("sem", ("relaxed",), optional=True),
+            ModifierSlot("scope", ("cta", "cluster", "gpu", "sys"), optional=True),
+            ModifierSlot("dst", ("global",)),
+            ModifierSlot("src", ("shared::cta",)),
+            ModifierSlot("completion", ("bulk_group",)),
+            ModifierSlot("redop", tuple(_CP_REDUCE_BULK_TYPES["global"])),
+            ModifierSlot("noftz", ("noftz",), optional=True),
+            ModifierSlot(
+                "type", ("f16", "bf16", "b32", "u32", "s32", "b64", "u64", "s64", "f32", "f64")
+            ),
+        ),
+        check=_check_cp_reduce_async_bulk_93,
+        cert_arch="sm_103a",
+        operands=(
+            OperandSlot("dst_mem", kind="addr", allow_imm_offset=True, space="global"),
+            OperandSlot("src_mem", kind="addr", allow_imm_offset=True, space="shared::cta"),
+            OperandSlot("size", dtype="u32"),
+        ),
+    ),
+    # cp.async.bulk.tensor (TMA), per ISA 9.7.10.28.5.3-5. The tensor address
     # is the composite `[tensorMap, tensorCoords]` -- one PTX operand holding
     # a 64-bit tensor-map pointer plus an .s32 coordinate vector -- which is
     # what OperandSlot.bracket transcribes. The coordinate count follows .dim
@@ -5954,9 +8846,6 @@ _ENTRIES = [
     # a zero-lanes function each.
     #
     # NOT REGISTERED:
-    # - the .im2col family of load modes (im2col/im2col::w/im2col::w::128 and
-    #   s2g's im2col_no_offs) with their `{, im2colInfo}` operand: no call
-    #   site uses im2col, and the legacy helpers never supported it.
     # - `.tile::scatter4` under cp.reduce: absent from that syntax line.
     InstructionEntry(  # global -> shared::cluster (the TMA load every kernel uses)
         name="cp_async_bulk_tensor_g2s_cluster",
@@ -6093,10 +8982,164 @@ _ENTRIES = [
         operands=(),
     ),
     # ------------------------------------------------------------------
-    # PTX ISA 9.7.13 — Parallel Synchronization and Communication Instructions
+    # PTX ISA 9.7.11 — Fabric Instructions (introduced in PTX ISA 9.3)
     # ------------------------------------------------------------------
-    # bar / barrier per PTX ISA 9.7.13.1, bar.warp.sync per 9.7.13.2,
-    # barrier.cluster per 9.7.13.3.
+    # A fabric handle is the composite [logical-endpoint id, byte offset].
+    # Counted completion adds a third counter-offset member and is therefore a
+    # distinct operand shape. Likewise, cp_mask has a trailing byte-mask
+    # operand and is incompatible with counted::bytes (ISA 9.7.11.5.2).
+    InstructionEntry(
+        name="fabric_try_get",
+        mnemonic="fabric",
+        slots=(
+            ModifierSlot("action", ("try_get",)),
+            ModifierSlot("api", ("async",)),
+            ModifierSlot("dst", ("shared::cta",)),
+            ModifierSlot("completion", ("mbarrier::complete_tx::bytes.mbarrier::report::fabric",)),
+            ModifierSlot("sem", ("relaxed",)),
+            ModifierSlot("scope", ("sys",)),
+            ModifierSlot("type", ("b128",)),
+        ),
+        cert_arch="sm_103a",
+        operands=(
+            OperandSlot("dst_mem", kind="addr", allow_imm_offset=True, space="shared::cta"),
+            OperandSlot("src_le_id", dtype="u32", bracket="src"),
+            OperandSlot("src_data_off", dtype="u64", bracket="src"),
+            OperandSlot("size", dtype="u32"),
+            OperandSlot("mbar", kind="addr", allow_imm_offset=True, space="shared::cta"),
+        ),
+    ),
+    *[
+        InstructionEntry(
+            name=name,
+            mnemonic="fabric",
+            slots=(
+                ModifierSlot("action", ("try_put",)),
+                ModifierSlot("api", ("async",)),
+                ModifierSlot("multimem", ("multimem",), optional=True),
+                ModifierSlot("src", ("shared::cta",)),
+                ModifierSlot(
+                    "completion",
+                    (
+                        "mbarrier::complete_tx::16B.mbarrier::report::fabric"
+                        + (".counted::bytes" if counted else ""),
+                    ),
+                ),
+                *((ModifierSlot("cp_mask", ("cp_mask",)),) if cp_mask else ()),
+                ModifierSlot("sem", ("relaxed",)),
+                ModifierSlot("scope", ("sys",)),
+                ModifierSlot("type", ("b128",)),
+            ),
+            cert_arch="sm_103a",
+            operands=(
+                OperandSlot("dst_le_id", dtype="u32", bracket="dst"),
+                OperandSlot("dst_data_off", dtype="u64", bracket="dst"),
+                *((OperandSlot("dst_counter_off", dtype="u64", bracket="dst"),) if counted else ()),
+                OperandSlot("src_mem", kind="addr", allow_imm_offset=True, space="shared::cta"),
+                OperandSlot("size", dtype="u32"),
+                OperandSlot("mbar", kind="addr", allow_imm_offset=True, space="shared::cta"),
+                *((OperandSlot("byte_mask", dtype="u16"),) if cp_mask else ()),
+            ),
+        )
+        for name, counted, cp_mask in (
+            ("fabric_try_put", False, False),
+            ("fabric_try_put_cp_mask", False, True),
+            ("fabric_try_put_counted", True, False),
+        )
+    ],
+    *[
+        InstructionEntry(
+            name=name,
+            mnemonic="fabric",
+            slots=(
+                ModifierSlot("action", ("try_red",)),
+                ModifierSlot("api", ("async",)),
+                ModifierSlot("multimem", ("multimem",), optional=True),
+                ModifierSlot("src", ("shared::cta",)),
+                ModifierSlot(
+                    "completion",
+                    (
+                        "mbarrier::complete_tx::16B.mbarrier::report::fabric"
+                        + (".counted::bytes" if counted else ""),
+                    ),
+                ),
+                ModifierSlot("sem", ("relaxed",)),
+                ModifierSlot("scope", ("sys",)),
+                ModifierSlot("redop", tuple(_FABRIC_RED_TYPES)),
+                ModifierSlot(
+                    "type",
+                    ("b32", "b64", "u32", "s32", "u64", "s64", "f16", "bf16", "f32", "f64"),
+                ),
+            ),
+            check=_check_fabric_red,
+            cert_arch="sm_103a",
+            operands=(
+                OperandSlot("dst_le_id", dtype="u32", bracket="dst"),
+                OperandSlot("dst_data_off", dtype="u64", bracket="dst"),
+                *((OperandSlot("dst_counter_off", dtype="u64", bracket="dst"),) if counted else ()),
+                OperandSlot("src_mem", kind="addr", allow_imm_offset=True, space="shared::cta"),
+                OperandSlot("size", dtype="u32"),
+                OperandSlot("mbar", kind="addr", allow_imm_offset=True, space="shared::cta"),
+            ),
+        )
+        for name, counted in (
+            ("fabric_try_red", False),
+            ("fabric_try_red_counted", True),
+        )
+    ],
+    InstructionEntry(
+        name="fabric_try_pullred",
+        mnemonic="fabric",
+        slots=(
+            ModifierSlot("action", ("try_pullred",)),
+            ModifierSlot("api", ("async",)),
+            ModifierSlot("multimem", ("multimem",)),
+            ModifierSlot("dst", ("shared::cta",)),
+            ModifierSlot("completion", ("mbarrier::complete_tx::bytes.mbarrier::report::fabric",)),
+            ModifierSlot("sem", ("relaxed",)),
+            ModifierSlot("scope", ("sys",)),
+            ModifierSlot("redop", tuple(_FABRIC_PULLRED_TYPES)),
+            ModifierSlot("type", ("b32", "b64", "u32", "s32", "u64", "s64", "f16", "bf16", "f32")),
+            ModifierSlot("sync", ("sync",)),
+        ),
+        check=_check_fabric_pullred,
+        cert_arch="sm_103a",
+        operands=(
+            OperandSlot("dst_mem", kind="addr", allow_imm_offset=True, space="shared::cta"),
+            OperandSlot("src_le_id", dtype="u32", bracket="src"),
+            OperandSlot("src_data_off", dtype="u64", bracket="src"),
+            OperandSlot("size", dtype="u32"),
+            OperandSlot("mbar", kind="addr", allow_imm_offset=True, space="shared::cta"),
+            OperandSlot("membermask", kind="imm", literal="0xFFFFFFFF"),
+        ),
+    ),
+    InstructionEntry(
+        name="fabric_submit",
+        mnemonic="fabric",
+        slots=(
+            ModifierSlot("action", ("submit",)),
+            ModifierSlot("submitop", ("op_restrict::fetching",), optional=True),
+        ),
+        cert_arch="sm_103a",
+        orders_memory=True,
+        operands=(),
+    ),
+    InstructionEntry(
+        name="fabric_wait",
+        mnemonic="fabric",
+        slots=(
+            ModifierSlot("action", ("wait",)),
+            ModifierSlot("waitop", ("sync_restrict::reads",)),
+        ),
+        cert_arch="sm_103a",
+        orders_memory=True,
+        operands=(),
+    ),
+    # ------------------------------------------------------------------
+    # PTX ISA 9.7.15 — Parallel Synchronization and Communication Instructions
+    # ------------------------------------------------------------------
+    # bar / barrier per PTX ISA 9.7.15.1, bar.warp.sync per 9.7.15.2,
+    # barrier.cluster per 9.7.15.3.
     #
     #   barrier{.cta}.sync{.aligned}   a{, b};    bar{.cta}.sync   a{, b};
     #   barrier{.cta}.arrive{.aligned} a,  b;     bar{.cta}.arrive a,  b;
@@ -6179,7 +9222,7 @@ _ENTRIES = [
     *[
         InstructionEntry(  # barrier.cluster.arrive{.sem}{.aligned} / .wait{.acquire}{.aligned}
             name=f"barrier_cluster_{act}",
-            # Shares the `barrier` mnemonic with 9.7.13.1 so the surface reads
+            # Shares the `barrier` mnemonic with 9.7.15.1 so the surface reads
             # `T.ptx.barrier.cluster.arrive(...)`; `cluster` is the token that
             # tells the two ISA sections apart.
             mnemonic="barrier",
@@ -6199,7 +9242,7 @@ _ENTRIES = [
         for act in ("arrive", "wait")
     ],
     InstructionEntry(  # bar.warp.sync      membermask;
-        # The `bar` mnemonic's warp-level line, ISA 9.7.13.2 -- a different
+        # The `bar` mnemonic's warp-level line, ISA 9.7.15.2 -- a different
         # section from the CTA barriers above and a different operand: not a
         # barrier id but a lane mask. "Operand membermask specifies a 32-bit
         # integer which is a mask indicating threads participating in barrier
@@ -6224,7 +9267,7 @@ _ENTRIES = [
         orders_memory=True,
         operands=(OperandSlot("membermask", dtype="u32"),),
     ),
-    # The reduction forms of bar / barrier (PTX ISA 9.7.13.1), which combine a
+    # The reduction forms of bar / barrier (PTX ISA 9.7.15.1), which combine a
     # predicate across the barrier's threads instead of only waiting:
     #   bar{.cta}.red.popc.u32       d, a{, b}, {!}c;
     #   bar{.cta}.red.op.pred        p, a{, b}, {!}c;   .op = {.and, .or}
@@ -6261,10 +9304,10 @@ _ENTRIES = [
         for kind in ("popc", "pred")
         for count in (False, True)
     ],
-    # vote.sync per PTX ISA 9.7.13.9: reduce a predicate across a warp. The
+    # vote.sync per PTX ISA 9.7.15.10: reduce a predicate across a warp. The
     # `.ballot` line returns one bit per lane instead of a single answer, so it
     # is a second entry rather than a fourth `.mode` token.
-    # NOT REGISTERED: `vote` without `.sync` (9.7.13.8), deprecated in PTX ISA
+    # NOT REGISTERED: `vote` without `.sync` (9.7.15.9), deprecated in PTX ISA
     # 6.0 and rejected outright by ptxas at sm_70 and higher, exactly as the
     # non-sync `shfl` is; and the `{!}a` negation, per the usual policy.
     *[
@@ -6286,7 +9329,7 @@ _ENTRIES = [
             ("vote_sync_ballot", ("ballot",), "b32"),
         )
     ],
-    # match.sync per PTX ISA 9.7.13.10: which lanes of the warp hold the same
+    # match.sync per PTX ISA 9.7.15.11: which lanes of the warp hold the same
     # value. `.all` optionally reports, through a second predicate, whether
     # every lane agreed -- `.any` has no such answer to give, and ptxas says so
     # ("Predicate output not allowed for instruction 'match.any'"), so the
@@ -6322,14 +9365,14 @@ _ENTRIES = [
             ("match_all_sync_p", "all", True),
         )
     ],
-    # activemask per PTX ISA 9.7.13.11: the one instruction in the table that
+    # activemask per PTX ISA 9.7.15.12: the one instruction in the table that
     # writes a destination and reads nothing at all.
     InstructionEntry(
         name="activemask",
         slots=(ModifierSlot("type", ("b32",)),),
         operands=(OperandSlot("d", rw="w"),),
     ),
-    # elect.sync per PTX ISA 9.7.13.14: pick one leader lane out of the member
+    # elect.sync per PTX ISA 9.7.15.15: pick one leader lane out of the member
     # mask. Its `d|p` is not optional the way match's is -- ptxas answers
     # "Predicate output expected for instruction 'elect'" to a bare
     # destination -- so this family has exactly one shape, and it is the pipe.
@@ -6346,7 +9389,7 @@ _ENTRIES = [
             OperandSlot("membermask", dtype="u32"),
         ),
     ),
-    # redux.sync per PTX ISA 9.7.13.12: reduce a value across the warp.
+    # redux.sync per PTX ISA 9.7.15.13: reduce a value across the warp.
     *[
         InstructionEntry(
             name=name,
@@ -6392,7 +9435,7 @@ _ENTRIES = [
             OperandSlot("membermask", dtype="u32"),
         ),
     ),
-    # fence / membar per PTX ISA 9.7.13.4, griddepcontrol per 9.7.13.13.
+    # fence / membar per PTX ISA 9.7.15.4, griddepcontrol per 9.7.15.14.
     #
     # These name no address yet constrain everyone else's memory order, so they
     # set `orders_memory=True` -- see InstructionEntry for why `asm volatile`
@@ -6434,6 +9477,20 @@ _ENTRIES = [
         orders_memory=True,
         operands=(),
     ),
+    InstructionEntry(  # fence.proxy.{generic::fabric,...}.alias.{acquire,release}.sys;
+        name="fence_proxy_fabric",
+        mnemonic="fence",
+        slots=(
+            ModifierSlot("proxy", ("proxy",)),
+            ModifierSlot("direction", ("generic::fabric", "fabric::generic", "fabric::fabric")),
+            ModifierSlot("proxykind", ("alias",)),
+            ModifierSlot("sem", ("acquire", "release")),
+            ModifierSlot("scope", ("sys",)),
+        ),
+        cert_arch="sm_103a",
+        orders_memory=True,
+        operands=(),
+    ),
     InstructionEntry(  # fence.proxy.tensormap::generic.release.scope;
         name="fence_proxy_tensormap_release",
         mnemonic="fence",
@@ -6459,7 +9516,7 @@ _ENTRIES = [
         operands=(
             OperandSlot("addr", kind="addr", allow_imm_offset=True),
             # "The only supported value for the size operand is 128, which must
-            # be a constant integer literal" -- ISA 9.7.13.4.
+            # be a constant integer literal" -- ISA 9.7.15.4.
             OperandSlot("size", kind="imm", literal="128"),
         ),
     ),
@@ -6484,7 +9541,7 @@ _ENTRIES = [
             OperandSlot("cache_policy", dtype="u64", lanes=_present_lanes("cache"), vector=False),
         ),
     ),
-    # atom's other syntax lines (PTX ISA 9.7.13.5), each its own entry because
+    # atom's other syntax lines (PTX ISA 9.7.15.5), each its own entry because
     # each differs in shape or in type domain from the `.op` line above.
     #
     # `.cas` compares and swaps, so it takes a fourth value; it is also the one
@@ -6626,7 +9683,7 @@ _ENTRIES = [
             ("red_vec_f32", ("add",), False, ("f32",)),
         )
     ],
-    # red / atom scalar `.op` forms per PTX ISA 9.7.13.6 and 9.7.13.5.
+    # red / atom scalar `.op` forms per PTX ISA 9.7.15.6 and 9.7.15.5.
     InstructionEntry(
         name="red",
         slots=(
@@ -6650,7 +9707,7 @@ _ENTRIES = [
         orders_memory=True,
         operands=(),
     ),
-    # mbarrier, per PTX ISA 9.7.13.15: the PTX 9.2 operation instructions from
+    # mbarrier, per PTX ISA 9.7.15.16: the PTX 9.2 operation instructions from
     # init through pending_count are registered below.
     #
     # A syntax line with an optional operand is represented by one entry per
@@ -6673,6 +9730,7 @@ _ENTRIES = [
         mnemonic="mbarrier",
         slots=(
             ModifierSlot("action", ("init",)),
+            ModifierSlot("layout", ("layout::v0", "layout::v1"), optional=True),
             ModifierSlot("space", ("shared", "shared::cta"), optional=True),
             ModifierSlot("type", ("b64",)),
         ),
@@ -6681,7 +9739,7 @@ _ENTRIES = [
             OperandSlot("count", dtype="u32"),
         ),
     ),
-    # mbarrier.arrive (9.7.13.15.13) and mbarrier.arrive_drop (9.7.13.15.14)
+    # mbarrier.arrive (9.7.15.16.16) and mbarrier.arrive_drop (9.7.15.16.17)
     # are the same five syntax lines under two action tokens -- compare
     #
     #   mbarrier.arrive{.sem.scope}{.shared{::cta}}.b64           state, [addr]{, count};
@@ -6690,7 +9748,7 @@ _ENTRIES = [
     #   mbarrier.arrive.expect_tx{.sem.scope}{.shared::cluster}.b64   _, [addr], txCount;
     #   mbarrier.arrive.noComplete{.release.cta}{.shared{::cta}}.b64  state, [addr], count;
     #
-    # with 9.7.13.15.14's five, which differ only in the mnemonic's action and
+    # with 9.7.15.16.17's five, which differ only in the mnemonic's action and
     # in arrive_drop also decrementing the expected count ("Decrements the
     # expected arrival count of the mbarrier object by the value specified by
     # the 32-bit integer operand count"). So each shape below is one
@@ -6698,7 +9756,7 @@ _ENTRIES = [
     #
     # Both sections state the pairing rule `_check_mbarrier_sem_scope` enforces
     # in the same words: "Qualifiers .sem and .scope must be specified
-    # together." (9.7.13.15.13, 9.7.13.15.14).
+    # together." (9.7.15.16.16, 9.7.15.16.17).
     *[
         InstructionEntry(  # mbarrier.<act>{.sem.scope}{.space}.b64 _, [addr];
             # The `{, count}` optionality is one ISA line; here it is two entries
@@ -6826,6 +9884,9 @@ _ENTRIES = [
             slots=(
                 ModifierSlot("action", (act,)),
                 ModifierSlot("parity", ("parity",)),
+                ModifierSlot(
+                    "phase_type", ("phase_type::primary", "phase_type::conditional"), optional=True
+                ),
                 ModifierSlot("sem", ("acquire", "relaxed"), optional=True),
                 ModifierSlot("scope", ("cta", "cluster"), optional=True),
                 ModifierSlot("space", ("shared", "shared::cta"), optional=True),
@@ -6848,6 +9909,9 @@ _ENTRIES = [
         slots=(
             ModifierSlot("action", ("try_wait",)),
             ModifierSlot("parity", ("parity",)),
+            ModifierSlot(
+                "phase_type", ("phase_type::primary", "phase_type::conditional"), optional=True
+            ),
             ModifierSlot("sem", ("acquire", "relaxed"), optional=True),
             ModifierSlot("scope", ("cta", "cluster"), optional=True),
             ModifierSlot("space", ("shared", "shared::cta"), optional=True),
@@ -6890,7 +9954,7 @@ _ENTRIES = [
         ),
         operands=(OperandSlot("addr", kind="addr", allow_imm_offset=True),),
     ),
-    # The state-returning arrive lines (PTX ISA 9.7.13.15.13 / .14). The
+    # The state-returning arrive lines (PTX ISA 9.7.15.16.16 / .17). The
     # entries above bake `_` into the text, which is the only spelling the
     # `.shared::cluster` lines offer; these return the phase state instead, and
     # the ISA gives them `.shared{::cta}` alone.
@@ -6922,7 +9986,7 @@ _ENTRIES = [
         # count and its state/sink siblings are registered separately above.
         for suffix, count in (("", False), ("_count", True), ("_expect_tx", True))
     ],
-    # The non-parity waits (PTX ISA 9.7.13.15.16), which take the state token
+    # The non-parity waits (PTX ISA 9.7.15.16.19), which take the state token
     # an arrive returned rather than a phase parity. try_wait's optional
     # timeHint is represented by two arities of the same ISA syntax line.
     *[
@@ -6931,6 +9995,7 @@ _ENTRIES = [
             mnemonic="mbarrier",
             slots=(
                 ModifierSlot("action", (act,)),
+                ModifierSlot("phase_type", ("phase_type::primary",), optional=True),
                 ModifierSlot("sem", ("acquire", "relaxed"), optional=True),
                 ModifierSlot("scope", ("cta", "cluster"), optional=True),
                 ModifierSlot("space", ("shared", "shared::cta"), optional=True),
@@ -6947,7 +10012,45 @@ _ENTRIES = [
         )
         for act, hint in (("test_wait", False), ("try_wait", False), ("try_wait", True))
     ],
-    # tensormap.cp_fenceproxy per PTX ISA 9.7.13.16: copy a tensor-map object
+    # PTX 9.3 report forms write `waitComplete|reportPredicate` and may also
+    # return an 8-bit reportValue.  Each arity is its own syntax shape; the
+    # reportValue sibling uses a measured block-local .b8 bridge.
+    *[
+        InstructionEntry(
+            name=(
+                f"mbarrier_{act}{'_parity' if parity else ''}_report"
+                f"{'_value' if report_value else ''}{'_hint' if hint else ''}"
+            ),
+            mnemonic="mbarrier",
+            slots=(
+                ModifierSlot("action", (act,)),
+                *((ModifierSlot("parity", ("parity",)),) if parity else ()),
+                ModifierSlot("phase_type", ("phase_type::primary",)),
+                ModifierSlot("sem", ("acquire", "relaxed"), optional=True),
+                ModifierSlot("scope", ("cta", "cluster"), optional=True),
+                ModifierSlot("space", ("shared", "shared::cta"), optional=True),
+                ModifierSlot("type", ("b64",)),
+            ),
+            check=_check_mbarrier_sem_scope,
+            cert_arch="sm_90",
+            operands=(
+                OperandSlot("wait_complete", rw="w", dtype="pred", pipe="report"),
+                OperandSlot("report_predicate", rw="w", dtype="pred", pipe="report"),
+                *(
+                    (OperandSlot("report_value", rw="w", dtype="mbarrier_report_b8reg"),)
+                    if report_value
+                    else ()
+                ),
+                OperandSlot("addr", kind="addr", allow_imm_offset=True),
+                OperandSlot("phase", dtype="u32" if parity else "b64i"),
+                *((OperandSlot("time_hint", dtype="u32"),) if hint else ()),
+            ),
+        )
+        for parity in (False, True)
+        for act, hint in (("test_wait", False), ("try_wait", False), ("try_wait", True))
+        for report_value in (False, True)
+    ],
+    # tensormap.cp_fenceproxy per PTX ISA 9.7.15.17: copy a tensor-map object
     # from shared to global and fence the tensormap proxy over it, in one
     # instruction. `size` is the literal 128 -- ptxas both refuses a register
     # there ("Arguments mismatch") and names the only legal value ("unexpected
@@ -6971,7 +10074,7 @@ _ENTRIES = [
             OperandSlot("size", kind="imm", literal="128"),
         ),
     ),
-    # red.async per PTX ISA 9.7.13.7: an asynchronous reduction whose
+    # red.async per PTX ISA 9.7.15.7: an asynchronous reduction whose
     # completion is signalled through an mbarrier. The ISA writes one syntax
     # line per op group; `_check_red_async` is that grid.
     InstructionEntry(
@@ -7014,10 +10117,29 @@ _ENTRIES = [
             OperandSlot("value"),
         ),
     ),
+    # multimem.red.async, introduced in PTX ISA 9.3 (9.7.15.8): an
+    # asynchronous add with release ordering to every location named by a
+    # multimem address.
+    InstructionEntry(
+        name="multimem_red_async",
+        mnemonic="multimem.red.async",
+        slots=(
+            ModifierSlot("sem", ("release",)),
+            ModifierSlot("scope", ("gpu", "sys")),
+            ModifierSlot("space", ("global",), optional=True),
+            ModifierSlot("op", ("add",)),
+            ModifierSlot("type", ("u32", "s32", "u64")),
+        ),
+        cert_arch="sm_100",
+        operands=(
+            OperandSlot("addr", kind="addr", allow_imm_offset=True),
+            OperandSlot("value"),
+        ),
+    ),
     # cp.async completion tracking: cp.async.mbarrier.arrive per PTX ISA
-    # 9.7.13.15.15, cp.async.commit_group per 9.7.9.25.3.2, cp.async.wait_group
-    # and cp.async.wait_all per 9.7.9.25.3.3, cp.async.bulk.commit_group /
-    # .wait_group per 9.7.9.25.6.1 / 9.7.9.25.6.2.
+    # 9.7.15.16.18, cp.async.commit_group per 9.7.10.28.3.2, cp.async.wait_group
+    # and cp.async.wait_all per 9.7.10.28.3.3, cp.async.bulk.commit_group /
+    # .wait_group per 9.7.10.28.6.1 / 9.7.10.28.6.2.
     #
     # The wait_group counts are caller-chosen immediates: the ISA gives N no
     # register form, so each value is its own helper, and the closed `choices`
@@ -7025,7 +10147,7 @@ _ENTRIES = [
     # site (pipeline depths); widen the tuple if a deeper pipeline appears.
     #
     # (The `cp.async` ca/cg copy lines this note once excluded are registered
-    # in the 9.7.9 group above, ignore-src operand and all.)
+    # in the 9.7.10 group above, ignore-src operand and all.)
     InstructionEntry(  # cp.async.mbarrier.arrive{.noinc}{.shared{::cta}}.b64 [addr];
         name="cp_async_mbarrier_arrive",
         mnemonic="cp",
@@ -7039,7 +10161,7 @@ _ENTRIES = [
         ),
         # No fixed space on addr, for the reason the mbarrier family states at
         # length below: "If no state space is specified then Generic Addressing
-        # is used." (ISA 9.7.13.15.15), and a generic address is 64-bit on
+        # is used." (ISA 9.7.15.16.18), and a generic address is 64-bit on
         # sm_90+, so pinning the operand to shared would bind a 32-bit register
         # under the space-omitted spelling. `operand_space` reads the entry's
         # `space` slot instead, so the carrier follows the spelling.
@@ -7049,7 +10171,7 @@ _ENTRIES = [
         # The reader of the `state` result the state-returning `.noComplete`
         # entries above produce: "The state operand is a 64-bit register that
         # must be the result of a prior mbarrier.arrive.noComplete or
-        # mbarrier.arrive_drop.noComplete instruction." (ISA 9.7.13.15.17).
+        # mbarrier.arrive_drop.noComplete instruction." (ISA 9.7.15.16.20).
         #
         # No address and no state space -- the instruction reads a register,
         # not the mbarrier object -- so there is no `space` slot here and
@@ -7065,6 +10187,7 @@ _ENTRIES = [
         mnemonic="mbarrier",
         slots=(
             ModifierSlot("action", ("pending_count",)),
+            ModifierSlot("layout", ("layout::v0",), optional=True),
             ModifierSlot("type", ("b64",)),
         ),
         operands=(
@@ -7072,7 +10195,22 @@ _ENTRIES = [
             OperandSlot("state", dtype="b64i"),
         ),
     ),
-    # clusterlaunchcontrol.try_cancel per PTX ISA 9.7.13.17.
+    InstructionEntry(
+        name="mbarrier_check_layout",
+        mnemonic="mbarrier",
+        slots=(
+            ModifierSlot("action", ("check_layout",)),
+            ModifierSlot("layout", ("layout::v0", "layout::v1")),
+            ModifierSlot("space", ("shared::cta",), optional=True),
+            ModifierSlot("type", ("b64",)),
+        ),
+        cert_arch="sm_90",
+        operands=(
+            OperandSlot("matches", rw="w", dtype="pred"),
+            OperandSlot("addr", kind="addr", allow_imm_offset=True),
+        ),
+    ),
+    # clusterlaunchcontrol.try_cancel per PTX ISA 9.7.15.18.
     InstructionEntry(
         name="clusterlaunchcontrol_try_cancel",
         mnemonic="clusterlaunchcontrol",
@@ -7085,7 +10223,7 @@ _ENTRIES = [
             ModifierSlot("type", ("b128",)),
         ),
         # The instruction itself needs sm_100, but `.multicast::cluster::all`
-        # is restricted: ISA 9.7.13.17 lists sm_100a, sm_101a and sm_120a,
+        # is restricted: ISA 9.7.15.18 lists sm_100a, sm_101a and sm_120a,
         # plus the family-specific sm_100f / sm_101f / sm_110f / sm_120f "or
         # higher in the same family" from PTX ISA 8.8. sm_100a is the
         # certification target.
@@ -7093,7 +10231,7 @@ _ENTRIES = [
         # Neither address operand takes a fixed space: `.space` is optional on
         # the syntax line, and "The .space qualifier is specified, both operands
         # addr and mbar must be in the .shared::cta state space. Otherwise,
-        # generic addressing will be assumed for both." (ISA 9.7.13.17). A
+        # generic addressing will be assumed for both." (ISA 9.7.15.18). A
         # generic address is 64-bit on sm_100, so pinning both to shared would
         # bind 32-bit registers under the space-omitted spelling. Letting
         # `operand_space` read the entry's `space` slot gives each variant the
@@ -7103,9 +10241,9 @@ _ENTRIES = [
             OperandSlot("mbar", kind="addr", allow_imm_offset=True),
         ),
     ),
-    # clusterlaunchcontrol.query_cancel per PTX ISA 9.7.13.18: decode the
+    # clusterlaunchcontrol.query_cancel per PTX ISA 9.7.15.19: decode the
     # opaque b128 response a try_cancel wrote. Three syntax shapes, so three
-    # entries -- the ISA writes them as separate lines (9.7.13.18, wrapped but
+    # entries -- the ISA writes them as separate lines (9.7.15.19, wrapped but
     # otherwise verbatim):
     #
     #   clusterlaunchcontrol.query_cancel.is_canceled.pred.b128
@@ -7120,8 +10258,8 @@ _ENTRIES = [
     # are the x, y and z coordinate of first CTA in canceled cluster." Writing
     # the third line with `{::dimension}` omitted therefore does not give a
     # single-register form -- ptxas resolves the bare name to the `.v4` shape
-    # and reports "Vector of size 4 is expected for argument 0 of instruction
-    # 'clusterlaunchcontrol.query_cancel'" (toolchain fact, CUDA 13.2, sm_100a).
+    # and reports "Unexpected instruction types specified for
+    # 'clusterlaunchcontrol.query_cancel'" (toolchain fact, CUDA 13.4, sm_100a).
     # So the bare form is a different operand shape, i.e. its own entry below,
     # not a fourth token on the per-dimension slot.
     #
@@ -7197,9 +10335,9 @@ _ENTRIES = [
         ),
     ),
     # ------------------------------------------------------------------
-    # PTX ISA 9.7.14 — Warp Level Matrix Multiply-Accumulate Instructions
+    # PTX ISA 9.7.16 — Warp Level Matrix Multiply-Accumulate Instructions
     # ------------------------------------------------------------------
-    # mma per PTX ISA 9.7.14.5.14. Four operand groups (d, a, b, c), each a
+    # mma per PTX ISA 9.7.16.5.14. Four operand groups (d, a, b, c), each a
     # register vector whose length follows the Matrix Fragments tables -- four
     # callable `lanes`, one per group. `d` and `c` are separate operands: the
     # ISA lists them separately and the legacy helper bound them to separate
@@ -7209,7 +10347,7 @@ _ENTRIES = [
     # NOT REGISTERED:
     # - The `.kind::`/`.block_scale` lines and the .e3m2/.e2m3/.e2m1 types,
     #   which require sm_120a -- outside the architectures this table certifies.
-    # (`mma.sp` / `mma.sp::ordered_metadata` per 9.7.14.6.3 is registered in
+    # (`mma.sp` / `mma.sp::ordered_metadata` per 9.7.16.6.3 is registered in
     # the `mma_sp*` entries below.)
     InstructionEntry(  # half precision, and the alternate formats that share it
         name="mma",
@@ -7261,7 +10399,7 @@ _ENTRIES = [
     ),
     InstructionEntry(  # mma.sync.aligned.m8n8k4.alayout.blayout.f32.f16.f16.f16
         # The one dense mma line whose .dtype and .ctype differ. The
-        # half-precision syntax line of 9.7.14.5.14 quantifies both ends
+        # half-precision syntax line of 9.7.16.5.14 quantifies both ends
         # independently --
         #
         #   mma.sync.aligned.m8n8k4.alayout.blayout.dtype.f16.f16.ctype  d, a, b, c;
@@ -7288,7 +10426,7 @@ _ENTRIES = [
         # be the same as .ctype." and the identical rule at .m16n8k16 /
         # .m16n8k32.
         #
-        # ptxas 13.2 assembles all four layout pairs at sm_90. Its sm_90a SASS
+        # ptxas 13.4 assembles all four layout pairs at sm_90. Its sm_90a SASS
         # is an FFMA expansion rather than an HMMA -- the same expansion the
         # already-registered .m8n8k4 spellings get there, and what the ISA's
         # own note leads one to expect: "mma.sync.m8n8k4 is optimized for
@@ -7364,7 +10502,7 @@ _ENTRIES = [
             # floating point type mma operation with .m8n8k4 shape introduced
             # in PTX ISA version 7.0.", ".f64 floating point type mma operation
             # with .m8n8k4 shape requires sm_80 or higher.", and a fragment
-            # section of its own, 9.7.14.5.2 "Matrix Fragments for mma.m8n8k4
+            # section of its own, 9.7.16.5.2 "Matrix Fragments for mma.m8n8k4
             # with .f64 floating point type".
             #
             # This slot used to omit the shape under a note claiming ptxas
@@ -7372,7 +10510,7 @@ _ENTRIES = [
             # evidence were both wrong: that probe fed the operand vectors
             # `_mma_threads` produced while it still divided every .m8n8k4 by
             # 8, and ptxas was objecting to the vectors, not to the shape. With
-            # 9.7.14.5.2's counts (a = b = 1, c = d = 2) ptxas 13.2 assembles
+            # 9.7.16.5.2's counts (a = b = 1, c = d = 2) ptxas 13.4 assembles
             # the line at sm_80, sm_90 and sm_90a, and its sm_90a SASS is
             # `DMMA.8x8x4 R4, R4, R6, R8` -- one real hardware instruction,
             # unlike the .m8n8k4 .bf16 / .tf32 spellings ptxas takes and then
@@ -7395,7 +10533,7 @@ _ENTRIES = [
             # are : .rn : mantissa LSB rounds to nearest even. This is the
             # default. .rz : mantissa LSB rounds towards zero. .rm : mantissa
             # LSB rounds towards negative infinity. .rp : mantissa LSB rounds
-            # towards positive infinity." (9.7.14.5.14)
+            # towards positive infinity." (9.7.16.5.14)
             #
             # The syntax line leaves the position out; the section's own f64
             # examples spell it, last, after .ctype -- they write the operands
@@ -7411,7 +10549,7 @@ _ENTRIES = [
             # -- so that is where the slot sits. Optional because .rn is the
             # default, which keeps every spelling this entry rendered before
             # exactly as it was. All four modifiers assemble on all four
-            # shapes (ptxas 13.2, sm_90).
+            # shapes (ptxas 13.4, sm_90).
             ModifierSlot("rnd", ("rn", "rz", "rm", "rp"), optional=True),
         ),
         operands=(
@@ -7483,7 +10621,7 @@ _ENTRIES = [
             ("_all", ("m16n8k64", "m16n8k128"), ("0",), _check_mma_sp_int_all),
         )
     ],
-    # ldmatrix per PTX ISA 9.7.14.5.15 -- warp-level matrix load. Three syntax
+    # ldmatrix per PTX ISA 9.7.16.5.15 -- warp-level matrix load. Three syntax
     # lines; the destination is a brace-enclosed vector of 1/2/4 32-bit
     # registers "as per the value of .num", which is what a callable `lanes`
     # transcribes. The first line's two shapes split into two entries because
@@ -7553,7 +10691,7 @@ _ENTRIES = [
             OperandSlot("p", kind="addr", allow_imm_offset=True),
         ),
     ),
-    # movmatrix per PTX ISA 9.7.14.5.17 -- transpose one distributed m8n8
+    # movmatrix per PTX ISA 9.7.16.5.17 -- transpose one distributed m8n8
     # matrix whose 16-bit elements are carried by one b32 register per lane.
     #
     #   movmatrix.sync.aligned.m8n8.trans.b16 d, a;
@@ -7572,7 +10710,7 @@ _ENTRIES = [
             OperandSlot("a", dtype="b32"),
         ),
     ),
-    # stmatrix per PTX ISA 9.7.14.5.16 -- the store mirror of ldmatrix. One
+    # stmatrix per PTX ISA 9.7.16.5.16 -- the store mirror of ldmatrix. One
     # syntax line; the two shapes split into two entries because their type and
     # target floors differ.
     #
@@ -7618,14 +10756,14 @@ _ENTRIES = [
             OperandSlot("r", dtype="b32", lanes=_matrix_num_lanes),
         ),
     ),
-    # mma.sp / mma.sp::ordered_metadata per PTX ISA 9.7.14.6.3: the same
+    # mma.sp / mma.sp::ordered_metadata per PTX ISA 9.7.16.6.3: the same
     # multiply-accumulate with a structured-sparse A. A holds half of K (the
     # other half is implied), so only its group shrinks; `e` carries the
     # sparsity metadata and `f` selects which threads contributed it -- the ISA
     # calls it "a 32-bit integer constant with values in the range 0..3", an
     # instruction-text immediate rather than a register.
     #
-    # That domain is not 0..3 everywhere: ISA 9.7.14.6.1 states it per shape and
+    # That domain is not 0..3 everywhere: ISA 9.7.16.6.1 states it per shape and
     # type as "one thread within a group of four" (0..3), "a thread-pair" (0 or
     # 1), or "all threads ... must be 0". A `check` sees only the modifier map,
     # never the immediate axis, so each selector domain is its own entry -- the
@@ -7684,7 +10822,7 @@ _ENTRIES = [
             ),
             # "All threads within a group of four ... must be 0."
             #
-            # No check: this entry is one syntax line, ISA 9.7.14.6.3:22,
+            # No check: this entry is one syntax line, ISA 9.7.16.6.3:22,
             # "mma.spvariant.sync.aligned.m16n8k64.row.col.f32.f8type.f8type.f32
             # d, a, b, c, e, f;" with ".f8type     = {.e4m3, .e5m2};", and the
             # slots spell it exactly -- one shape, and .atype/.btype domains
@@ -7692,14 +10830,14 @@ _ENTRIES = [
             # so .e4m3 x .e5m2 is in the grammar (the section's own example at
             # :249 is "mma.sp.sync.aligned.m16n8k64.row.col.f32.e5m2.e4m3.f32").
             # The same-type rule this entry used to carry was wmma.mma's
-            # (9.7.14.4.5:77-78), not mma.sp's -- see `_check_mma_sp_fp_types`.
+            # (9.7.16.4.5:77-78), not mma.sp's -- see `_check_mma_sp_fp_types`.
             ("_all", ("m16n8k64",), ("e4m3", "e5m2"), ("0",), None),
         )
     ],
     # ------------------------------------------------------------------
-    # PTX ISA 9.7.15 — Asynchronous Warpgroup Level Matrix Multiply-Accumulate Instructions
+    # PTX ISA 9.7.17 — Asynchronous Warpgroup Level Matrix Multiply-Accumulate Instructions
     # ------------------------------------------------------------------
-    # wgmma.mma_async per PTX ISA 9.7.15.5.2 (sm_90a). Six type groups, each
+    # wgmma.mma_async per PTX ISA 9.7.17.5.2 (sm_90a). Six type groups, each
     # with an ss line (both A and B from shared memory, named by 64-bit matrix
     # descriptors) and an rs line (A from registers -- always four .b32, see
     # the fragment note above -- which also drops imm-trans-a). Like mma, one
@@ -7971,8 +11109,8 @@ _ENTRIES = [
         )
         for form in ("ss", "rs")
     ],
-    # wgmma group synchronisation, per PTX ISA 9.7.15.7: fence 9.7.15.7.1,
-    # commit_group 9.7.15.7.2, wait_group 9.7.15.7.3. (wait_group's textual
+    # wgmma group synchronisation, per PTX ISA 9.7.17.7: fence 9.7.17.7.1,
+    # commit_group 9.7.17.7.2, wait_group 9.7.17.7.3. (wait_group's textual
     # group count is the `choices` immediate registered below; the mma_async
     # lines are the accumulator entries above.)
     *[
@@ -7990,10 +11128,10 @@ _ENTRIES = [
         )
         for act in ("fence", "commit_group")
     ],
-    # wgmma.wait_group per PTX ISA 9.7.15.7.3, same caller-immediate shape.
+    # wgmma.wait_group per PTX ISA 9.7.17.7.3, same caller-immediate shape.
     #
     # The ISA's domain for N is open: the whole section says only "Operand N is
-    # an integer constant." (9.7.15.7.3:14), with no upper bound anywhere --
+    # an integer constant." (9.7.17.7.3:14), with no upper bound anywhere --
     # unlike setmaxnreg, whose [24, 256] the ISA closes itself. The 0..7
     # below is therefore this table's closure, not an ISA rule: `choices` needs
     # a finite set to enumerate and certify, and every variant of a registered
@@ -8020,11 +11158,11 @@ _ENTRIES = [
         operands=(OperandSlot("group", kind="imm", choices=tuple(str(n) for n in range(8))),),
     ),
     # ------------------------------------------------------------------
-    # PTX ISA 9.7.16 — TensorCore 5th Generation Family Instructions
+    # PTX ISA 9.7.18 — TensorCore 5th Generation Family Instructions
     # ------------------------------------------------------------------
-    # tcgen05 memory-allocation and synchronisation, per PTX ISA 9.7.16:
-    # alloc / dealloc / relinquish_alloc_permit 9.7.16.7.1, wait 9.7.16.8.5,
-    # fence 9.7.16.11.1, commit 9.7.16.12.1.
+    # tcgen05 memory-allocation and synchronisation, per PTX ISA 9.7.18:
+    # alloc / dealloc / relinquish_alloc_permit 9.7.18.7.1, wait 9.7.18.8.5,
+    # fence 9.7.18.11.1, commit 9.7.18.12.1.
     #
     # Every one of these carries `orders_memory=True`: the legacy helpers all
     # had `::: "memory"`, and the waits/fences name no address at all.
@@ -8082,7 +11220,7 @@ _ENTRIES = [
         orders_memory=True,
         operands=(),
     ),
-    # tcgen05.ld / .st per PTX ISA 9.7.16.8.3 / 9.7.16.8.4. Per Table 49 / 50,
+    # tcgen05.ld / .st per PTX ISA 9.7.18.8.3 / 9.7.18.8.4. Per Table 59 / 61,
     # the register vector is `.num` lanes for .16x32bx2/.16x64b/.32x32b,
     # 2x`.num` for .16x128b, and 4x`.num` for .16x256b; that table is what a
     # callable `lanes` transcribes. `taddr` is a tmem address, a packed 32-bit
@@ -8096,9 +11234,10 @@ _ENTRIES = [
     # The `.16x32bx2` shape is the entry pair below: its syntax line carries an
     # extra `immHalfSplitoff` operand, which is a different operand shape.
     #
-    # NOT REGISTERED:
-    # - `tcgen05.ld.red`, which is sm_101a-only (not sm_100a, so it cannot be
-    #   certified here) and has no call sites.
+    # The `tcgen05.ld.red` shapes are registered below at their own sm_103a
+    # floor (the ISA lists them for sm_101a and the sm_103f/sm_110f families,
+    # not sm_100a); PTX 9.4's distinct `.ld.red.spcompress` shape is registered
+    # in the SM107 delta.
     InstructionEntry(
         name="tcgen05_ld",
         mnemonic="tcgen05",
@@ -8118,7 +11257,7 @@ _ENTRIES = [
             OperandSlot("taddr", kind="addr", space="tmem"),
         ),
     ),
-    # The `.16x32bx2` lines, ISA 9.7.16.8.3:11 / 9.7.16.8.4:9 --
+    # The `.16x32bx2` lines, ISA 9.7.18.8.3:11 / 9.7.18.8.4:9 --
     #
     #   tcgen05.ld.sync.aligned.16x32bx2.num{.pack}.b32   r, [taddr], immHalfSplitoff;
     #   tcgen05.st.sync.aligned.16x32bx2.num{.unpack}.b32 [taddr], immHalfSplitoff, r;
@@ -8149,6 +11288,42 @@ _ENTRIES = [
             OperandSlot("imm_half_splitoff", kind="imm"),
         ),
     ),
+    # tcgen05.ld.red (PTX ISA 9.4, 9.7.18.8.3; an SM103a capability first
+    # exposed by PTX ISA 9.3).  Slot order follows the documented syntax lines
+    #   tcgen05.ld.red.sync.aligned.shape.num.redOp{.abs}{.NaN}.f32  r, redval, [taddr];
+    #   tcgen05.ld.red.sync.aligned.shape.num.redOp.type             r, redval, [taddr];
+    # -- the same order the 9.4 `tcgen05_ld_red_spcompress` entry uses.
+    # MEASURED on CUDA 13.4 ptxas at sm_103a: this order and the `.type.redOp`
+    # order NVIDIA's generated wrappers spell both assemble for every type and
+    # for the 16x32bx2 split form; the ISA's order is the one registered.
+    # `.x1` is "Illegal modifier '.x1'" (the ISA: .num must be at least .x2).
+    *[
+        InstructionEntry(
+            name=f"tcgen05_ld_red{'_split' if split else ''}",
+            mnemonic="tcgen05",
+            slots=(
+                ModifierSlot("action", ("ld",)),
+                ModifierSlot("red", ("red",)),
+                ModifierSlot("sync", ("sync",)),
+                ModifierSlot("aligned", ("aligned",)),
+                ModifierSlot("shape", (("16x32bx2",) if split else ("32x32b",))),
+                ModifierSlot("num", ("x1", "x2", "x4", "x8", "x16", "x32", "x64", "x128")),
+                ModifierSlot("redop", ("min", "max")),
+                ModifierSlot("abs", ("abs",), optional=True),
+                ModifierSlot("nan", ("NaN",), optional=True),
+                ModifierSlot("type", ("u32", "s32", "f32")),
+            ),
+            check=_check_tcgen05_ld_red,
+            cert_arch="sm_103a",
+            operands=(
+                OperandSlot("r", rw="w", lanes=_tcgen05_ldst_lanes),
+                OperandSlot("redval"),
+                OperandSlot("taddr", kind="addr", space="tmem"),
+                *((OperandSlot("imm_half_splitoff", kind="imm"),) if split else ()),
+            ),
+        )
+        for split in (False, True)
+    ],
     InstructionEntry(
         name="tcgen05_st",
         mnemonic="tcgen05",
@@ -8199,7 +11374,7 @@ _ENTRIES = [
         orders_memory=True,
         operands=(),
     ),
-    # tcgen05.cp per PTX ISA 9.7.16.9.2: an async shared -> tmem copy of one
+    # tcgen05.cp per PTX ISA 9.7.18.9.2: an async shared -> tmem copy of one
     # shape, optionally multicast across the warps of a warpgroup and
     # optionally decompressing fp4/fp6 into fp8 on the way. `s-desc` is the
     # same 64-bit shared-memory matrix descriptor tcgen05.mma takes.
@@ -8225,7 +11400,7 @@ _ENTRIES = [
             OperandSlot("s_desc", dtype="b64"),
         ),
     ),
-    # tcgen05.mma per PTX ISA 9.7.16.10.9.1 (sm_100a): D = A*B + D where D
+    # tcgen05.mma per PTX ISA 9.7.18.10.10.1 (sm_100a): D = A*B + D where D
     # lives in Tensor Memory (an address, not registers -- so the instruction
     # has no dst and @p stays available). Two entries per family split on the
     # A operand's home: a 64-bit shared-memory descriptor ("ss") or a tmem
@@ -8237,13 +11412,16 @@ _ENTRIES = [
     # NOT REGISTERED:
     # - `{, scale-input-d}`: an instruction-text immediate in [0, 15], no
     #   call site uses it.
-    # - `tcgen05.mma.sp` / `.ws.sp` (sparse metadata operand), the
-    #   .collector::/.ashift qualifiers, and the i8 convolution lines that
-    #   only differ by those qualifiers: no call sites.
-    # - .ws without the zero-column-mask-desc operand: every caller passes
-    #   the mask (as literal zero).
-    # - block_scale's scale_vec-omitted spelling without a .block16/.block32
-    #   size: no call site uses that form.
+    # - Pre-9.4 sparse MMA forms without `.kind::ti16` or collector B, and
+    #   convolution ashift forms: no call sites. The shared-A dense form below
+    #   carries optional collector A for SM107 kernels.
+    #   PTX 9.4's ti16 dense/sparse/WS shapes and every SM107 collector-B
+    #   shape are registered in `_PTX_94_ENTRIES`.
+    # - The pre-9.4 .ws kinds without zero-column-mask-desc: every existing
+    #   caller passes the mask (as literal zero). The new ti16 siblings expose
+    #   both documented arities.
+    # - Pre-9.4 block_scale's scale-vector-omitted spelling without collector
+    #   B. The SM107 collector-A+B spelling and LUT-B spellings are registered.
     *[
         InstructionEntry(
             name=f"tcgen05_mma_{form}",
@@ -8252,6 +11430,11 @@ _ENTRIES = [
                 ModifierSlot("action", ("mma",)),
                 ModifierSlot("cta_group", ("cta_group::1", "cta_group::2")),
                 ModifierSlot("kind", ("kind::f16", "kind::tf32", "kind::f8f6f4", "kind::i8")),
+                *(
+                    (ModifierSlot("collector_a", _TCGEN05_COLLECTOR_A, optional=True),)
+                    if form == "ss"
+                    else ()
+                ),
             ),
             cert_arch="sm_100a",
             operands=(
@@ -8403,9 +11586,9 @@ _ENTRIES = [
         ),
     ),
     # ------------------------------------------------------------------
-    # PTX ISA 9.7.19 — Miscellaneous Instructions
+    # PTX ISA 9.7.21 — Miscellaneous Instructions
     # ------------------------------------------------------------------
-    # setmaxnreg per PTX ISA 9.7.19.5: the register count is an immediate the
+    # setmaxnreg per PTX ISA 9.7.21.5: the register count is an immediate the
     # ISA bounds to [24, 256] in steps of 8 -- exactly a closed choices set.
     InstructionEntry(
         name="setmaxnreg",
@@ -8423,19 +11606,18 @@ _ENTRIES = [
     ),
 ]
 
-
-# ISA 9.7.13.5: "Simple reductions may be specified by using the bit bucket
+# ISA 9.7.15.5: "Simple reductions may be specified by using the bit bucket
 # destination operand `_`." This is a whole PTX operand, including on vector
 # atom, rather than a brace group of per-lane sinks. Derive one fixed-literal
 # sibling from every returned-value atom shape; the shorter Python-call arity
 # selects the bit bucket.
 #
-# One documented subset cannot stay modifier-for-modifier identical: CUDA 13.2
-# ptxas does not compile scalar or vector bf16 atom bit buckets (it segfaults on
-# exact force-inlined kernel probes), although PTX ISA 9.2 explicitly supports
-# them and the returned-value bf16 forms compile. The two half-entry checks
-# below therefore withhold only bf16/bf16x2 bit buckets. This is a registration
-# restriction for the current callable toolchain, not an ISA restriction.
+# One documented subset is withheld: the scalar and vector bf16 atom bit
+# buckets.  An earlier toolchain crashed on them (ptxas segmentation fault on
+# exact force-inlined probes); MEASURED on CUDA 13.4 they compile, but they have
+# not been added with full certification yet (follow-up).  The two half-entry
+# checks below therefore withhold only bf16/bf16x2 bit buckets.  This is a
+# registration decision, not an ISA restriction.
 _ATOM_BITBUCKET_BASES = (
     "atom",
     "atom_cas",
@@ -8443,6 +11625,8 @@ _ATOM_BITBUCKET_BASES = (
     "atom_half",
     "atom_vec_half",
     "atom_vec_f32",
+    "atom_f32_noftz",
+    "atom_vec_f32_noftz",
 )
 
 

--- a/python/tvm/script/tirx.pyi
+++ b/python/tvm/script/tirx.pyi
@@ -52,8 +52,8 @@ class _Chain_activemask:
     ) -> None: ...
 
 class _Chain_add:
-    """`add` — 3 entries sharing this mnemonic; PTX puts their difference in the operand list,
-    so the call selects one. Shapes: (d, a, b)
+    """`add` — 6 entries sharing this mnemonic; PTX puts their difference in the operand list,
+    so the call selects one. Shapes: (d, a, c); (d, a, b)
     """
 
     bf16: _Chain_add
@@ -97,14 +97,29 @@ class _Chain_and:
     ) -> None: ...
 
 class _Chain_applypriority:
-    """`applypriority` — space∈{global} (opt); level∈{L2::evict_normal}"""
+    """`applypriority` — 10 entries sharing this mnemonic; PTX puts their difference in the
+    operand list, so the call selects one. Shapes: (addr, size); (*__operands); (tmap,
+    global_address, tensor_size, coords); (addr)
+    """
 
     L2__evict_normal: _Chain_applypriority
+    async_: _Chain_applypriority
+    bulk: _Chain_applypriority
+    bulk_group: _Chain_applypriority
     global_: _Chain_applypriority
-    def __call__(self, addr: Any, *args: Any, pred: Any = None) -> None: ...
+    im2col: _Chain_applypriority
+    im2col__w: _Chain_applypriority
+    im2col__w__128: _Chain_applypriority
+    override__global_address: _Chain_applypriority
+    override__global_dim: _Chain_applypriority
+    override__global_dim_stride: _Chain_applypriority
+    tensor: _Chain_applypriority
+    tile: _Chain_applypriority
+    tile__gather4: _Chain_applypriority
+    def __call__(self, *args: Any, pred: Any = None) -> None: ...
 
 class _Chain_atom:
-    """`atom` — 12 entries sharing this mnemonic; PTX puts their difference in the operand
+    """`atom` — 16 entries sharing this mnemonic; PTX puts their difference in the operand
     list, so the call selects one. Shapes: (*__operands); (d, addr, compare, value); (addr,
     compare, value)
     """
@@ -273,6 +288,23 @@ class _Chain_brev:
         preserve_dst: bool = False,
     ) -> None: ...
 
+class _Chain_clmad:
+    """`clmad` — mode∈{hi,lo}; type∈{u64}"""
+
+    hi: _Chain_clmad
+    lo: _Chain_clmad
+    u64: _Chain_clmad
+    def __call__(
+        self,
+        d: Any,
+        a: Any,
+        b: Any,
+        c: Any,
+        *args: Any,
+        pred: Any = None,
+        preserve_dst: bool = False,
+    ) -> None: ...
+
 class _Chain_clusterlaunchcontrol:
     """`clusterlaunchcontrol` — 4 entries sharing this mnemonic; PTX puts their difference in
     the operand list, so the call selects one. Shapes: (addr, mbar); (p, response); (d,
@@ -356,9 +388,9 @@ class _Chain_cos:
     ) -> None: ...
 
 class _Chain_cp:
-    """`cp` — 24 entries sharing this mnemonic; PTX puts their difference in the operand list,
-    so the call selects one. Shapes: (*__operands); (group); (); (dst_mem, src_mem, size,
-    mbar); (addr)
+    """`cp` — 77 entries sharing this mnemonic; PTX puts their difference in the operand list,
+    so the call selects one. Shapes: (*__operands); (src_mem, size); (tmap, global_address,
+    tensor_size, coords); (group); (); (dst_mem, src_mem, size, mbar); (addr)
     """
 
     L2: _Chain_cp
@@ -366,10 +398,12 @@ class _Chain_cp:
     L2__256B: _Chain_cp
     L2__64B: _Chain_cp
     L2__cache_hint: _Chain_cp
+    L2__evict_last: _Chain_cp
     add: _Chain_cp
     and_: _Chain_cp
     arrive: _Chain_cp
     async_: _Chain_cp
+    b128: _Chain_cp
     b32: _Chain_cp
     b64: _Chain_cp
     bf16: _Chain_cp
@@ -377,8 +411,10 @@ class _Chain_cp:
     bulk_group: _Chain_cp
     ca: _Chain_cp
     cg: _Chain_cp
+    cluster: _Chain_cp
     commit_group: _Chain_cp
     cp_mask: _Chain_cp
+    cta: _Chain_cp
     cta_group__1: _Chain_cp
     cta_group__2: _Chain_cp
     dec: _Chain_cp
@@ -386,24 +422,43 @@ class _Chain_cp:
     f32: _Chain_cp
     f64: _Chain_cp
     global_: _Chain_cp
+    gpu: _Chain_cp
     ignore_oob: _Chain_cp
+    im2col: _Chain_cp
+    im2col__w: _Chain_cp
+    im2col__w__128: _Chain_cp
+    im2col_no_offs: _Chain_cp
+    im2col_no_offs__w: _Chain_cp
     inc: _Chain_cp
     max: _Chain_cp
     mbarrier: _Chain_cp
     mbarrier__complete_tx__bytes: _Chain_cp
+    mbarrier__report__disabled: _Chain_cp
+    mbarrier__report__validity__per_16bytes__8: _Chain_cp
+    mbarrier__report__validity__per_16bytes__80: _Chain_cp
+    mbarrier__report__validity__per_16bytes__8000: _Chain_cp
+    mbarrier__report__validity__per_16bytes__80000000: _Chain_cp
+    mbarrier__report__validity__per_element__ff: _Chain_cp
     min: _Chain_cp
     multicast__cluster: _Chain_cp
+    multicast__cluster__16b: _Chain_cp
+    multicast__cluster__32b: _Chain_cp
     noftz: _Chain_cp
     noinc: _Chain_cp
     or_: _Chain_cp
+    override__global_address: _Chain_cp
+    override__global_dim: _Chain_cp
+    override__global_dim_stride: _Chain_cp
     prefetch: _Chain_cp
     read: _Chain_cp
     reduce: _Chain_cp
+    relaxed: _Chain_cp
     s32: _Chain_cp
     s64: _Chain_cp
     shared: _Chain_cp
     shared__cluster: _Chain_cp
     shared__cta: _Chain_cp
+    sys: _Chain_cp
     tensor: _Chain_cp
     tile: _Chain_cp
     tile__gather4: _Chain_cp
@@ -412,6 +467,7 @@ class _Chain_cp:
     u64: _Chain_cp
     wait_all: _Chain_cp
     wait_group: _Chain_cp
+    weak: _Chain_cp
     xor: _Chain_cp
     def __call__(self, *args: Any, pred: Any = None) -> None: ...
 
@@ -434,9 +490,10 @@ class _Chain_createpolicy:
     def __call__(self, *args: Any, pred: Any = None, preserve_dst: bool = False) -> None: ...
 
 class _Chain_cvt:
-    """`cvt` — 27 entries sharing this mnemonic; PTX puts their difference in the operand list,
-    so the call selects one. Shapes: (d, a); (d, a, b); (d, a, b, rbits); (*__operands); (d,
-    abef0, abef1, abef2, abef3, rbits)
+    """`cvt` — 38 entries sharing this mnemonic; PTX puts their difference in the operand list,
+    so the call selects one. Shapes: (d, a); (d, a, b); (*__operands); (d, a, b,
+    scale_factor); (d, a, scale_factor); (d, a, b, rbits); (d, abef0, abef1, abef2, abef3,
+    rbits)
     """
 
     bf16: _Chain_cvt
@@ -456,6 +513,7 @@ class _Chain_cvt:
     f32: _Chain_cvt
     f64: _Chain_cvt
     ftz: _Chain_cvt
+    pzo: _Chain_cvt
     relu: _Chain_cvt
     rm: _Chain_cvt
     rmi: _Chain_cvt
@@ -474,12 +532,14 @@ class _Chain_cvt:
     s8: _Chain_cvt
     sat: _Chain_cvt
     satfinite: _Chain_cvt
+    scaled__n1__ue8m0: _Chain_cvt
     scaled__n2__ue8m0: _Chain_cvt
     tf32: _Chain_cvt
     u16: _Chain_cvt
     u32: _Chain_cvt
     u64: _Chain_cvt
     u8: _Chain_cvt
+    ue5m3x2: _Chain_cvt
     ue8m0x2: _Chain_cvt
     def __call__(self, *args: Any, pred: Any = None, preserve_dst: bool = False) -> None: ...
 
@@ -608,8 +668,49 @@ class _Chain_ex2:
     ftz: _Chain_ex2
     def __call__(self, *args: Any, pred: Any = None, preserve_dst: bool = False) -> None: ...
 
+class _Chain_fabric:
+    """`fabric` — 9 entries sharing this mnemonic; PTX puts their difference in the operand
+    list, so the call selects one. Shapes: (dst_mem, src_le_id, src_data_off, size, mbar);
+    (dst_le_id, dst_data_off, src_mem, size, mbar); (dst_le_id, dst_data_off, src_mem, size,
+    mbar, byte_mask); (dst_le_id, dst_data_off, dst_counter_off, src_mem, size, mbar); ()
+    """
+
+    add: _Chain_fabric
+    and_: _Chain_fabric
+    async_: _Chain_fabric
+    b128: _Chain_fabric
+    b32: _Chain_fabric
+    b64: _Chain_fabric
+    bf16: _Chain_fabric
+    cp_mask: _Chain_fabric
+    f16: _Chain_fabric
+    f32: _Chain_fabric
+    f64: _Chain_fabric
+    max: _Chain_fabric
+    min: _Chain_fabric
+    multimem: _Chain_fabric
+    op_restrict__fetching: _Chain_fabric
+    or_: _Chain_fabric
+    relaxed: _Chain_fabric
+    s32: _Chain_fabric
+    s64: _Chain_fabric
+    shared__cta: _Chain_fabric
+    submit: _Chain_fabric
+    sync: _Chain_fabric
+    sync_restrict__reads: _Chain_fabric
+    sys: _Chain_fabric
+    try_get: _Chain_fabric
+    try_pullred: _Chain_fabric
+    try_put: _Chain_fabric
+    try_red: _Chain_fabric
+    u32: _Chain_fabric
+    u64: _Chain_fabric
+    wait: _Chain_fabric
+    xor: _Chain_fabric
+    def __call__(self, *args: Any, pred: Any = None) -> None: ...
+
 class _Chain_fence:
-    """`fence` — 5 entries sharing this mnemonic; PTX puts their difference in the operand
+    """`fence` — 6 entries sharing this mnemonic; PTX puts their difference in the operand
     list, so the call selects one. Shapes: (); (addr)
     """
 
@@ -619,6 +720,9 @@ class _Chain_fence:
     async_: _Chain_fence
     cluster: _Chain_fence
     cta: _Chain_fence
+    fabric__fabric: _Chain_fence
+    fabric__generic: _Chain_fence
+    generic__fabric: _Chain_fence
     global_: _Chain_fence
     gpu: _Chain_fence
     mbarrier_init: _Chain_fence
@@ -632,7 +736,7 @@ class _Chain_fence:
     def __call__(self, *args: Any, pred: Any = None) -> None: ...
 
 class _Chain_fma:
-    """`fma` — 2 entries sharing this mnemonic; PTX puts their difference in the operand list,
+    """`fma` — 3 entries sharing this mnemonic; PTX puts their difference in the operand list,
     so the call selects one. Shapes: (d, a, b, c)
     """
 
@@ -708,8 +812,8 @@ class _Chain_isspacep:
     ) -> None: ...
 
 class _Chain_ld:
-    """`ld` — 3 entries sharing this mnemonic; PTX puts their difference in the operand list,
-    so the call selects one. Shapes: (*__operands)
+    """`ld` — 4 entries sharing this mnemonic; PTX puts their difference in the operand list,
+    so the call selects one. Shapes: (d, addr); (*__operands)
     """
 
     L1__evict_first: _Chain_ld
@@ -744,6 +848,7 @@ class _Chain_ld:
     lu: _Chain_ld
     mmio: _Chain_ld
     nc: _Chain_ld
+    proxy__readonly: _Chain_ld
     relaxed: _Chain_ld
     s16: _Chain_ld
     s32: _Chain_ld
@@ -765,7 +870,7 @@ class _Chain_ld:
     def __call__(self, *args: Any, pred: Any = None, preserve_dst: bool = False) -> None: ...
 
 class _Chain_ldmatrix:
-    """`ldmatrix` — 3 entries sharing this mnemonic; PTX puts their difference in the operand
+    """`ldmatrix` — 4 entries sharing this mnemonic; PTX puts their difference in the operand
     list, so the call selects one. Shapes: (*__operands)
     """
 
@@ -778,6 +883,8 @@ class _Chain_ldmatrix:
     m16n16: _Chain_ldmatrix
     m8n16: _Chain_ldmatrix
     m8n8: _Chain_ldmatrix
+    s4: _Chain_ldmatrix
+    s8: _Chain_ldmatrix
     shared: _Chain_ldmatrix
     shared__cta: _Chain_ldmatrix
     sync: _Chain_ldmatrix
@@ -866,7 +973,7 @@ class _Chain_mad24:
     """`mad24` — mode∈{hi,lo}; sat∈{sat} (opt); type∈{u32,s32} — `.sat` on the multiply-add
     lines: `.hi` mode, `.s32` type, nothing else. Both lines spell it as a syntax line of
     its own -- `mad.hi.sat.s32 d, a, b, c;` (ISA 9.7.1.4) and `mad24.hi.sat.s32 d, a, b, c;`
-    (9.7.1.6) -- with the Notes repeating "Applies only to .s32 type in .hi mode".
+    (9.7.1.7) -- with the Notes repeating "Applies only to .s32 type in .hi mode".
     """
 
     hi: _Chain_mad24
@@ -934,26 +1041,35 @@ class _Chain_max:
     def __call__(self, *args: Any, pred: Any = None, preserve_dst: bool = False) -> None: ...
 
 class _Chain_mbarrier:
-    """`mbarrier` — 27 entries sharing this mnemonic; PTX puts their difference in the operand
-    list, so the call selects one. Shapes: (addr, count); (addr); (addr, tx_count); (state,
-    addr, count); (wait_complete, addr, phase); (wait_complete, addr, phase, time_hint);
-    (state, addr); (wait_complete, addr, state); (wait_complete, addr, state, time_hint);
-    (count, state)
+    """`mbarrier` — 48 entries sharing this mnemonic; PTX puts their difference in the operand
+    list, so the call selects one. Shapes: (addr, tx_count, cta_mask); (addr, cta_mask);
+    (addr, count, cta_mask); (addr, count); (addr); (addr, tx_count); (state, addr, count);
+    (wait_complete, addr, phase); (wait_complete, addr, phase, time_hint); (state, addr);
+    (wait_complete, addr, state); (wait_complete, addr, state, time_hint); (wait_complete,
+    report_predicate, addr, phase); (wait_complete, report_predicate, report_value, addr,
+    phase); (wait_complete, report_predicate, addr, phase, time_hint); (wait_complete,
+    report_predicate, report_value, addr, phase, time_hint); (count, state); (matches, addr)
     """
 
     acquire: _Chain_mbarrier
     arrive: _Chain_mbarrier
     arrive_drop: _Chain_mbarrier
     b64: _Chain_mbarrier
+    check_layout: _Chain_mbarrier
     cluster: _Chain_mbarrier
     complete_tx: _Chain_mbarrier
     cta: _Chain_mbarrier
     expect_tx: _Chain_mbarrier
     init: _Chain_mbarrier
     inval: _Chain_mbarrier
+    layout__v0: _Chain_mbarrier
+    layout__v1: _Chain_mbarrier
+    multicast__cluster__32b: _Chain_mbarrier
     noComplete: _Chain_mbarrier
     parity: _Chain_mbarrier
     pending_count: _Chain_mbarrier
+    phase_type__conditional: _Chain_mbarrier
+    phase_type__primary: _Chain_mbarrier
     relaxed: _Chain_mbarrier
     release: _Chain_mbarrier
     shared: _Chain_mbarrier
@@ -1073,8 +1189,8 @@ class _Chain_movmatrix:
     ) -> None: ...
 
 class _Chain_mul:
-    """`mul` — 4 entries sharing this mnemonic; PTX puts their difference in the operand list,
-    so the call selects one. Shapes: (d, a, b)
+    """`mul` — 8 entries sharing this mnemonic; PTX puts their difference in the operand list,
+    so the call selects one. Shapes: (d, a, c); (d, a, b)
     """
 
     bf16: _Chain_mul
@@ -1117,6 +1233,46 @@ class _Chain_mul24:
         pred: Any = None,
         preserve_dst: bool = False,
     ) -> None: ...
+
+class _Chain_multimem_cp:
+    """`multimem_cp` — 3 entries sharing this mnemonic; PTX puts their difference in the
+    operand list, so the call selects one. Shapes: (dst_mem, src_mem, size); (*__operands)
+    """
+
+    add: _Chain_multimem_cp
+    and_: _Chain_multimem_cp
+    async_: _Chain_multimem_cp
+    b128: _Chain_multimem_cp
+    b32: _Chain_multimem_cp
+    b64: _Chain_multimem_cp
+    bf16: _Chain_multimem_cp
+    bulk: _Chain_multimem_cp
+    bulk_group: _Chain_multimem_cp
+    cluster: _Chain_multimem_cp
+    cp_mask: _Chain_multimem_cp
+    cta: _Chain_multimem_cp
+    dec: _Chain_multimem_cp
+    f16: _Chain_multimem_cp
+    f32: _Chain_multimem_cp
+    f64: _Chain_multimem_cp
+    global_: _Chain_multimem_cp
+    gpu: _Chain_multimem_cp
+    inc: _Chain_multimem_cp
+    max: _Chain_multimem_cp
+    min: _Chain_multimem_cp
+    noftz: _Chain_multimem_cp
+    or_: _Chain_multimem_cp
+    reduce: _Chain_multimem_cp
+    relaxed: _Chain_multimem_cp
+    s32: _Chain_multimem_cp
+    s64: _Chain_multimem_cp
+    shared__cta: _Chain_multimem_cp
+    sys: _Chain_multimem_cp
+    u32: _Chain_multimem_cp
+    u64: _Chain_multimem_cp
+    weak: _Chain_multimem_cp
+    xor: _Chain_multimem_cp
+    def __call__(self, *args: Any, pred: Any = None) -> None: ...
 
 class _Chain_multimem_ld_reduce:
     """`multimem_ld_reduce` — 3 entries sharing this mnemonic; PTX puts their difference in the
@@ -1190,6 +1346,21 @@ class _Chain_multimem_red:
     xor: _Chain_multimem_red
     def __call__(self, *args: Any, pred: Any = None) -> None: ...
 
+class _Chain_multimem_red_async:
+    """`multimem_red_async` — sem∈{release}; scope∈{gpu,sys}; space∈{global} (opt); op∈{add};
+    type∈{u32,s32,u64}
+    """
+
+    add: _Chain_multimem_red_async
+    global_: _Chain_multimem_red_async
+    gpu: _Chain_multimem_red_async
+    release: _Chain_multimem_red_async
+    s32: _Chain_multimem_red_async
+    sys: _Chain_multimem_red_async
+    u32: _Chain_multimem_red_async
+    u64: _Chain_multimem_red_async
+    def __call__(self, addr: Any, value: Any, *args: Any, pred: Any = None) -> None: ...
+
 class _Chain_multimem_st:
     """`multimem_st` — 3 entries sharing this mnemonic; PTX puts their difference in the
     operand list, so the call selects one. Shapes: (addr, b); (*__operands)
@@ -1219,6 +1390,31 @@ class _Chain_multimem_st:
     v8: _Chain_multimem_st
     weak: _Chain_multimem_st
     def __call__(self, *args: Any, pred: Any = None) -> None: ...
+
+class _Chain_multimem_st_async:
+    """`multimem_st_async` — sem∈{release}; scope∈{gpu,sys}; space∈{global} (opt);
+    type∈{b8,b16,b32,b64,u8,u16,u32,u64,s8,s16,s32,s64,f32,f64}
+    """
+
+    b16: _Chain_multimem_st_async
+    b32: _Chain_multimem_st_async
+    b64: _Chain_multimem_st_async
+    b8: _Chain_multimem_st_async
+    f32: _Chain_multimem_st_async
+    f64: _Chain_multimem_st_async
+    global_: _Chain_multimem_st_async
+    gpu: _Chain_multimem_st_async
+    release: _Chain_multimem_st_async
+    s16: _Chain_multimem_st_async
+    s32: _Chain_multimem_st_async
+    s64: _Chain_multimem_st_async
+    s8: _Chain_multimem_st_async
+    sys: _Chain_multimem_st_async
+    u16: _Chain_multimem_st_async
+    u32: _Chain_multimem_st_async
+    u64: _Chain_multimem_st_async
+    u8: _Chain_multimem_st_async
+    def __call__(self, addr: Any, b: Any, *args: Any, pred: Any = None) -> None: ...
 
 class _Chain_neg:
     """`neg` — 3 entries sharing this mnemonic; PTX puts their difference in the operand list,
@@ -1285,16 +1481,12 @@ class _Chain_popc:
     ) -> None: ...
 
 class _Chain_prefetch:
-    """`prefetch` — space∈{global,local,const,param} (opt); level∈{L1,L2} (opt);
-    evict∈{L2::evict_last,L2::evict_normal} (opt); tensormap∈{tensormap} (opt) — Each
-    prefetch syntax line names exactly one target (PTX ISA 9.7.9.15).
-    `.level::eviction_priority` stays bound to `.global` on purpose: its syntax line is
-    `prefetch.global.level::eviction_priority`, with `.global` written in rather than the
-    `{.ss}` that the `ld` lines carry. Generic addressing is not offered there, so neither
-    is it here.
+    """`prefetch` — 2 entries sharing this mnemonic; PTX puts their difference in the operand
+    list, so the call selects one. Shapes: (addr)
     """
 
     L1: _Chain_prefetch
+    L1__32B: _Chain_prefetch
     L2: _Chain_prefetch
     L2__evict_last: _Chain_prefetch
     L2__evict_normal: _Chain_prefetch
@@ -1303,7 +1495,8 @@ class _Chain_prefetch:
     local: _Chain_prefetch
     param: _Chain_prefetch
     tensormap: _Chain_prefetch
-    def __call__(self, addr: Any, *args: Any, pred: Any = None) -> None: ...
+    valid_addr: _Chain_prefetch
+    def __call__(self, *args: Any, pred: Any = None) -> None: ...
 
 class _Chain_prefetchu:
     """`prefetchu` — level∈{L1}"""
@@ -1361,7 +1554,7 @@ class _Chain_rcp:
     ) -> None: ...
 
 class _Chain_red:
-    """`red` — 4 entries sharing this mnemonic; PTX puts their difference in the operand list,
+    """`red` — 6 entries sharing this mnemonic; PTX puts their difference in the operand list,
     so the call selects one. Shapes: (*__operands)
     """
 
@@ -1531,7 +1724,7 @@ class _Chain_selp:
     ) -> None: ...
 
 class _Chain_set:
-    """`set` — 4 entries sharing this mnemonic; PTX puts their difference in the operand list,
+    """`set` — 5 entries sharing this mnemonic; PTX puts their difference in the operand list,
     so the call selects one. Shapes: (d, a, b); (d, a, b, c)
     """
 
@@ -1566,11 +1759,15 @@ class _Chain_set:
     num: _Chain_set
     or_: _Chain_set
     s16: _Chain_set
+    s16x2: _Chain_set
     s32: _Chain_set
     s64: _Chain_set
+    s8x4: _Chain_set
     u16: _Chain_set
+    u16x2: _Chain_set
     u32: _Chain_set
     u64: _Chain_set
+    u8x4: _Chain_set
     xor: _Chain_set
     def __call__(self, *args: Any, pred: Any = None, preserve_dst: bool = False) -> None: ...
 
@@ -1715,7 +1912,7 @@ class _Chain_sin:
 
 class _Chain_slct:
     """`slct` — ftz∈{ftz} (opt); dtype∈{b16,b32,b64,u16,u32,u64,s16,s32,s64,f32,f64};
-    ctype∈{s32,f32} — slct's two lines (ISA 9.7.6.4), which differ only in the selector
+    ctype∈{s32,f32} — slct's two lines (ISA 9.7.7.4), which differ only in the selector
     type. slct.dtype.s32 d, a, b, c; slct{.ftz}.dtype.f32 d, a, b, c; `.ftz` is spelled on
     the .f32 selector line alone -- there is nothing to flush when the sign being tested is
     an integer's.
@@ -1743,6 +1940,54 @@ class _Chain_slct:
         pred: Any = None,
         preserve_dst: bool = False,
     ) -> None: ...
+
+class _Chain_spcompress:
+    """`spcompress` — elemsize∈{b8,b16}; idxsize∈{b2,b4}; spfactor∈{sp::2:4};
+    num∈{x1,x2,x4,x8,x16,x32,x64}
+    """
+
+    b16: _Chain_spcompress
+    b2: _Chain_spcompress
+    b4: _Chain_spcompress
+    b8: _Chain_spcompress
+    sp__2__colon__4: _Chain_spcompress
+    x1: _Chain_spcompress
+    x16: _Chain_spcompress
+    x2: _Chain_spcompress
+    x32: _Chain_spcompress
+    x4: _Chain_spcompress
+    x64: _Chain_spcompress
+    x8: _Chain_spcompress
+    def __call__(self, *__operands: Any, pred: Any = None, preserve_dst: bool = False) -> None: ...
+
+class _Chain_spdecompress:
+    """`spdecompress` — elemsize∈{b8,b16}; idxsize∈{b2,b4};
+    spfactor∈{sp::1:2,sp::1:4,sp::1:8,sp::1:16,sp::2:4,sp::2:8,sp::2:16,sp::4:8,sp::4:16};
+    num∈{x1,x2,x4,x8,x16,x32,x64} — Enforce PTX 9.4's five spdecompress vector-size
+    constraints.
+    """
+
+    b16: _Chain_spdecompress
+    b2: _Chain_spdecompress
+    b4: _Chain_spdecompress
+    b8: _Chain_spdecompress
+    sp__1__colon__16: _Chain_spdecompress
+    sp__1__colon__2: _Chain_spdecompress
+    sp__1__colon__4: _Chain_spdecompress
+    sp__1__colon__8: _Chain_spdecompress
+    sp__2__colon__16: _Chain_spdecompress
+    sp__2__colon__4: _Chain_spdecompress
+    sp__2__colon__8: _Chain_spdecompress
+    sp__4__colon__16: _Chain_spdecompress
+    sp__4__colon__8: _Chain_spdecompress
+    x1: _Chain_spdecompress
+    x16: _Chain_spdecompress
+    x2: _Chain_spdecompress
+    x32: _Chain_spdecompress
+    x4: _Chain_spdecompress
+    x64: _Chain_spdecompress
+    x8: _Chain_spdecompress
+    def __call__(self, *__operands: Any, pred: Any = None, preserve_dst: bool = False) -> None: ...
 
 class _Chain_sqrt:
     """`sqrt` — mode∈{approx,rn,rz,rm,rp}; ftz∈{ftz} (opt); type∈{f32,f64} — sqrt's three lines
@@ -1879,8 +2124,8 @@ class _Chain_stmatrix:
     def __call__(self, *args: Any, pred: Any = None) -> None: ...
 
 class _Chain_sub:
-    """`sub` — 3 entries sharing this mnemonic; PTX puts their difference in the operand list,
-    so the call selects one. Shapes: (d, a, b)
+    """`sub` — 6 entries sharing this mnemonic; PTX puts their difference in the operand list,
+    so the call selects one. Shapes: (d, a, c); (d, a, b)
     """
 
     bf16: _Chain_sub
@@ -1935,16 +2180,30 @@ class _Chain_tanh:
     def __call__(self, *args: Any, pred: Any = None, preserve_dst: bool = False) -> None: ...
 
 class _Chain_tcgen05:
-    """`tcgen05` — 20 entries sharing this mnemonic; PTX puts their difference in the operand
-    list, so the call selects one. Shapes: (dst, ncols); (taddr, ncols); (); (*__operands);
-    (taddr, s_desc); (d_tmem, a_desc, b_desc, idesc, sfa_tmem, sfb_tmem, enable_input_d);
-    (d_tmem, a_tmem, b_desc, idesc, sfa_tmem, sfb_tmem, enable_input_d); (d_tmem, a_desc,
+    """`tcgen05` — 59 entries sharing this mnemonic; PTX puts their difference in the operand
+    list, so the call selects one. Shapes: (dst, ncols); (taddr, ncols); (mbar, cta_mask);
+    (mbar); (*__operands); (d_tmem, a_desc, b_desc, idesc, enable_input_d); (d_tmem, a_desc,
     b_desc, idesc, enable_input_d, zero_col_mask); (d_tmem, a_tmem, b_desc, idesc,
-    enable_input_d, zero_col_mask); (mbar); (mbar, mask)
+    enable_input_d); (d_tmem, a_tmem, b_desc, idesc, enable_input_d, zero_col_mask);
+    (d_tmem, a_desc, b_desc, sp_meta_tmem, idesc, enable_input_d); (d_tmem, a_desc, b_desc,
+    sp_meta_tmem, idesc, enable_input_d, zero_col_mask); (d_tmem, a_tmem, b_desc,
+    sp_meta_tmem, idesc, enable_input_d); (d_tmem, a_tmem, b_desc, sp_meta_tmem, idesc,
+    enable_input_d, zero_col_mask); (d_tmem, a_desc, b_compressed_desc,
+    b_decompress_metadata, idesc, sfa_tmem, sfb_tmem, enable_input_d); (d_tmem, a_tmem,
+    b_compressed_desc, b_decompress_metadata, idesc, sfa_tmem, sfb_tmem, enable_input_d);
+    (d_tmem, a_desc, b_desc, idesc, sfa_tmem, sfb_tmem, enable_input_d); (d_tmem, a_tmem,
+    b_desc, idesc, sfa_tmem, sfb_tmem, enable_input_d); (d_tmem, a_desc, b_desc,
+    sp_meta_tmem, idesc, sfa_tmem, sfb_tmem, enable_input_d); (d_tmem, a_tmem, b_desc,
+    sp_meta_tmem, idesc, sfa_tmem, sfb_tmem, enable_input_d); (); (taddr, s_desc); (mbar,
+    mask)
     """
 
+    NaN: _Chain_tcgen05
+    abs: _Chain_tcgen05
     aligned: _Chain_tcgen05
     alloc: _Chain_tcgen05
+    ashift: _Chain_tcgen05
+    b2: _Chain_tcgen05
     b32: _Chain_tcgen05
     b4x16_p64: _Chain_tcgen05
     b64: _Chain_tcgen05
@@ -1953,11 +2212,38 @@ class _Chain_tcgen05:
     block16: _Chain_tcgen05
     block32: _Chain_tcgen05
     block_scale: _Chain_tcgen05
+    collector__a__discard: _Chain_tcgen05
+    collector__a__fill: _Chain_tcgen05
+    collector__a__lastuse: _Chain_tcgen05
+    collector__a__use: _Chain_tcgen05
+    collector__b0__discard: _Chain_tcgen05
+    collector__b0__fill: _Chain_tcgen05
+    collector__b0__lastuse: _Chain_tcgen05
+    collector__b0__use: _Chain_tcgen05
+    collector__b1__discard: _Chain_tcgen05
+    collector__b1__fill: _Chain_tcgen05
+    collector__b1__lastuse: _Chain_tcgen05
+    collector__b1__use: _Chain_tcgen05
+    collector__b2__discard: _Chain_tcgen05
+    collector__b2__fill: _Chain_tcgen05
+    collector__b2__lastuse: _Chain_tcgen05
+    collector__b2__use: _Chain_tcgen05
+    collector__b3__discard: _Chain_tcgen05
+    collector__b3__fill: _Chain_tcgen05
+    collector__b3__lastuse: _Chain_tcgen05
+    collector__b3__use: _Chain_tcgen05
+    collector__b__discard: _Chain_tcgen05
+    collector__b__fill: _Chain_tcgen05
+    collector__b__lastuse: _Chain_tcgen05
+    collector__b__use: _Chain_tcgen05
     commit: _Chain_tcgen05
     cp: _Chain_tcgen05
     cta_group__1: _Chain_tcgen05
     cta_group__2: _Chain_tcgen05
     dealloc: _Chain_tcgen05
+    decompress__lut__b: _Chain_tcgen05
+    exclusive: _Chain_tcgen05
+    f32: _Chain_tcgen05
     fence__after_thread_sync: _Chain_tcgen05
     fence__before_thread_sync: _Chain_tcgen05
     kind__f16: _Chain_tcgen05
@@ -1967,19 +2253,31 @@ class _Chain_tcgen05:
     kind__mxf4nvf4: _Chain_tcgen05
     kind__mxf8f6f4: _Chain_tcgen05
     kind__tf32: _Chain_tcgen05
+    kind__ti16: _Chain_tcgen05
     ld: _Chain_tcgen05
+    max: _Chain_tcgen05
     mbarrier__arrive__one: _Chain_tcgen05
+    min: _Chain_tcgen05
     mma: _Chain_tcgen05
     multicast__cluster: _Chain_tcgen05
+    multicast__cluster__16b: _Chain_tcgen05
+    multicast__cluster__32b: _Chain_tcgen05
     pack__16b: _Chain_tcgen05
+    red: _Chain_tcgen05
     relinquish_alloc_permit: _Chain_tcgen05
+    s32: _Chain_tcgen05
     scale_vec__1X: _Chain_tcgen05
     scale_vec__2X: _Chain_tcgen05
     scale_vec__4X: _Chain_tcgen05
     shared__cluster: _Chain_tcgen05
     shared__cta: _Chain_tcgen05
+    sp: _Chain_tcgen05
+    sp__2__colon__4: _Chain_tcgen05
+    spcompress: _Chain_tcgen05
     st: _Chain_tcgen05
     sync: _Chain_tcgen05
+    sync_restrict__shared__read__mma__a: _Chain_tcgen05
+    u32: _Chain_tcgen05
     unpack__16b: _Chain_tcgen05
     wait__ld: _Chain_tcgen05
     wait__st: _Chain_tcgen05
@@ -2015,7 +2313,7 @@ class _Chain_tensormap_cp_fenceproxy:
     def __call__(self, dst_mem: Any, src_mem: Any, *args: Any, pred: Any = None) -> None: ...
 
 class _Chain_tensormap_replace:
-    """`tensormap_replace` — 8 entries sharing this mnemonic; PTX puts their difference in the
+    """`tensormap_replace` — 9 entries sharing this mnemonic; PTX puts their difference in the
     operand list, so the call selects one. Shapes: (addr, new_val); (addr, ord, new_val)
     """
 
@@ -2242,6 +2540,7 @@ class _PTX:
     bfind: _Chain_bfind
     bmsk: _Chain_bmsk
     brev: _Chain_brev
+    clmad: _Chain_clmad
     clusterlaunchcontrol: _Chain_clusterlaunchcontrol
     clz: _Chain_clz
     cnot: _Chain_cnot
@@ -2258,6 +2557,7 @@ class _PTX:
     dp4a: _Chain_dp4a
     elect_sync: _Chain_elect_sync
     ex2: _Chain_ex2
+    fabric: _Chain_fabric
     fence: _Chain_fence
     fma: _Chain_fma
     fns: _Chain_fns
@@ -2281,9 +2581,12 @@ class _PTX:
     movmatrix: _Chain_movmatrix
     mul: _Chain_mul
     mul24: _Chain_mul24
+    multimem_cp: _Chain_multimem_cp
     multimem_ld_reduce: _Chain_multimem_ld_reduce
     multimem_red: _Chain_multimem_red
+    multimem_red_async: _Chain_multimem_red_async
     multimem_st: _Chain_multimem_st
+    multimem_st_async: _Chain_multimem_st_async
     neg: _Chain_neg
     not_: _Chain_not
     or_: _Chain_or
@@ -2308,6 +2611,8 @@ class _PTX:
     shr: _Chain_shr
     sin: _Chain_sin
     slct: _Chain_slct
+    spcompress: _Chain_spcompress
+    spdecompress: _Chain_spdecompress
     sqrt: _Chain_sqrt
     st: _Chain_st
     st_async: _Chain_st_async

--- a/python/tvm/testing/env.py
+++ b/python/tvm/testing/env.py
@@ -53,12 +53,14 @@ import tvm
 
 __all__ = [
     "build_flag_enabled",
+    "cuda_arch",
     "has_adreno_opencl",
     # cpu features
     "has_cpu_feature",
     "has_cublas",
     # runtime device
     "has_cuda",
+    "has_cuda_arch",
     # version / capability
     "has_cuda_compute",
     "has_cudagraph",
@@ -259,6 +261,41 @@ def has_nvshmem() -> bool:
 
 
 # --- version / capability probes -------------------------------------------
+
+
+def _cuda_arch_from_compute_version(compute_version: str) -> str | None:
+    """Return the canonical physical CUDA architecture for a compute version."""
+    try:
+        major_string, minor_string = compute_version.split(".", maxsplit=2)[:2]
+        major = int(major_string)
+        minor = int(minor_string)
+    except (AttributeError, TypeError, ValueError):
+        return None
+    suffix = "a" if major >= 9 else ""
+    return f"sm_{major}{minor}{suffix}"
+
+
+@functools.cache
+def cuda_arch(device_id: int = 0) -> str | None:
+    """Return a CUDA device's canonical runtime architecture, if available.
+
+    Architecture-specific targets use the same spelling as CUDA compilation
+    targets (for example, 'sm_100a' and 'sm_103a'), rather than collapsing
+    them to a major compute-capability floor.
+    """
+    try:
+        device = tvm.cuda(device_id)
+        if not device.exist:
+            return None
+        return _cuda_arch_from_compute_version(device.compute_version)
+    except Exception:  # pylint: disable=broad-except
+        return None
+
+
+def has_cuda_arch(*arches: str, device_id: int = 0) -> bool:
+    """True if a CUDA device exactly matches one of arches."""
+    actual = cuda_arch(device_id)
+    return actual is not None and actual in arches
 
 
 @functools.cache

--- a/src/backend/cuda/runtime/cuda_module.cc
+++ b/src/backend/cuda/runtime/cuda_module.cc
@@ -224,10 +224,39 @@ class CUDAWrappedFunc {
     int device_id;
     TVM_FFI_CHECK_CUDA_ERROR(cudaGetDevice(&device_id));
     ThreadWorkLoad wl = launch_param_config_.Extract(args);
+    bool use_oversized_shared_memory = false;
 
     if (fcache_[device_id] == nullptr) {
       fcache_[device_id] = m_->GetFunc(device_id, func_name_);
-      if (wl.dyn_shmem_size >= (48 << 10)) {
+      // SM107 cluster kernels may use an oversized shared-memory configuration above the
+      // ordinary per-CTA opt-in limit.  Match CUDA 13/CUTLASS DSL by selecting that mode
+      // before setting the dynamic-SMEM size; the latter attribute is ignored in this mode.
+      if (launch_param_config_.use_cluster_launch()) {
+#if CUDA_VERSION >= 13040
+        int max_portable_dynamic_shared = 0;
+        TVM_FFI_CHECK_CUDA_ERROR(cudaDeviceGetAttribute(
+            &max_portable_dynamic_shared, cudaDevAttrMaxSharedMemoryPerBlockOptin, device_id));
+        use_oversized_shared_memory =
+            wl.dyn_shmem_size > static_cast<size_t>(max_portable_dynamic_shared);
+        if (use_oversized_shared_memory) {
+          CUresult result =
+              cuFuncSetAttribute(fcache_[device_id], CU_FUNC_ATTRIBUTE_SHARED_MEMORY_MODE,
+                                 CU_SHARED_MEMORY_MODE_ALLOW_OVERSIZED_SHARED_MEMORY);
+          if (result != CUDA_SUCCESS) {
+            TVM_FFI_THROW(InternalError)
+                << "Failed to allow oversized dynamic shared memory size " << wl.dyn_shmem_size;
+          }
+        }
+#endif  // CUDA_VERSION >= 13040
+        CUresult result = cuFuncSetAttribute(
+            fcache_[device_id], CU_FUNC_ATTRIBUTE_NON_PORTABLE_CLUSTER_SIZE_ALLOWED, 1);
+        if (result != CUDA_SUCCESS) {
+          TVM_FFI_THROW(InternalError)
+              << "Failed to allow non-portable CUDA cluster size (" << wl.cluster_dim(0) << ", "
+              << wl.cluster_dim(1) << ", " << wl.cluster_dim(2) << ")";
+        }
+      }
+      if (wl.dyn_shmem_size >= (48 << 10) && !use_oversized_shared_memory) {
         // Assumption: dyn_shmem_size doesn't change across different invocations of
         // fcache_[device_id]
         CUresult result = cuFuncSetAttribute(
@@ -235,15 +264,6 @@ class CUDAWrappedFunc {
         if (result != CUDA_SUCCESS) {
           TVM_FFI_THROW(InternalError)
               << "Failed to set the allowed dynamic shared memory size to " << wl.dyn_shmem_size;
-        }
-      }
-      if (wl.cluster_dim(0) * wl.cluster_dim(1) * wl.cluster_dim(2) > 8) {
-        CUresult result = cuFuncSetAttribute(
-            fcache_[device_id], CU_FUNC_ATTRIBUTE_NON_PORTABLE_CLUSTER_SIZE_ALLOWED, 1);
-        if (result != CUDA_SUCCESS) {
-          TVM_FFI_THROW(InternalError)
-              << "Failed to allow non-portable CUDA cluster size (" << wl.cluster_dim(0) << ", "
-              << wl.cluster_dim(1) << ", " << wl.cluster_dim(2) << ")";
         }
       }
     }

--- a/tests/python/testing/test_env.py
+++ b/tests/python/testing/test_env.py
@@ -102,6 +102,48 @@ def test_cuda_compute_is_monotonic():
     assert env.has_cuda_compute(0, 0)
 
 
+@pytest.mark.parametrize(
+    ("compute_version", "expected"),
+    [
+        ("8.0", "sm_80"),
+        ("9.0", "sm_90a"),
+        ("10.0", "sm_100a"),
+        ("10.3", "sm_103a"),
+        ("invalid", None),
+    ],
+)
+def test_cuda_arch_from_compute_version(compute_version, expected):
+    assert env._cuda_arch_from_compute_version(compute_version) == expected
+
+
+def test_has_cuda_arch_matches_detected_device():
+    actual = env.cuda_arch()
+    if actual is None:
+        assert not env.has_cuda_arch("sm_100a")
+    else:
+        assert env.has_cuda_arch(actual)
+
+
+def test_cuda_arch_uses_requested_device(monkeypatch):
+    class Device:
+        exist = True
+        compute_version = "10.3"
+
+    requested = []
+
+    def cuda(device_id):
+        requested.append(device_id)
+        return Device()
+
+    env.cuda_arch.cache_clear()
+    monkeypatch.setattr(tvm, "cuda", cuda)
+    try:
+        assert env.cuda_arch(7) == "sm_103a"
+        assert requested == [7]
+    finally:
+        env.cuda_arch.cache_clear()
+
+
 def test_has_multi_gpu_is_bool():
     assert isinstance(env.has_multi_gpu(), bool)
     assert isinstance(env.has_multi_gpu(1), bool)

--- a/tests/python/tirx/codegen/conftest.py
+++ b/tests/python/tirx/codegen/conftest.py
@@ -17,7 +17,6 @@
 """Hardware requirements for TIRx codegen tests."""
 
 import gc
-import os
 from pathlib import Path
 
 import pytest
@@ -25,28 +24,8 @@ import pytest
 from tvm.testing import env
 
 
-def _set_cuda_device_for_xdist_worker():
-    try:
-        import torch
-    except ImportError:
-        return
-
-    if not torch.cuda.is_available():
-        return
-
-    worker = os.environ.get("PYTEST_XDIST_WORKER", "gw0")
-    worker_index = int(worker[2:]) if worker.startswith("gw") and worker[2:].isdigit() else 0
-    torch.cuda.set_device(worker_index % torch.cuda.device_count())
-
-
-def pytest_configure(config):
-    del config
-    _set_cuda_device_for_xdist_worker()
-
-
 @pytest.fixture(autouse=True)
 def _release_cuda_cache_between_tests():
-    _set_cuda_device_for_xdist_worker()
     yield
     gc.collect()
     try:

--- a/tests/python/tirx/codegen/test_codegen_cuda.py
+++ b/tests/python/tirx/codegen/test_codegen_cuda.py
@@ -125,7 +125,7 @@ def test_cuda_module_destructor_preserves_current_device():
         if tx == 0:
             A[0] = A[0] + 1
 
-    _, mod = _get_source(main)
+    _, mod = _get_source(main, target="cuda")
     original_device = torch.cuda.current_device()
     try:
         torch.cuda.set_device(0)
@@ -460,7 +460,7 @@ def test_cuda_atomic_add():
             T.cuda.atomic_add(A.data, T.int32(1))
             T.cuda.atomic_add(B.data, T.float32(1.0))
 
-    src, mod = _get_source(main)
+    src, mod = _get_source(main, target="cuda")
     assert "tvm_builtin_cuda_atomic_add" in src
     A_np = np.zeros(1, dtype="int32")
     B_np = np.zeros(1, dtype="float32")
@@ -554,8 +554,8 @@ def test_ptx_sub_f16x2_codegen():
 
 
 @pytest.mark.skipif(
-    not (env.has_cuda_compute(10, 0) and env.has_nvcc_version(13, 2)),
-    reason="PTX 9.2 packed bf16 conversion requires sm_100 and CUDA 13.2",
+    not (env.has_cuda_compute(10, 0) and env.has_nvcc_version(13, 4)),
+    reason="packed bf16 conversion requires sm_100; the dialect certifies on CUDA 13.4",
 )
 def test_sparse_decode_conversion_intrinsics_codegen(monkeypatch):
     monkeypatch.setenv("TVM_CUDA_COMPILE_MODE", "nvcc")
@@ -986,7 +986,7 @@ __device__ int32_t add_one(int32_t a) {
                         "add_one", a[i, j], source_code=add_one, return_type="int32"
                     )
 
-        src, mod = _get_source(main)
+        src, mod = _get_source(main, target="cuda")
         A = np.random.randint(0, 10, (16, 16)).astype("int32")
         B = np.zeros((16, 16), dtype="int32")
 
@@ -1018,7 +1018,7 @@ __device__ void print(int32_t a) {
                 for i, j in T.grid(16, 16):
                     T.cuda.func_call("print", a[i, j], source_code=print_func)
 
-        src, mod = _get_source(main)
+        src, mod = _get_source(main, target="cuda")
         A = np.random.randint(0, 10, (16, 16)).astype("int32")
 
         def run_and_check():
@@ -1121,7 +1121,7 @@ def test_ptx_cp_async(cp_size, cache_hint, prefetch_size, predicate, fill_mode):
             A[i] = A_shared[i] + 1.0
         # fmt: on
 
-    src, mod = _get_source(main)
+    src, mod = _get_source(main, target="cuda")
     A_np = np.ones(N, dtype="float16")
     A_ref = np.ones(N, dtype="float16") * 2
     if int(predicate) == 0:
@@ -1187,7 +1187,7 @@ def test_ptx_ldmatrix(trans, num):
             B[row + tx // 4, col + tx % 4 * 2 + i % 2] = A_local[i]
         # fmt: on
 
-    src, mod = _get_source(main)
+    src, mod = _get_source(main, target="cuda")
     A_np = np.arange(16 * 16, dtype="float16").reshape((16, 16))
     B_np = np.zeros((16, 16), dtype="float16")
     B_ref = np.zeros((16, 16), dtype="float16")
@@ -1242,7 +1242,7 @@ def test_uint32_loop_var_runs_correctly():
             acc[0] = acc[0] + A[tx] + T.int32(k)
         B[tx] = acc[0]
 
-    _, mod = _get_source(main)
+    _, mod = _get_source(main, target="cuda")
 
     A_np = np.arange(128, dtype="int32")
     B_ref = A_np * 4 + (0 + 1 + 2 + 3)

--- a/tests/python/tirx/codegen/test_ptx_addr.py
+++ b/tests/python/tirx/codegen/test_ptx_addr.py
@@ -54,10 +54,10 @@ def test_ptx_addr_registration_and_table_capabilities():
     assert "tirx.ptx.addr" in CODEGEN_REGISTRY
 
     addresses = [slot for entry in TABLE.values() for slot in entry.operands if slot.kind == "addr"]
-    assert len(addresses) == 160
-    assert sum(slot.allow_imm_offset for slot in addresses) == 130
-    assert sum(slot.bracket is not None and not slot.allow_imm_offset for slot in addresses) == 5
-    assert sum(slot.space == "tmem" and not slot.allow_imm_offset for slot in addresses) == 25
+    assert len(addresses) == 417
+    assert sum(slot.allow_imm_offset for slot in addresses) == 253
+    assert sum(slot.bracket is not None and not slot.allow_imm_offset for slot in addresses) == 60
+    assert sum(slot.space == "tmem" and not slot.allow_imm_offset for slot in addresses) == 104
 
 
 def test_ptx_addr_table_validation_rejects_wrong_operand_classes():

--- a/tests/python/tirx/codegen/test_ptx_cvt.py
+++ b/tests/python/tirx/codegen/test_ptx_cvt.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""The ptx cvt entries: one case per registered syntax line of ISA 9.7.9.21."""
+"""The ptx cvt entries: one case per registered syntax line of ISA 9.7.10.24."""
 
 import pytest
 
@@ -231,12 +231,96 @@ _FORM_CASES = [
         dict(rnd="rn", relu="relu", dtype="bf16x2", atype="s2f6x2"),
         "cvt.rn.relu.bf16x2.s2f6x2",
     ),
+    # PTX ISA 9.4: pzo, narrow rz/n1 scaling, and UE5M3.
+    (
+        "cvt_pzo_scalar_f32",
+        dict(rnd="rn", pzo="pzo", dtype="f16", atype="f32"),
+        "cvt.rn.pzo.f16.f32",
+    ),
+    (
+        "cvt_pzo_fp16x2_f32",
+        dict(rnd="rz", satfinite="satfinite", pzo="pzo", dtype="bf16x2", atype="f32"),
+        "cvt.rz.satfinite.pzo.bf16x2.f32",
+    ),
+    (
+        "cvt_pzo_tf32_f32",
+        dict(rnd="rn", relu="relu", pzo="pzo", dtype="tf32", atype="f32"),
+        "cvt.rn.relu.pzo.tf32.f32",
+    ),
+    (
+        "cvt_94_narrow_f32",
+        dict(
+            rnd="rz",
+            satfinite="satfinite",
+            scaled="scaled::n1::ue8m0",
+            dtype="e4m3x2",
+            atype="f32",
+        ),
+        "cvt.rz.satfinite.scaled::n1::ue8m0.e4m3x2.f32",
+    ),
+    (
+        "cvt_94_narrow_fp16x2",
+        dict(
+            rnd="rn",
+            satfinite="satfinite",
+            pzo="pzo",
+            dtype="e2m1x2",
+            atype="bf16x2",
+        ),
+        "cvt.rn.satfinite.pzo.e2m1x2.bf16x2",
+    ),
+    (
+        "cvt_ue5m3x2_f32",
+        dict(rnd="rp", satfinite="satfinite", dtype="ue5m3x2", atype="f32"),
+        "cvt.rp.satfinite.ue5m3x2.f32",
+    ),
+    (
+        "cvt_ue5m3x2_f32_scaled",
+        dict(
+            rnd="rz",
+            scaled="scaled::n1::ue8m0",
+            dtype="ue5m3x2",
+            atype="f32",
+        ),
+        "cvt.rz.scaled::n1::ue8m0.ue5m3x2.f32",
+    ),
+    (
+        "cvt_ue5m3x2_fp16x2",
+        dict(rnd="rn", dtype="ue5m3x2", atype="f16x2"),
+        "cvt.rn.ue5m3x2.f16x2",
+    ),
+    (
+        "cvt_ue5m3x2_fp16x2_scaled",
+        dict(
+            rnd="rn",
+            satfinite="satfinite",
+            scaled="scaled::n1::ue8m0",
+            dtype="ue5m3x2",
+            atype="bf16x2",
+        ),
+        "cvt.rn.satfinite.scaled::n1::ue8m0.ue5m3x2.bf16x2",
+    ),
+    (
+        "cvt_f16x2_ue5m3x2",
+        dict(rnd="rn", dtype="f16x2", atype="ue5m3x2"),
+        "cvt.rn.f16x2.ue5m3x2",
+    ),
+    (
+        "cvt_bf16x2_ue5m3x2",
+        dict(
+            rnd="rn",
+            scaled="scaled::n2::ue8m0",
+            dtype="bf16x2",
+            atype="ue5m3x2",
+        ),
+        "cvt.rn.scaled::n2::ue8m0.bf16x2.ue5m3x2",
+    ),
 ]
 
 # The generic scalar line is one entry named plain "cvt"; the packed lines are
 # the "cvt_*" family.
-# Every entry of the `cvt` instruction (ISA 9.7.9.21). Keyed off the mnemonic
-# rather than the table name: `cvt.pack` (9.7.9.22) is a different instruction
+# Every entry of the `cvt` instruction (ISA 9.7.10.24). Keyed off the mnemonic
+# rather than the table name: `cvt.pack` (9.7.10.25) is a different instruction
 # that happens to sort under the same prefix, and its forms are not points on
 # this conversion grid.
 _CVT_ENTRIES = {name for name, entry in TABLE.items() if entry.ptx_name == "cvt"}
@@ -371,8 +455,8 @@ def test_cvt_generic_scalar_relaxed_carriers(ptx_type, dst_expected, src_expecte
     assert operand_dtypes(entry.operands[1], mod_map) == (src_expected or dst_expected)
 
 
-def test_cvt_generic_scalar_cuda_13_2_bf16_opposite_operand_gap():
-    """CUDA 13.2 also rejects widening the operand opposite `.bf16`."""
+def test_cvt_generic_scalar_cuda_13_4_bf16_opposite_operand_gap():
+    """CUDA 13.4 ptxas also rejects widening the operand opposite `.bf16`."""
     entry = TABLE["cvt"]
     to_bf16 = mods(entry, tokens_for(entry, rnd="rn", dtype="bf16", atype="u32"))
     assert operand_dtypes(entry.operands[0], to_bf16) == ("uint16",)
@@ -392,8 +476,8 @@ def test_cvt_generic_scalar_cuda_13_2_bf16_opposite_operand_gap():
     )
 
 
-def test_cvt_generic_scalar_cuda_13_2_ftz_destination_gaps():
-    """Pin the two destination-only `.ftz` gaps measured on CUDA 13.2."""
+def test_cvt_generic_scalar_cuda_13_4_ftz_destination_gaps():
+    """Pin the two destination-only `.ftz` gaps measured on CUDA 13.4 ptxas."""
     entry = TABLE["cvt"]
 
     u64_from_f32 = mods(entry, tokens_for(entry, rnd="rni", ftz="ftz", dtype="u64", atype="f32"))
@@ -425,7 +509,7 @@ def test_cvt_generic_scalar_cuda_13_2_ftz_destination_gaps():
 
 
 def test_cvt_generic_scalar_keeps_supported_wide_carriers():
-    """Do not turn CUDA 13.2's narrow gaps into a blanket cvt restriction."""
+    """Do not turn CUDA 13.4's narrow gaps into a blanket cvt restriction."""
     entry = TABLE["cvt"]
 
     no_ftz = mods(entry, tokens_for(entry, rnd="rn", dtype="f32", atype="f64"))
@@ -454,8 +538,8 @@ def test_cvt_generic_scalar_relaxed_carriers_render_exact_instruction():
     assert '"cvt.s16.u16 %0, %1;" : "=l"(__d) : "l"(__a)' in source
 
     # Destination widening remains supported, while the floating source is
-    # exact-width because ptxas rejects the wider source form permitted by PTX
-    # 9.2 Table 27.
+    # exact-width because ptxas rejects the wider source form permitted by ISA
+    # section 9.4.1, Table 27.
     tokens = tokens_for(entry, rnd="rn", dtype="f16", atype="f32")
     opcode, helper, source = render_variant(entry, tokens, dtypes=("uint128", "uint32"))
     assert opcode == "cvt.rn.f16.f32"
@@ -492,7 +576,7 @@ def test_cvt_bf16_sat_diagnostics_distinguish_isa_and_toolchain():
 def test_cvt_e2m1x2_stages_its_b8_operand():
     """`.e2m1x2` is the one cvt format with no register of its own width.
 
-    ISA 9.7.9.21:92 "When converting to .e2m1x2 data formats, the destination
+    ISA 9.7.10.24:92 "When converting to .e2m1x2 data formats, the destination
     operand d has .b8 type." and :101 "When converting from .e2m1x2 to
     .f16x2/.bf16x2, source operand a has .b8 type." Inline asm has no 8-bit
     constraint letter, so both directions declare the register inside the block
@@ -522,7 +606,7 @@ def test_cvt_e2m1x2_stages_its_b8_operand():
     assert "cvt.rn.scaled::n2::ue8m0.bf16x2.e2m1x2 %0, raw_a, %2;" in source
 
 
-# The cvt type tokens ISA 9.7.9.21's Target ISA Notes list architecture by
+# The cvt type tokens ISA 9.7.10.24's Target ISA Notes list architecture by
 # architecture (:527-639), plus the .rs rounding mode (":602 .rs rounding mode
 # is supported on following architectures:", listing sm_100a and sm_103a).
 _CVT_BLACKWELL_TOKENS = {
@@ -555,12 +639,28 @@ def _needs_sm100a(written: set[str]) -> bool:
     )
 
 
-def test_cvt_blackwell_lines_carry_their_arch_floor():
-    """The Blackwell-only cvt lines must certify at sm_100a; certifying them at
-    the sm_90 default would report legal forms as illegal.
+_PTX94_CVT_ENTRIES = {
+    "cvt_pzo_scalar_f32",
+    "cvt_pzo_fp16x2_f32",
+    "cvt_pzo_tf32_f32",
+    "cvt_94_narrow_f32",
+    "cvt_94_narrow_fp16x2",
+    "cvt_ue5m3x2_f32",
+    "cvt_ue5m3x2_f32_scaled",
+    "cvt_ue5m3x2_fp16x2",
+    "cvt_ue5m3x2_fp16x2_scaled",
+    "cvt_f16x2_ue5m3x2",
+    "cvt_bf16x2_ue5m3x2",
+}
 
+
+def test_cvt_blackwell_lines_carry_their_arch_floor():
+    """Blackwell-only cvt lines carry their maximum documented family floor.
+
+    The baseline lines certify at sm_100a and PTX 9.4's SM107 lines at sm_107f;
+    certifying either at the sm_90 default would report legal forms as illegal.
     The floor rides the narrow format, not `.bf16x2` on its own: ISA
-    9.7.9.21:517-518 puts `.bf16x2` as a destination format at "sm_80 or
+    9.7.10.24:517-518 puts `.bf16x2` as a destination format at "sm_80 or
     higher", which is where cvt.frnd2{.relu}{.satfinite}.bf16x2.f32 lives,
     while :634-639 restrict `.bf16x2` *from* an fp8/fp6/fp4 format to
     family-specific architectures.
@@ -568,11 +668,12 @@ def test_cvt_blackwell_lines_carry_their_arch_floor():
     for name in _CVT_ENTRIES:
         entry = TABLE[name]
         if any(_needs_sm100a(set(tokens)) for tokens, *_ in renderings(entry)):
-            assert entry.cert_arch == "sm_100a", name
+            expected = "sm_107f" if name in _PTX94_CVT_ENTRIES else "sm_100a"
+            assert entry.cert_arch == expected, name
 
 
 def test_cvt_tf32_satfinite_carries_its_sm_100_floor():
-    """ISA 9.7.9.21:526 "cvt.{rn/rz}.satfinite.tf32.f32 requires sm_100 or
+    """ISA 9.7.10.24:526 "cvt.{rn/rz}.satfinite.tf32.f32 requires sm_100 or
     higher." -- the maximum floor over the entry, whose other spellings sit at
     sm_80/sm_90."""
     entry = TABLE["cvt_tf32_f32"]
@@ -585,7 +686,7 @@ def test_cvt_rs_and_scale_factor_shapes():
     """The two operand shapes this family added: the .rs lines' trailing rbits
     (with a grouped ``{a, b, e, f}`` source on the x4 forms), and the
     scale-factor operand that exists exactly when .scaled::n2::ue8m0 is
-    written (ISA 9.7.9.21:180-182 "Operand scale-factor and qualifier
+    written (ISA 9.7.10.24:180-182 "Operand scale-factor and qualifier
     .scaled::n2::ue8m0 must be used together.")."""
     _, _, source = render_variant(TABLE["cvt_rs_f16x2_f32"], ("rs", "", "", "f16x2", "f32"))
     assert "uint32_t& __d, float __a, float __b, uint32_t __rbits" in source

--- a/tests/python/tirx/codegen/test_ptx_dialect.py
+++ b/tests/python/tirx/codegen/test_ptx_dialect.py
@@ -64,7 +64,7 @@ def test_ptx_registration():
         op = Op.get(entry.op_name)  # raises if unregistered
         assert op.get_attr("TCallEffectKind") is not None, entry.name
         # The printer name is the attribute path a program types, so it is the
-        # *escaped* family: `and`/`or`/`not` (ISA 9.7.8) are Python keywords and
+        # *escaped* family: `and`/`or`/`not` (ISA 9.7.9) are Python keywords and
         # print as `T.ptx.and_`. Identity for every other family.
         family = escape_token(entry.family)  # several entries may share a mnemonic
         assert op.get_attr("TScriptPrinterName") == f"ptx.{family}", entry.name
@@ -410,7 +410,151 @@ def test_ptx_92_cp_bulk_exact_renderings():
         assert f'asm volatile("{expected}"' in source, source
 
 
+def test_ptx_93_sm103a_exact_renderings():
+    """Representative PTX 9.3 forms keep their documented operand shapes."""
+    from tvm.backend.cuda.ptx.render import render_variant
+    from tvm.backend.cuda.ptx.table import TABLE, tokens_for
+
+    cases = (
+        (
+            "clmad",
+            dict(mode="hi", type="u64"),
+            "clmad.hi.u64 %0, %1, %2, %3;",
+        ),
+        (
+            "ld",
+            dict(mmio="mmio", sem="acquire", scope="sys", space="global", type="u32"),
+            "ld.mmio.acquire.sys.global.u32 %0, [%1];",
+        ),
+        (
+            "st",
+            dict(mmio="mmio", sem="release", scope="sys", space="global", type="u32"),
+            "st.mmio.release.sys.global.u32 [%0], %1;",
+        ),
+        (
+            "multimem_st_async",
+            dict(sem="release", scope="sys", space="global", type="u32"),
+            "multimem.st.async.release.sys.global.u32 [%0], %1;",
+        ),
+        (
+            "cp_async_bulk_s2c",
+            dict(
+                api="async",
+                kind="bulk",
+                sem="relaxed",
+                scope="cluster",
+                dst="shared::cluster",
+                src="shared::cta",
+                completion="mbarrier::complete_tx::bytes",
+                type="b128",
+            ),
+            "cp.async.bulk.relaxed.cluster.shared::cluster.shared::cta."
+            "mbarrier::complete_tx::bytes.b128 [%0], [%1], %2, [%3];",
+        ),
+        (
+            "fabric_try_put_counted",
+            dict(
+                action="try_put",
+                api="async",
+                src="shared::cta",
+                completion=("mbarrier::complete_tx::16B.mbarrier::report::fabric.counted::bytes"),
+                sem="relaxed",
+                scope="sys",
+                type="b128",
+            ),
+            "fabric.try_put.async.shared::cta.mbarrier::complete_tx::16B."
+            "mbarrier::report::fabric.counted::bytes.relaxed.sys.b128 "
+            "[%0, %1, %2], [%3], %4, [%5];",
+        ),
+        (
+            "fence_proxy_fabric",
+            dict(
+                proxy="proxy",
+                direction="generic::fabric",
+                proxykind="alias",
+                sem="release",
+                scope="sys",
+            ),
+            "fence.proxy.generic::fabric.alias.release.sys;",
+        ),
+        (
+            "mbarrier_check_layout",
+            dict(action="check_layout", layout="layout::v1", space="shared::cta", type="b64"),
+            "mbarrier.check_layout.layout::v1.shared::cta.b64 pd0, [%1];",
+        ),
+        (
+            "tcgen05_ld_red",
+            dict(
+                action="ld",
+                red="red",
+                sync="sync",
+                aligned="aligned",
+                shape="32x32b",
+                num="x2",
+                type="f32",
+                redop="max",
+                abs="abs",
+                nan="NaN",
+            ),
+            "tcgen05.ld.red.sync.aligned.32x32b.x2.max.abs.NaN.f32 {%0, %1}, %2, [%3];",
+        ),
+        (
+            "tcgen05_ld_red",
+            dict(
+                action="ld",
+                red="red",
+                sync="sync",
+                aligned="aligned",
+                shape="32x32b",
+                num="x2",
+                redop="min",
+                type="u32",
+            ),
+            "tcgen05.ld.red.sync.aligned.32x32b.x2.min.u32 {%0, %1}, %2, [%3];",
+        ),
+    )
+    for name, modifiers, expected in cases:
+        entry = TABLE[name]
+        _, _, source = render_variant(entry, tokens_for(entry, **modifiers))
+        assert expected in source, source
+    # The split shape carries the immHalfSplitoff immediate after the address.
+    split = TABLE["tcgen05_ld_red_split"]
+    _, _, source = render_variant(
+        split,
+        tokens_for(
+            split,
+            action="ld",
+            red="red",
+            sync="sync",
+            aligned="aligned",
+            shape="16x32bx2",
+            num="x2",
+            redop="min",
+            type="s32",
+        ),
+        imms=("0",),
+    )
+    assert "tcgen05.ld.red.sync.aligned.16x32bx2.x2.min.s32 {%0, %1}, %2, [%3], 0;" in source, (
+        source
+    )
+
+    report = TABLE["mbarrier_test_wait_report_value"]
+    _, _, source = render_variant(
+        report,
+        tokens_for(
+            report,
+            action="test_wait",
+            phase_type="phase_type::primary",
+            space="shared::cta",
+            type="b64",
+        ),
+    )
+    assert ".reg .b8 raw_report_value;" in source
+    assert "pd0|pd1, raw_report_value, [%3], %4;" in source
+
+
 def test_ptx_92_cp_reduce_negative_grids():
+    from tvm.backend.cuda.ptx.render import render_variant
     from tvm.backend.cuda.ptx.table import TABLE, tokens_for
     from tvm.ir.type import PointerType, PrimType
 
@@ -453,6 +597,48 @@ def test_ptx_92_cp_reduce_negative_grids():
         T.ptx["cp.reduce.async.bulk.global.shared::cta.bulk_group.add.f16"](
             global_ptr, shared_ptr, size
         )
+
+    # `.add.noftz.f32` is PTX ISA 9.4: the pre-9.4 entry refuses it and names
+    # the sibling, which renders the documented spelling and is the single
+    # dispatch hit for the string form.
+    with pytest.raises(ValueError, match=r"PTX 9\.4 sibling"):
+        tokens_for(
+            global_reduce,
+            op="reduce",
+            api="async",
+            kind="bulk",
+            dst="global",
+            src="shared::cta",
+            completion="bulk_group",
+            redop="add",
+            noftz="noftz",
+            type="f32",
+        )
+    sibling = TABLE["cp_reduce_async_bulk_s2g_f32_noftz"]
+    _, _, source = render_variant(
+        sibling,
+        tokens_for(
+            sibling,
+            op="reduce",
+            api="async",
+            kind="bulk",
+            dst="global",
+            src="shared::cta",
+            completion="bulk_group",
+            redop="add",
+            noftz="noftz",
+            type="f32",
+        ),
+    )
+    assert (
+        "cp.reduce.async.bulk.global.shared::cta.bulk_group.add.noftz.f32 [%0], [%1], %2;" in source
+    )
+    T.ptx["cp.reduce.async.bulk.global.shared::cta.bulk_group.add.noftz.f32"](
+        global_ptr, shared_ptr, size
+    )
+    T.ptx["multimem_cp.reduce.async.bulk.relaxed.gpu.global.shared::cta.bulk_group.add.noftz.f32"](
+        global_ptr, shared_ptr, size
+    )
 
 
 def test_ptx_92_cp_bulk_roundtrip():
@@ -576,7 +762,7 @@ def test_ptx_destination_errors():
 def test_ptx_register_group_codegen():
     """A `.lanes > 1` operand renders as braces in the asm, flat params in C.
 
-    `{%1, %2}` is ONE PTX operand occupying two registers (ISA 9.7.9.4), which
+    `{%1, %2}` is ONE PTX operand occupying two registers (ISA 9.7.10.4), which
     is why the lane count appears nowhere in the instruction text -- `mov.b64`
     names the aggregate width, and the operand shape carries the rest.
     """
@@ -736,7 +922,7 @@ def test_ptx_mbarrier_92_shapes_render_and_roundtrip():
     from tvm.backend.cuda.ptx.table import TABLE
 
     selected = (
-        ("mbarrier_init", ("init", "shared", "b64"), False),
+        ("mbarrier_init", ("init", "", "shared", "b64"), False),
         (
             "mbarrier_arrive_no_complete_sink",
             ("arrive", "noComplete", "", "", "shared", "b64"),
@@ -747,11 +933,11 @@ def test_ptx_mbarrier_92_shapes_render_and_roundtrip():
             ("arrive_drop", "noComplete", "", "", "shared::cta", "b64"),
             False,
         ),
-        ("mbarrier_pending_count", ("pending_count", "b64"), False),
-        ("mbarrier_test_wait", ("test_wait", "", "", "shared::cta", "b64"), False),
+        ("mbarrier_pending_count", ("pending_count", "", "b64"), False),
+        ("mbarrier_test_wait", ("test_wait", "", "", "", "shared::cta", "b64"), False),
         (
             "mbarrier_try_wait_parity",
-            ("try_wait", "parity", "relaxed", "cluster", "shared::cta", "b64"),
+            ("try_wait", "parity", "", "relaxed", "cluster", "shared::cta", "b64"),
             False,
         ),
     )
@@ -831,7 +1017,7 @@ def test_ptx_bit_width_axis():
 
 
 def test_ptx_relaxed_load_store_typing():
-    """Scalar/vector ld, st and ldu accept ISA 9.4.1's wider register carriers."""
+    """Scalar/vector ld, st and ldu accept ISA section 9.4.1's wider register carriers."""
 
     @T.prim_func
     def kernel(a_ptr: T.handle):
@@ -875,8 +1061,8 @@ def test_ptx_relaxed_load_store_typing():
             T.ptx.st.global_.u16(A.ptr_to([0]), T.float32(1))
 
 
-def test_ptx_st_vec_f64_cuda_13_2_carrier_gap():
-    """Keep CUDA 13.2's st.v2.f64 gap local to that source-operand shape."""
+def test_ptx_st_vec_f64_cuda_13_4_carrier_gap():
+    """Keep CUDA 13.4's st.v2.f64 carrier gap (ptxas C7907) local to that source-operand shape."""
     from tvm.backend.cuda.ptx.table import TABLE, dtype_combos, tokens_for
 
     st_vec_tokens = tokens_for(TABLE["st_vec"], vec="v2", type="f64")
@@ -1337,7 +1523,7 @@ def test_ptx_mixed_precision_dispatch():
 
 
 def test_ptx_comparison_selection_dispatch():
-    """ISA 9.7.6, the section whose results and selectors are predicates.
+    """ISA 9.7.7, the section whose results and selectors are predicates.
 
     Four mnemonics, eight entries: `setp` alone is four, because `{.BoolOp}`
     adds an operand and `[|q]` adds a destination, and those are two
@@ -1479,7 +1665,7 @@ def test_ptx_slct_relaxed_value_dtype_domain():
 
 
 def test_ptx_half_comparison_dispatch():
-    """ISA 9.7.7, the half twin of 9.7.6 -- same two mnemonics, different grids.
+    """ISA 9.7.8, the half twin of 9.7.7 -- same two mnemonics, different grids.
 
     Two things separate it from the section it shares names with. `setp`'s
     destination shape is decided by the type rather than chosen: the scalar
@@ -1577,7 +1763,7 @@ def test_ptx_half_comparison_dispatch():
             T.device_entry()
             T.ptx.set.lt.f16.b16(out[0], T.uint16(0), T.uint16(0))
 
-    # 9.7.7 spells no unsigned alternates at all, so `lo` never resolves here.
+    # 9.7.8 spells no unsigned alternates at all, so `lo` never resolves here.
     with pytest.raises((AttributeError, tvm.error.DiagnosticError), match="not a valid modifier"):
 
         @T.prim_func
@@ -1587,7 +1773,7 @@ def test_ptx_half_comparison_dispatch():
 
 
 def test_ptx_logic_shift_dispatch():
-    """ISA 9.7.8, including the three mnemonics that are Python keywords.
+    """ISA 9.7.9, including the three mnemonics that are Python keywords.
 
     `and`, `or` and `not` cannot be attributes as they stand, so the surface
     spells them `and_`/`or_`/`not_` and the escape is carried through both
@@ -1754,7 +1940,7 @@ def test_ptx_logic_shift_dispatch():
 
 
 def test_ptx_data_movement_dispatch():
-    """ISA 9.7.9's newly registered instructions, end to end.
+    """ISA 9.7.10's newly registered instructions, end to end.
 
     The section's own difficulty is that its shapes vary more than its
     qualifiers: `mov` shares a mnemonic with ten vector pack/unpack entries and
@@ -1884,7 +2070,7 @@ def test_ptx_data_movement_dispatch():
 
 
 def test_ptx_parallel_sync_dispatch():
-    """ISA 9.7.13's warp-level primitives and the atom shapes beside `.op`.
+    """ISA 9.7.15's warp-level primitives and the atom shapes beside `.op`.
 
     The section is where predicates are most load-bearing: they are sources
     (bar.red's `c`), destinations (vote, elect), and both at once. It is also
@@ -1976,6 +2162,28 @@ def test_ptx_parallel_sync_dispatch():
             T.ptx.red_async.relaxed.cluster.shared__cluster.mbarrier__complete_tx__bytes.and_.u64(
                 A.ptr_to([0]), v, A.ptr_to([0])
             )
+
+
+def test_ptx_lazy_subscript_operands_realize():
+    """Raw buffer elements realize before PTX predicate operand validation."""
+
+    @T.prim_func
+    def kernel(a_ptr: T.handle):
+        A = T.match_buffer(a_ptr, (1,), "uint32")
+        T.device_entry()
+        T.cta_id([1])
+        T.thread_id([32])
+        regs = T.alloc_buffer((2,), "uint32", scope="local")
+        full = T.uint32(0xFFFFFFFF)
+        T.ptx.elect_sync(regs[0], regs[1], full)
+        T.ptx.vote_sync.all.pred(regs[0], T.ptx.pred(regs[1]), full)
+        T.ptx.activemask.b32(regs[1], pred=regs[0])
+        A[0] = regs[0] + regs[1]
+
+    src = _cuda_source(kernel)
+    assert "elect.sync" in src
+    assert "vote.sync.all.pred" in src
+    assert "@p activemask.b32" in src
 
 
 def test_ptx_parser_roundtrip():
@@ -2245,7 +2453,7 @@ def test_ptx_sink_rejected_where_the_isa_has_no_underscore():
             T.ptx.mov.b64(packed, lo, T.ptx.SINK)
             T.evaluate(hi)
 
-    # ISA 9.7.9.4: "provided that at least one element is a scalar register".
+    # ISA 9.7.10.4: "provided that at least one element is a scalar register".
     with pytest.raises((ValueError, tvm.error.DiagnosticError), match="must be a real register"):
 
         @T.prim_func
@@ -2276,6 +2484,411 @@ def test_ptx_printer_form():
 # Registered-instruction unit tests: pin down the engine's generated helpers
 # and its trace-time coercion so the behavior is readable here, not implicit.
 # ---------------------------------------------------------------------------
+def test_ptx_94_sm107_helpers_render():
+    """Representative SM107 forms preserve PTX 9.4 modifier order and shape."""
+    from tvm.backend.cuda.ptx.render import render_variant
+    from tvm.backend.cuda.ptx.table import TABLE, escape_token, tokens_for, unescape_token
+
+    cases = (
+        (
+            "mul_mixed_vec_bf16_f16",
+            dict(dtype="bf16x2", atype="bf16x2", ctype="f16x2"),
+            "mul.bf16x2.bf16x2.f16x2",
+        ),
+        (
+            "mul_mixed_vec_f16_bf16",
+            dict(dtype="f16x2", atype="f16x2", ctype="bf16x2"),
+            "mul.f16x2.f16x2.bf16x2",
+        ),
+        ("set_packed", dict(cmp="eq", type="u8x4"), "set.eq.u8x4"),
+        (
+            "ld_proxy_readonly",
+            dict(space="global", type="u32", proxy="proxy::readonly"),
+            "ld.global.u32.proxy::readonly",
+        ),
+        (
+            "prefetch_valid_addr",
+            dict(space="global", level="L1::32B", valid_addr="valid_addr"),
+            "prefetch.global.L1::32B.valid_addr",
+        ),
+        (
+            "spcompress",
+            dict(elemsize="b8", idxsize="b2", spfactor="sp::2:4", num="x4"),
+            "spcompress.b8.b2.sp::2:4.x4",
+        ),
+        (
+            "tcgen05_mma_ti16_ss_collector_b",
+            dict(
+                action="mma",
+                cta_group="cta_group::1",
+                kind="kind::ti16",
+                collector_b="collector::b::fill",
+            ),
+            "tcgen05.mma.cta_group::1.kind::ti16.collector::b::fill",
+        ),
+        (
+            "tcgen05_mma_ss",
+            dict(
+                action="mma",
+                cta_group="cta_group::2",
+                kind="kind::f8f6f4",
+                collector_a="collector::a::discard",
+            ),
+            "tcgen05.mma.cta_group::2.kind::f8f6f4.collector::a::discard",
+        ),
+        (
+            "tcgen05_mma_lut_b_ts",
+            dict(
+                action="mma",
+                cta_group="cta_group::1",
+                kind="kind::f8f6f4",
+                decompress="decompress::lut::b",
+                collector_b="collector::b::use",
+            ),
+            "tcgen05.mma.cta_group::1.kind::f8f6f4.decompress::lut::b.collector::b::use",
+        ),
+        (
+            "cp_async_bulk_tensor_g2s_cta_override_address_im2col",
+            dict(
+                api="async",
+                kind="bulk",
+                unit="tensor",
+                dim="3d",
+                dst="shared::cta",
+                src="global",
+                load_mode="im2col",
+                completion="mbarrier::complete_tx::bytes",
+                override_address="override::global_address",
+            ),
+            (
+                "cp.async.bulk.tensor.3d.shared::cta.global.im2col."
+                "mbarrier::complete_tx::bytes.override::global_address"
+            ),
+        ),
+        (
+            "cp_async_bulk_tensor_g2s_cta_override_address",
+            dict(
+                api="async",
+                kind="bulk",
+                unit="tensor",
+                dim="2d",
+                dst="shared::cta",
+                src="global",
+                load_mode="tile",
+                completion="mbarrier::complete_tx::bytes",
+                report="mbarrier::report::disabled",
+                override_address="override::global_address",
+            ),
+            (
+                "cp.async.bulk.tensor.2d.shared::cta.global.tile."
+                "mbarrier::complete_tx::bytes.mbarrier::report::disabled."
+                "override::global_address"
+            ),
+        ),
+        (
+            "cp_async_bulk_tensor_s2g_im2col_no_offs_w",
+            dict(
+                api="async",
+                kind="bulk",
+                unit="tensor",
+                dim="3d",
+                dst="global",
+                src="shared::cta",
+                load_mode="im2col_no_offs",
+                completion="bulk_group",
+            ),
+            "cp.async.bulk.tensor.3d.global.shared::cta.im2col_no_offs.bulk_group",
+        ),
+        (
+            "atom_f32_noftz_bitbucket",
+            dict(space="global", op="add", noftz="noftz", type="f32"),
+            "atom.global.add.noftz.f32",
+        ),
+        (
+            "ldmatrix_s8_s4",
+            dict(
+                sync="sync",
+                aligned="aligned",
+                shape="m8n16",
+                num="x1",
+                space="shared",
+                dtype="s8",
+                ctype="s4",
+            ),
+            "ldmatrix.sync.aligned.m8n16.x1.shared.s8.s4",
+        ),
+    )
+    for name, slots, expected in cases:
+        entry = TABLE[name]
+        opcode, _, source = render_variant(entry, tokens_for(entry, **slots))
+        assert opcode == expected
+        assert f"{expected} " in source
+
+    cluster_override_im2col = TABLE["cp_async_bulk_tensor_g2s_cluster_override_address_im2col"]
+    opcode, _, source = render_variant(
+        cluster_override_im2col,
+        tokens_for(
+            cluster_override_im2col,
+            api="async",
+            kind="bulk",
+            unit="tensor",
+            dim="3d",
+            dst="shared::cluster",
+            src="global",
+            load_mode="im2col",
+            completion="mbarrier::complete_tx::bytes",
+            multicast="multicast::cluster::16b",
+            override_address="override::global_address",
+        ),
+    )
+    assert (
+        opcode == "cp.async.bulk.tensor.3d.shared::cluster.global.im2col."
+        "mbarrier::complete_tx::bytes.multicast::cluster::16b.override::global_address"
+    )
+    assert "uint16_t __cta_mask" in source
+
+    tma = TABLE["cp_async_bulk_tensor_g2s_cta_override_address_im2col"]
+    _, _, source = render_variant(
+        tma,
+        tokens_for(
+            tma,
+            api="async",
+            kind="bulk",
+            unit="tensor",
+            dim="3d",
+            dst="shared::cta",
+            src="global",
+            load_mode="im2col",
+            completion="mbarrier::complete_tx::bytes",
+            override_address="override::global_address",
+        ),
+    )
+    assert "[%1, %2, {%3, %4, %5}], [%6], {%7};" in source
+
+    escaped = escape_token("sp::2:4")
+    assert escaped == "sp__2__colon__4"
+    assert unescape_token(escaped) == "sp::2:4"
+
+
+def test_ptx_94_cp_bulk_semantic_renderings():
+    """Report and mask-width siblings retain every non-tensor semantic line."""
+    from tvm.backend.cuda.ptx.render import render_variant
+    from tvm.backend.cuda.ptx.table import TABLE, tokens_for
+
+    cases = (
+        (
+            "cp_async_bulk_g2s_cta_report",
+            dict(
+                api="async",
+                kind="bulk",
+                sem="weak",
+                dst="shared::cta",
+                src="global",
+                completion="mbarrier::complete_tx::bytes",
+                report="mbarrier::report::disabled",
+                ignore_oob="ignore_oob",
+            ),
+            "cp.async.bulk.weak.shared::cta.global.mbarrier::complete_tx::bytes."
+            "mbarrier::report::disabled.ignore_oob "
+            "[%0], [%1], %2, %3, %4, [%5];",
+        ),
+        (
+            "cp_async_bulk_g2s_cta_report",
+            dict(
+                api="async",
+                kind="bulk",
+                sem="relaxed",
+                scope="sys",
+                dst="shared::cta",
+                src="global",
+                completion="mbarrier::complete_tx::bytes",
+                report="mbarrier::report::validity::per_16bytes::8",
+                cache="L2::cache_hint",
+                type="b128",
+            ),
+            "cp.async.bulk.relaxed.sys.shared::cta.global."
+            "mbarrier::complete_tx::bytes."
+            "mbarrier::report::validity::per_16bytes::8.L2::cache_hint.b128 "
+            "[%0], [%1], %2, [%3], %4;",
+        ),
+        (
+            "cp_async_bulk_g2s_cluster_multicast16",
+            dict(
+                api="async",
+                kind="bulk",
+                sem="weak",
+                dst="shared::cluster",
+                src="global",
+                completion="mbarrier::complete_tx::bytes",
+                multicast="multicast::cluster::16b",
+            ),
+            "cp.async.bulk.weak.shared::cluster.global.mbarrier::complete_tx::bytes."
+            "multicast::cluster::16b [%0], [%1], %2, [%3], %4;",
+        ),
+        (
+            "cp_async_bulk_g2s_cluster_multicast32",
+            dict(
+                api="async",
+                kind="bulk",
+                sem="relaxed",
+                scope="cluster",
+                dst="shared::cluster",
+                src="global",
+                completion="mbarrier::complete_tx::bytes",
+                multicast="multicast::cluster::32b",
+                type="b128",
+            ),
+            "cp.async.bulk.relaxed.cluster.shared::cluster.global."
+            "mbarrier::complete_tx::bytes.multicast::cluster::32b.b128 "
+            "[%0], [%1], %2, [%3], %4;",
+        ),
+        (
+            "cp_async_bulk_g2s_cluster_report",
+            dict(
+                api="async",
+                kind="bulk",
+                sem="relaxed",
+                scope="gpu",
+                dst="shared::cluster",
+                src="global",
+                completion="mbarrier::complete_tx::bytes",
+                report="mbarrier::report::validity::per_element::ff",
+                multicast="multicast::cluster::32b",
+                type="b128",
+            ),
+            "cp.async.bulk.relaxed.gpu.shared::cluster.global."
+            "mbarrier::complete_tx::bytes."
+            "mbarrier::report::validity::per_element::ff."
+            "multicast::cluster::32b.b128 [%0], [%1], %2, [%3], %4;",
+        ),
+    )
+    for name, modifiers, expected in cases:
+        entry = TABLE[name]
+        _, _, source = render_variant(entry, tokens_for(entry, **modifiers))
+        assert f'asm volatile("{expected}"' in source, source
+
+
+def test_ptx_94_cp_bulk_semantics_roundtrip():
+    """The string namespace dispatches every widened PTX 9.4 sibling."""
+
+    @T.prim_func
+    def kernel(src: T.Buffer((64,), "uint32")):
+        T.device_entry()
+        smem = T.alloc_buffer((64,), "uint32", scope="shared")
+        mbar = T.alloc_buffer((2,), "uint64", scope="shared")
+        T.ptx[
+            "cp.async.bulk.relaxed.sys.shared::cta.global."
+            "mbarrier::complete_tx::bytes."
+            "mbarrier::report::validity::per_16bytes::8.L2::cache_hint.b128"
+        ](
+            smem.ptr_to([0]),
+            src.ptr_to([0]),
+            T.uint32(16),
+            mbar.ptr_to([0]),
+            T.uint64(0),
+        )
+        T.ptx[
+            "cp.async.bulk.weak.shared::cluster.global."
+            "mbarrier::complete_tx::bytes.multicast::cluster::16b"
+        ](
+            T.uint32(0),
+            src.ptr_to([0]),
+            T.uint32(16),
+            mbar.ptr_to([0]),
+            T.uint16(1),
+        )
+        T.ptx[
+            "cp.async.bulk.relaxed.cluster.shared::cluster.global."
+            "mbarrier::complete_tx::bytes.multicast::cluster::32b.b128"
+        ](
+            T.uint32(0),
+            src.ptr_to([0]),
+            T.uint32(16),
+            mbar.ptr_to([0]),
+            T.uint32(1),
+        )
+        T.ptx[
+            "cp.async.bulk.relaxed.gpu.shared::cluster.global."
+            "mbarrier::complete_tx::bytes."
+            "mbarrier::report::validity::per_element::ff."
+            "multicast::cluster::32b.b128"
+        ](
+            T.uint32(0),
+            src.ptr_to([0]),
+            T.uint32(16),
+            mbar.ptr_to([0]),
+            T.uint32(1),
+        )
+
+    reparsed = tvm.script.from_source(kernel.script())
+    tvm.ir.assert_structural_equal(kernel, reparsed)
+
+
+def test_ptx_94_cp_bulk_semantic_negative_grids():
+    """The widened siblings reject malformed strong semantics and report/OOB pairs."""
+    from tvm.backend.cuda.ptx.table import TABLE, tokens_for
+
+    multicast = TABLE["cp_async_bulk_g2s_cluster_multicast32"]
+    required = dict(
+        api="async",
+        kind="bulk",
+        dst="shared::cluster",
+        src="global",
+        completion="mbarrier::complete_tx::bytes",
+        multicast="multicast::cluster::32b",
+    )
+    with pytest.raises(ValueError, match=r"requires both \.scope and \.b128"):
+        tokens_for(multicast, **required, sem="relaxed")
+    with pytest.raises(ValueError, match=r"belong only to the \.relaxed"):
+        tokens_for(multicast, **required, sem="weak", scope="cta", type="b128")
+
+    report = TABLE["cp_async_bulk_g2s_cta_report"]
+    with pytest.raises(ValueError, match=r"\.ignore_oob requires .*report::disabled"):
+        tokens_for(
+            report,
+            api="async",
+            kind="bulk",
+            dst="shared::cta",
+            src="global",
+            completion="mbarrier::complete_tx::bytes",
+            report="mbarrier::report::validity::per_element::ff",
+            ignore_oob="ignore_oob",
+        )
+
+
+def test_ptx_94_family_specific_arch_floors_and_delta():
+    """SM107 family-only forms certify at 107f and remain in the 9.4 delta."""
+    from tvm.backend.cuda.ptx.table import _PTX_94_ENTRIES, TABLE
+
+    family_specific = {
+        "add_mixed_vec_up",
+        "sub_mixed_vec_up",
+        "add_mixed_vec_down_f16",
+        "sub_mixed_vec_down_f16",
+        "add_mixed_vec_down_bf16",
+        "sub_mixed_vec_down_bf16",
+        "fma_mixed_vec",
+        "mul_mixed_vec_down_f16",
+        "mul_mixed_vec_down_bf16",
+        "mul_mixed_vec_bf16_f16",
+        "mul_mixed_vec_f16_bf16",
+        "set_packed",
+    }
+    assert {TABLE[name].cert_arch for name in family_specific} == {"sm_107f"}
+
+    delta_names = {entry.name for entry in _PTX_94_ENTRIES}
+    noftz_siblings = {
+        "atom_f32_noftz",
+        "red_f32_noftz",
+        "atom_vec_f32_noftz",
+        "red_vec_f32_noftz",
+        "cp_reduce_async_bulk_s2g_f32_noftz",
+        "multimem_cp_reduce_async_bulk_f32_noftz",
+    }
+    assert {"ldmatrix_s8_s4", *noftz_siblings} <= delta_names
+    # `.noftz` with `.f32` is a PTX ISA 9.4 line that requires sm_90, not a
+    # family-specific one; the siblings certify at that floor.
+    assert {TABLE[name].cert_arch for name in noftz_siblings} == {"sm_90"}
 
 
 def test_ptx_tcgen05_mapa_address_rendering():
@@ -2569,7 +3182,7 @@ def test_ptx_helper_source_golden():
     )
     # Two written type tokens, and an accumulator derived from both: c and d
     # are .u32 only when atype and btype both are, so this mixed pair makes
-    # them .s32 (ISA 9.7.1.23).
+    # them .s32 (ISA 9.7.1.24).
     assert render("dp4a", atype="u32", btype="s32") == (
         "__forceinline__ __device__ void tvm_builtin_ptx_dp4a_u32_s32"
         "(int32_t& __d, uint32_t __a, int32_t __b, int32_t __c) {\n"
@@ -2675,7 +3288,7 @@ def test_ptx_helper_source_golden():
         "}\n"
     )
 
-    # Comparison and selection (ISA 9.7.6). setp's `p|q`: ONE operand position
+    # Comparison and selection (ISA 9.7.7). setp's `p|q`: ONE operand position
     # holding two predicate destinations, joined by the ISA's own separator
     # rather than a comma. Each half is a real register with its own selp on
     # the way out -- q carries the Boolean applied to the complement of the
@@ -2730,8 +3343,8 @@ def test_ptx_helper_source_golden():
         "}\n"
     )
 
-    # Half-precision comparison (ISA 9.7.7). The packed setp reuses the pipe
-    # pair, but its two halves mean something else than 9.7.6's: p and q are
+    # Half-precision comparison (ISA 9.7.8). The packed setp reuses the pipe
+    # pair, but its two halves mean something else than 9.7.7's: p and q are
     # the two lanes' comparisons, not a result and its complement.
     assert render("setp_half_pq", cmp="lt", ftz="ftz", type="f16x2") == (
         "__forceinline__ __device__ void tvm_builtin_ptx_setp_half_pq_lt_ftz_f16x2"
@@ -2758,7 +3371,7 @@ def test_ptx_helper_source_golden():
         "}\n"
     )
 
-    # Logic and shift (ISA 9.7.8). `.pred` as an instruction type, rather than
+    # Logic and shift (ISA 9.7.9). `.pred` as an instruction type, rather than
     # as one operand's class: three bridges -- two setp in, one selp out --
     # wrapped around a single instruction that never touches the carriers.
     assert render("and", type="pred") == (
@@ -2802,7 +3415,7 @@ def test_ptx_helper_source_golden():
         "}\n"
     )
 
-    # Data movement (ISA 9.7.9). shfl.sync's `d|p`: a pipe pair whose halves
+    # Data movement (ISA 9.7.10). shfl.sync's `d|p`: a pipe pair whose halves
     # are DIFFERENT register classes -- an ordinary b32 result bound straight
     # to %0, and an in-range predicate that rides the bridge.
     assert render("shfl_sync_p", mode="up", type="b32") == (
@@ -2853,7 +3466,7 @@ def test_ptx_helper_source_golden():
         "}\n"
     )
 
-    # Parallel synchronization (ISA 9.7.13). elect.sync's `d|p` is the one
+    # Parallel synchronization (ISA 9.7.15). elect.sync's `d|p` is the one
     # pipe pair the ISA makes mandatory -- ptxas rejects a bare destination --
     # and its halves are two different register classes.
     assert render("elect_sync") == (
@@ -2892,9 +3505,10 @@ def test_ptx_helper_source_golden():
         '"l"(__addr), "f"(__value0), "f"(__value1) : "memory");\n'
         "}\n"
     )
-    # PTX ISA 9.2 documents the same bit-bucket spelling for bf16 atom, but
-    # CUDA 13.2 ptxas does not compile it (an exact inlined caller segfaults).
-    # Returned-value bf16 atom and f16 bit buckets remain registered.
+    # The ISA documents the same bit-bucket spelling for bf16 atom; the table
+    # withholds it pending certification on CUDA 13.4 (see
+    # `_check_atom_half_bitbucket`).  Returned-value bf16 atom and f16 bit
+    # buckets remain registered.
     for entry_name, by_name in (
         ("atom_half_bitbucket", {"op": "add", "noftz": "noftz", "type": "bf16"}),
         (
@@ -2902,7 +3516,7 @@ def test_ptx_helper_source_golden():
             {"op": "add", "noftz": "noftz", "vec": "v2", "type": "bf16"},
         ),
     ):
-        with pytest.raises(ValueError, match="PTX ISA 9.2 supports.*ptxas does not compile"):
+        with pytest.raises(ValueError, match="bf16 atom bit-bucket destination.*withholds"):
             tokens_for(TABLE[entry_name], **by_name)
     # red's half-word and packed vector syntax lines share this entry; the
     # conditional policy operand follows the value group.
@@ -3169,7 +3783,7 @@ _BLOCK_RE = re.compile(r"^\{ (?P<body>.*) \}$")
 # semantics -- see BRIDGE.
 #
 # Matched in FULL, not by opcode prefix, because an opcode is no longer a
-# discriminator: `setp` and `selp` are registered instructions (ISA 9.7.6), so
+# discriminator: `setp` and `selp` are registered instructions (ISA 9.7.7), so
 # a helper's one real instruction can carry the same mnemonic as the bridge
 # statements around it. What separates them is the shape the bridge always
 # has -- it names a bridge-local register (`p`, `ps<n>`, `pd<n>`, `raw_<slot>`)
@@ -3376,7 +3990,7 @@ def test_ptx_all_variants_render_unique():
             _, helper, _ = render_variant(entry, *args, addr_offsets=addr_offsets)
             assert helper not in names, f"address-offset helper name collision: {helper}"
             names.add(helper)
-    assert total == 660867  # update when the table grows or a ptxas gap narrows it
+    assert total == 761703  # update when the table grows or a ptxas gap narrows it
 
 
 def test_ptx_no_instruction_registered_twice():
@@ -3403,9 +4017,10 @@ def test_ptx_no_instruction_registered_twice():
 def test_ptx_dispatch_unambiguous():
     """No two entries may accept the same call.
 
-    Models what the engine resolves by, and only that: the written tokens (slot
-    names and order are invisible to `_fill`), the operand count, and each
-    position's acceptance class. Declared spaces that `_coerce_address` treats
+    Models what the engine resolves by, and only that: the written token
+    multiset (slot names are invisible to `_fill`, but repeated tokens remain
+    repeated), the operand count, and each position's acceptance class.
+    Declared spaces that `_coerce_address` treats
     alike collapse into one class, which is what makes this stricter than the
     rendering check above — two entries can emit different assembly and still
     leave a call with nothing to choose between them.
@@ -3426,6 +4041,8 @@ def test_ptx_dispatch_unambiguous():
             if space == "tmem":
                 return ("addr", "tmem")
             return ("addr", "shared*" if space.startswith("shared") else "generic")
+        if slot.kind == "imm":
+            return ("imm", slot.literal, slot.choices)
         if slot.kind != "reg":
             return (slot.kind,)
         if pred_is_distinct and operand_type(slot, mod_map) == "pred":
@@ -3444,7 +4061,7 @@ def test_ptx_dispatch_unambiguous():
             mod_map = mods(entry, tokens)
             layout = operand_layout(entry, mod_map)
             shape = tuple(accepts(s, mod_map) for s, _, n in layout for _ in range(n))
-            key = (entry.family, frozenset(t for t in tokens if t), shape)
+            key = (entry.family, tuple(sorted(t for t in tokens if t)), shape)
             first = owners.setdefault(key, entry.name)
             assert first == entry.name, (
                 f"{first} and {entry.name} both accept "
@@ -3478,6 +4095,8 @@ def test_ptx_dispatch_model_detects_a_collapsed_class():
             if space == "tmem":
                 return ("addr", "tmem")
             return ("addr", "shared*" if space.startswith("shared") else "generic")
+        if slot.kind == "imm":
+            return ("imm", slot.literal, slot.choices)
         if slot.kind != "reg":
             return (slot.kind,)
         return (slot.rw, tuple(sorted(operand_dtypes(slot, mod_map))))
@@ -3488,7 +4107,7 @@ def test_ptx_dispatch_model_detects_a_collapsed_class():
             mod_map = mods(entry, tokens)
             layout = operand_layout(entry, mod_map)
             shape = tuple(accepts(s, mod_map) for s, _, n in layout for _ in range(n))
-            key = (entry.family, frozenset(t for t in tokens if t), shape)
+            key = (entry.family, tuple(sorted(t for t in tokens if t)), shape)
             first = owners.setdefault(key, entry.name)
             if first != entry.name:
                 collisions.add(tuple(sorted((first, entry.name))))
@@ -3524,7 +4143,7 @@ def test_ptxas_gate_rejects_invalid():
 
 
 def test_ptx_vec256_wide_carriers_not_registered():
-    """PTX documents wider carriers, but CUDA 13.2 ptxas cannot compile this axis."""
+    """PTX documents wider carriers; CUDA 13.4 ptxas does not compile the axis uniformly (C7907)."""
     from tvm.backend.cuda.ptx.table import TABLE, dtype_combos, tokens_for
 
     expected = (
@@ -3538,6 +4157,102 @@ def test_ptx_vec256_wide_carriers_not_registered():
         assert dtype_combos(entry, tokens) == expected
 
 
+_PTX_93_SM103A_FULL_ENTRIES = frozenset(
+    {
+        "clmad",
+        "multimem_st_async",
+        "multimem_red_async",
+        "tensormap_replace_swizzle_mode_sm103a",
+        "multimem_cp_async_bulk",
+        "multimem_cp_reduce_async_bulk",
+        "mbarrier_check_layout",
+        "tcgen05_ld_red",
+        "tcgen05_ld_red_split",
+        "fabric_try_get",
+        "fabric_try_put",
+        "fabric_try_put_cp_mask",
+        "fabric_try_put_counted",
+        "fabric_try_red",
+        "fabric_try_red_counted",
+        "fabric_try_pullred",
+        "fabric_submit",
+        "fabric_wait",
+        "fence_proxy_fabric",
+    }
+)
+_PTX_93_SM103A_BULK_ENTRIES = frozenset(
+    {
+        "cp_async_bulk_g2s_cta",
+        "cp_async_bulk_g2s_cluster",
+        "cp_async_bulk_s2c",
+        "cp_async_bulk_s2g",
+        "cp_reduce_async_bulk_s2c",
+        "cp_reduce_async_bulk_s2g",
+    }
+)
+_PTX_93_SM103A_PHASE_ENTRIES = frozenset(
+    {
+        "mbarrier_test_wait_parity",
+        "mbarrier_try_wait_parity",
+        "mbarrier_try_wait_parity_no_hint",
+        "mbarrier_test_wait",
+        "mbarrier_try_wait",
+        "mbarrier_try_wait_hint",
+    }
+)
+
+
+def _ptx_93_sm103a_manifest():
+    """Yield every rendering introduced or extended by PTX 9.3 for SM103a."""
+    from tvm.backend.cuda.ptx.table import _PTX_94_ENTRIES, TABLE, mods, renderings
+
+    ptx94 = {entry.name for entry in _PTX_94_ENTRIES}
+    for name, entry in TABLE.items():
+        if name in ptx94:
+            # The 9.4 delta (sm_107f floors, including the cp.async.bulk
+            # `*_report` entries) is certified at its own arch by
+            # test_ptx_all_helpers_certify, not at sm_103a here.
+            continue
+        for rendering in renderings(entry):
+            tokens = rendering[0]
+            mod_map = mods(entry, tokens)
+            if (
+                name in _PTX_93_SM103A_FULL_ENTRIES
+                or "_report" in name
+                or (name == "ld" and mod_map["mmio"] and mod_map["sem"] == "acquire")
+                or (name == "st" and mod_map["mmio"] and mod_map["sem"] == "release")
+                or (name in _PTX_93_SM103A_BULK_ENTRIES and bool(mod_map.get("sem")))
+                or (name == "mbarrier_init" and bool(mod_map["layout"]))
+                or (name == "mbarrier_pending_count" and bool(mod_map["layout"]))
+                or (name in _PTX_93_SM103A_PHASE_ENTRIES and bool(mod_map["phase_type"]))
+            ):
+                yield entry, rendering
+
+
+@pytest.mark.skipif(
+    not os.environ.get("PTX_CERT"),
+    reason="exhaustive PTX 9.3 helpers; run with PTX_CERT=1 after changing the table",
+)
+@requires_nvcc
+def test_ptx_93_sm103a_helpers_certify():
+    """Every PTX 9.3 addition assembles as a production-shaped SM103a caller."""
+    from tvm.backend.cuda.ptx.render import render_variant
+
+    by_arch = {}
+    covered = 0
+    for entry, rendering in _ptx_93_sm103a_manifest():
+        tokens, dtypes, predicated, imms, sinks = rendering
+        _, helper, source = render_variant(entry, tokens, predicated, dtypes, imms, sinks)
+        _append_certification(by_arch, "sm_103a", helper, source)
+        covered += 1
+    assert covered == 2668
+    _assert_certifications_ok(by_arch)
+
+
+@pytest.mark.skipif(
+    not env.has_nvcc_version(13, 4),
+    reason="whole-table certification includes PTX 9.4 forms; need nvcc >= 13.4",
+)
 @requires_nvcc
 def test_ptx_sampled_helpers_assemble():
     """Fast tier: production-shaped calls to a seeded sample assemble."""
@@ -3570,6 +4285,10 @@ _CERT_SHARDS = 32
 @pytest.mark.skipif(
     not os.environ.get("PTX_CERT"),
     reason="full-table ptxas certification; run with PTX_CERT=1 after changing the table",
+)
+@pytest.mark.skipif(
+    not env.has_nvcc_version(13, 4),
+    reason="whole-table certification includes PTX 9.4 forms; need nvcc >= 13.4",
 )
 @requires_nvcc
 @pytest.mark.parametrize("shard", range(_CERT_SHARDS))

--- a/tests/python/tirx/codegen/test_tcgen05_descriptor_encoders.py
+++ b/tests/python/tirx/codegen/test_tcgen05_descriptor_encoders.py
@@ -105,6 +105,8 @@ def test_smem_descriptor_matches_runtime_encoder(ldo, sdo, swizzle):
         (128, 128, 32, "float8_e4m3fn", "float8_e4m3fn", True, True, 1),
         (256, 256, 32, "float8_e4m3fn", "float8_e5m2", False, True, 2),
         (128, 64, 64, "float4_e2m1fn", "float4_e2m1fn", False, False, 1),
+        (256, 128, 96, "float4_e2m1fn", "float4_e2m1fn", False, False, 2),
+        (128, 64, 96, "float4_e2m1fn", "float4_e2m1fn", False, False, 1),
     ],
 )
 def test_instr_descriptor_block_scaled_matches_runtime_encoder(
@@ -154,6 +156,35 @@ def test_instr_descriptor_block_scaled_matches_runtime_encoder(
         f"for M={m} N={n} a={a_dtype} b={b_dtype} trans=({trans_a},{trans_b}) "
         f"cta_group={cta_group}"
     )
+
+
+@pytest.mark.parametrize("cta_group,m", [(2, 256), (1, 128)])
+def test_instr_descriptor_block_scaled_k96_validation_and_bit(cta_group, m):
+    """Dense K=96 (PTX ISA 9.4, 9.7.18.2.1.1: sm_103a / sm_107a) sets Table 53's bit 31."""
+    common = dict(
+        M=m,
+        N=128,
+        K=96,
+        d_dtype="float32",
+        a_dtype="float4_e2m1fn",
+        b_dtype="float4_e2m1fn",
+        sf_dtype="float8_e8m0fnu",
+        trans_a=False,
+        trans_b=False,
+        cta_group=cta_group,
+    )
+    assert encode_instr_descriptor_block_scaled_uint32(**common) & (1 << 31)
+
+    for changed in (
+        # K=96 pairs cta_group::2 with M=256 and cta_group::1 with M=128 only.
+        {"M": 128 if m == 256 else 256},
+        {"cta_group": 1 if cta_group == 2 else 2},
+        {"K": 95},
+        {"is_sparse": True},
+        {"a_dtype": "float8_e4m3fn", "b_dtype": "float8_e4m3fn"},
+    ):
+        with pytest.raises(ValueError, match="Invalid matrix shape"):
+            encode_instr_descriptor_block_scaled_uint32(**(common | changed))
 
 
 if __name__ == "__main__":

--- a/tests/python/tirx/conftest.py
+++ b/tests/python/tirx/conftest.py
@@ -1,0 +1,112 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Shared CUDA device and exact-architecture handling for TIRx tests."""
+
+import os
+import re
+
+import pytest
+
+from tvm.testing import env
+
+_CUDA_ARCH_PATTERN = re.compile(r"sm_[1-9][0-9]*(?:a|f)?\Z")
+_XDIST_CUDA_DEVICE = None
+
+
+def _visible_cuda_archs():
+    try:
+        import torch
+    except ImportError:
+        return ()
+
+    if not torch.cuda.is_available():
+        return ()
+    return tuple(env.cuda_arch(device_id) for device_id in range(torch.cuda.device_count()))
+
+
+def _require_homogeneous_cuda_archs():
+    arches = _visible_cuda_archs()
+    if not arches:
+        return None
+    if any(arch is None for arch in arches):
+        raise pytest.UsageError(f"could not determine every visible CUDA architecture: {arches}")
+    if len(set(arches)) != 1:
+        profile = ", ".join(f"cuda:{device_id}={arch}" for device_id, arch in enumerate(arches))
+        raise pytest.UsageError(
+            "mixed-architecture CUDA pools are unsupported by the TIRx test suite: " + profile
+        )
+    return arches[0]
+
+
+def _set_cuda_device_for_xdist_worker():
+    global _XDIST_CUDA_DEVICE
+
+    try:
+        import torch
+    except ImportError:
+        return None
+
+    if not torch.cuda.is_available():
+        return None
+    if _XDIST_CUDA_DEVICE is None:
+        worker = os.environ.get("PYTEST_XDIST_WORKER", "gw0")
+        worker_index = int(worker[2:]) if worker.startswith("gw") and worker[2:].isdigit() else 0
+        _XDIST_CUDA_DEVICE = worker_index % torch.cuda.device_count()
+    torch.cuda.set_device(_XDIST_CUDA_DEVICE)
+    return _XDIST_CUDA_DEVICE
+
+
+def pytest_configure(config):
+    del config
+    _require_homogeneous_cuda_archs()
+    _set_cuda_device_for_xdist_worker()
+
+
+def pytest_runtest_setup(item):
+    current_device = _set_cuda_device_for_xdist_worker()
+    marker = item.get_closest_marker("cuda_arch")
+    if marker is None:
+        return
+
+    unknown_kwargs = set(marker.kwargs) - {"device"}
+    if unknown_kwargs:
+        raise pytest.UsageError(
+            f"cuda_arch marker has unsupported keyword(s): {sorted(unknown_kwargs)}"
+        )
+    arches = tuple(marker.args)
+    if not arches or any(
+        not isinstance(arch, str) or _CUDA_ARCH_PATTERN.fullmatch(arch) is None for arch in arches
+    ):
+        raise pytest.UsageError(
+            "cuda_arch marker requires one or more canonical architectures such as sm_100a"
+        )
+
+    device_source = marker.kwargs.get("device", "cuda0")
+    if device_source == "cuda0":
+        device_id = 0
+    elif device_source == "current":
+        device_id = current_device if current_device is not None else 0
+    else:
+        raise pytest.UsageError("cuda_arch marker device must be 'cuda0' or 'current'")
+
+    actual = env.cuda_arch(device_id)
+    if actual not in arches:
+        required = ", ".join(arches)
+        pytest.skip(
+            f"requires CUDA architecture {required} on {device_source}; "
+            f"actual architecture is {actual or 'unavailable'}"
+        )

--- a/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_tma.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/copy_async/test_tma.py
@@ -1497,7 +1497,7 @@ def test_explicit_gather_uses_extracted_swizzled_slice_pointer():
     _, operands = _ptx_call_parts(_count_tma(impl).calls[0])
     shared_ptr = _unwrap_shared_addr(operands["dst_mem"][0])
     assert shared_ptr.op.name == "tirx.address_of"
-    assert int(shared_ptr.args[0].buffer.elem_offset) == 0
+    assert int(shared_ptr.args[0].source.elem_offset) == 0
     assert int(shared_ptr.args[0].indices[0]) == 256
 
 
@@ -2038,7 +2038,7 @@ def _build_selector_gather_gpu_kernel(dtype="float16"):
 def test_explicit_gather_selector_gpu_roundtrip():
     dtype = "float16"
     kernel = _build_selector_gather_gpu_kernel(dtype)
-    executable = _compile_module(kernel)
+    executable = _compile_module(kernel, arch=env.cuda_arch())
     dev = tvm.cuda(0)
     rng = np.random.default_rng(0)
     a_np = rng.standard_normal((256, 64)).astype(dtype)

--- a/tests/python/tirx/operator/tile_primitive/cuda/reduction/test_reduction.py
+++ b/tests/python/tirx/operator/tile_primitive/cuda/reduction/test_reduction.py
@@ -713,7 +713,7 @@ def test_reduction_local_optimized_3input_maxmin(reduction_len, op_type, accum):
 
 
 @pytest.mark.gpu
-@pytest.mark.skipif(not env.has_cuda(), reason="need cuda")
+@pytest.mark.skipif(not env.has_cuda_compute(10), reason="need cuda compute >= 10.0")
 @pytest.mark.parametrize("reduction_len", [8, 16, 64, 128, 256, 9, 17, 63, 65, 100])
 @pytest.mark.parametrize("accum", [False, True])
 def test_reduction_local_optimized_packed_add_sum(reduction_len, accum):
@@ -747,8 +747,8 @@ def test_reduction_local_optimized_packed_add_sum(reduction_len, accum):
         B[0] = B_local[0]
         # fmt: on
 
-        # Use sm_100a target for packed add sum dispatch
-    target = tvm.target.Target({"kind": "cuda", "arch": "sm_100a"})
+        # Compile for the device that will execute the packed SM100+ operation.
+    target = tvm.target.Target("cuda")
     with target:
         mod = tvm.IRModule({"main": test_func})
         mod = tvm.compile(mod, target=target, tir_pipeline="tirx")

--- a/tests/python/tirx/test_cuda_arch_marker.py
+++ b/tests/python/tirx/test_cuda_arch_marker.py
@@ -1,0 +1,99 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Unit tests for TIRx's exact CUDA architecture marker."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+def _tirx_conftest(pytestconfig):
+    expected = Path(__file__).with_name("conftest.py").resolve()
+    for plugin in pytestconfig.pluginmanager.get_plugins():
+        plugin_path = getattr(plugin, "__file__", None)
+        if plugin_path is not None and Path(plugin_path).resolve() == expected:
+            return plugin
+    raise AssertionError(f"TIRx conftest plugin {expected} is not loaded")
+
+
+def _item(marker):
+    return SimpleNamespace(get_closest_marker=lambda name: marker if name == "cuda_arch" else None)
+
+
+@pytest.mark.parametrize("arches", [(), ("sm_100a",), ("sm_100a", "sm_100a")])
+def test_cuda_arch_pool_accepts_empty_or_homogeneous(arches, pytestconfig, monkeypatch):
+    plugin = _tirx_conftest(pytestconfig)
+    monkeypatch.setattr(plugin, "_visible_cuda_archs", lambda: arches)
+
+    expected = None if not arches else "sm_100a"
+    assert plugin._require_homogeneous_cuda_archs() == expected
+
+
+def test_cuda_arch_pool_rejects_mixed_architectures(pytestconfig, monkeypatch):
+    plugin = _tirx_conftest(pytestconfig)
+    monkeypatch.setattr(plugin, "_visible_cuda_archs", lambda: ("sm_100a", "sm_107a"))
+
+    with pytest.raises(
+        pytest.UsageError, match=r"mixed-architecture.*cuda:0=sm_100a.*cuda:1=sm_107a"
+    ):
+        plugin._require_homogeneous_cuda_archs()
+
+
+def test_cuda_arch_pool_rejects_unknown_architecture(pytestconfig, monkeypatch):
+    plugin = _tirx_conftest(pytestconfig)
+    monkeypatch.setattr(plugin, "_visible_cuda_archs", lambda: ("sm_100a", None))
+
+    with pytest.raises(pytest.UsageError, match="could not determine"):
+        plugin._require_homogeneous_cuda_archs()
+
+
+def test_cuda_arch_marker_accepts_current_device(pytestconfig, monkeypatch):
+    plugin = _tirx_conftest(pytestconfig)
+    marker = pytest.mark.cuda_arch("sm_100a", "sm_103a", device="current").mark
+    monkeypatch.setattr(plugin, "_set_cuda_device_for_xdist_worker", lambda: 7)
+    monkeypatch.setattr(plugin.env, "cuda_arch", lambda device_id: "sm_103a")
+
+    plugin.pytest_runtest_setup(_item(marker))
+
+
+def test_cuda_arch_marker_skips_mismatched_device(pytestconfig, monkeypatch):
+    plugin = _tirx_conftest(pytestconfig)
+    marker = pytest.mark.cuda_arch("sm_100a", device="current").mark
+    monkeypatch.setattr(plugin, "_set_cuda_device_for_xdist_worker", lambda: 7)
+    monkeypatch.setattr(plugin.env, "cuda_arch", lambda device_id: "sm_103a")
+
+    with pytest.raises(pytest.skip.Exception, match="actual architecture is sm_103a"):
+        plugin.pytest_runtest_setup(_item(marker))
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        pytest.mark.cuda_arch().mark,
+        pytest.mark.cuda_arch("SM_100a").mark,
+        pytest.mark.cuda_arch("sm_100x").mark,
+        pytest.mark.cuda_arch("sm_100a", device="worker").mark,
+        pytest.mark.cuda_arch("sm_100a", unsupported=True).mark,
+    ],
+)
+def test_cuda_arch_marker_rejects_invalid_usage(marker, pytestconfig, monkeypatch):
+    plugin = _tirx_conftest(pytestconfig)
+    monkeypatch.setattr(plugin, "_set_cuda_device_for_xdist_worker", lambda: 0)
+
+    with pytest.raises(pytest.UsageError):
+        plugin.pytest_runtest_setup(_item(marker))

--- a/tests/python/tirx/test_tirx_kernels_registry_correctness.py
+++ b/tests/python/tirx/test_tirx_kernels_registry_correctness.py
@@ -25,6 +25,8 @@ from pathlib import Path
 
 import pytest
 
+from tvm.testing import env
+
 _WORKSPACE_TIRX_KERNELS = Path(__file__).resolve().parents[4] / "tirx-kernels"
 if _WORKSPACE_TIRX_KERNELS.exists():
     sys.path.insert(0, str(_WORKSPACE_TIRX_KERNELS))
@@ -67,7 +69,6 @@ _BROKEN_REFERENCE_REASONS = {
         "initialize or reset its shared threshold bin"
     ),
 }
-_XDIST_CUDA_DEVICE = None
 
 
 def _manifest_kernel_config_cases():
@@ -91,31 +92,25 @@ def _manifest_kernel_config_cases():
                 f"but its config requires {required_devices}"
             )
         marks = []
+        runtime_cuda_archs = getattr(mod, "KERNEL_META", {}).get("runtime_cuda_archs", ())
+        if runtime_cuda_archs:
+            marks.append(pytest.mark.cuda_arch(*runtime_cuda_archs, device="current"))
+        unmet_references = kernel_registry.unmet_reference_requirements(
+            getattr(mod, "KERNEL_META", {}).get("reference_requirements")
+        )
+        if unmet_references:
+            marks.append(
+                pytest.mark.skip(
+                    reason="unsatisfied reference requirements: "
+                    + "; ".join(unmet_references)
+                )
+            )
         if kernel_name in _DISTRIBUTED_KERNELS:
             marks.append(pytest.mark.xdist_group(name="distributed_device_zero"))
         if kernel_name in _BROKEN_REFERENCE_REASONS:
             marks.append(pytest.mark.skip(reason=_BROKEN_REFERENCE_REASONS[kernel_name]))
         cases.append(pytest.param(kernel_name, config, id=f"{kernel_name}::{label}", marks=marks))
     return cases
-
-
-def _set_cuda_device_for_xdist_worker():
-    global _XDIST_CUDA_DEVICE
-
-    try:
-        import torch
-    except ImportError:
-        return False
-
-    if not torch.cuda.is_available():
-        return False
-
-    if _XDIST_CUDA_DEVICE is None:
-        worker = os.environ.get("PYTEST_XDIST_WORKER", "gw0")
-        worker_index = int(worker[2:]) if worker.startswith("gw") and worker[2:].isdigit() else 0
-        _XDIST_CUDA_DEVICE = worker_index % torch.cuda.device_count()
-    torch.cuda.set_device(_XDIST_CUDA_DEVICE)
-    return True
 
 
 def _visible_cuda_device_count():
@@ -131,6 +126,31 @@ def _visible_cuda_device_count():
 
 def _required_cuda_device_count(config):
     return int(config.get("num_processes", config.get("world_size", 1)))
+
+
+@contextmanager
+def _current_cuda_prepare_arch():
+    try:
+        import torch
+    except ImportError:
+        yield
+        return
+
+    arch = env.cuda_arch(torch.cuda.current_device()) if torch.cuda.is_available() else None
+    if arch is None:
+        yield
+        return
+
+    variable = kernel_runner.PREPARE_CUDA_ARCH_ENV
+    previous = os.environ.get(variable)
+    os.environ[variable] = arch
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop(variable, None)
+        else:
+            os.environ[variable] = previous
 
 
 @contextmanager
@@ -181,7 +201,6 @@ def _registry_gpu_lock(kernel_name, config):
 
 @pytest.mark.parametrize(("kernel_name", "config"), _manifest_kernel_config_cases())
 def test_manifest_tirx_kernel_correctness(kernel_name, config):
-    _set_cuda_device_for_xdist_worker()
     required_devices = _required_cuda_device_count(config)
     visible_devices = _visible_cuda_device_count()
     if required_devices > visible_devices:
@@ -193,7 +212,5 @@ def test_manifest_tirx_kernel_correctness(kernel_name, config):
             "MegaMoE requires its dedicated multi-process scheduler; this suite's "
             "processes own CUDA contexts that its physical-device assignment rejects"
         )
-    if getattr(_KERNELS[kernel_name], "KERNEL_META", {}).get("category") == "msa":
-        pytest.skip("MSA references require an isolated CuTeDSL 4.5.3 process")
-    with _registry_gpu_lock(kernel_name, config):
+    with _registry_gpu_lock(kernel_name, config), _current_cuda_prepare_arch():
         kernel_runner.run_kernel_test(kernel_name, config, registry=_KERNELS)

--- a/tests/python/tirx/test_tirx_kernels_registry_correctness.py
+++ b/tests/python/tirx/test_tirx_kernels_registry_correctness.py
@@ -101,8 +101,7 @@ def _manifest_kernel_config_cases():
         if unmet_references:
             marks.append(
                 pytest.mark.skip(
-                    reason="unsatisfied reference requirements: "
-                    + "; ".join(unmet_references)
+                    reason="unsatisfied reference requirements: " + "; ".join(unmet_references)
                 )
             )
         if kernel_name in _DISTRIBUTED_KERNELS:


### PR DESCRIPTION
## Summary

Align the TIRx CUDA backend with CUDA 13.4 / PTX ISA 9.4 and add support for SM103a and SM107a (Rubin).

This squashes the following changes:
- Add PTX 9.3 SM103a support and architecture-aware TIRx tests
- Add PTX 9.4 SM107a support
- Support Rubin FP8 BMM requirements
- Route kernel tests by exact runtime architecture
- Align the PTX dialect with CUDA 13.4 / PTX ISA 9.4 only

## `T.ptx` table (`python/tvm/backend/cuda/ptx`)

- PTX ISA 9.3 additions certified at sm_103a: `fabric.*`, `clmad`, `multimem.st.async` / `multimem.red.async` / `multimem.cp[.reduce].async.bulk`, strong (`.relaxed.scope.b128`) bulk copies, mbarrier `.layout` / `.phase_type` / report forms / `check_layout`, `ld.mmio.acquire` / `st.mmio.release`, `tcgen05.ld.red`, `tensormap.replace` swizzle_mode 4, `fence.proxy.*::fabric`.
- PTX ISA 9.4 / SM107 delta (`_PTX_94_ENTRIES`, sm_107f / sm_107a): mixed precision packed add/sub/mul/fma, packed set, `ld.proxy::readonly`, `prefetch.L1::32B.valid_addr`, cvt `.pzo` / `.rz` narrow / `.scaled::n1::ue8m0` / `.ue5m3x2`, `cp.async.bulk[.tensor]` multicast `::16b` / `::32b`, report mechanisms, tensor base-address / attribute overrides, `im2col_no_offs::w`, `applypriority.async.bulk[.tensor]`, eviction-priority bulk prefetch, `spcompress` / `spdecompress`, `tcgen05.ld[.red].spcompress`, `tcgen05.alloc` / `dealloc .exclusive`, `tcgen05.commit ::16b` / `::32b` and `.sync_restrict::shared::read::mma::a`, `tcgen05.mma .kind::ti16` / `.decompress::lut::b` / `.collector::b::*`, `atom` / `red` / `cp.reduce.async.bulk .add.noftz.f32`, `ldmatrix .m8n16 .s8.s4`.
- Every section and table number cites the CUDA 13.4 developer-preview PTX ISA 9.4 manual; every MEASURED clause records CUDA 13.4 ptxas behaviour (re-measured: gaps that closed are noted, none widened). `tcgen05.ld.red` uses the documented `.redOp{.abs}{.NaN}.type` slot order.

## Runtime and codegen

- Instruction descriptor: dense K=96 for `.kind::mxf4` / `.kind::mxf4nvf4` (cta_group::1 M=128, cta_group::2 M=256; sm_103a / sm_107a) via Table 53 bit 31.
- `cuda_module.cc`: CUDA 13.4 oversized shared-memory mode (`CU_SHARED_MEMORY_MODE_ALLOW_OVERSIZED_SHARED_MEMORY`) for cluster kernels above the portable opt-in limit.

## Tests

- Tests route by exact runtime architecture (`cuda_arch` marker, `tvm.testing.env.cuda_arch`), so the sm_100a / sm_103a / sm_107a suites run only on their own devices.

## Docs

- `.agents/skills/tirx-ptx-dialect/SKILL.md` describes the CUDA 13.4 / PTX ISA 9.4 toolchain model and the ISA-migration procedure.
- `tirx.pyi` and `docs/tirx/api/ptx.rst` regenerated / updated.

## Verification

Verified on CUDA 13.4 (V13.4.59), 4x sm_107a:
- `PTX_CERT=1` full-table certification (33 shards, including the sm_103a manifest)
- sampled tier and codegen unit suites
- full `tests/python/tirx` suite: 2791 passed, 251 skipped
