### PR TITLE
[REFACTOR][IR] Add structural hooks for Expr and Stmt

### DIFF
--- a/include/tvm/ir/base_expr.h
+++ b/include/tvm/ir/base_expr.h
@@ -65,6 +65,7 @@ class TypeNode : public ffi::Object {
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
+  static constexpr bool _type_s_eq_hash_subclass_kind_fixed = true;
 
   static constexpr const uint32_t _type_child_slots = 14;
   TVM_FFI_DECLARE_OBJECT_INFO("ir.Type", TypeNode, ffi::Object);
@@ -484,8 +485,9 @@ struct TypeTraits<TypedExpr<ExpectedType>>
         !details::IsObjectInstance<ExprNode>(src->type_index)) {
       return false;
     }
-    const auto* expr = static_cast<const ExprNode*>(
-        details::ObjectUnsafe::ObjectPtrFromUnowned<Object>(src->v_obj).get());
+    // Non-owning: this only reads `ty`, and the owning form's incref/decref pair costs two
+    // atomics per check on a path every typed field assignment takes.
+    const auto* expr = details::ObjectUnsafe::RawObjectPtrFromUnowned<ExprNode>(src->v_obj);
     return details::AnyUnsafe::CheckAnyStrict<ExpectedType>(expr->ty);
   }
 

--- a/include/tvm/ir/expr.h
+++ b/include/tvm/ir/expr.h
@@ -365,6 +365,9 @@ class VarNode : public ExprNode {
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindFreeVar;
   static constexpr const uint32_t _type_child_slots = 1;
+  // VarNode reserves its sole child slot for the final relax::DataflowVarNode subtype, so its
+  // descendant type-index range cannot overflow.
+  static constexpr bool _type_child_slots_can_overflow = false;
   TVM_FFI_DECLARE_OBJECT_INFO("ir.Var", VarNode, ExprNode);
 };
 

--- a/include/tvm/ir/prim/expr.h
+++ b/include/tvm/ir/prim/expr.h
@@ -545,8 +545,7 @@ class LetNode : public ExprNode {
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<LetNode>()
-        // TODO(tqchen): use SEqHashDefNonRecursive after the next pypi tvm-ffi release
-        .def_ro("var", &LetNode::var, refl::AttachFieldFlag::SEqHashDefRecursive())
+        .def_ro("var", &LetNode::var, refl::AttachFieldFlag::SEqHashDefNonRecursive())
         .def_ro("value", &LetNode::value)
         .def_ro("body", &LetNode::body);
   }

--- a/include/tvm/tirx/exec_scope.h
+++ b/include/tvm/tirx/exec_scope.h
@@ -124,7 +124,8 @@ class ScopeIdDefNode : public ffi::Object {
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<ScopeIdDefNode>()
-        .def_ro("def_ids", &ScopeIdDefNode::def_ids, refl::AttachFieldFlag::SEqHashDefRecursive())
+        .def_ro("def_ids", &ScopeIdDefNode::def_ids,
+                refl::AttachFieldFlag::SEqHashDefNonRecursive())
         .def_ro("extents", &ScopeIdDefNode::extents)
         .def_ro("scope", &ScopeIdDefNode::scope)
         .def_ro("preferred_extents", &ScopeIdDefNode::preferred_extents);

--- a/include/tvm/tirx/stmt.h
+++ b/include/tvm/tirx/stmt.h
@@ -58,6 +58,7 @@ class StmtNode : public ffi::Object {
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
+  static constexpr bool _type_s_eq_hash_subclass_kind_fixed = true;
 
   static constexpr const uint32_t _type_child_slots = 15;
   TVM_FFI_DECLARE_OBJECT_INFO("tirx.Stmt", StmtNode, ffi::Object);
@@ -86,8 +87,7 @@ class BindNode : public StmtNode {
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<BindNode>()
-        // TODO(tqchen): use SEqHashDefNonRecursive after the next pypi tvm-ffi release
-        .def_ro("var", &BindNode::var, refl::AttachFieldFlag::SEqHashDefRecursive())
+        .def_ro("var", &BindNode::var, refl::AttachFieldFlag::SEqHashDefNonRecursive())
         .def_ro("value", &BindNode::value);
   }
   TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tirx.Bind", BindNode, StmtNode);
@@ -244,7 +244,7 @@ class DeclBufferNode : public StmtNode {
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<DeclBufferNode>()
-        .def_ro("buffer", &DeclBufferNode::buffer, refl::AttachFieldFlag::SEqHashDefRecursive())
+        .def_ro("buffer", &DeclBufferNode::buffer, refl::AttachFieldFlag::SEqHashDefNonRecursive())
         .def_ro("data", &DeclBufferNode::data);
   }
   TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tirx.DeclBuffer", DeclBufferNode, StmtNode);
@@ -274,8 +274,7 @@ class AllocBufferNode : public StmtNode {
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<AllocBufferNode>()
-        // TODO(tqchen): use SEqHashDefNonRecursive after the next pypi tvm-ffi release
-        .def_ro("buffer", &AllocBufferNode::buffer, refl::AttachFieldFlag::SEqHashDefRecursive())
+        .def_ro("buffer", &AllocBufferNode::buffer, refl::AttachFieldFlag::SEqHashDefNonRecursive())
         .def_ro("annotations", &AllocBufferNode::annotations);
   }
   TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tirx.AllocBuffer", AllocBufferNode, StmtNode);
@@ -621,7 +620,7 @@ class ForNode : public StmtNode {
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<ForNode>()
-        .def_ro("loop_var", &ForNode::loop_var, refl::AttachFieldFlag::SEqHashDefRecursive())
+        .def_ro("loop_var", &ForNode::loop_var, refl::AttachFieldFlag::SEqHashDefNonRecursive())
         .def_ro("min", &ForNode::min)
         .def_ro("extent", &ForNode::extent)
         .def_ro("kind", &ForNode::kind)
@@ -788,7 +787,7 @@ class MatchBufferRegionNode : public ffi::Object {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<MatchBufferRegionNode>()
         .def_ro("buffer", &MatchBufferRegionNode::buffer,
-                refl::AttachFieldFlag::SEqHashDefRecursive())
+                refl::AttachFieldFlag::SEqHashDefNonRecursive())
         .def_ro("source", &MatchBufferRegionNode::source);
   }
 
@@ -860,12 +859,12 @@ class SBlockNode : public StmtNode {
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<SBlockNode>()
-        .def_ro("iter_vars", &SBlockNode::iter_vars, refl::AttachFieldFlag::SEqHashDefRecursive())
+        .def_ro("iter_vars", &SBlockNode::iter_vars)
         .def_ro("reads", &SBlockNode::reads)
         .def_ro("writes", &SBlockNode::writes)
         .def_ro("name_hint", &SBlockNode::name_hint, refl::AttachFieldFlag::SEqHashIgnore())
         .def_ro("alloc_buffers", &SBlockNode::alloc_buffers,
-                refl::AttachFieldFlag::SEqHashDefRecursive())
+                refl::AttachFieldFlag::SEqHashDefNonRecursive())
         .def_ro("match_buffers", &SBlockNode::match_buffers)
         .def_ro("annotations", &SBlockNode::annotations)
         .def_ro("init", &SBlockNode::init)

--- a/include/tvm/tirx/var.h
+++ b/include/tvm/tirx/var.h
@@ -174,7 +174,7 @@ class IterVarNode : public PrimExprConvertibleNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<IterVarNode>()
         .def_ro("dom", &IterVarNode::dom)
-        .def_ro("var", &IterVarNode::var, refl::AttachFieldFlag::SEqHashDefRecursive())
+        .def_ro("var", &IterVarNode::var, refl::AttachFieldFlag::SEqHashDefNonRecursive())
         .def_ro("iter_type", &IterVarNode::iter_type)
         .def_ro("thread_tag", &IterVarNode::thread_tag)
         .def_ro("span", &IterVarNode::span, refl::DefaultValue(Span()),

--- a/src/ir/expr.cc
+++ b/src/ir/expr.cc
@@ -22,35 +22,493 @@
  * \brief The expression AST nodes for the common IR infra.
  */
 #include <tvm/arith/analyzer.h>
+#include <tvm/ffi/extra/structural_mutate.h>
+#include <tvm/ffi/extra/structural_visit.h>
 #include <tvm/ffi/function.h>
 #include <tvm/ffi/reflection/registry.h>
 #include <tvm/ir/expr.h>
 #include <tvm/ir/function.h>
+#include <tvm/ir/op.h>
 #include <tvm/ir/prim/expr.h>
 #include <tvm/ir/type.h>
 #include <tvm/te/tensor.h>
 
 #include <cmath>
+#include <utility>
 
 #include "../support/limits.h"
 
 namespace tvm {
 
-TVM_FFI_STATIC_INIT_BLOCK() {
-  ExprNode::RegisterReflection();
-  OpaqueExprNode::RegisterReflection();
-  BaseFuncNode::RegisterReflection();
-  VarNode::RegisterReflection();
-  GlobalVarNode::RegisterReflection();
-  CallNode::RegisterReflection();
-  TupleNode::RegisterReflection();
-  TupleGetItemNode::RegisterReflection();
-  TensorLoadNode::RegisterReflection();
-  IntImmNode::RegisterReflection();
-  FloatImmNode::RegisterReflection();
-  RangeNode::RegisterReflection();
+namespace {
+
+// Structural traversal hooks
+
+TVMFFIAny OpaqueExprVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
+  const OpaqueExprNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const OpaqueExprNode>(value);
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->ty));
+  // Any None is Expected<Optional<VisitInterrupt>>'s successful empty value.
+  TVM_FFI_S_VISIT_RETURN_NONE();
 }
 
+TVMFFIAny OpaqueExprMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  const OpaqueExprNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const OpaqueExprNode>(value);
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Type, mapped_ty, mutator->MutateExpected(self->ty));
+  if (mapped_ty.same_as(self->ty)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  ffi::ObjectPtr<OpaqueExprNode> copy = ffi::make_object<OpaqueExprNode>(*self);
+  copy->ty = std::move(mapped_ty);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
+}
+
+TVMFFIAny OpaqueExprMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
+                                       ffi::AnyView value) noexcept {
+  OpaqueExprNode* self = const_cast<OpaqueExprNode*>(
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const OpaqueExprNode>(value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Type, mapped_ty,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->ty));
+  if (mapped_ty.same_as(self->ty)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  self->ty = std::move(mapped_ty);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny TensorLoadVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
+  const TensorLoadNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const TensorLoadNode>(value);
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->ty));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->source));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->indices));
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+TVMFFIAny TensorLoadMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  const TensorLoadNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const TensorLoadNode>(value);
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Type, mapped_ty, mutator->MutateExpected(self->ty));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Expr, mapped_source, mutator->MutateExpected(self->source));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<PrimExpr>, mapped_indices,
+                                    mutator->MutateExpected(self->indices));
+  if (mapped_ty.same_as(self->ty) && mapped_source.same_as(self->source) &&
+      mapped_indices.same_as(self->indices)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  ffi::ObjectPtr<TensorLoadNode> copy = ffi::make_object<TensorLoadNode>(*self);
+  copy->ty = std::move(mapped_ty);
+  copy->source = std::move(mapped_source);
+  copy->indices = std::move(mapped_indices);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
+}
+
+TVMFFIAny TensorLoadMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
+                                       ffi::AnyView value) noexcept {
+  TensorLoadNode* self = const_cast<TensorLoadNode*>(
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const TensorLoadNode>(value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Type, mapped_ty,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->ty));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Expr, mapped_source,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->source));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<PrimExpr>, mapped_indices,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->indices));
+  if (mapped_ty.same_as(self->ty) && mapped_source.same_as(self->source) &&
+      mapped_indices.same_as(self->indices)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  self->ty = std::move(mapped_ty);
+  self->source = std::move(mapped_source);
+  self->indices = std::move(mapped_indices);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny TupleVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
+  const TupleNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const TupleNode>(value);
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->ty));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->fields));
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+TVMFFIAny TupleMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  const TupleNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const TupleNode>(value);
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Type, mapped_ty, mutator->MutateExpected(self->ty));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<Expr>, mapped_fields,
+                                    mutator->MutateExpected(self->fields));
+  if (mapped_ty.same_as(self->ty) && mapped_fields.same_as(self->fields)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  ffi::ObjectPtr<TupleNode> copy = ffi::make_object<TupleNode>(*self);
+  copy->ty = std::move(mapped_ty);
+  copy->fields = std::move(mapped_fields);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
+}
+
+TVMFFIAny TupleMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  TupleNode* self = const_cast<TupleNode*>(
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const TupleNode>(value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Type, mapped_ty,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->ty));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<Expr>, mapped_fields,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->fields));
+  if (mapped_ty.same_as(self->ty) && mapped_fields.same_as(self->fields)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  self->ty = std::move(mapped_ty);
+  self->fields = std::move(mapped_fields);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny TupleGetItemVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
+  // skips: index
+  const TupleGetItemNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const TupleGetItemNode>(value);
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->ty));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->tuple));
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+TVMFFIAny TupleGetItemMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  // skips: index
+  const TupleGetItemNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const TupleGetItemNode>(value);
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Type, mapped_ty, mutator->MutateExpected(self->ty));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Expr, mapped_tuple, mutator->MutateExpected(self->tuple));
+  if (mapped_ty.same_as(self->ty) && mapped_tuple.same_as(self->tuple)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  ffi::ObjectPtr<TupleGetItemNode> copy = ffi::make_object<TupleGetItemNode>(*self);
+  copy->ty = std::move(mapped_ty);
+  copy->tuple = std::move(mapped_tuple);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
+}
+
+TVMFFIAny TupleGetItemMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
+                                         ffi::AnyView value) noexcept {
+  // skips: index
+  TupleGetItemNode* self = const_cast<TupleGetItemNode*>(
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const TupleGetItemNode>(value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Type, mapped_ty,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->ty));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Expr, mapped_tuple,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->tuple));
+  if (mapped_ty.same_as(self->ty) && mapped_tuple.same_as(self->tuple)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  self->ty = std::move(mapped_ty);
+  self->tuple = std::move(mapped_tuple);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny IntImmVisit(ffi::StructuralVisitorObj*, ffi::AnyView) noexcept {
+  // skips: value
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+TVMFFIAny IntImmMutate(ffi::StructuralMutatorObj*, ffi::AnyView value) noexcept {
+  // skips: value
+  const IntImmNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const IntImmNode>(value);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny IntImmMaybeInplaceMutate(ffi::StructuralMutatorObj*, ffi::AnyView value) noexcept {
+  // skips: value
+  const IntImmNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const IntImmNode>(value);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny FloatImmVisit(ffi::StructuralVisitorObj*, ffi::AnyView) noexcept {
+  // skips: value
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+TVMFFIAny FloatImmMutate(ffi::StructuralMutatorObj*, ffi::AnyView value) noexcept {
+  // skips: value
+  const FloatImmNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const FloatImmNode>(value);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny FloatImmMaybeInplaceMutate(ffi::StructuralMutatorObj*, ffi::AnyView value) noexcept {
+  // skips: value
+  const FloatImmNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const FloatImmNode>(value);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny RangeVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
+  const RangeNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const RangeNode>(value);
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->min));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->extent));
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+TVMFFIAny RangeMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  const RangeNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const RangeNode>(value);
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_min, mutator->MutateExpected(self->min));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_extent, mutator->MutateExpected(self->extent));
+  if (mapped_min.same_as(self->min) && mapped_extent.same_as(self->extent)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  ffi::ObjectPtr<RangeNode> copy = ffi::make_object<RangeNode>(*self);
+  copy->min = std::move(mapped_min);
+  copy->extent = std::move(mapped_extent);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
+}
+
+TVMFFIAny RangeMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  RangeNode* self = const_cast<RangeNode*>(
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const RangeNode>(value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_min,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->min));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_extent,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->extent));
+  if (mapped_min.same_as(self->min) && mapped_extent.same_as(self->extent)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  self->min = std::move(mapped_min);
+  self->extent = std::move(mapped_extent);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny VarVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
+  // skips: name
+  const VarNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const VarNode>(value);
+  // A PrimType carries only a dtype, so it has nothing to visit.  Broad callbacks do not see this
+  // skipped field; dynamically typed Vars still descend through the Type value.
+  if (!self->ty.as<PrimTypeNode>()) {
+    // Only NonRecursive is clamped: Recursive co-introduces type fields such as BufferType shape
+    // variables, so that ambient region must continue through the dynamic type.
+    if (visitor->def_region_kind() == kTVMFFIDefRegionKindNonRecursive) {
+      TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->WithDefRegionKind(
+          kTVMFFIDefRegionKindNone, [&]() { return visitor->VisitExpected(self->ty); }));
+    } else {
+      TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->ty));
+    }
+  }
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+TVMFFIAny VarMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  // skips: name
+  const VarNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const VarNode>(value);
+  ffi::Expected<ffi::Any> remap_result = mutator->VarRemapGetExpected(value);
+  TVM_FFI_S_MUTATE_MAYBE_EARLY_RETURN(remap_result);
+  if (ffi::details::ExpectedUnsafe::GetData(remap_result).type_index() !=
+      ffi::TypeIndex::kTVMFFINone) {
+    return ffi::details::ExpectedUnsafe::MoveToTVMFFIAny(std::move(remap_result));
+  }
+  auto return_mapped_var = [&](ffi::Any mapped_var) -> TVMFFIAny {
+    auto set_result = mutator->VarRemapSetExpected(value, mapped_var);
+    if (TVM_FFI_PREDICT_FALSE(set_result.is_err())) {
+      // Hooks propagate errors untouched; the engine names this node.
+      return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(set_result).error()));
+    }
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(std::move(mapped_var));
+  };
+  // A PrimType carries only a dtype, so it has nothing to substitute.  Broad callbacks do not see
+  // this skipped field; dynamically typed Vars still descend through the Type value.
+  if (self->ty.as<PrimTypeNode>()) {
+    return return_mapped_var(ffi::Any(self));
+  }
+  // Only NonRecursive is clamped: Recursive co-introduces type fields such as BufferType shape
+  // variables, so that ambient region must continue through the dynamic type.
+  auto mutate_ty = [&]() { return mutator->MutateExpected(self->ty); };
+  ffi::Expected<ffi::Any> mapped_ty_result =
+      mutator->def_region_kind() == kTVMFFIDefRegionKindNonRecursive
+          ? mutator->WithDefRegionKind(kTVMFFIDefRegionKindNone, mutate_ty)
+          : mutate_ty();
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Type, mapped_ty, std::move(mapped_ty_result));
+  ffi::Any mapped_var = ffi::Any(self);
+  if (!mapped_ty.same_as(self->ty)) {
+    ffi::ObjectPtr<VarNode> copy = ffi::make_object<VarNode>(*self);
+    copy->ty = std::move(mapped_ty);
+    mapped_var = ffi::Any(std::move(copy));
+  }
+  return return_mapped_var(std::move(mapped_var));
+}
+
+TVMFFIAny VarMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  // skips: name
+  VarNode* self = const_cast<VarNode*>(
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const VarNode>(value));
+  ffi::Expected<ffi::Any> remap_result = mutator->VarRemapGetExpected(value);
+  TVM_FFI_S_MUTATE_MAYBE_EARLY_RETURN(remap_result);
+  if (ffi::details::ExpectedUnsafe::GetData(remap_result).type_index() !=
+      ffi::TypeIndex::kTVMFFINone) {
+    return ffi::details::ExpectedUnsafe::MoveToTVMFFIAny(std::move(remap_result));
+  }
+  auto return_mapped_var = [&](ffi::Any mapped_var) -> TVMFFIAny {
+    auto set_result = mutator->VarRemapSetExpected(value, mapped_var);
+    if (TVM_FFI_PREDICT_FALSE(set_result.is_err())) {
+      // Hooks propagate errors untouched; the engine names this node.
+      return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(set_result).error()));
+    }
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(std::move(mapped_var));
+  };
+  // A PrimType carries only a dtype, so it has nothing to substitute.  Broad callbacks do not see
+  // this skipped field; dynamically typed Vars still descend through the Type value.
+  if (self->ty.as<PrimTypeNode>()) {
+    return return_mapped_var(ffi::Any(self));
+  }
+  // Only NonRecursive is clamped: Recursive co-introduces type fields such as BufferType shape
+  // variables, so that ambient region must continue through the dynamic type.
+  auto mutate_ty = [&]() { return mutator->MaybeInplaceMutateIfUniqueExpected(self->ty); };
+  ffi::Expected<ffi::Any> mapped_ty_result =
+      mutator->def_region_kind() == kTVMFFIDefRegionKindNonRecursive
+          ? mutator->WithDefRegionKind(kTVMFFIDefRegionKindNone, mutate_ty)
+          : mutate_ty();
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Type, mapped_ty, std::move(mapped_ty_result));
+  if (!mapped_ty.same_as(self->ty)) self->ty = std::move(mapped_ty);
+  return return_mapped_var(ffi::Any(self));
+}
+
+TVMFFIAny CallVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
+  // skips: attrs, constant metadata left untouched like the classic Expr functors.
+  const CallNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const CallNode>(value);
+  // A PrimType carries only a dtype, so it has nothing to visit.  Broad callbacks do not see this
+  // skipped field; dynamically typed Call results still descend through the Type value.
+  if (!self->ty.as<PrimTypeNode>()) {
+    TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->ty));
+  }
+  // An Op is an interned registry singleton, so it has nothing to visit.  Broad callbacks do not
+  // see this skipped field; function-valued Call operators still descend through the Expr value.
+  if (!self->op.as<OpNode>()) {
+    TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->op));
+  }
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->args));
+  // An empty ty_args has no element to traverse.  Broad callbacks do not see the empty container;
+  // nonempty type arguments retain normal container descent and callback behavior.
+  if (!self->ty_args.empty()) {
+    TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->ty_args));
+  }
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+TVMFFIAny CallMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  // skips: attrs, constant metadata left untouched like the classic Expr functors.
+  const CallNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const CallNode>(value);
+  // A PrimType carries only a dtype, so it has nothing to substitute.  Broad callbacks do not see
+  // this skipped field; dynamically typed Call results still descend through the Type value.
+  // Deliberate copy: avoids Any boxing on the dominant primitive skip path.
+  Type mapped_ty = self->ty;
+  if (!self->ty.as<PrimTypeNode>()) {
+    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Type, descended_ty, mutator->MutateExpected(self->ty));
+    mapped_ty = std::move(descended_ty);
+  }
+  // An Op is an interned registry singleton, so it has nothing to substitute.  Broad callbacks do
+  // not see this skipped field; function-valued Call operators still descend through the Expr.
+  Expr mapped_op = self->op;
+  if (!self->op.as<OpNode>()) {
+    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Expr, descended_op, mutator->MutateExpected(self->op));
+    mapped_op = std::move(descended_op);
+  }
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<Expr>, mapped_args,
+                                    mutator->MutateExpected(self->args));
+  // An empty ty_args has no element to substitute.  Broad callbacks do not see the empty
+  // container; nonempty type arguments retain normal container descent and callback behavior.
+  ffi::Array<Type> mapped_ty_args = self->ty_args;
+  if (!self->ty_args.empty()) {
+    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<Type>, descended_ty_args,
+                                      mutator->MutateExpected(self->ty_args));
+    mapped_ty_args = std::move(descended_ty_args);
+  }
+  if (mapped_ty.same_as(self->ty) && mapped_op.same_as(self->op) &&
+      mapped_args.same_as(self->args) && mapped_ty_args.same_as(self->ty_args)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  ffi::ObjectPtr<CallNode> copy = ffi::make_object<CallNode>(*self);
+  copy->ty = std::move(mapped_ty);
+  copy->op = std::move(mapped_op);
+  copy->args = std::move(mapped_args);
+  copy->ty_args = std::move(mapped_ty_args);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
+}
+
+TVMFFIAny CallMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  // skips: attrs, constant metadata left untouched like the classic Expr functors.
+  CallNode* self = const_cast<CallNode*>(
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const CallNode>(value));
+  // A PrimType carries only a dtype, so it has nothing to substitute.  Broad callbacks do not see
+  // this skipped field; dynamically typed Call results still descend through the Type value.
+  // Deliberate copy: avoids Any boxing on the dominant primitive skip path.
+  Type mapped_ty = self->ty;
+  if (!self->ty.as<PrimTypeNode>()) {
+    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Type, descended_ty,
+                                      mutator->MaybeInplaceMutateIfUniqueExpected(self->ty));
+    mapped_ty = std::move(descended_ty);
+  }
+  // An Op is an interned registry singleton, so it has nothing to substitute.  Broad callbacks do
+  // not see this skipped field; function-valued Call operators still descend through the Expr.
+  Expr mapped_op = self->op;
+  if (!self->op.as<OpNode>()) {
+    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Expr, descended_op,
+                                      mutator->MaybeInplaceMutateIfUniqueExpected(self->op));
+    mapped_op = std::move(descended_op);
+  }
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<Expr>, mapped_args,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->args));
+  // An empty ty_args has no element to substitute.  Broad callbacks do not see the empty
+  // container; nonempty type arguments retain normal container descent and callback behavior.
+  ffi::Array<Type> mapped_ty_args = self->ty_args;
+  if (!self->ty_args.empty()) {
+    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<Type>, descended_ty_args,
+                                      mutator->MaybeInplaceMutateIfUniqueExpected(self->ty_args));
+    mapped_ty_args = std::move(descended_ty_args);
+  }
+  if (mapped_ty.same_as(self->ty) && mapped_op.same_as(self->op) &&
+      mapped_args.same_as(self->args) && mapped_ty_args.same_as(self->ty_args)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  self->ty = std::move(mapped_ty);
+  self->op = std::move(mapped_op);
+  self->args = std::move(mapped_args);
+  self->ty_args = std::move(mapped_ty_args);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+}  // namespace
+
+TVM_FFI_STATIC_INIT_BLOCK() { ExprNode::RegisterReflection(); }
+
+TVM_FFI_STATIC_INIT_BLOCK() { BaseFuncNode::RegisterReflection(); }
+
+// OpaqueExpr
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace refl = tvm::ffi::reflection;
+  OpaqueExprNode::RegisterReflection();
+  refl::TypeAttrDef<OpaqueExprNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&OpaqueExprVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&OpaqueExprMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&OpaqueExprMaybeInplaceMutate));
+}
+
+// TensorLoad
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace refl = tvm::ffi::reflection;
+  TensorLoadNode::RegisterReflection();
+  refl::TypeAttrDef<TensorLoadNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&TensorLoadVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&TensorLoadMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&TensorLoadMaybeInplaceMutate));
+}
+
+// Tuple
 Tuple::Tuple(ffi::Array<Expr> fields, Span span) {
   ffi::Optional<Type> tuple_ty = [&]() -> ffi::Optional<Type> {
     ffi::Array<Type> field_ty;
@@ -72,6 +530,17 @@ Tuple::Tuple(ffi::Array<Expr> fields, Span span) {
   data_ = std::move(node);
 }
 
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace refl = tvm::ffi::reflection;
+  TupleNode::RegisterReflection();
+  refl::TypeAttrDef<TupleNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&TupleVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&TupleMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&TupleMaybeInplaceMutate));
+}
+
+// TupleGetItem
 TupleGetItem::TupleGetItem(Expr tuple, int index, Span span) {
   TVM_FFI_CHECK_GE(index, 0, IndexError) << "Index out of bounds: Tuple " << tuple
                                          << " cannot be accessed with negative index " << index;
@@ -86,17 +555,6 @@ TupleGetItem::TupleGetItem(Expr tuple, int index, Span span) {
   node->index = index;
   node->span = std::move(span);
   data_ = std::move(node);
-}
-
-TVM_FFI_STATIC_INIT_BLOCK() {
-  namespace refl = tvm::ffi::reflection;
-  refl::GlobalDef()
-      .def("ir.Tuple", [](ffi::Array<Expr> fields, Span span) { return Tuple(fields, span); })
-      .def("ir.TupleGetItem",
-           [](Expr tuple, int index, Span span) { return TupleGetItem(tuple, index, span); })
-      .def("relax.Tuple", [](ffi::Array<Expr> fields, Span span) { return Tuple(fields, span); })
-      .def("relax.TupleGetItem",
-           [](Expr tuple, int index, Span span) { return TupleGetItem(tuple, index, span); });
 }
 
 PrimExpr::PrimExpr(Call call) : PrimExpr(std::move(call).as_or_throw<PrimExpr>()) {}
@@ -123,6 +581,24 @@ PrimExpr TypeTraits<PrimExpr>::ConvertFallbackValue(double value) {
 
 }  // namespace ffi
 
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace refl = tvm::ffi::reflection;
+  TupleGetItemNode::RegisterReflection();
+  refl::GlobalDef()
+      .def("ir.Tuple", [](ffi::Array<Expr> fields, Span span) { return Tuple(fields, span); })
+      .def("ir.TupleGetItem",
+           [](Expr tuple, int index, Span span) { return TupleGetItem(tuple, index, span); })
+      .def("relax.Tuple", [](ffi::Array<Expr> fields, Span span) { return Tuple(fields, span); })
+      .def("relax.TupleGetItem",
+           [](Expr tuple, int index, Span span) { return TupleGetItem(tuple, index, span); });
+  refl::TypeAttrDef<TupleGetItemNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&TupleGetItemVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&TupleGetItemMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&TupleGetItemMaybeInplaceMutate));
+}
+
+// IntImm
 IntImm::IntImm(PrimType value_ty, int64_t value, Span span) {
   DLDataType runtime_dtype = value_ty->dtype;
   DLDataTypeCode code = value_ty.code();
@@ -159,11 +635,18 @@ IntImm::IntImm(PrimType value_ty, int64_t value, Span span) {
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  IntImmNode::RegisterReflection();
   refl::GlobalDef().def("ir.IntImm", [](DLDataType dtype, int64_t value, Span span) {
     return IntImm(PrimType(dtype), value, span);
   });
+  refl::TypeAttrDef<IntImmNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&IntImmVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&IntImmMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&IntImmMaybeInplaceMutate));
 }
 
+// FloatImm
 FloatImm::FloatImm(PrimType value_ty, double value, Span span) {
   DLDataType runtime_dtype = value_ty->dtype;
   DLDataTypeCode code = value_ty.code();
@@ -278,11 +761,18 @@ FloatImm::FloatImm(PrimType value_ty, double value, Span span) {
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  FloatImmNode::RegisterReflection();
   refl::GlobalDef().def("ir.FloatImm", [](DLDataType dtype, double value, Span span) {
     return FloatImm(PrimType(dtype), value, span);
   });
+  refl::TypeAttrDef<FloatImmNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&FloatImmVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&FloatImmMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&FloatImmMaybeInplaceMutate));
 }
 
+// Range
 Range::Range(PrimExpr begin, PrimExpr end, Span span)
     : Range(ffi::make_object<RangeNode>(begin, tirx::is_zero(begin) ? end : (end - begin), span)) {}
 
@@ -292,6 +782,7 @@ Range Range::FromMinExtent(PrimExpr min, PrimExpr extent, Span span) {
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  RangeNode::RegisterReflection();
   refl::GlobalDef()
       .def("ir.Range_from_min_extent", Range::FromMinExtent)
       .def("ir.Range", [](PrimExpr begin, ffi::Optional<PrimExpr> end, Span span) -> Range {
@@ -301,8 +792,14 @@ TVM_FFI_STATIC_INIT_BLOCK() {
           return Range(IntImm(begin.ty(), 0), begin, span);
         }
       });
+  refl::TypeAttrDef<RangeNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&RangeVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&RangeMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&RangeMaybeInplaceMutate));
 }
 
+// Var
 Var::Var(ffi::String name, ffi::Optional<Type> ty_annotation, Span span) {
   ffi::ObjectPtr<VarNode> n = ffi::make_object<VarNode>();
   n->name = std::move(name);
@@ -333,6 +830,17 @@ Var Var::CopyWithDType(PrimType dtype) const {
   return Var(std::move(copy));
 }
 
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace refl = tvm::ffi::reflection;
+  VarNode::RegisterReflection();
+  refl::TypeAttrDef<VarNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&VarVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&VarMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&VarMaybeInplaceMutate));
+}
+
+// GlobalVar
 GlobalVar::GlobalVar(ffi::String name_hint, Span span) {
   ffi::ObjectPtr<GlobalVarNode> n = ffi::make_object<GlobalVarNode>();
   n->name_hint = std::move(name_hint);
@@ -340,6 +848,9 @@ GlobalVar::GlobalVar(ffi::String name_hint, Span span) {
   data_ = std::move(n);
 }
 
+TVM_FFI_STATIC_INIT_BLOCK() { GlobalVarNode::RegisterReflection(); }
+
+// Call
 Call::Call(Type ret_ty, Expr op, ffi::Array<Expr> args, Attrs attrs, ffi::Array<Type> ty_args,
            Span span) {
   TVM_FFI_CHECK(op.defined(), ValueError) << "Call expects a defined operator";
@@ -356,6 +867,7 @@ Call::Call(Type ret_ty, Expr op, ffi::Array<Expr> args, Attrs attrs, ffi::Array<
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  CallNode::RegisterReflection();
   refl::GlobalDef()
       .def("ir.Var", [](ffi::String name, ffi::Optional<Type> ty_annotation,
                         Span span) { return Var(name, ty_annotation, span); })
@@ -370,6 +882,11 @@ TVM_FFI_STATIC_INIT_BLOCK() {
       });
   // Note: kRepr for GlobalVarNode is registered in script/printer/ir/ir.cc
   // via TVM_REGISTER_SCRIPT_AS_REPR(GlobalVarNode, ReprPrintIR).
+  refl::TypeAttrDef<CallNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&CallVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&CallMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&CallMaybeInplaceMutate));
 }
 
 }  // namespace tvm

--- a/src/ir/prim/expr.cc
+++ b/src/ir/prim/expr.cc
@@ -20,20 +20,24 @@
 /*!
  * \file expr.cc
  */
+#include <tvm/ffi/extra/structural_mutate.h>
+#include <tvm/ffi/extra/structural_visit.h>
 #include <tvm/ffi/function.h>
 #include <tvm/ffi/reflection/registry.h>
 #include <tvm/ir/prim/expr.h>
+
+#include <utility>
 
 namespace tvm {
 namespace prim {
 
 namespace {
+
 int GetLanesOrVScaleFactor(const PrimType& ty) {
   return ty.IsScalableVector() ? ty.VScaleFactor() : ty.lanes();
 }
 
 TVM_FFI_INLINE const PrimTypeNode* GetPrimTypeNode(const PrimExpr& expr) {
-  // Avoid PrimExpr::ty() ObjectRef materialization in expression constructor hot paths.
   const auto* node = expr.get();
   TVM_FFI_DCHECK(node != nullptr);
   TVM_FFI_DCHECK(!node->ExprNode::ty.IsMissing());
@@ -41,35 +45,385 @@ TVM_FFI_INLINE const PrimTypeNode* GetPrimTypeNode(const PrimExpr& expr) {
   TVM_FFI_DCHECK(prim_ty != nullptr);
   return prim_ty;
 }
-}  // namespace
 
-TVM_FFI_STATIC_INIT_BLOCK() {
-  StringImmNode::RegisterReflection();
-  CastNode::RegisterReflection();
-  AddNode::RegisterReflection();
-  SubNode::RegisterReflection();
-  MulNode::RegisterReflection();
-  DivNode::RegisterReflection();
-  ModNode::RegisterReflection();
-  FloorDivNode::RegisterReflection();
-  FloorModNode::RegisterReflection();
-  MinNode::RegisterReflection();
-  MaxNode::RegisterReflection();
-  EQNode::RegisterReflection();
-  NENode::RegisterReflection();
-  LTNode::RegisterReflection();
-  LENode::RegisterReflection();
-  GTNode::RegisterReflection();
-  GENode::RegisterReflection();
-  AndNode::RegisterReflection();
-  OrNode::RegisterReflection();
-  NotNode::RegisterReflection();
-  SelectNode::RegisterReflection();
-  RampNode::RegisterReflection();
-  BroadcastNode::RegisterReflection();
-  LetNode::RegisterReflection();
-  ShuffleNode::RegisterReflection();
+// Structural traversal hooks
+
+template <typename TNode>
+TVMFFIAny BinaryVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
+  // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
+  const TNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const TNode>(value);
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->a));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->b));
+  TVM_FFI_S_VISIT_RETURN_NONE();
 }
+
+template <typename TNode>
+TVMFFIAny BinaryMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
+  const TNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const TNode>(value);
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, a, mutator->MutateExpected(self->a));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, b, mutator->MutateExpected(self->b));
+  if (a.same_as(self->a) && b.same_as(self->b)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  ffi::ObjectPtr<TNode> copy = ffi::make_object<TNode>(*self);
+  // StructuralMap preserves node types. A rewrite that changes operand dtypes must keep the
+  // operands compatible and set the result type itself; a generic traversal cannot infer the
+  // casts that would require.
+  copy->a = std::move(a);
+  copy->b = std::move(b);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
+}
+
+template <typename TNode>
+TVMFFIAny BinaryMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
+                                   ffi::AnyView value) noexcept {
+  // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
+  TNode* self = const_cast<TNode*>(
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const TNode>(value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, a,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->a));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, b,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->b));
+  if (!a.same_as(self->a)) self->a = std::move(a);
+  if (!b.same_as(self->b)) self->b = std::move(b);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny RampVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
+  // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
+  const RampNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const RampNode>(value);
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->base));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->stride));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->lanes));
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+TVMFFIAny RampMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
+  const RampNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const RampNode>(value);
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_base, mutator->MutateExpected(self->base));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_stride, mutator->MutateExpected(self->stride));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_lanes, mutator->MutateExpected(self->lanes));
+  if (mapped_base.same_as(self->base) && mapped_stride.same_as(self->stride) &&
+      mapped_lanes.same_as(self->lanes)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  ffi::ObjectPtr<RampNode> copy = ffi::make_object<RampNode>(*self);
+  copy->base = std::move(mapped_base);
+  copy->stride = std::move(mapped_stride);
+  copy->lanes = std::move(mapped_lanes);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
+}
+
+TVMFFIAny RampMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
+  RampNode* self = const_cast<RampNode*>(
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const RampNode>(value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_base,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->base));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_stride,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->stride));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_lanes,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->lanes));
+  if (mapped_base.same_as(self->base) && mapped_stride.same_as(self->stride) &&
+      mapped_lanes.same_as(self->lanes)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  self->base = std::move(mapped_base);
+  self->stride = std::move(mapped_stride);
+  self->lanes = std::move(mapped_lanes);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny BroadcastVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
+  // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
+  const BroadcastNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const BroadcastNode>(value);
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->value));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->lanes));
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+TVMFFIAny BroadcastMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
+  const BroadcastNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const BroadcastNode>(value);
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_value, mutator->MutateExpected(self->value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_lanes, mutator->MutateExpected(self->lanes));
+  if (mapped_value.same_as(self->value) && mapped_lanes.same_as(self->lanes)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  ffi::ObjectPtr<BroadcastNode> copy = ffi::make_object<BroadcastNode>(*self);
+  copy->value = std::move(mapped_value);
+  copy->lanes = std::move(mapped_lanes);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
+}
+
+TVMFFIAny BroadcastMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
+                                      ffi::AnyView value) noexcept {
+  // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
+  BroadcastNode* self = const_cast<BroadcastNode*>(
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const BroadcastNode>(value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_value,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_lanes,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->lanes));
+  if (mapped_value.same_as(self->value) && mapped_lanes.same_as(self->lanes)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  self->value = std::move(mapped_value);
+  self->lanes = std::move(mapped_lanes);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny ShuffleVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
+  // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
+  const ShuffleNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const ShuffleNode>(value);
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->vectors));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->indices));
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+TVMFFIAny ShuffleMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
+  const ShuffleNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const ShuffleNode>(value);
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<PrimExpr>, mapped_vectors,
+                                    mutator->MutateExpected(self->vectors));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<PrimExpr>, mapped_indices,
+                                    mutator->MutateExpected(self->indices));
+  if (mapped_vectors.same_as(self->vectors) && mapped_indices.same_as(self->indices)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  ffi::ObjectPtr<ShuffleNode> copy = ffi::make_object<ShuffleNode>(*self);
+  copy->vectors = std::move(mapped_vectors);
+  copy->indices = std::move(mapped_indices);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
+}
+
+TVMFFIAny ShuffleMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
+                                    ffi::AnyView value) noexcept {
+  // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
+  ShuffleNode* self = const_cast<ShuffleNode*>(
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const ShuffleNode>(value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<PrimExpr>, mapped_vectors,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->vectors));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<PrimExpr>, mapped_indices,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->indices));
+  if (mapped_vectors.same_as(self->vectors) && mapped_indices.same_as(self->indices)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  self->vectors = std::move(mapped_vectors);
+  self->indices = std::move(mapped_indices);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny StringImmVisit(ffi::StructuralVisitorObj*, ffi::AnyView) noexcept {
+  // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
+  // value is a constant: reflected for StructuralEqual/Hash,
+  // not traversed by the visitor/mutator contract.
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+TVMFFIAny StringImmMutate(ffi::StructuralMutatorObj*, ffi::AnyView value) noexcept {
+  // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
+  // value is a constant: reflected for StructuralEqual/Hash,
+  // not traversed by the visitor/mutator contract.
+  const StringImmNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const StringImmNode>(value);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny StringImmMaybeInplaceMutate(ffi::StructuralMutatorObj*, ffi::AnyView value) noexcept {
+  // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
+  // value is a constant: reflected for StructuralEqual/Hash,
+  // not traversed by the visitor/mutator contract.
+  const StringImmNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const StringImmNode>(value);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny CastVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
+  // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
+  const CastNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const CastNode>(value);
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->value));
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+TVMFFIAny CastMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
+  const CastNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const CastNode>(value);
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_value, mutator->MutateExpected(self->value));
+  if (mapped_value.same_as(self->value)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  ffi::ObjectPtr<CastNode> copy = ffi::make_object<CastNode>(*self);
+  copy->value = std::move(mapped_value);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
+}
+
+TVMFFIAny CastMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
+  CastNode* self = const_cast<CastNode*>(
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const CastNode>(value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_value,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->value));
+  if (mapped_value.same_as(self->value)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  self->value = std::move(mapped_value);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny NotVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
+  // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
+  const NotNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const NotNode>(value);
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->a));
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+TVMFFIAny NotMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
+  const NotNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const NotNode>(value);
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_a, mutator->MutateExpected(self->a));
+  if (mapped_a.same_as(self->a)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  ffi::ObjectPtr<NotNode> copy = ffi::make_object<NotNode>(*self);
+  copy->a = std::move(mapped_a);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
+}
+
+TVMFFIAny NotMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
+  NotNode* self = const_cast<NotNode*>(
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const NotNode>(value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_a,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->a));
+  if (mapped_a.same_as(self->a)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  self->a = std::move(mapped_a);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny SelectVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
+  // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
+  const SelectNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const SelectNode>(value);
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->condition));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->true_value));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->false_value));
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+TVMFFIAny SelectMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
+  const SelectNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const SelectNode>(value);
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_condition,
+                                    mutator->MutateExpected(self->condition));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_true_value,
+                                    mutator->MutateExpected(self->true_value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_false_value,
+                                    mutator->MutateExpected(self->false_value));
+  if (mapped_condition.same_as(self->condition) && mapped_true_value.same_as(self->true_value) &&
+      mapped_false_value.same_as(self->false_value)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  ffi::ObjectPtr<SelectNode> copy = ffi::make_object<SelectNode>(*self);
+  copy->condition = std::move(mapped_condition);
+  copy->true_value = std::move(mapped_true_value);
+  copy->false_value = std::move(mapped_false_value);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
+}
+
+TVMFFIAny SelectMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
+                                   ffi::AnyView value) noexcept {
+  // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
+  SelectNode* self = const_cast<SelectNode*>(
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const SelectNode>(value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_condition,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->condition));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_true_value,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->true_value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_false_value,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->false_value));
+  if (mapped_condition.same_as(self->condition) && mapped_true_value.same_as(self->true_value) &&
+      mapped_false_value.same_as(self->false_value)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  self->condition = std::move(mapped_condition);
+  self->true_value = std::move(mapped_true_value);
+  self->false_value = std::move(mapped_false_value);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny LetVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
+  // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
+  const LetNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const LetNode>(value);
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->WithDefRegionKind(
+      kTVMFFIDefRegionKindNonRecursive, [&]() { return visitor->VisitExpected(self->var); }));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->value));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->body));
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+TVMFFIAny LetMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
+  const LetNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const LetNode>(value);
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(
+      Var, mapped_var, mutator->WithDefRegionKind(kTVMFFIDefRegionKindNonRecursive, [&]() {
+        return mutator->MutateExpected(self->var);
+      }));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_value, mutator->MutateExpected(self->value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_body, mutator->MutateExpected(self->body));
+  if (mapped_var.same_as(self->var) && mapped_value.same_as(self->value) &&
+      mapped_body.same_as(self->body)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  ffi::ObjectPtr<LetNode> copy = ffi::make_object<LetNode>(*self);
+  copy->var = std::move(mapped_var);
+  copy->value = std::move(mapped_value);
+  copy->body = std::move(mapped_body);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
+}
+
+TVMFFIAny LetMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
+  LetNode* self = const_cast<LetNode*>(
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const LetNode>(value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(
+      Var, mapped_var, mutator->WithDefRegionKind(kTVMFFIDefRegionKindNonRecursive, [&]() {
+        return mutator->MaybeInplaceMutateIfUniqueExpected(self->var);
+      }));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_value,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_body,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->body));
+  if (mapped_var.same_as(self->var) && mapped_value.same_as(self->value) &&
+      mapped_body.same_as(self->body)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  self->var = std::move(mapped_var);
+  self->value = std::move(mapped_value);
+  self->body = std::move(mapped_body);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+}  // namespace
 
 /* \brief Convert an object to a PrimExpr
  *
@@ -79,14 +433,6 @@ TVM_FFI_STATIC_INIT_BLOCK() {
  * `expr.dtype` field), this function allows the FFI conversions to be
  * explicitly invoked.
  */
-TVM_FFI_STATIC_INIT_BLOCK() {
-  namespace refl = tvm::ffi::reflection;
-  refl::GlobalDef().def("tirx.convert",
-                        [](ffi::Variant<PrimExpr, ffi::Array<PrimExpr>> expr) { return expr; });
-  // Note: kRepr for VarNode is registered via TVM_REGISTER_SCRIPT_AS_REPR in
-  // src/script/printer/tirx/expr.cc (-> ReprPrintTIR which delegates to TVMScriptPrinter).
-}
-
 #define TVM_DEFINE_BINOP_CONSTRUCTOR(Name)                                        \
   Name::Name(PrimExpr a, PrimExpr b, Span span) {                                 \
     using T = Name::ContainerType;                                                \
@@ -121,6 +467,52 @@ TVM_FFI_STATIC_INIT_BLOCK() {
     data_ = std::move(node);                                                      \
   }
 
+// Binary operators
+
+// Ramp
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace refl = tvm::ffi::reflection;
+  RampNode::RegisterReflection();
+  refl::TypeAttrDef<RampNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&RampVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&RampMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&RampMaybeInplaceMutate));
+}
+
+// Broadcast
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace refl = tvm::ffi::reflection;
+  BroadcastNode::RegisterReflection();
+  refl::TypeAttrDef<BroadcastNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&BroadcastVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&BroadcastMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&BroadcastMaybeInplaceMutate));
+}
+
+// Shuffle
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace refl = tvm::ffi::reflection;
+  ShuffleNode::RegisterReflection();
+  refl::TypeAttrDef<ShuffleNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&ShuffleVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&ShuffleMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&ShuffleMaybeInplaceMutate));
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace refl = tvm::ffi::reflection;
+  refl::GlobalDef().def("tirx.convert",
+                        [](ffi::Variant<PrimExpr, ffi::Array<PrimExpr>> expr) { return expr; });
+  // Note: kRepr for VarNode is registered via TVM_REGISTER_SCRIPT_AS_REPR in
+  // src/script/printer/tirx/expr.cc (-> ReprPrintTIR which delegates to TVMScriptPrinter).
+}
+
 // StringImm
 StringImm::StringImm(ffi::String value, Span span) {
   ffi::ObjectPtr<StringImmNode> node = ffi::make_object<StringImmNode>();
@@ -132,8 +524,14 @@ StringImm::StringImm(ffi::String value, Span span) {
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  StringImmNode::RegisterReflection();
   refl::GlobalDef().def("ir.prim.StringImm",
                         [](ffi::String value, Span span) { return StringImm(value, span); });
+  refl::TypeAttrDef<StringImmNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&StringImmVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&StringImmMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&StringImmMaybeInplaceMutate));
 }
 
 // Cast
@@ -150,9 +548,15 @@ Cast::Cast(PrimType value_ty, PrimExpr value, Span span) {
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  CastNode::RegisterReflection();
   refl::GlobalDef().def("ir.prim.Cast", [](PrimType dtype, PrimExpr value, Span span) {
     return Cast(dtype, value, span);
   });
+  refl::TypeAttrDef<CastNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&CastVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&CastMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&CastMaybeInplaceMutate));
 }
 
 // Add
@@ -160,8 +564,14 @@ TVM_DEFINE_BINOP_CONSTRUCTOR(Add);
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  AddNode::RegisterReflection();
   refl::GlobalDef().def("ir.prim.Add",
                         [](PrimExpr a, PrimExpr b, Span span) { return Add(a, b, span); });
+  refl::TypeAttrDef<AddNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&BinaryVisit<AddNode>))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&BinaryMutate<AddNode>))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&BinaryMaybeInplaceMutate<AddNode>));
 }
 
 // Sub
@@ -169,8 +579,14 @@ TVM_DEFINE_BINOP_CONSTRUCTOR(Sub);
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  SubNode::RegisterReflection();
   refl::GlobalDef().def("ir.prim.Sub",
                         [](PrimExpr a, PrimExpr b, Span span) { return Sub(a, b, span); });
+  refl::TypeAttrDef<SubNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&BinaryVisit<SubNode>))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&BinaryMutate<SubNode>))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&BinaryMaybeInplaceMutate<SubNode>));
 }
 
 // Mul
@@ -178,8 +594,14 @@ TVM_DEFINE_BINOP_CONSTRUCTOR(Mul);
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  MulNode::RegisterReflection();
   refl::GlobalDef().def("ir.prim.Mul",
                         [](PrimExpr a, PrimExpr b, Span span) { return Mul(a, b, span); });
+  refl::TypeAttrDef<MulNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&BinaryVisit<MulNode>))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&BinaryMutate<MulNode>))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&BinaryMaybeInplaceMutate<MulNode>));
 }
 
 // Div
@@ -187,8 +609,14 @@ TVM_DEFINE_BINOP_CONSTRUCTOR(Div);
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  DivNode::RegisterReflection();
   refl::GlobalDef().def("ir.prim.Div",
                         [](PrimExpr a, PrimExpr b, Span span) { return Div(a, b, span); });
+  refl::TypeAttrDef<DivNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&BinaryVisit<DivNode>))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&BinaryMutate<DivNode>))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&BinaryMaybeInplaceMutate<DivNode>));
 }
 
 // Mod
@@ -196,8 +624,14 @@ TVM_DEFINE_BINOP_CONSTRUCTOR(Mod);
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  ModNode::RegisterReflection();
   refl::GlobalDef().def("ir.prim.Mod",
                         [](PrimExpr a, PrimExpr b, Span span) { return Mod(a, b, span); });
+  refl::TypeAttrDef<ModNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&BinaryVisit<ModNode>))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&BinaryMutate<ModNode>))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&BinaryMaybeInplaceMutate<ModNode>));
 }
 
 // FloorDiv
@@ -205,8 +639,15 @@ TVM_DEFINE_BINOP_CONSTRUCTOR(FloorDiv);
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  FloorDivNode::RegisterReflection();
   refl::GlobalDef().def("ir.prim.FloorDiv",
                         [](PrimExpr a, PrimExpr b, Span span) { return FloorDiv(a, b, span); });
+  refl::TypeAttrDef<FloorDivNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&BinaryVisit<FloorDivNode>))
+      .attr(refl::type_attr::kStructuralMutate,
+            reinterpret_cast<void*>(&BinaryMutate<FloorDivNode>))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&BinaryMaybeInplaceMutate<FloorDivNode>));
 }
 
 // FloorMod
@@ -214,8 +655,15 @@ TVM_DEFINE_BINOP_CONSTRUCTOR(FloorMod);
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  FloorModNode::RegisterReflection();
   refl::GlobalDef().def("ir.prim.FloorMod",
                         [](PrimExpr a, PrimExpr b, Span span) { return FloorMod(a, b, span); });
+  refl::TypeAttrDef<FloorModNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&BinaryVisit<FloorModNode>))
+      .attr(refl::type_attr::kStructuralMutate,
+            reinterpret_cast<void*>(&BinaryMutate<FloorModNode>))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&BinaryMaybeInplaceMutate<FloorModNode>));
 }
 
 // Min
@@ -223,8 +671,14 @@ TVM_DEFINE_BINOP_CONSTRUCTOR(Min);
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  MinNode::RegisterReflection();
   refl::GlobalDef().def("ir.prim.Min",
                         [](PrimExpr a, PrimExpr b, Span span) { return Min(a, b, span); });
+  refl::TypeAttrDef<MinNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&BinaryVisit<MinNode>))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&BinaryMutate<MinNode>))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&BinaryMaybeInplaceMutate<MinNode>));
 }
 
 // Max
@@ -232,8 +686,14 @@ TVM_DEFINE_BINOP_CONSTRUCTOR(Max);
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  MaxNode::RegisterReflection();
   refl::GlobalDef().def("ir.prim.Max",
                         [](PrimExpr a, PrimExpr b, Span span) { return Max(a, b, span); });
+  refl::TypeAttrDef<MaxNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&BinaryVisit<MaxNode>))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&BinaryMutate<MaxNode>))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&BinaryMaybeInplaceMutate<MaxNode>));
 }
 
 // EQ
@@ -241,8 +701,14 @@ TVM_DEFINE_CMPOP_CONSTRUCTOR(EQ);
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  EQNode::RegisterReflection();
   refl::GlobalDef().def("ir.prim.EQ",
                         [](PrimExpr a, PrimExpr b, Span span) { return EQ(a, b, span); });
+  refl::TypeAttrDef<EQNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&BinaryVisit<EQNode>))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&BinaryMutate<EQNode>))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&BinaryMaybeInplaceMutate<EQNode>));
 }
 
 // NE
@@ -250,8 +716,14 @@ TVM_DEFINE_CMPOP_CONSTRUCTOR(NE);
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  NENode::RegisterReflection();
   refl::GlobalDef().def("ir.prim.NE",
                         [](PrimExpr a, PrimExpr b, Span span) { return NE(a, b, span); });
+  refl::TypeAttrDef<NENode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&BinaryVisit<NENode>))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&BinaryMutate<NENode>))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&BinaryMaybeInplaceMutate<NENode>));
 }
 
 // LT
@@ -259,8 +731,14 @@ TVM_DEFINE_CMPOP_CONSTRUCTOR(LT);
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  LTNode::RegisterReflection();
   refl::GlobalDef().def("ir.prim.LT",
                         [](PrimExpr a, PrimExpr b, Span span) { return LT(a, b, span); });
+  refl::TypeAttrDef<LTNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&BinaryVisit<LTNode>))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&BinaryMutate<LTNode>))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&BinaryMaybeInplaceMutate<LTNode>));
 }
 
 // LE
@@ -268,8 +746,14 @@ TVM_DEFINE_CMPOP_CONSTRUCTOR(LE);
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  LENode::RegisterReflection();
   refl::GlobalDef().def("ir.prim.LE",
                         [](PrimExpr a, PrimExpr b, Span span) { return LE(a, b, span); });
+  refl::TypeAttrDef<LENode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&BinaryVisit<LENode>))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&BinaryMutate<LENode>))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&BinaryMaybeInplaceMutate<LENode>));
 }
 
 // GT
@@ -277,8 +761,14 @@ TVM_DEFINE_CMPOP_CONSTRUCTOR(GT);
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  GTNode::RegisterReflection();
   refl::GlobalDef().def("ir.prim.GT",
                         [](PrimExpr a, PrimExpr b, Span span) { return GT(a, b, span); });
+  refl::TypeAttrDef<GTNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&BinaryVisit<GTNode>))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&BinaryMutate<GTNode>))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&BinaryMaybeInplaceMutate<GTNode>));
 }
 
 // GE
@@ -286,8 +776,14 @@ TVM_DEFINE_CMPOP_CONSTRUCTOR(GE);
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  GENode::RegisterReflection();
   refl::GlobalDef().def("ir.prim.GE",
                         [](PrimExpr a, PrimExpr b, Span span) { return GE(a, b, span); });
+  refl::TypeAttrDef<GENode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&BinaryVisit<GENode>))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&BinaryMutate<GENode>))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&BinaryMaybeInplaceMutate<GENode>));
 }
 
 // And
@@ -310,8 +806,14 @@ And::And(PrimExpr a, PrimExpr b, Span span) {
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  AndNode::RegisterReflection();
   refl::GlobalDef().def("ir.prim.And",
                         [](PrimExpr a, PrimExpr b, Span span) { return And(a, b, span); });
+  refl::TypeAttrDef<AndNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&BinaryVisit<AndNode>))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&BinaryMutate<AndNode>))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&BinaryMaybeInplaceMutate<AndNode>));
 }
 
 // Or
@@ -334,8 +836,14 @@ Or::Or(PrimExpr a, PrimExpr b, Span span) {
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  OrNode::RegisterReflection();
   refl::GlobalDef().def("ir.prim.Or",
                         [](PrimExpr a, PrimExpr b, Span span) { return Or(a, b, span); });
+  refl::TypeAttrDef<OrNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&BinaryVisit<OrNode>))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&BinaryMutate<OrNode>))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&BinaryMaybeInplaceMutate<OrNode>));
 }
 
 // Not
@@ -353,7 +861,13 @@ Not::Not(PrimExpr a, Span span) {
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  NotNode::RegisterReflection();
   refl::GlobalDef().def("ir.prim.Not", [](PrimExpr a, Span span) { return Not(a, span); });
+  refl::TypeAttrDef<NotNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&NotVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&NotMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&NotMaybeInplaceMutate));
 }
 
 // Select
@@ -382,9 +896,15 @@ Select::Select(PrimExpr condition, PrimExpr true_value, PrimExpr false_value, Sp
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  SelectNode::RegisterReflection();
   refl::GlobalDef().def("ir.prim.Select",
                         [](PrimExpr condition, PrimExpr true_value, PrimExpr false_value,
                            Span span) { return Select(condition, true_value, false_value, span); });
+  refl::TypeAttrDef<SelectNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&SelectVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&SelectMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&SelectMaybeInplaceMutate));
 }
 
 // Let
@@ -404,9 +924,15 @@ Let::Let(Var var, PrimExpr value, PrimExpr body, Span span) {
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  LetNode::RegisterReflection();
   refl::GlobalDef().def("ir.prim.Let", [](Var var, PrimExpr value, PrimExpr body, Span span) {
     return Let(var, value, body, span);
   });
+  refl::TypeAttrDef<LetNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&LetVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&LetMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&LetMaybeInplaceMutate));
 }
 
 }  // namespace prim

--- a/src/ir/type.cc
+++ b/src/ir/type.cc
@@ -21,6 +21,8 @@
  * \file src/ir/type.cc
  * \brief Common type system AST nodes throughout the IR.
  */
+#include <tvm/ffi/extra/structural_mutate.h>
+#include <tvm/ffi/extra/structural_visit.h>
 #include <tvm/ffi/function.h>
 #include <tvm/ffi/reflection/registry.h>
 #include <tvm/ir/type.h>
@@ -65,21 +67,31 @@ ffi::ObjectPtr<PrimTypeNode> GetCachedPrimTypeNode(DLDataType dtype) {
   return cache.emplace(key, std::move(node)).first->second;
 }
 
-}  // namespace
+// Structural traversal hooks
 
-TVM_FFI_STATIC_INIT_BLOCK() {
-  namespace refl = tvm::ffi::reflection;
-  TypeNode::RegisterReflection();
-  OpaqueTypeNode::RegisterReflection();
-  PrimTypeNode::RegisterReflection();
-  refl::TypeAttrDef<PrimTypeNode>()
-      .attr(refl::type_attr::kAnyHash, reinterpret_cast<void*>(&PrimTypeAnyHash))
-      .attr(refl::type_attr::kAnyEqual, reinterpret_cast<void*>(&PrimTypeAnyEqual));
-  PointerTypeNode::RegisterReflection();
-  TupleTypeNode::RegisterReflection();
-  FuncTypeNode::RegisterReflection();
-  TensorMapTypeNode::RegisterReflection();
+TVMFFIAny PrimTypeVisit(ffi::StructuralVisitorObj*, ffi::AnyView) noexcept {
+  // dtype is a constant: reflected for StructuralEqual/Hash,
+  // not traversed by the visitor/mutator contract.
+  TVM_FFI_S_VISIT_RETURN_NONE();
 }
+
+TVMFFIAny PrimTypeMutate(ffi::StructuralMutatorObj*, ffi::AnyView value) noexcept {
+  // dtype is a constant: reflected for StructuralEqual/Hash,
+  // not traversed by the visitor/mutator contract.
+  const PrimTypeNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const PrimTypeNode>(value);
+  return ffi::details::ExpectedUnsafe::MoveToTVMFFIAny(ffi::Expected<ffi::Any>(ffi::Any(self)));
+}
+
+TVMFFIAny PrimTypeMaybeInplaceMutate(ffi::StructuralMutatorObj*, ffi::AnyView value) noexcept {
+  // dtype is a constant: reflected for StructuralEqual/Hash,
+  // not traversed by the visitor/mutator contract.
+  const PrimTypeNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const PrimTypeNode>(value);
+  return ffi::details::ExpectedUnsafe::MoveToTVMFFIAny(ffi::Expected<ffi::Any>(ffi::Any(self)));
+}
+
+}  // namespace
 
 Type Type::Missing() {
   static Type missing = []() {
@@ -94,6 +106,11 @@ bool Type::IsMissing() const { return this->same_as(Type::Missing()); }
 
 OpaqueType::OpaqueType() : Type(ffi::UnsafeInit{}) { data_ = ffi::make_object<OpaqueTypeNode>(); }
 
+TVM_FFI_STATIC_INIT_BLOCK() { TypeNode::RegisterReflection(); }
+
+TVM_FFI_STATIC_INIT_BLOCK() { OpaqueTypeNode::RegisterReflection(); }
+
+// PrimType
 PrimType::PrimType(DLDataType dtype) : Type(ffi::UnsafeInit{}) {
   bool is_opaque_handle = dtype.code == static_cast<uint8_t>(DLDataTypeCode::kDLOpaqueHandle);
   bool is_void = is_opaque_handle && dtype.bits == 0 && dtype.lanes == 0;
@@ -152,13 +169,22 @@ PrimType PrimType::ScalableVector(DLDataTypeCode code, int bits, int lanes) {
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  PrimTypeNode::RegisterReflection();
   refl::GlobalDef()
       .def("ir.TypeMissing", []() { return Type::Missing(); })
       .def("ir.TypeIsMissing", [](Type type) { return type.IsMissing(); })
       .def("ir.OpaqueType", []() { return OpaqueType(); })
       .def("ir.PrimType", [](DLDataType dtype) { return PrimType(dtype); });
+  refl::TypeAttrDef<PrimTypeNode>()
+      .attr(refl::type_attr::kAnyHash, reinterpret_cast<void*>(&PrimTypeAnyHash))
+      .attr(refl::type_attr::kAnyEqual, reinterpret_cast<void*>(&PrimTypeAnyEqual))
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&PrimTypeVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&PrimTypeMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&PrimTypeMaybeInplaceMutate));
 }
 
+// PointerType
 PointerType::PointerType(Type element_type, ffi::String storage_scope) : Type(ffi::UnsafeInit{}) {
   TVM_FFI_ICHECK(!element_type.IsMissing()) << "PointerType element_type cannot be Type::Missing()";
   ffi::ObjectPtr<PointerTypeNode> n = ffi::make_object<PointerTypeNode>();
@@ -175,13 +201,6 @@ PointerType PointerType::VoidPointerTy(ffi::String storage_scope) {
   return PointerType(PrimType::Void(), std::move(storage_scope));
 }
 
-TVM_FFI_STATIC_INIT_BLOCK() {
-  namespace refl = tvm::ffi::reflection;
-  refl::GlobalDef().def("ir.PointerType", [](Type element_type, ffi::String storage_scope = "") {
-    return PointerType(element_type, storage_scope);
-  });
-}
-
 FuncType::FuncType(tvm::ffi::Array<Type> arg_types, Type ret_type, Span span)
     : Type(ffi::UnsafeInit{}) {
   ffi::ObjectPtr<FuncTypeNode> n = ffi::make_object<FuncTypeNode>();
@@ -189,13 +208,6 @@ FuncType::FuncType(tvm::ffi::Array<Type> arg_types, Type ret_type, Span span)
   n->ret_type = std::move(ret_type);
   n->span = std::move(span);
   data_ = std::move(n);
-}
-
-TVM_FFI_STATIC_INIT_BLOCK() {
-  namespace refl = tvm::ffi::reflection;
-  refl::GlobalDef().def("ir.FuncType", [](tvm::ffi::Array<Type> arg_types, Type ret_type) {
-    return FuncType(arg_types, ret_type);
-  });
 }
 
 TupleType::TupleType(ffi::Array<Type> fields, Span span) : Type(ffi::UnsafeInit{}) {
@@ -207,18 +219,36 @@ TupleType::TupleType(ffi::Array<Type> fields, Span span) : Type(ffi::UnsafeInit{
 
 TupleType TupleType::Empty() { return TupleType(ffi::Array<Type>()); }
 
-TVM_FFI_STATIC_INIT_BLOCK() {
-  namespace refl = tvm::ffi::reflection;
-  refl::GlobalDef()
-      .def("ir.TupleType",
-           [](ffi::Array<Type> fields, Span span) { return TupleType(fields, span); })
-      .def("ir.TensorMapType", [](Span span) { return TensorMapType(span); });
-}
-
 TensorMapType::TensorMapType(Span span) : Type(ffi::UnsafeInit{}) {
   ffi::ObjectPtr<TensorMapTypeNode> n = ffi::make_object<TensorMapTypeNode>();
   n->span = std::move(span);
   data_ = std::move(n);
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace refl = tvm::ffi::reflection;
+  PointerTypeNode::RegisterReflection();
+  refl::GlobalDef().def("ir.PointerType", [](Type element_type, ffi::String storage_scope = "") {
+    return PointerType(element_type, storage_scope);
+  });
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace refl = tvm::ffi::reflection;
+  FuncTypeNode::RegisterReflection();
+  refl::GlobalDef().def("ir.FuncType", [](tvm::ffi::Array<Type> arg_types, Type ret_type) {
+    return FuncType(arg_types, ret_type);
+  });
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace refl = tvm::ffi::reflection;
+  TupleTypeNode::RegisterReflection();
+  TensorMapTypeNode::RegisterReflection();
+  refl::GlobalDef()
+      .def("ir.TupleType",
+           [](ffi::Array<Type> fields, Span span) { return TupleType(fields, span); })
+      .def("ir.TensorMapType", [](Span span) { return TensorMapType(span); });
 }
 
 }  // namespace tvm

--- a/src/tirx/ir/buffer.cc
+++ b/src/tirx/ir/buffer.cc
@@ -21,6 +21,8 @@
  * \file buffer.cc
  */
 #include <tvm/arith/analyzer.h>
+#include <tvm/ffi/extra/structural_mutate.h>
+#include <tvm/ffi/extra/structural_visit.h>
 #include <tvm/ffi/function.h>
 #include <tvm/ffi/reflection/registry.h>
 #include <tvm/ir/prim/builtin.h>
@@ -35,6 +37,7 @@
 #include <iterator>
 #include <list>
 #include <stack>
+#include <utility>
 
 #include "../../arith/pattern_match.h"
 
@@ -102,12 +105,131 @@ ffi::ObjectRef RealizeBufferSubscript(
   return BufferRegion(buffer, region, span);
 }
 
+BufferVar RebuildBufferVarFromType(const BufferVar& buffer, BufferType type,
+                                   ffi::String name_suffix = "") {
+  return BufferVar(buffer.name() + name_suffix, std::move(type), buffer.span());
+}
+
+// Structural traversal hooks
+
+TVMFFIAny BufferTypeVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
+  // skips: storage_scope, data_alignment, offset_factor
+  const BufferTypeNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const BufferTypeNode>(value);
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->dtype));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->shape));
+  // Empty strides denote the common compact layout.  Broad callbacks do not see the empty
+  // container; explicit strides retain normal container descent and callback behavior.
+  if (!self->strides.empty()) {
+    TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->strides));
+  }
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->elem_offset));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->layout));
+  // allocated_addr is empty outside specialized storage scopes.  Broad callbacks do not see the
+  // empty container; present addresses retain normal container descent and callback behavior.
+  if (!self->allocated_addr.empty()) {
+    TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->allocated_addr));
+  }
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+TVMFFIAny BufferTypeMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  // skips: storage_scope, data_alignment, offset_factor
+  const BufferTypeNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const BufferTypeNode>(value);
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimType, mapped_dtype, mutator->MutateExpected(self->dtype));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<PrimExpr>, mapped_shape,
+                                    mutator->MutateExpected(self->shape));
+  // Empty strides denote the common compact layout.  Broad callbacks do not see the empty
+  // container; explicit strides retain normal container descent and callback behavior.
+  auto mapped_strides = self->strides;
+  if (!self->strides.empty()) {
+    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<PrimExpr>, descended_strides,
+                                      mutator->MutateExpected(self->strides));
+    mapped_strides = std::move(descended_strides);
+  }
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_elem_offset,
+                                    mutator->MutateExpected(self->elem_offset));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Optional<Layout>, mapped_layout,
+                                    mutator->MutateExpected(self->layout));
+  // allocated_addr is empty outside specialized storage scopes.  Broad callbacks do not see the
+  // empty container; present addresses retain normal container descent and callback behavior.
+  auto mapped_allocated_addr = self->allocated_addr;
+  if (!self->allocated_addr.empty()) {
+    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<PrimExpr>, descended_allocated_addr,
+                                      mutator->MutateExpected(self->allocated_addr));
+    mapped_allocated_addr = std::move(descended_allocated_addr);
+  }
+  if (mapped_dtype.same_as(self->dtype) && mapped_shape.same_as(self->shape) &&
+      mapped_strides.same_as(self->strides) && mapped_elem_offset.same_as(self->elem_offset) &&
+      mapped_layout.same_as(self->layout) && mapped_allocated_addr.same_as(self->allocated_addr)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  ffi::ObjectPtr<BufferTypeNode> copy = ffi::make_object<BufferTypeNode>(*self);
+  copy->dtype = std::move(mapped_dtype);
+  copy->shape = std::move(mapped_shape);
+  copy->strides = std::move(mapped_strides);
+  copy->elem_offset = std::move(mapped_elem_offset);
+  copy->layout = std::move(mapped_layout);
+  copy->allocated_addr = std::move(mapped_allocated_addr);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
+}
+
+TVMFFIAny BufferTypeMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
+                                       ffi::AnyView value) noexcept {
+  // skips: storage_scope, data_alignment, offset_factor
+  BufferTypeNode* self = const_cast<BufferTypeNode*>(
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const BufferTypeNode>(value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimType, mapped_dtype,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->dtype));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<PrimExpr>, mapped_shape,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->shape));
+  // Empty strides denote the common compact layout.  Broad callbacks do not see the empty
+  // container; explicit strides retain normal container descent and callback behavior.
+  auto mapped_strides = self->strides;
+  if (!self->strides.empty()) {
+    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<PrimExpr>, descended_strides,
+                                      mutator->MaybeInplaceMutateIfUniqueExpected(self->strides));
+    mapped_strides = std::move(descended_strides);
+  }
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_elem_offset,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->elem_offset));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Optional<Layout>, mapped_layout,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->layout));
+  // allocated_addr is empty outside specialized storage scopes.  Broad callbacks do not see the
+  // empty container; present addresses retain normal container descent and callback behavior.
+  auto mapped_allocated_addr = self->allocated_addr;
+  if (!self->allocated_addr.empty()) {
+    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(
+        ffi::Array<PrimExpr>, descended_allocated_addr,
+        mutator->MaybeInplaceMutateIfUniqueExpected(self->allocated_addr));
+    mapped_allocated_addr = std::move(descended_allocated_addr);
+  }
+  if (mapped_dtype.same_as(self->dtype) && mapped_shape.same_as(self->shape) &&
+      mapped_strides.same_as(self->strides) && mapped_elem_offset.same_as(self->elem_offset) &&
+      mapped_layout.same_as(self->layout) && mapped_allocated_addr.same_as(self->allocated_addr)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  self->dtype = std::move(mapped_dtype);
+  self->shape = std::move(mapped_shape);
+  self->strides = std::move(mapped_strides);
+  self->elem_offset = std::move(mapped_elem_offset);
+  self->layout = std::move(mapped_layout);
+  self->allocated_addr = std::move(mapped_allocated_addr);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
 }  // namespace
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
   BufferTypeNode::RegisterReflection();
   refl::TypeAttrDef<BufferTypeNode>().def("__subscript_expr_realize__", RealizeBufferSubscript);
+  refl::TypeAttrDef<BufferTypeNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&BufferTypeVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&BufferTypeMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&BufferTypeMaybeInplaceMutate));
 }
 
 using IndexMod = prim::FloorModNode;
@@ -135,15 +257,6 @@ BufferType::BufferType(ffi::String storage_scope, PrimType dtype, ffi::Array<Pri
   n->span = std::move(span);
   data_ = std::move(n);
 }
-
-namespace {
-
-BufferVar RebuildBufferVarFromType(const BufferVar& buffer, BufferType type,
-                                   ffi::String name_suffix = "") {
-  return BufferVar(buffer.name() + name_suffix, std::move(type), buffer.span());
-}
-
-}  // namespace
 
 ffi::Array<PrimExpr> SimplifyArray(arith::AnalyzerObj* ana, ffi::Array<PrimExpr> array) {
   for (size_t i = 0; i < array.size(); ++i) {

--- a/src/tirx/ir/iter_var.cc
+++ b/src/tirx/ir/iter_var.cc
@@ -21,13 +21,68 @@
  * \file iter_var.cc
  * \brief Iteration-variable definitions.
  */
+#include <tvm/ffi/extra/structural_mutate.h>
+#include <tvm/ffi/extra/structural_visit.h>
 #include <tvm/ffi/reflection/registry.h>
 #include <tvm/tirx/var.h>
+
+#include <utility>
 
 namespace tvm {
 namespace tirx {
 
-TVM_FFI_STATIC_INIT_BLOCK() { IterVarNode::RegisterReflection(); }
+namespace {
+
+// Structural traversal hooks
+
+TVMFFIAny IterVarVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
+  // skips: iter_type, thread_tag
+  const IterVarNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const IterVarNode>(value);
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->dom));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->WithDefRegionKind(
+      kTVMFFIDefRegionKindNonRecursive, [&]() { return visitor->VisitExpected(self->var); }));
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+TVMFFIAny IterVarMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  // skips: iter_type, thread_tag
+  const IterVarNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const IterVarNode>(value);
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Range, mapped_dom, mutator->MutateExpected(self->dom));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(
+      PrimVar, mapped_var, mutator->WithDefRegionKind(kTVMFFIDefRegionKindNonRecursive, [&]() {
+        return mutator->MutateExpected(self->var);
+      }));
+  if (mapped_dom.same_as(self->dom) && mapped_var.same_as(self->var)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  ffi::ObjectPtr<IterVarNode> copy = ffi::make_object<IterVarNode>(*self);
+  copy->dom = std::move(mapped_dom);
+  copy->var = std::move(mapped_var);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
+}
+
+TVMFFIAny IterVarMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
+                                    ffi::AnyView value) noexcept {
+  // skips: iter_type, thread_tag
+  IterVarNode* self = const_cast<IterVarNode*>(
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const IterVarNode>(value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Range, mapped_dom,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->dom));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(
+      PrimVar, mapped_var, mutator->WithDefRegionKind(kTVMFFIDefRegionKindNonRecursive, [&]() {
+        return mutator->MaybeInplaceMutateIfUniqueExpected(self->var);
+      }));
+  if (mapped_dom.same_as(self->dom) && mapped_var.same_as(self->var)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  self->dom = std::move(mapped_dom);
+  self->var = std::move(mapped_var);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+}  // namespace
 
 // IterVar
 IterVar::IterVar(Range dom, PrimVar var, IterVarType t, ffi::String thread_tag, Span span) {
@@ -53,10 +108,16 @@ IterVar::IterVar(Range dom, PrimVar var, IterVarType t, ffi::String thread_tag, 
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  IterVarNode::RegisterReflection();
   refl::GlobalDef().def(
       "tirx.IterVar", [](Range dom, PrimVar var, int iter_type, ffi::String thread_tag, Span span) {
         return IterVar(dom, var, static_cast<IterVarType>(iter_type), thread_tag, span);
       });
+  refl::TypeAttrDef<IterVarNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&IterVarVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&IterVarMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&IterVarMaybeInplaceMutate));
 }
 
 }  // namespace tirx

--- a/src/tirx/ir/layout/tile_core.cc
+++ b/src/tirx/ir/layout/tile_core.cc
@@ -20,6 +20,12 @@
 /*
  * Core TileLayout and Iter methods, basic queries, and reflection registration.
  */
+#include <tvm/ffi/extra/structural_mutate.h>
+#include <tvm/ffi/extra/structural_visit.h>
+#include <tvm/ffi/reflection/registry.h>
+
+#include <utility>
+
 #include "tile_internal.h"
 #include "utils.h"
 
@@ -28,10 +34,122 @@ namespace tirx {
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   AxisNode::RegisterReflection();
-  IterNode::RegisterReflection();
-  TileLayoutNode::RegisterReflection();
   ComposeLayoutNode::RegisterReflection();
 }
+
+namespace {
+
+TVMFFIAny IterVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
+  const IterNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const IterNode>(value);
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->extent));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->stride));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->axis));
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+TVMFFIAny IterMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  const IterNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const IterNode>(value);
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_extent, mutator->MutateExpected(self->extent));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_stride, mutator->MutateExpected(self->stride));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Axis, mapped_axis, mutator->MutateExpected(self->axis));
+  if (mapped_extent.same_as(self->extent) && mapped_stride.same_as(self->stride) &&
+      mapped_axis.same_as(self->axis)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  ffi::ObjectPtr<IterNode> copy = ffi::make_object<IterNode>(*self);
+  copy->extent = std::move(mapped_extent);
+  copy->stride = std::move(mapped_stride);
+  copy->axis = std::move(mapped_axis);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
+}
+
+TVMFFIAny IterMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  IterNode* self = const_cast<IterNode*>(
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const IterNode>(value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_extent,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->extent));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_stride,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->stride));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Axis, mapped_axis,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->axis));
+  if (mapped_extent.same_as(self->extent) && mapped_stride.same_as(self->stride) &&
+      mapped_axis.same_as(self->axis)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  self->extent = std::move(mapped_extent);
+  self->stride = std::move(mapped_stride);
+  self->axis = std::move(mapped_axis);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny TileLayoutVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
+  const TileLayoutNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const TileLayoutNode>(value);
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->shard));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->replica));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->offset));
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+TVMFFIAny TileLayoutMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  const TileLayoutNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const TileLayoutNode>(value);
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<Iter>, mapped_shard,
+                                    mutator->MutateExpected(self->shard));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<Iter>, mapped_replica,
+                                    mutator->MutateExpected(self->replica));
+  auto mapped_offset_result = mutator->MutateExpected(self->offset);
+  TVM_FFI_S_MUTATE_MAYBE_EARLY_RETURN(mapped_offset_result);
+  bool mapped_offset_type_ok = ffi::details::AnyUnsafe::CheckAnyStrict<ffi::Map<Axis, PrimExpr>>(
+      ffi::details::ExpectedUnsafe::GetData(mapped_offset_result));
+  if (TVM_FFI_PREDICT_FALSE(!mapped_offset_type_ok)) {
+    return ffi::details::ExpectedUnsafe::MoveToTVMFFIAny(ffi::details::SMutateDeclaredTypeError());
+  }
+  ffi::Map<Axis, PrimExpr> mapped_offset =
+      ffi::details::AnyUnsafe::MoveFromAnyAfterCheck<ffi::Map<Axis, PrimExpr>>(
+          std::move(ffi::details::ExpectedUnsafe::GetData(mapped_offset_result)));
+  if (mapped_shard.same_as(self->shard) && mapped_replica.same_as(self->replica) &&
+      mapped_offset.same_as(self->offset)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  ffi::ObjectPtr<TileLayoutNode> copy = ffi::make_object<TileLayoutNode>(*self);
+  copy->shard = std::move(mapped_shard);
+  copy->replica = std::move(mapped_replica);
+  copy->offset = std::move(mapped_offset);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
+}
+
+TVMFFIAny TileLayoutMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
+                                       ffi::AnyView value) noexcept {
+  TileLayoutNode* self = const_cast<TileLayoutNode*>(
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const TileLayoutNode>(value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<Iter>, mapped_shard,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->shard));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<Iter>, mapped_replica,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->replica));
+  auto mapped_offset_result = mutator->MaybeInplaceMutateIfUniqueExpected(self->offset);
+  TVM_FFI_S_MUTATE_MAYBE_EARLY_RETURN(mapped_offset_result);
+  bool mapped_offset_type_ok = ffi::details::AnyUnsafe::CheckAnyStrict<ffi::Map<Axis, PrimExpr>>(
+      ffi::details::ExpectedUnsafe::GetData(mapped_offset_result));
+  if (TVM_FFI_PREDICT_FALSE(!mapped_offset_type_ok)) {
+    return ffi::details::ExpectedUnsafe::MoveToTVMFFIAny(ffi::details::SMutateDeclaredTypeError());
+  }
+  ffi::Map<Axis, PrimExpr> mapped_offset =
+      ffi::details::AnyUnsafe::MoveFromAnyAfterCheck<ffi::Map<Axis, PrimExpr>>(
+          std::move(ffi::details::ExpectedUnsafe::GetData(mapped_offset_result)));
+  if (mapped_shard.same_as(self->shard) && mapped_replica.same_as(self->replica) &&
+      mapped_offset.same_as(self->offset)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  self->shard = std::move(mapped_shard);
+  self->replica = std::move(mapped_replica);
+  self->offset = std::move(mapped_offset);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+}  // namespace
 
 /**************** Iter ****************/
 Iter::Iter(PrimExpr extent, PrimExpr stride, Axis axis) {
@@ -44,9 +162,15 @@ Iter::Iter(PrimExpr extent, PrimExpr stride, Axis axis) {
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  IterNode::RegisterReflection();
   refl::GlobalDef().def("tirx.Iter", [](PrimExpr extent, PrimExpr stride, Axis axis) {
     return Iter(extent, stride, axis);
   });
+  refl::TypeAttrDef<IterNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&IterVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&IterMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&IterMaybeInplaceMutate));
 }
 
 /**************** TileLayout ****************/
@@ -61,10 +185,16 @@ TileLayout::TileLayout(ffi::Array<Iter> shard, ffi::Array<Iter> replica,
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  TileLayoutNode::RegisterReflection();
   refl::GlobalDef().def("tirx.TileLayout", [](ffi::Array<Iter> shard, ffi::Array<Iter> replica,
                                               ffi::Map<Axis, PrimExpr> offset) {
     return TileLayout(shard, replica, offset);
   });
+  refl::TypeAttrDef<TileLayoutNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&TileLayoutVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&TileLayoutMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&TileLayoutMaybeInplaceMutate));
 }
 
 bool TileLayoutNode::CompatibleWithShape(const Array<PrimExpr>& shape) const { return true; }

--- a/src/tirx/ir/stmt.cc
+++ b/src/tirx/ir/stmt.cc
@@ -22,12 +22,16 @@
  */
 #include <tvm/arith/analyzer.h>
 #include <tvm/ffi/dtype.h>
+#include <tvm/ffi/extra/structural_mutate.h>
+#include <tvm/ffi/extra/structural_visit.h>
 #include <tvm/ffi/function.h>
 #include <tvm/ffi/reflection/registry.h>
 #include <tvm/ir/op.h>
 #include <tvm/tirx/op.h>
 #include <tvm/tirx/op_attr_types.h>
 #include <tvm/tirx/stmt.h>
+
+#include <utility>
 
 #include "buffer_common.h"
 
@@ -90,35 +94,1002 @@ ffi::ObjectRef RealizeBufferRegionSubscript(Expr value, SubscriptSlice slice, Sp
   return BufferRegion(source->buffer, region, span);
 }
 
+/*!
+ * \brief Whether an integer literal can be represented exactly by `ty`.
+ * \note Mirrors the range checks performed by the IntImm constructor.
+ */
+bool IntImmValueFits(int64_t value, const PrimType& ty) {
+  int bits = ty.bits();
+  if (ty.MatchesCode(DLDataTypeCode::kDLUInt)) {
+    return value >= 0 && (bits >= 64 || value < (int64_t{1} << bits));
+  }
+  if (bits >= 64) return true;
+  return value >= -(int64_t{1} << (bits - 1)) && value < (int64_t{1} << (bits - 1));
+}
+
+// Structural traversal hooks
+
+TVMFFIAny BindVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
+  const BindNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const BindNode>(value);
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->WithDefRegionKind(
+      kTVMFFIDefRegionKindNonRecursive, [&]() { return visitor->VisitExpected(self->var); }));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->value));
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+TVMFFIAny BindMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  const BindNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const BindNode>(value);
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(
+      Var, mapped_var, mutator->WithDefRegionKind(kTVMFFIDefRegionKindNonRecursive, [&]() {
+        return mutator->MutateExpected(self->var);
+      }));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Expr, mapped_value, mutator->MutateExpected(self->value));
+  if (mapped_var.same_as(self->var) && mapped_value.same_as(self->value)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  ffi::ObjectPtr<BindNode> copy = ffi::make_object<BindNode>(*self);
+  copy->var = std::move(mapped_var);
+  copy->value = std::move(mapped_value);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
+}
+
+TVMFFIAny BindMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  BindNode* self = const_cast<BindNode*>(
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const BindNode>(value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(
+      Var, mapped_var, mutator->WithDefRegionKind(kTVMFFIDefRegionKindNonRecursive, [&]() {
+        return mutator->MaybeInplaceMutateIfUniqueExpected(self->var);
+      }));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Expr, mapped_value,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->value));
+  if (mapped_var.same_as(self->var) && mapped_value.same_as(self->value)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  self->var = std::move(mapped_var);
+  self->value = std::move(mapped_value);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny AttrStmtVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
+  // skips: attr_key
+  const AttrStmtNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const AttrStmtNode>(value);
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->node));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->value));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->body));
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+TVMFFIAny AttrStmtMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  // skips: attr_key
+  const AttrStmtNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const AttrStmtNode>(value);
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Any, mapped_node, mutator->MutateExpected(self->node));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_value, mutator->MutateExpected(self->value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Stmt, mapped_body, mutator->MutateExpected(self->body));
+  if (mapped_node.same_as(self->node) && mapped_value.same_as(self->value) &&
+      mapped_body.same_as(self->body)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  ffi::ObjectPtr<AttrStmtNode> copy = ffi::make_object<AttrStmtNode>(*self);
+  copy->node = std::move(mapped_node);
+  copy->value = std::move(mapped_value);
+  copy->body = std::move(mapped_body);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
+}
+
+TVMFFIAny AttrStmtMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
+                                     ffi::AnyView value) noexcept {
+  // skips: attr_key
+  AttrStmtNode* self = const_cast<AttrStmtNode*>(
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const AttrStmtNode>(value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Any, mapped_node,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->node));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_value,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Stmt, mapped_body,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->body));
+  if (mapped_node.same_as(self->node) && mapped_value.same_as(self->value) &&
+      mapped_body.same_as(self->body)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  self->node = std::move(mapped_node);
+  self->value = std::move(mapped_value);
+  self->body = std::move(mapped_body);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny AssertStmtVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
+  // skips: error_kind and message_parts, which are constant assertion metadata.
+  const AssertStmtNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const AssertStmtNode>(value);
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->condition));
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+TVMFFIAny AssertStmtMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  // skips: error_kind and message_parts, which are constant assertion metadata.
+  const AssertStmtNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const AssertStmtNode>(value);
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_condition,
+                                    mutator->MutateExpected(self->condition));
+  if (mapped_condition.same_as(self->condition)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  ffi::ObjectPtr<AssertStmtNode> copy = ffi::make_object<AssertStmtNode>(*self);
+  copy->condition = std::move(mapped_condition);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
+}
+
+TVMFFIAny AssertStmtMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
+                                       ffi::AnyView value) noexcept {
+  // skips: error_kind and message_parts, which are constant assertion metadata.
+  AssertStmtNode* self = const_cast<AssertStmtNode*>(
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const AssertStmtNode>(value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_condition,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->condition));
+  if (mapped_condition.same_as(self->condition)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  self->condition = std::move(mapped_condition);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny ForVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
+  // skips: kind and constant annotations; unlike SBlock annotations, these carry no expressions.
+  const ForNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const ForNode>(value);
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->WithDefRegionKind(
+      kTVMFFIDefRegionKindNonRecursive, [&]() { return visitor->VisitExpected(self->loop_var); }));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->min));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->extent));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->body));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->thread_binding));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->step));
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+TVMFFIAny ForMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  // skips: kind and constant annotations; unlike SBlock annotations, these carry no expressions.
+  const ForNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const ForNode>(value);
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(
+      PrimVar, mapped_loop_var, mutator->WithDefRegionKind(kTVMFFIDefRegionKindNonRecursive, [&]() {
+        return mutator->MutateExpected(self->loop_var);
+      }));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_min, mutator->MutateExpected(self->min));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_extent, mutator->MutateExpected(self->extent));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Stmt, mapped_body, mutator->MutateExpected(self->body));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Optional<IterVar>, mapped_thread_binding,
+                                    mutator->MutateExpected(self->thread_binding));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Optional<PrimExpr>, mapped_step,
+                                    mutator->MutateExpected(self->step));
+  if (mapped_loop_var.same_as(self->loop_var) && mapped_min.same_as(self->min) &&
+      mapped_extent.same_as(self->extent) && mapped_body.same_as(self->body) &&
+      mapped_thread_binding.same_as(self->thread_binding) && mapped_step.same_as(self->step)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  ffi::ObjectPtr<ForNode> copy = ffi::make_object<ForNode>(*self);
+  copy->loop_var = std::move(mapped_loop_var);
+  copy->min = std::move(mapped_min);
+  copy->extent = std::move(mapped_extent);
+  copy->body = std::move(mapped_body);
+  copy->thread_binding = std::move(mapped_thread_binding);
+  copy->step = std::move(mapped_step);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
+}
+
+TVMFFIAny ForMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  // skips: kind and constant annotations; unlike SBlock annotations, these carry no expressions.
+  ForNode* self = const_cast<ForNode*>(
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const ForNode>(value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(
+      PrimVar, mapped_loop_var, mutator->WithDefRegionKind(kTVMFFIDefRegionKindNonRecursive, [&]() {
+        return mutator->MaybeInplaceMutateIfUniqueExpected(self->loop_var);
+      }));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_min,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->min));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_extent,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->extent));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Stmt, mapped_body,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->body));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(
+      ffi::Optional<IterVar>, mapped_thread_binding,
+      mutator->MaybeInplaceMutateIfUniqueExpected(self->thread_binding));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Optional<PrimExpr>, mapped_step,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->step));
+  if (mapped_loop_var.same_as(self->loop_var) && mapped_min.same_as(self->min) &&
+      mapped_extent.same_as(self->extent) && mapped_body.same_as(self->body) &&
+      mapped_thread_binding.same_as(self->thread_binding) && mapped_step.same_as(self->step)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  self->loop_var = std::move(mapped_loop_var);
+  self->min = std::move(mapped_min);
+  self->extent = std::move(mapped_extent);
+  self->body = std::move(mapped_body);
+  self->thread_binding = std::move(mapped_thread_binding);
+  self->step = std::move(mapped_step);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny WhileVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
+  const WhileNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const WhileNode>(value);
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->condition));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->body));
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+TVMFFIAny WhileMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  const WhileNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const WhileNode>(value);
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_condition,
+                                    mutator->MutateExpected(self->condition));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Stmt, mapped_body, mutator->MutateExpected(self->body));
+  if (mapped_condition.same_as(self->condition) && mapped_body.same_as(self->body)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  ffi::ObjectPtr<WhileNode> copy = ffi::make_object<WhileNode>(*self);
+  copy->condition = std::move(mapped_condition);
+  copy->body = std::move(mapped_body);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
+}
+
+TVMFFIAny WhileMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  WhileNode* self = const_cast<WhileNode*>(
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const WhileNode>(value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_condition,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->condition));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Stmt, mapped_body,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->body));
+  if (mapped_condition.same_as(self->condition) && mapped_body.same_as(self->body)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  self->condition = std::move(mapped_condition);
+  self->body = std::move(mapped_body);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny ReturnVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
+  const ReturnNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const ReturnNode>(value);
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->value));
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+TVMFFIAny ReturnMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  const ReturnNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const ReturnNode>(value);
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Expr, mapped_value, mutator->MutateExpected(self->value));
+  if (mapped_value.same_as(self->value)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  ffi::ObjectPtr<ReturnNode> copy = ffi::make_object<ReturnNode>(*self);
+  copy->value = std::move(mapped_value);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
+}
+
+TVMFFIAny ReturnMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
+                                   ffi::AnyView value) noexcept {
+  ReturnNode* self = const_cast<ReturnNode*>(
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const ReturnNode>(value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Expr, mapped_value,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->value));
+  if (mapped_value.same_as(self->value)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  self->value = std::move(mapped_value);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny BreakVisit(ffi::StructuralVisitorObj*, ffi::AnyView) noexcept {
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+TVMFFIAny BreakMutate(ffi::StructuralMutatorObj*, ffi::AnyView value) noexcept {
+  const BreakNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const BreakNode>(value);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny BreakMaybeInplaceMutate(ffi::StructuralMutatorObj*, ffi::AnyView value) noexcept {
+  const BreakNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const BreakNode>(value);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny ContinueVisit(ffi::StructuralVisitorObj*, ffi::AnyView) noexcept {
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+TVMFFIAny ContinueMutate(ffi::StructuralMutatorObj*, ffi::AnyView value) noexcept {
+  const ContinueNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const ContinueNode>(value);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny ContinueMaybeInplaceMutate(ffi::StructuralMutatorObj*, ffi::AnyView value) noexcept {
+  const ContinueNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const ContinueNode>(value);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny DeclBufferVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
+  const DeclBufferNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const DeclBufferNode>(value);
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->WithDefRegionKind(
+      kTVMFFIDefRegionKindNonRecursive, [&]() { return visitor->VisitExpected(self->buffer); }));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->data));
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+TVMFFIAny DeclBufferMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  const DeclBufferNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const DeclBufferNode>(value);
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(
+      BufferVar, mapped_buffer, mutator->WithDefRegionKind(kTVMFFIDefRegionKindNonRecursive, [&]() {
+        return mutator->MutateExpected(self->buffer);
+      }));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Expr, mapped_data, mutator->MutateExpected(self->data));
+  if (mapped_buffer.same_as(self->buffer) && mapped_data.same_as(self->data)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  ffi::ObjectPtr<DeclBufferNode> copy = ffi::make_object<DeclBufferNode>(*self);
+  copy->buffer = std::move(mapped_buffer);
+  copy->data = std::move(mapped_data);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
+}
+
+TVMFFIAny DeclBufferMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
+                                       ffi::AnyView value) noexcept {
+  DeclBufferNode* self = const_cast<DeclBufferNode*>(
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const DeclBufferNode>(value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(
+      BufferVar, mapped_buffer, mutator->WithDefRegionKind(kTVMFFIDefRegionKindNonRecursive, [&]() {
+        return mutator->MaybeInplaceMutateIfUniqueExpected(self->buffer);
+      }));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Expr, mapped_data,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->data));
+  if (mapped_buffer.same_as(self->buffer) && mapped_data.same_as(self->data)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  self->buffer = std::move(mapped_buffer);
+  self->data = std::move(mapped_data);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny AllocBufferVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
+  // skips: constant annotations; unlike SBlock annotations, these carry no expressions.
+  const AllocBufferNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const AllocBufferNode>(value);
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->WithDefRegionKind(
+      kTVMFFIDefRegionKindNonRecursive, [&]() { return visitor->VisitExpected(self->buffer); }));
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+TVMFFIAny AllocBufferMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  // skips: constant annotations; unlike SBlock annotations, these carry no expressions.
+  const AllocBufferNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const AllocBufferNode>(value);
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(
+      BufferVar, mapped_buffer, mutator->WithDefRegionKind(kTVMFFIDefRegionKindNonRecursive, [&]() {
+        return mutator->MutateExpected(self->buffer);
+      }));
+  if (mapped_buffer.same_as(self->buffer)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  ffi::ObjectPtr<AllocBufferNode> copy = ffi::make_object<AllocBufferNode>(*self);
+  copy->buffer = std::move(mapped_buffer);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
+}
+
+TVMFFIAny AllocBufferMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
+                                        ffi::AnyView value) noexcept {
+  // skips: constant annotations; unlike SBlock annotations, these carry no expressions.
+  AllocBufferNode* self = const_cast<AllocBufferNode*>(
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const AllocBufferNode>(value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(
+      BufferVar, mapped_buffer, mutator->WithDefRegionKind(kTVMFFIDefRegionKindNonRecursive, [&]() {
+        return mutator->MaybeInplaceMutateIfUniqueExpected(self->buffer);
+      }));
+  if (mapped_buffer.same_as(self->buffer)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  self->buffer = std::move(mapped_buffer);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny SeqStmtVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
+  const SeqStmtNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const SeqStmtNode>(value);
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->seq));
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+bool IsSeqStmtNoOp(const Stmt& stmt) {
+  const auto* evaluate = stmt.as<EvaluateNode>();
+  const auto* value = evaluate == nullptr ? nullptr : evaluate->value.as<IntImmNode>();
+  return value != nullptr && value->value == 0;
+}
+
+void AppendSeqStmtResult(ffi::Array<Stmt>* output, Stmt mapped) {
+  if (IsSeqStmtNoOp(mapped)) {
+    return;
+  }
+  if (const auto* nested = mapped.as<SeqStmtNode>()) {
+    for (const Stmt& stmt : nested->seq) {
+      output->push_back(stmt);
+    }
+  } else {
+    output->push_back(std::move(mapped));
+  }
+}
+
+TVMFFIAny MutateSeqStmtChanged(ffi::StructuralMutatorObj* mutator, const SeqStmtNode* self,
+                               int64_t index, Stmt mapped) noexcept {
+  const int64_t size = static_cast<int64_t>(self->seq.size());
+  ffi::ObjectPtr<ffi::ArrayObj> output_obj = ffi::ArrayObj::CreateRepeated(size, ffi::Any());
+  output_obj->InitRange(0, self->seq.begin(), self->seq.begin() + index);
+  output_obj->resize(index);
+  ffi::Array<Stmt> output(std::move(output_obj));
+  AppendSeqStmtResult(&output, std::move(mapped));
+  for (int64_t i = index + 1; i < size; ++i) {
+    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Stmt, mapped, mutator->MutateExpected(self->seq[i]));
+    AppendSeqStmtResult(&output, std::move(mapped));
+  }
+  if (output.empty()) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(Evaluate(0)));
+  }
+  if (output.size() == 1) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(output[0]));
+  }
+  ffi::ObjectPtr<SeqStmtNode> copy = ffi::make_object<SeqStmtNode>(*self);
+  copy->seq = std::move(output);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
+}
+
+TVMFFIAny MutateSeqStmtRaw(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  const SeqStmtNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const SeqStmtNode>(value);
+  const int64_t size = static_cast<int64_t>(self->seq.size());
+  for (int64_t i = 0; i < size; ++i) {
+    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Stmt, mapped, mutator->MutateExpected(self->seq[i]));
+    if (!self->seq[i].same_as(mapped)) {
+      return MutateSeqStmtChanged(mutator, self, i, std::move(mapped));
+    }
+  }
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny InplaceSplice(ffi::StructuralMutatorObj* mutator, SeqStmtNode* self, ffi::ArrayObj* seq,
+                        int64_t total, int64_t index, const SeqStmtNode* nested) noexcept {
+  const int64_t size = static_cast<int64_t>(seq->size());
+  ffi::Array<Stmt> output;
+  output.reserve(size + static_cast<int64_t>(nested->seq.size()) - 1);
+  for (int64_t i = 0; i < total; ++i) {
+    output.push_back(seq->begin()[i].cast<Stmt>());
+  }
+  for (const Stmt& stmt : nested->seq) {
+    output.push_back(stmt);
+  }
+  for (int64_t i = index + 1; i < size; ++i) {
+    const ffi::Any& item = seq->begin()[i];
+    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Stmt, mapped,
+                                      mutator->MaybeInplaceMutateIfUniqueExpected(item));
+    AppendSeqStmtResult(&output, std::move(mapped));
+  }
+  if (output.empty()) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(Evaluate(0)));
+  }
+  if (output.size() == 1) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(output[0]));
+  }
+  self->seq = std::move(output);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny MaybeInplaceMutateSeqStmtChanged(ffi::StructuralMutatorObj* mutator, SeqStmtNode* self,
+                                           ffi::ArrayObj* seq, int64_t index,
+                                           Stmt mapped) noexcept {
+  const int64_t size = static_cast<int64_t>(seq->size());
+  int64_t total = index;
+  if (IsSeqStmtNoOp(mapped)) {
+    // Drop Evaluate(0), matching SeqStmt::Flatten.
+  } else if (const auto* nested = mapped.as<SeqStmtNode>()) {
+    const int64_t nested_size = static_cast<int64_t>(nested->seq.size());
+    if (total + nested_size > index + 1) {
+      return InplaceSplice(mutator, self, seq, total, index, nested);
+    }
+    for (const Stmt& stmt : nested->seq) {
+      seq->SetItemAfterCheck(total++, ffi::Any(stmt));
+    }
+  } else {
+    seq->SetItemAfterCheck(total++, ffi::Any(std::move(mapped)));
+  }
+  for (int64_t i = index + 1; i < size; ++i) {
+    const ffi::Any& item = seq->begin()[i];
+    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Stmt, mapped,
+                                      mutator->MaybeInplaceMutateIfUniqueExpected(item));
+    if (IsSeqStmtNoOp(mapped)) {
+      continue;
+    }
+    if (const auto* nested = mapped.as<SeqStmtNode>()) {
+      const int64_t nested_size = static_cast<int64_t>(nested->seq.size());
+      if (total + nested_size > i + 1) {
+        return InplaceSplice(mutator, self, seq, total, i, nested);
+      }
+      for (const Stmt& stmt : nested->seq) {
+        seq->SetItemAfterCheck(total++, ffi::Any(stmt));
+      }
+      continue;
+    }
+    if (total != i || !item.same_as(mapped)) {
+      seq->SetItemAfterCheck(total, ffi::Any(std::move(mapped)));
+    }
+    ++total;
+  }
+  seq->resize(total);
+  if (total == 0) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(Evaluate(0)));
+  }
+  if (total == 1) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(seq->begin()[0].cast<Stmt>()));
+  }
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny MaybeInplaceMutateSeqStmtRaw(ffi::StructuralMutatorObj* mutator,
+                                       ffi::AnyView value) noexcept {
+  SeqStmtNode* self = const_cast<SeqStmtNode*>(
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const SeqStmtNode>(value));
+  // The engine establishes ownership of the SeqStmt, but seq is a field and needs its own check.
+  if (!self->seq.unique()) {
+    return MutateSeqStmtRaw(mutator, value);
+  }
+  ffi::ArrayObj* seq = self->seq.GetArrayObj();
+  const int64_t size = static_cast<int64_t>(seq->size());
+  for (int64_t i = 0; i < size; ++i) {
+    // Borrow the storage slot so the element stays unique during in-place dispatch.
+    const ffi::Any& item = seq->begin()[i];
+    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Stmt, mapped,
+                                      mutator->MaybeInplaceMutateIfUniqueExpected(item));
+    if (!item.same_as(mapped)) {
+      return MaybeInplaceMutateSeqStmtChanged(mutator, self, seq, i, std::move(mapped));
+    }
+  }
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny SeqStmtMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  return MutateSeqStmtRaw(mutator, value);
+}
+
+TVMFFIAny SeqStmtMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
+                                    ffi::AnyView value) noexcept {
+  return MaybeInplaceMutateSeqStmtRaw(mutator, value);
+}
+
+TVMFFIAny IfThenElseVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
+  const IfThenElseNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const IfThenElseNode>(value);
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->condition));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->then_case));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->else_case));
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+TVMFFIAny IfThenElseMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  const IfThenElseNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const IfThenElseNode>(value);
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_condition,
+                                    mutator->MutateExpected(self->condition));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Stmt, mapped_then_case,
+                                    mutator->MutateExpected(self->then_case));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Optional<Stmt>, mapped_else_case,
+                                    mutator->MutateExpected(self->else_case));
+  if (mapped_condition.same_as(self->condition) && mapped_then_case.same_as(self->then_case) &&
+      mapped_else_case.same_as(self->else_case)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  ffi::ObjectPtr<IfThenElseNode> copy = ffi::make_object<IfThenElseNode>(*self);
+  copy->condition = std::move(mapped_condition);
+  copy->then_case = std::move(mapped_then_case);
+  copy->else_case = std::move(mapped_else_case);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
+}
+
+TVMFFIAny IfThenElseMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
+                                       ffi::AnyView value) noexcept {
+  IfThenElseNode* self = const_cast<IfThenElseNode*>(
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const IfThenElseNode>(value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_condition,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->condition));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Stmt, mapped_then_case,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->then_case));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Optional<Stmt>, mapped_else_case,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->else_case));
+  if (mapped_condition.same_as(self->condition) && mapped_then_case.same_as(self->then_case) &&
+      mapped_else_case.same_as(self->else_case)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  self->condition = std::move(mapped_condition);
+  self->then_case = std::move(mapped_then_case);
+  self->else_case = std::move(mapped_else_case);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny EvaluateVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
+  const EvaluateNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const EvaluateNode>(value);
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->value));
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+TVMFFIAny EvaluateMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  const EvaluateNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const EvaluateNode>(value);
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Expr, mapped_value, mutator->MutateExpected(self->value));
+  if (mapped_value.same_as(self->value)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  ffi::ObjectPtr<EvaluateNode> copy = ffi::make_object<EvaluateNode>(*self);
+  copy->value = std::move(mapped_value);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
+}
+
+TVMFFIAny EvaluateMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
+                                     ffi::AnyView value) noexcept {
+  EvaluateNode* self = const_cast<EvaluateNode*>(
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const EvaluateNode>(value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Expr, mapped_value,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->value));
+  if (mapped_value.same_as(self->value)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  self->value = std::move(mapped_value);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny BufferStoreVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
+  const BufferStoreNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const BufferStoreNode>(value);
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->buffer));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->value));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->indices));
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+TVMFFIAny BufferStoreMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  const BufferStoreNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const BufferStoreNode>(value);
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(BufferVar, mapped_buffer,
+                                    mutator->MutateExpected(self->buffer));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_value, mutator->MutateExpected(self->value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<PrimExpr>, mapped_indices,
+                                    mutator->MutateExpected(self->indices));
+  if (mapped_buffer.same_as(self->buffer) && mapped_value.same_as(self->value) &&
+      mapped_indices.same_as(self->indices)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  ffi::ObjectPtr<BufferStoreNode> copy = ffi::make_object<BufferStoreNode>(*self);
+  copy->buffer = std::move(mapped_buffer);
+  copy->value = std::move(mapped_value);
+  copy->indices = std::move(mapped_indices);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
+}
+
+TVMFFIAny BufferStoreMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
+                                        ffi::AnyView value) noexcept {
+  BufferStoreNode* self = const_cast<BufferStoreNode*>(
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const BufferStoreNode>(value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(BufferVar, mapped_buffer,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->buffer));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_value,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<PrimExpr>, mapped_indices,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->indices));
+  if (mapped_buffer.same_as(self->buffer) && mapped_value.same_as(self->value) &&
+      mapped_indices.same_as(self->indices)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  self->buffer = std::move(mapped_buffer);
+  self->value = std::move(mapped_value);
+  self->indices = std::move(mapped_indices);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny BufferRegionVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
+  const BufferRegionNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const BufferRegionNode>(value);
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->buffer));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->region));
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+TVMFFIAny BufferRegionMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  const BufferRegionNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const BufferRegionNode>(value);
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(BufferVar, mapped_buffer,
+                                    mutator->MutateExpected(self->buffer));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<Range>, mapped_region,
+                                    mutator->MutateExpected(self->region));
+  if (mapped_buffer.same_as(self->buffer) && mapped_region.same_as(self->region)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  ffi::ObjectPtr<BufferRegionNode> copy = ffi::make_object<BufferRegionNode>(*self);
+  copy->buffer = std::move(mapped_buffer);
+  copy->region = std::move(mapped_region);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
+}
+
+TVMFFIAny BufferRegionMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
+                                         ffi::AnyView value) noexcept {
+  BufferRegionNode* self = const_cast<BufferRegionNode*>(
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const BufferRegionNode>(value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(BufferVar, mapped_buffer,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->buffer));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<Range>, mapped_region,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->region));
+  if (mapped_buffer.same_as(self->buffer) && mapped_region.same_as(self->region)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  self->buffer = std::move(mapped_buffer);
+  self->region = std::move(mapped_region);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny MatchBufferRegionVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
+  const MatchBufferRegionNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const MatchBufferRegionNode>(
+          value);
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->WithDefRegionKind(
+      kTVMFFIDefRegionKindNonRecursive, [&]() { return visitor->VisitExpected(self->buffer); }));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->source));
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+TVMFFIAny MatchBufferRegionMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  const MatchBufferRegionNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const MatchBufferRegionNode>(
+          value);
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(
+      BufferVar, mapped_buffer, mutator->WithDefRegionKind(kTVMFFIDefRegionKindNonRecursive, [&]() {
+        return mutator->MutateExpected(self->buffer);
+      }));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(BufferRegion, mapped_source,
+                                    mutator->MutateExpected(self->source));
+  if (mapped_buffer.same_as(self->buffer) && mapped_source.same_as(self->source)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  ffi::ObjectPtr<MatchBufferRegionNode> copy = ffi::make_object<MatchBufferRegionNode>(*self);
+  copy->buffer = std::move(mapped_buffer);
+  copy->source = std::move(mapped_source);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
+}
+
+TVMFFIAny MatchBufferRegionMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
+                                              ffi::AnyView value) noexcept {
+  MatchBufferRegionNode* self = const_cast<MatchBufferRegionNode*>(
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const MatchBufferRegionNode>(
+          value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(
+      BufferVar, mapped_buffer, mutator->WithDefRegionKind(kTVMFFIDefRegionKindNonRecursive, [&]() {
+        return mutator->MaybeInplaceMutateIfUniqueExpected(self->buffer);
+      }));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(BufferRegion, mapped_source,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->source));
+  if (mapped_buffer.same_as(self->buffer) && mapped_source.same_as(self->source)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  self->buffer = std::move(mapped_buffer);
+  self->source = std::move(mapped_source);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny SBlockVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
+  // skips: name_hint
+  const SBlockNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const SBlockNode>(value);
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->iter_vars));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->reads));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->writes));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(
+      visitor->WithDefRegionKind(kTVMFFIDefRegionKindNonRecursive,
+                                 [&]() { return visitor->VisitExpected(self->alloc_buffers); }));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->match_buffers));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->annotations));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->init));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->body));
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+TVMFFIAny SBlockMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  // skips: name_hint
+  const SBlockNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const SBlockNode>(value);
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<IterVar>, mapped_iter_vars,
+                                    mutator->MutateExpected(self->iter_vars));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<BufferRegion>, mapped_reads,
+                                    mutator->MutateExpected(self->reads));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<BufferRegion>, mapped_writes,
+                                    mutator->MutateExpected(self->writes));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(
+      ffi::Array<BufferVar>, mapped_alloc_buffers,
+      mutator->WithDefRegionKind(kTVMFFIDefRegionKindNonRecursive,
+                                 [&]() { return mutator->MutateExpected(self->alloc_buffers); }));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<MatchBufferRegion>, mapped_match_buffers,
+                                    mutator->MutateExpected(self->match_buffers));
+  auto mapped_annotations_result = mutator->MutateExpected(self->annotations);
+  TVM_FFI_S_MUTATE_MAYBE_EARLY_RETURN(mapped_annotations_result);
+  bool mapped_annotations_type_ok =
+      ffi::details::AnyUnsafe::CheckAnyStrict<ffi::Map<ffi::String, ffi::Any>>(
+          ffi::details::ExpectedUnsafe::GetData(mapped_annotations_result));
+  if (TVM_FFI_PREDICT_FALSE(!mapped_annotations_type_ok)) {
+    return ffi::details::ExpectedUnsafe::MoveToTVMFFIAny(ffi::details::SMutateDeclaredTypeError());
+  }
+  ffi::Map<ffi::String, ffi::Any> mapped_annotations =
+      ffi::details::AnyUnsafe::MoveFromAnyAfterCheck<ffi::Map<ffi::String, ffi::Any>>(
+          std::move(ffi::details::ExpectedUnsafe::GetData(mapped_annotations_result)));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Optional<Stmt>, mapped_init,
+                                    mutator->MutateExpected(self->init));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Stmt, mapped_body, mutator->MutateExpected(self->body));
+  if (mapped_iter_vars.same_as(self->iter_vars) && mapped_reads.same_as(self->reads) &&
+      mapped_writes.same_as(self->writes) && mapped_alloc_buffers.same_as(self->alloc_buffers) &&
+      mapped_match_buffers.same_as(self->match_buffers) &&
+      mapped_annotations.same_as(self->annotations) && mapped_init.same_as(self->init) &&
+      mapped_body.same_as(self->body)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  ffi::ObjectPtr<SBlockNode> copy = ffi::make_object<SBlockNode>(*self);
+  copy->iter_vars = std::move(mapped_iter_vars);
+  copy->reads = std::move(mapped_reads);
+  copy->writes = std::move(mapped_writes);
+  copy->alloc_buffers = std::move(mapped_alloc_buffers);
+  copy->match_buffers = std::move(mapped_match_buffers);
+  copy->annotations = std::move(mapped_annotations);
+  copy->init = std::move(mapped_init);
+  copy->body = std::move(mapped_body);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
+}
+
+TVMFFIAny SBlockMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
+                                   ffi::AnyView value) noexcept {
+  // skips: name_hint
+  SBlockNode* self = const_cast<SBlockNode*>(
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const SBlockNode>(value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<IterVar>, mapped_iter_vars,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->iter_vars));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<BufferRegion>, mapped_reads,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->reads));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<BufferRegion>, mapped_writes,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->writes));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(
+      ffi::Array<BufferVar>, mapped_alloc_buffers,
+      mutator->WithDefRegionKind(kTVMFFIDefRegionKindNonRecursive, [&]() {
+        return mutator->MaybeInplaceMutateIfUniqueExpected(self->alloc_buffers);
+      }));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(
+      ffi::Array<MatchBufferRegion>, mapped_match_buffers,
+      mutator->MaybeInplaceMutateIfUniqueExpected(self->match_buffers));
+  auto mapped_annotations_result = mutator->MaybeInplaceMutateIfUniqueExpected(self->annotations);
+  TVM_FFI_S_MUTATE_MAYBE_EARLY_RETURN(mapped_annotations_result);
+  bool mapped_annotations_type_ok =
+      ffi::details::AnyUnsafe::CheckAnyStrict<ffi::Map<ffi::String, ffi::Any>>(
+          ffi::details::ExpectedUnsafe::GetData(mapped_annotations_result));
+  if (TVM_FFI_PREDICT_FALSE(!mapped_annotations_type_ok)) {
+    return ffi::details::ExpectedUnsafe::MoveToTVMFFIAny(ffi::details::SMutateDeclaredTypeError());
+  }
+  ffi::Map<ffi::String, ffi::Any> mapped_annotations =
+      ffi::details::AnyUnsafe::MoveFromAnyAfterCheck<ffi::Map<ffi::String, ffi::Any>>(
+          std::move(ffi::details::ExpectedUnsafe::GetData(mapped_annotations_result)));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Optional<Stmt>, mapped_init,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->init));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Stmt, mapped_body,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->body));
+  if (mapped_iter_vars.same_as(self->iter_vars) && mapped_reads.same_as(self->reads) &&
+      mapped_writes.same_as(self->writes) && mapped_alloc_buffers.same_as(self->alloc_buffers) &&
+      mapped_match_buffers.same_as(self->match_buffers) &&
+      mapped_annotations.same_as(self->annotations) && mapped_init.same_as(self->init) &&
+      mapped_body.same_as(self->body)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  self->iter_vars = std::move(mapped_iter_vars);
+  self->reads = std::move(mapped_reads);
+  self->writes = std::move(mapped_writes);
+  self->alloc_buffers = std::move(mapped_alloc_buffers);
+  self->match_buffers = std::move(mapped_match_buffers);
+  self->annotations = std::move(mapped_annotations);
+  self->init = std::move(mapped_init);
+  self->body = std::move(mapped_body);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny ScopeIdDefStmtVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
+  const ScopeIdDefStmtNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const ScopeIdDefStmtNode>(value);
+  // ScopeIdDef reflection marks only def_ids as definitions; its extent fields remain uses.
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->def));
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+TVMFFIAny ScopeIdDefStmtMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  const ScopeIdDefStmtNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const ScopeIdDefStmtNode>(value);
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ScopeIdDef, mapped_def, mutator->MutateExpected(self->def));
+  if (mapped_def.same_as(self->def)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  ffi::ObjectPtr<ScopeIdDefStmtNode> copy = ffi::make_object<ScopeIdDefStmtNode>(*self);
+  copy->def = std::move(mapped_def);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
+}
+
+TVMFFIAny ScopeIdDefStmtMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
+                                           ffi::AnyView value) noexcept {
+  ScopeIdDefStmtNode* self = const_cast<ScopeIdDefStmtNode*>(
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const ScopeIdDefStmtNode>(value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ScopeIdDef, mapped_def,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->def));
+  if (mapped_def.same_as(self->def)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  self->def = std::move(mapped_def);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+TVMFFIAny SBlockRealizeVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
+  const SBlockRealizeNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const SBlockRealizeNode>(value);
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->iter_values));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->predicate));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->block));
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+TVMFFIAny SBlockRealizeMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  const SBlockRealizeNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const SBlockRealizeNode>(value);
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<PrimExpr>, mapped_iter_values,
+                                    mutator->MutateExpected(self->iter_values));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_predicate,
+                                    mutator->MutateExpected(self->predicate));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(SBlock, mapped_block, mutator->MutateExpected(self->block));
+  if (mapped_iter_values.same_as(self->iter_values) && mapped_predicate.same_as(self->predicate) &&
+      mapped_block.same_as(self->block)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  ffi::ObjectPtr<SBlockRealizeNode> copy = ffi::make_object<SBlockRealizeNode>(*self);
+  copy->iter_values = std::move(mapped_iter_values);
+  copy->predicate = std::move(mapped_predicate);
+  copy->block = std::move(mapped_block);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
+}
+
+TVMFFIAny SBlockRealizeMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
+                                          ffi::AnyView value) noexcept {
+  SBlockRealizeNode* self = const_cast<SBlockRealizeNode*>(
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const SBlockRealizeNode>(value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<PrimExpr>, mapped_iter_values,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->iter_values));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_predicate,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->predicate));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(SBlock, mapped_block,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->block));
+  if (mapped_iter_values.same_as(self->iter_values) && mapped_predicate.same_as(self->predicate) &&
+      mapped_block.same_as(self->block)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  self->iter_values = std::move(mapped_iter_values);
+  self->predicate = std::move(mapped_predicate);
+  self->block = std::move(mapped_block);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
 }  // namespace
 
-TVM_FFI_STATIC_INIT_BLOCK() {
-  namespace refl = tvm::ffi::reflection;
-  StmtNode::RegisterReflection();
-  BindNode::RegisterReflection();
-
-  AttrStmtNode::RegisterReflection();
-  AssertStmtNode::RegisterReflection();
-  BufferStoreNode::RegisterReflection();
-  DeclBufferNode::RegisterReflection();
-  AllocBufferNode::RegisterReflection();
-  SeqStmtNode::RegisterReflection();
-  EvaluateNode::RegisterReflection();
-  IfThenElseNode::RegisterReflection();
-  ForNode::RegisterReflection();
-  WhileNode::RegisterReflection();
-  ReturnNode::RegisterReflection();
-  BreakNode::RegisterReflection();
-  ContinueNode::RegisterReflection();
-  BufferRegionTypeNode::RegisterReflection();
-  refl::TypeAttrDef<BufferRegionTypeNode>().def("__subscript_expr_realize__",
-                                                RealizeBufferRegionSubscript);
-  BufferRegionNode::RegisterReflection();
-  MatchBufferRegionNode::RegisterReflection();
-  SBlockNode::RegisterReflection();
-  SBlockRealizeNode::RegisterReflection();
-  ScopeIdDefStmtNode::RegisterReflection();
-}
+TVM_FFI_STATIC_INIT_BLOCK() { StmtNode::RegisterReflection(); }
 
 // Bind
 Bind::Bind(Var var, Expr value, Span span) {
@@ -134,8 +1105,14 @@ Bind::Bind(Var var, Expr value, Span span) {
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  BindNode::RegisterReflection();
   refl::GlobalDef().def("tirx.Bind",
                         [](Var var, Expr value, Span span) { return Bind(var, value, span); });
+  refl::TypeAttrDef<BindNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&BindVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&BindMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&BindMaybeInplaceMutate));
 }
 
 // AttrStmt
@@ -151,10 +1128,16 @@ AttrStmt::AttrStmt(ffi::Any node, ffi::String attr_key, PrimExpr value, Stmt bod
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  AttrStmtNode::RegisterReflection();
   refl::GlobalDef().def("tirx.AttrStmt",
                         [](Any node, ffi::String attr_key, PrimExpr value, Stmt body, Span span) {
                           return AttrStmt(node, attr_key, value, body, span);
                         });
+  refl::TypeAttrDef<AttrStmtNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&AttrStmtVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&AttrStmtMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&AttrStmtMaybeInplaceMutate));
 }
 
 // AssertStmt
@@ -177,26 +1160,17 @@ AssertStmt::AssertStmt(PrimExpr condition, prim::StringImm error_kind,
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  AssertStmtNode::RegisterReflection();
   refl::GlobalDef().def(
       "tirx.AssertStmt",
       [](PrimExpr condition, prim::StringImm error_kind, ffi::Array<prim::StringImm> message_parts,
          Span span) { return AssertStmt(condition, error_kind, message_parts, span); });
+  refl::TypeAttrDef<AssertStmtNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&AssertStmtVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&AssertStmtMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&AssertStmtMaybeInplaceMutate));
 }
-
-namespace {
-/*!
- * \brief Whether an integer literal can be represented exactly by `ty`.
- * \note Mirrors the range checks performed by the IntImm constructor.
- */
-bool IntImmValueFits(int64_t value, const PrimType& ty) {
-  int bits = ty.bits();
-  if (ty.MatchesCode(DLDataTypeCode::kDLUInt)) {
-    return value >= 0 && (bits >= 64 || value < (int64_t{1} << bits));
-  }
-  if (bits >= 64) return true;
-  return value >= -(int64_t{1} << (bits - 1)) && value < (int64_t{1} << (bits - 1));
-}
-}  // namespace
 
 // For
 For::For(PrimVar loop_var, PrimExpr min, PrimExpr extent, ForKind kind, Stmt body,
@@ -265,17 +1239,6 @@ For::For(PrimVar loop_var, PrimExpr min, PrimExpr extent, ForKind kind, Stmt bod
 
 bool ForNode::HasTrivialStep() const { return !step.has_value() || is_one(*step); }
 
-TVM_FFI_STATIC_INIT_BLOCK() {
-  namespace refl = tvm::ffi::reflection;
-  refl::GlobalDef().def("tirx.For", [](PrimVar loop_var, PrimExpr min, PrimExpr extent, int kind,
-                                       Stmt body, ffi::Optional<IterVar> thread_binding,
-                                       ffi::Optional<ffi::Map<ffi::String, Any>> annotations,
-                                       ffi::Optional<PrimExpr> step, Span span) {
-    return For(loop_var, min, extent, static_cast<ForKind>(kind), body, thread_binding,
-               annotations.value_or(ffi::Map<ffi::String, Any>()), step, span);
-  });
-}
-
 std::ostream& operator<<(std::ostream& out, ForKind type) {  // NOLINT(*)
   switch (type) {
     case ForKind::kSerial:
@@ -297,6 +1260,23 @@ std::ostream& operator<<(std::ostream& out, ForKind type) {  // NOLINT(*)
   return out;
 }
 
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace refl = tvm::ffi::reflection;
+  ForNode::RegisterReflection();
+  refl::GlobalDef().def("tirx.For", [](PrimVar loop_var, PrimExpr min, PrimExpr extent, int kind,
+                                       Stmt body, ffi::Optional<IterVar> thread_binding,
+                                       ffi::Optional<ffi::Map<ffi::String, Any>> annotations,
+                                       ffi::Optional<PrimExpr> step, Span span) {
+    return For(loop_var, min, extent, static_cast<ForKind>(kind), body, thread_binding,
+               annotations.value_or(ffi::Map<ffi::String, Any>()), step, span);
+  });
+  refl::TypeAttrDef<ForNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&ForVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&ForMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&ForMaybeInplaceMutate));
+}
+
 // While
 While::While(PrimExpr condition, Stmt body, Span span) {
   TVM_FFI_ICHECK(condition.defined());
@@ -312,9 +1292,15 @@ While::While(PrimExpr condition, Stmt body, Span span) {
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  WhileNode::RegisterReflection();
   refl::GlobalDef().def("tirx.While", [](PrimExpr condition, Stmt body, Span span) {
     return While(condition, body, span);
   });
+  refl::TypeAttrDef<WhileNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&WhileVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&WhileMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&WhileMaybeInplaceMutate));
 }
 
 // Return
@@ -329,7 +1315,13 @@ Return::Return(Expr value, Span span) {
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  ReturnNode::RegisterReflection();
   refl::GlobalDef().def("tirx.Return", [](Expr value, Span span) { return Return(value, span); });
+  refl::TypeAttrDef<ReturnNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&ReturnVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&ReturnMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&ReturnMaybeInplaceMutate));
 }
 
 // Break
@@ -341,7 +1333,13 @@ Break::Break(Span span) {
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  BreakNode::RegisterReflection();
   refl::GlobalDef().def("tirx.Break", [](Span span) { return Break(span); });
+  refl::TypeAttrDef<BreakNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&BreakVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&BreakMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&BreakMaybeInplaceMutate));
 }
 
 // Continue
@@ -353,7 +1351,13 @@ Continue::Continue(Span span) {
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  ContinueNode::RegisterReflection();
   refl::GlobalDef().def("tirx.Continue", [](Span span) { return Continue(span); });
+  refl::TypeAttrDef<ContinueNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&ContinueVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&ContinueMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&ContinueMaybeInplaceMutate));
 }
 
 // DeclBuffer
@@ -380,9 +1384,15 @@ DeclBuffer::DeclBuffer(BufferVar buffer, Expr data, Span span) {
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  DeclBufferNode::RegisterReflection();
   refl::GlobalDef().def("tirx.DeclBuffer", [](BufferVar buffer, Expr data, Span span) {
     return DeclBuffer(buffer, data, span);
   });
+  refl::TypeAttrDef<DeclBufferNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&DeclBufferVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&DeclBufferMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&DeclBufferMaybeInplaceMutate));
 }
 
 // AllocBuffer
@@ -396,11 +1406,17 @@ AllocBuffer::AllocBuffer(BufferVar buffer, ffi::Map<ffi::String, Any> annotation
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  AllocBufferNode::RegisterReflection();
   refl::GlobalDef().def(
       "tirx.AllocBuffer",
       [](BufferVar buffer, ffi::Optional<ffi::Map<ffi::String, Any>> annotations, Span span) {
         return AllocBuffer(buffer, annotations.value_or(ffi::Map<ffi::String, Any>()), span);
       });
+  refl::TypeAttrDef<AllocBufferNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&AllocBufferVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&AllocBufferMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&AllocBufferMaybeInplaceMutate));
 }
 
 // SeqStmt
@@ -430,11 +1446,21 @@ SeqStmt::SeqStmt(ffi::Array<Stmt> seq, Span span) {
   data_ = std::move(node);
 }
 
+// A direct child that mutates into a SeqStmt is spliced into this sequence in the same pass,
+// matching StmtMutator's normalized result without a second scan and allocation. A well-formed
+// mapped SeqStmt already holds no SeqStmt child, so this single-level splice is sufficient and an
+// unchanged element never needs splicing.
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  SeqStmtNode::RegisterReflection();
   refl::GlobalDef().def("tirx.SeqStmt", [](ffi::Array<Stmt> seq, Span span) {
     return SeqStmt(std::move(seq), span);
   });
+  refl::TypeAttrDef<SeqStmtNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&SeqStmtVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&SeqStmtMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&SeqStmtMaybeInplaceMutate));
 }
 
 // IfThenElse
@@ -453,10 +1479,16 @@ IfThenElse::IfThenElse(PrimExpr condition, Stmt then_case, ffi::Optional<Stmt> e
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  IfThenElseNode::RegisterReflection();
   refl::GlobalDef().def("tirx.IfThenElse",
                         [](PrimExpr condition, Stmt then_case, Stmt else_case, Span span) {
                           return IfThenElse(condition, then_case, else_case, span);
                         });
+  refl::TypeAttrDef<IfThenElseNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&IfThenElseVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&IfThenElseMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&IfThenElseMaybeInplaceMutate));
 }
 
 // Evaluate
@@ -474,8 +1506,14 @@ Evaluate::Evaluate(Expr value, Span span) {
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  EvaluateNode::RegisterReflection();
   refl::GlobalDef().def("tirx.Evaluate",
                         [](Expr value, Span span) { return Evaluate(value, span); });
+  refl::TypeAttrDef<EvaluateNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&EvaluateVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&EvaluateMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&EvaluateMaybeInplaceMutate));
 }
 
 // BufferStore
@@ -542,15 +1580,28 @@ BufferStore::BufferStore(BufferVar buffer, PrimExpr value, ffi::Array<PrimExpr> 
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  BufferStoreNode::RegisterReflection();
   refl::GlobalDef().def("tirx.BufferStore",
                         [](BufferVar buffer, PrimExpr value, ffi::Array<PrimExpr> indices,
                            Span span) { return BufferStore(buffer, value, indices, span); });
+  refl::TypeAttrDef<BufferStoreNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&BufferStoreVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&BufferStoreMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&BufferStoreMaybeInplaceMutate));
 }
 
 // BufferRegion
 BufferRegionType::BufferRegionType() : Type(ffi::UnsafeInit{}) {
   static ffi::ObjectPtr<BufferRegionTypeNode> singleton = ffi::make_object<BufferRegionTypeNode>();
   data_ = singleton;
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace refl = tvm::ffi::reflection;
+  BufferRegionTypeNode::RegisterReflection();
+  refl::TypeAttrDef<BufferRegionTypeNode>().def("__subscript_expr_realize__",
+                                                RealizeBufferRegionSubscript);
 }
 
 BufferRegion::BufferRegion(BufferVar buffer, ffi::Array<Range> region, Span span) {
@@ -588,10 +1639,16 @@ BufferRegion BufferRegion::FromPoint(BufferVar buffer, ffi::Array<PrimExpr> indi
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  BufferRegionNode::RegisterReflection();
   refl::GlobalDef()
       .def("tirx.BufferRegionType", []() { return BufferRegionType(); })
       .def("tirx.BufferRegion",
            [](BufferVar buffer, ffi::Array<Range> region) { return BufferRegion(buffer, region); });
+  refl::TypeAttrDef<BufferRegionNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&BufferRegionVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&BufferRegionMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&BufferRegionMaybeInplaceMutate));
 }
 
 // MatchBufferRegion
@@ -643,9 +1700,15 @@ MatchBufferRegion::MatchBufferRegion(BufferVar buffer, BufferRegion source) {
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  MatchBufferRegionNode::RegisterReflection();
   refl::GlobalDef().def("tirx.MatchBufferRegion", [](BufferVar buffer, BufferRegion source) {
     return MatchBufferRegion(buffer, source);
   });
+  refl::TypeAttrDef<MatchBufferRegionNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&MatchBufferRegionVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&MatchBufferRegionMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&MatchBufferRegionMaybeInplaceMutate));
 }
 
 // Block
@@ -685,6 +1748,7 @@ SBlock::SBlock(ffi::String name_hint, Stmt body, ffi::Array<BufferVar> alloc_buf
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  SBlockNode::RegisterReflection();
   refl::GlobalDef().def("tirx.SBlock",
                         [](ffi::Array<IterVar> iter_vars, ffi::Array<BufferRegion> reads,
                            ffi::Array<BufferRegion> writes, ffi::String name_hint, Stmt body,
@@ -694,6 +1758,11 @@ TVM_FFI_STATIC_INIT_BLOCK() {
                           return SBlock(iter_vars, reads, writes, name_hint, body, init,
                                         alloc_buffers, match_buffers, annotations, span);
                         });
+  refl::TypeAttrDef<SBlockNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&SBlockVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&SBlockMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&SBlockMaybeInplaceMutate));
 }
 
 // ScopeIdDefStmt
@@ -707,8 +1776,14 @@ ScopeIdDefStmt::ScopeIdDefStmt(ScopeIdDef def, Span span) {
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  ScopeIdDefStmtNode::RegisterReflection();
   refl::GlobalDef().def("tirx.ScopeIdDefStmt",
                         [](ScopeIdDef def, Span span) { return ScopeIdDefStmt(def, span); });
+  refl::TypeAttrDef<ScopeIdDefStmtNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&ScopeIdDefStmtVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&ScopeIdDefStmtMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&ScopeIdDefStmtMaybeInplaceMutate));
 }
 
 // BlockRealize
@@ -729,10 +1804,16 @@ SBlockRealize::SBlockRealize(ffi::Array<PrimExpr> values, PrimExpr predicate, SB
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  SBlockRealizeNode::RegisterReflection();
   refl::GlobalDef().def("tirx.SBlockRealize", [](ffi::Array<PrimExpr> iter_values,
                                                  PrimExpr predicate, SBlock block, Span span) {
     return SBlockRealize(iter_values, predicate, block, span);
   });
+  refl::TypeAttrDef<SBlockRealizeNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&SBlockRealizeVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&SBlockRealizeMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&SBlockRealizeMaybeInplaceMutate));
 }
 
 PrimExpr TypeAnnotation(PrimType dtype, Span span) {

--- a/src/tirx/ir/tirx_stmt.cc
+++ b/src/tirx/ir/tirx_stmt.cc
@@ -22,14 +22,17 @@
  * TIRX statement nodes.
  */
 
+#include <tvm/ffi/extra/structural_mutate.h>
+#include <tvm/ffi/extra/structural_visit.h>
+#include <tvm/ffi/reflection/registry.h>
 #include <tvm/tirx/op.h>
 #include <tvm/tirx/op_attr_types.h>
 #include <tvm/tirx/tile_primitive.h>
 
+#include <utility>
+
 namespace tvm {
 namespace tirx {
-
-TVM_FFI_STATIC_INIT_BLOCK() { TilePrimitiveCallNode::RegisterReflection(); }
 
 // TilePrimitiveCall
 TilePrimitiveCall::TilePrimitiveCall(tvm::Op op, ffi::Array<ffi::Any> args,
@@ -46,8 +49,110 @@ TilePrimitiveCall::TilePrimitiveCall(tvm::Op op, ffi::Array<ffi::Any> args,
   data_ = std::move(n);
 }
 
+namespace {
+
+TVMFFIAny TilePrimitiveCallVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
+  // skips: op, dispatch, scope
+  const TilePrimitiveCallNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const TilePrimitiveCallNode>(
+          value);
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->args));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->workspace));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->config));
+  TVM_FFI_S_VISIT_RETURN_NONE();
+}
+
+TVMFFIAny TilePrimitiveCallMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
+  // skips: op, dispatch, scope
+  const TilePrimitiveCallNode* self =
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const TilePrimitiveCallNode>(
+          value);
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<ffi::Any>, mapped_args,
+                                    mutator->MutateExpected(self->args));
+
+  auto mapped_workspace_result = mutator->MutateExpected(self->workspace);
+  TVM_FFI_S_MUTATE_MAYBE_EARLY_RETURN(mapped_workspace_result);
+  bool mapped_workspace_type_ok =
+      ffi::details::AnyUnsafe::CheckAnyStrict<ffi::Map<ffi::String, BufferVar>>(
+          ffi::details::ExpectedUnsafe::GetData(mapped_workspace_result));
+  if (TVM_FFI_PREDICT_FALSE(!mapped_workspace_type_ok)) {
+    return ffi::details::ExpectedUnsafe::MoveToTVMFFIAny(ffi::details::SMutateDeclaredTypeError());
+  }
+  ffi::Map<ffi::String, BufferVar> mapped_workspace =
+      ffi::details::AnyUnsafe::MoveFromAnyAfterCheck<ffi::Map<ffi::String, BufferVar>>(
+          std::move(ffi::details::ExpectedUnsafe::GetData(mapped_workspace_result)));
+
+  auto mapped_config_result = mutator->MutateExpected(self->config);
+  TVM_FFI_S_MUTATE_MAYBE_EARLY_RETURN(mapped_config_result);
+  bool mapped_config_type_ok =
+      ffi::details::AnyUnsafe::CheckAnyStrict<ffi::Map<ffi::String, ffi::Any>>(
+          ffi::details::ExpectedUnsafe::GetData(mapped_config_result));
+  if (TVM_FFI_PREDICT_FALSE(!mapped_config_type_ok)) {
+    return ffi::details::ExpectedUnsafe::MoveToTVMFFIAny(ffi::details::SMutateDeclaredTypeError());
+  }
+  ffi::Map<ffi::String, ffi::Any> mapped_config =
+      ffi::details::AnyUnsafe::MoveFromAnyAfterCheck<ffi::Map<ffi::String, ffi::Any>>(
+          std::move(ffi::details::ExpectedUnsafe::GetData(mapped_config_result)));
+
+  if (mapped_args.same_as(self->args) && mapped_workspace.same_as(self->workspace) &&
+      mapped_config.same_as(self->config)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  ffi::ObjectPtr<TilePrimitiveCallNode> copy = ffi::make_object<TilePrimitiveCallNode>(*self);
+  copy->args = std::move(mapped_args);
+  copy->workspace = std::move(mapped_workspace);
+  copy->config = std::move(mapped_config);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
+}
+
+TVMFFIAny TilePrimitiveCallMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
+                                              ffi::AnyView value) noexcept {
+  // skips: op, dispatch, scope
+  TilePrimitiveCallNode* self = const_cast<TilePrimitiveCallNode*>(
+      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const TilePrimitiveCallNode>(
+          value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<ffi::Any>, mapped_args,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->args));
+
+  auto mapped_workspace_result = mutator->MaybeInplaceMutateIfUniqueExpected(self->workspace);
+  TVM_FFI_S_MUTATE_MAYBE_EARLY_RETURN(mapped_workspace_result);
+  bool mapped_workspace_type_ok =
+      ffi::details::AnyUnsafe::CheckAnyStrict<ffi::Map<ffi::String, BufferVar>>(
+          ffi::details::ExpectedUnsafe::GetData(mapped_workspace_result));
+  if (TVM_FFI_PREDICT_FALSE(!mapped_workspace_type_ok)) {
+    return ffi::details::ExpectedUnsafe::MoveToTVMFFIAny(ffi::details::SMutateDeclaredTypeError());
+  }
+  ffi::Map<ffi::String, BufferVar> mapped_workspace =
+      ffi::details::AnyUnsafe::MoveFromAnyAfterCheck<ffi::Map<ffi::String, BufferVar>>(
+          std::move(ffi::details::ExpectedUnsafe::GetData(mapped_workspace_result)));
+
+  auto mapped_config_result = mutator->MaybeInplaceMutateIfUniqueExpected(self->config);
+  TVM_FFI_S_MUTATE_MAYBE_EARLY_RETURN(mapped_config_result);
+  bool mapped_config_type_ok =
+      ffi::details::AnyUnsafe::CheckAnyStrict<ffi::Map<ffi::String, ffi::Any>>(
+          ffi::details::ExpectedUnsafe::GetData(mapped_config_result));
+  if (TVM_FFI_PREDICT_FALSE(!mapped_config_type_ok)) {
+    return ffi::details::ExpectedUnsafe::MoveToTVMFFIAny(ffi::details::SMutateDeclaredTypeError());
+  }
+  ffi::Map<ffi::String, ffi::Any> mapped_config =
+      ffi::details::AnyUnsafe::MoveFromAnyAfterCheck<ffi::Map<ffi::String, ffi::Any>>(
+          std::move(ffi::details::ExpectedUnsafe::GetData(mapped_config_result)));
+
+  if (mapped_args.same_as(self->args) && mapped_workspace.same_as(self->workspace) &&
+      mapped_config.same_as(self->config)) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  }
+  self->args = std::move(mapped_args);
+  self->workspace = std::move(mapped_workspace);
+  self->config = std::move(mapped_config);
+  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+}
+
+}  // namespace
+
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
+  TilePrimitiveCallNode::RegisterReflection();
   refl::GlobalDef().def(
       "tirx.TilePrimitiveCall",
       [](tvm::Op op, ffi::Array<ffi::Any> args, ffi::Map<ffi::String, BufferVar> workspace,
@@ -55,6 +160,11 @@ TVM_FFI_STATIC_INIT_BLOCK() {
          ExecScope scope) {
         return TilePrimitiveCall(op, args, workspace, config, dispatch, scope);
       });
+  refl::TypeAttrDef<TilePrimitiveCallNode>()
+      .attr(refl::type_attr::kStructuralVisit, reinterpret_cast<void*>(&TilePrimitiveCallVisit))
+      .attr(refl::type_attr::kStructuralMutate, reinterpret_cast<void*>(&TilePrimitiveCallMutate))
+      .attr(refl::type_attr::kStructuralMaybeInplaceMutate,
+            reinterpret_cast<void*>(&TilePrimitiveCallMaybeInplaceMutate));
 }
 
 TVM_FFI_STATIC_INIT_BLOCK() {

--- a/tests/cpp/ir_functor_test.cc
+++ b/tests/cpp/ir_functor_test.cc
@@ -19,6 +19,8 @@
 
 #include <gtest/gtest.h>
 #include <tvm/ffi/extra/structural_equal.h>
+#include <tvm/ffi/extra/structural_mutate.h>
+#include <tvm/ffi/extra/structural_visit.h>
 #include <tvm/ir/module.h>
 #include <tvm/ir/node_functor.h>
 #include <tvm/ir/prim/builtin.h>
@@ -30,6 +32,8 @@
 #include <tvm/tirx/function.h>
 #include <tvm/tirx/op.h>
 #include <tvm/tirx/stmt_functor.h>
+
+#include <initializer_list>
 
 TEST(IRF, Basic) {
   using namespace tvm;
@@ -328,6 +332,257 @@ TEST(IRF, StmtMutator) {
     TVM_FFI_ICHECK(new_block->writes[0]->region[0]->min.same_as(x));
     TVM_FFI_ICHECK(new_block->match_buffers[0]->source->region[0]->min.same_as(x));
   }
+}
+
+TEST(IRF, StructuralMapSplicesMappedSeqStmtChild) {
+  using namespace tvm;
+  using namespace tvm::tirx;
+
+  auto make_input = []() -> Stmt {
+    return SeqStmt(
+        {Evaluate(IntImm::Int32(5)), Evaluate(IntImm::Int32(1)), Evaluate(IntImm::Int32(4))});
+  };
+  auto expand_one = [](const Evaluate& evaluate) -> Stmt {
+    const auto* value = evaluate->value.as<IntImmNode>();
+    if (value != nullptr && value->value == 1) {
+      return SeqStmt({Evaluate(IntImm::Int32(2)), Evaluate(IntImm::Int32(3))});
+    }
+    return evaluate;
+  };
+  auto check_values = [](const Stmt& stmt, std::initializer_list<int64_t> expected) {
+    const auto* seq = stmt.as<SeqStmtNode>();
+    ASSERT_NE(seq, nullptr);
+    ASSERT_EQ(seq->seq.size(), expected.size());
+    size_t i = 0;
+    for (int64_t expected_value : expected) {
+      const auto* evaluate = seq->seq[i].as<EvaluateNode>();
+      ASSERT_NE(evaluate, nullptr);
+      const auto* value = evaluate->value.as<IntImmNode>();
+      ASSERT_NE(value, nullptr);
+      EXPECT_EQ(value->value, expected_value);
+      ++i;
+    }
+  };
+  {
+    Stmt input = make_input();
+    Stmt shared = input;
+    Stmt mapped = ffi::StructuralMap<ffi::WalkOrder::kPostOrder>(input, expand_one).cast<Stmt>();
+    EXPECT_FALSE(mapped.same_as(input));
+    EXPECT_EQ(shared.as<SeqStmtNode>()->seq.size(), 3);
+    check_values(mapped, {5, 2, 3, 4});
+  }
+
+  {
+    Stmt input = make_input();
+    const auto* original = input.get();
+    Stmt mapped =
+        ffi::StructuralMap<ffi::WalkOrder::kPostOrder>(std::move(input), expand_one).cast<Stmt>();
+    EXPECT_EQ(mapped.get(), original);
+    check_values(mapped, {5, 2, 3, 4});
+  }
+
+  auto make_boundary_input = []() -> Stmt {
+    return SeqStmt({Evaluate(IntImm::Int32(1)), Evaluate(IntImm::Int32(2)),
+                    Evaluate(IntImm::Int32(3)), Evaluate(IntImm::Int32(4))});
+  };
+  auto check_differential = [&](const auto& transform, std::initializer_list<int64_t> expected,
+                                bool expect_array_reuse) {
+    Stmt ordinary_input = make_boundary_input();
+    Stmt ordinary = ffi::StructuralMap<ffi::WalkOrder::kPostOrder>(ordinary_input, transform)
+                        .template cast<Stmt>();
+
+    Stmt inplace_input = make_boundary_input();
+    const auto* original_root = inplace_input.get();
+    const auto* original_array = inplace_input.as<SeqStmtNode>()->seq.GetArrayObj();
+    Stmt inplace =
+        ffi::StructuralMap<ffi::WalkOrder::kPostOrder>(std::move(inplace_input), transform)
+            .template cast<Stmt>();
+
+    EXPECT_EQ(inplace.get(), original_root);
+    if (expect_array_reuse) {
+      EXPECT_EQ(inplace.as<SeqStmtNode>()->seq.GetArrayObj(), original_array);
+    } else {
+      EXPECT_NE(inplace.as<SeqStmtNode>()->seq.GetArrayObj(), original_array);
+    }
+    EXPECT_TRUE(ffi::StructuralEqual()(ordinary, inplace));
+    check_values(inplace, expected);
+  };
+
+  auto shrink_first_grow_last = [](const Evaluate& evaluate) -> Stmt {
+    const auto* value = evaluate->value.as<IntImmNode>();
+    if (value != nullptr && value->value == 1) {
+      return Evaluate(0);
+    }
+    if (value != nullptr && value->value == 4) {
+      return SeqStmt({Evaluate(IntImm::Int32(30)), Evaluate(IntImm::Int32(31))});
+    }
+    return evaluate;
+  };
+  check_differential(shrink_first_grow_last, {2, 3, 30, 31}, true);
+
+  int overflow_callback_count = 0;
+  auto grow_first_shrink_last = [&overflow_callback_count](const Evaluate& evaluate) -> Stmt {
+    ++overflow_callback_count;
+    const auto* value = evaluate->value.as<IntImmNode>();
+    if (value != nullptr && value->value == 1) {
+      return SeqStmt({Evaluate(IntImm::Int32(10)), Evaluate(IntImm::Int32(11))});
+    }
+    if (value != nullptr && value->value == 4) {
+      return Evaluate(0);
+    }
+    return evaluate;
+  };
+  check_differential(grow_first_shrink_last, {10, 11, 2, 3}, false);
+  EXPECT_EQ(overflow_callback_count, 8);
+
+  auto replace_middle_with_one = [](const Evaluate& evaluate) -> Stmt {
+    const auto* value = evaluate->value.as<IntImmNode>();
+    if (value != nullptr && value->value == 2) {
+      return Evaluate(IntImm::Int32(10));
+    }
+    return evaluate;
+  };
+  check_differential(replace_middle_with_one, {1, 10, 3, 4}, true);
+
+  auto remove_first = [](const Evaluate& evaluate) -> Stmt {
+    const auto* value = evaluate->value.as<IntImmNode>();
+    return value != nullptr && value->value == 1 ? Evaluate(0) : Stmt(evaluate);
+  };
+  check_differential(remove_first, {2, 3, 4}, true);
+
+  auto remove_all = [](const Evaluate&) -> Stmt { return Evaluate(0); };
+  Stmt ordinary_input = make_boundary_input();
+  Stmt ordinary =
+      ffi::StructuralMap<ffi::WalkOrder::kPostOrder>(ordinary_input, remove_all).cast<Stmt>();
+  Stmt inplace_input = make_boundary_input();
+  Stmt inplace =
+      ffi::StructuralMap<ffi::WalkOrder::kPostOrder>(std::move(inplace_input), remove_all)
+          .cast<Stmt>();
+  EXPECT_TRUE(ffi::StructuralEqual()(ordinary, inplace));
+  for (const Stmt& result : {ordinary, inplace}) {
+    const auto* evaluate = result.as<EvaluateNode>();
+    ASSERT_NE(evaluate, nullptr);
+    const auto* value = evaluate->value.as<IntImmNode>();
+    ASSERT_NE(value, nullptr);
+    EXPECT_EQ(value->value, 0);
+  }
+
+  auto keep_last = [](const Evaluate& evaluate) -> Stmt {
+    const auto* value = evaluate->value.as<IntImmNode>();
+    return value != nullptr && value->value == 4 ? Stmt(evaluate) : Stmt(Evaluate(0));
+  };
+  ordinary_input = make_boundary_input();
+  ordinary = ffi::StructuralMap<ffi::WalkOrder::kPostOrder>(ordinary_input, keep_last).cast<Stmt>();
+  inplace_input = make_boundary_input();
+  inplace = ffi::StructuralMap<ffi::WalkOrder::kPostOrder>(std::move(inplace_input), keep_last)
+                .cast<Stmt>();
+  EXPECT_TRUE(ffi::StructuralEqual()(ordinary, inplace));
+  for (const Stmt& result : {ordinary, inplace}) {
+    const auto* evaluate = result.as<EvaluateNode>();
+    ASSERT_NE(evaluate, nullptr);
+    const auto* value = evaluate->value.as<IntImmNode>();
+    ASSERT_NE(value, nullptr);
+    EXPECT_EQ(value->value, 4);
+  }
+}
+
+TEST(IRF, StructuralMapPreservesSeqStmtElementUniqueness) {
+  using namespace tvm;
+  using namespace tvm::tirx;
+
+  auto replace_one = [](const IntImm& value) -> PrimExpr {
+    return value->value == 1 ? IntImm::Int32(2) : PrimExpr(value);
+  };
+
+  {
+    Stmt input = SeqStmt({Evaluate(IntImm::Int32(1)), Evaluate(IntImm::Int32(3))});
+    const auto* original_root = input.get();
+    const auto* original_first = input.as<SeqStmtNode>()->seq[0].as<EvaluateNode>();
+    Stmt mapped =
+        ffi::StructuralMap<ffi::WalkOrder::kPostOrder>(std::move(input), replace_one).cast<Stmt>();
+
+    const auto* mapped_seq = mapped.as<SeqStmtNode>();
+    ASSERT_NE(mapped_seq, nullptr);
+    EXPECT_EQ(mapped.get(), original_root);
+    EXPECT_EQ(mapped_seq->seq[0].get(), original_first);
+    EXPECT_EQ(mapped_seq->seq[0].as<EvaluateNode>()->value.as<IntImmNode>()->value, 2);
+  }
+
+  {
+    ffi::Array<Stmt> shared_seq = {Evaluate(IntImm::Int32(1)), Evaluate(IntImm::Int32(3))};
+    const auto* shared_first = shared_seq[0].as<EvaluateNode>();
+    Stmt input = SeqStmt(shared_seq);
+    Stmt mapped =
+        ffi::StructuralMap<ffi::WalkOrder::kPostOrder>(std::move(input), replace_one).cast<Stmt>();
+
+    const auto* mapped_seq = mapped.as<SeqStmtNode>();
+    ASSERT_NE(mapped_seq, nullptr);
+    EXPECT_FALSE(mapped_seq->seq.same_as(shared_seq));
+    EXPECT_EQ(shared_seq[0].get(), shared_first);
+    EXPECT_EQ(shared_seq[0].as<EvaluateNode>()->value.as<IntImmNode>()->value, 1);
+    EXPECT_EQ(mapped_seq->seq[0].as<EvaluateNode>()->value.as<IntImmNode>()->value, 2);
+
+    Stmt unchanged_input = SeqStmt(shared_seq);
+    const auto* unchanged_root = unchanged_input.get();
+    auto no_float_match = [](const FloatImm& value) -> PrimExpr { return value; };
+    Stmt unchanged =
+        ffi::StructuralMap<ffi::WalkOrder::kPostOrder>(std::move(unchanged_input), no_float_match)
+            .cast<Stmt>();
+    EXPECT_EQ(unchanged.get(), unchanged_root);
+    EXPECT_TRUE(unchanged.as<SeqStmtNode>()->seq.same_as(shared_seq));
+  }
+}
+
+TEST(IRF, StructuralHooksPreserveScopeIdDefRegions) {
+  using namespace tvm;
+  using namespace tvm::tirx;
+
+  auto make_input = []() -> Stmt {
+    return ScopeIdDefStmt(ScopeIdDef({PrimVar("binder")}, ffi::Array<PrimExpr>{PrimVar("extent")},
+                                     ScopeBinding::kCtaThread,
+                                     ffi::Array<PrimExpr>{PrimVar("preferred")}));
+  };
+  auto check_kinds = [](int binder, int extent, int preferred) {
+    EXPECT_EQ(binder, kTVMFFIDefRegionKindNonRecursive);
+    EXPECT_EQ(extent, kTVMFFIDefRegionKindNone);
+    EXPECT_EQ(preferred, kTVMFFIDefRegionKindNone);
+  };
+
+  {
+    int binder = -1;
+    int extent = -1;
+    int preferred = -1;
+    ffi::StructuralWalk<ffi::WalkOrder::kPostOrder>(
+        make_input(),
+        [&](const Var& var, TVMFFIDefRegionKind kind) -> ffi::Expected<ffi::WalkResult> {
+          if (var->name == "binder") binder = kind;
+          if (var->name == "extent") extent = kind;
+          if (var->name == "preferred") preferred = kind;
+          return ffi::WalkResult::Advance();
+        });
+    check_kinds(binder, extent, preferred);
+  }
+
+  auto check_map = [&](Stmt input) {
+    int binder = -1;
+    int extent = -1;
+    int preferred = -1;
+    ffi::StructuralMap<ffi::WalkOrder::kPostOrder>(
+        std::move(input), [&](const Var& var, TVMFFIDefRegionKind kind) -> Var {
+          if (var->name == "binder") binder = kind;
+          if (var->name == "extent") extent = kind;
+          if (var->name == "preferred") preferred = kind;
+          return var;
+        });
+    check_kinds(binder, extent, preferred);
+  };
+
+  {
+    Stmt input = make_input();
+    Stmt shared = input;
+    check_map(input);
+  }
+  check_map(make_input());
 }
 
 TEST(IRF, Substitute) {


### PR DESCRIPTION
Add compiled structural visit, mutate, and maybe-in-place-mutate
hooks for every Expr and Stmt node family using the current tvm-ffi
structural-hook ABI.

`StmtNode` and `TypeNode` declare
`_type_s_eq_hash_subclass_kind_fixed = true`. The current hierarchy census
finds 18 final registered children under Stmt and 14 under Type, with no FreeVar
or DAG kind override in either hierarchy. This lets typed structural-map
callbacks over Stmt and Type fold out the identity-remap branch. `Expr`,
`PrimExpr`, and `BaseFunc` retain the default because their descendants
include FreeVar or DAG kinds.

Definition-region annotations are aligned with reflected fallback behavior:
direct definitions use non-recursive regions, container-owned definitions are
established at their Var sites, and dynamic Var type descent remains a use. The
hooks preserve the established visitor/mutator field set and same-object short
circuits on unchanged mutations.
