### PR TITLE
[TIRx][Test] Gate collector-A-only block-scale MMA test on CUDA 13.4

### DIFF
--- a/tests/python/tirx/codegen/test_ptx_dialect.py
+++ b/tests/python/tirx/codegen/test_ptx_dialect.py
@@ -2419,6 +2419,10 @@ def test_ptx_tcgen05_mma_block_size_collector_form():
     _assert_ptxas_ok(collector_src, arch="sm_107f")
 
 
+@pytest.mark.skipif(
+    not env.has_nvcc_version(13, 4),
+    reason="collector-qualified block_scale MMA is a PTX 9.4 form; need nvcc >= 13.4",
+)
 @requires_nvcc
 def test_ptx_tcgen05_mma_block_scale_collector_a_without_block_size():
     """SM107 activation-stationary FP8 accepts collector A without `.block*`."""


### PR DESCRIPTION
## Summary

Follow-up to #20271. `test_ptx_tcgen05_mma_block_scale_collector_a_without_block_size` certifies a collector-qualified `tcgen05.mma` block-scale form, which is a PTX ISA 9.4 form and therefore needs nvcc / ptxas 13.4 or newer. This gates the test with `env.has_nvcc_version(13, 4)`, the same guard the other 9.4-only certifications in `tests/python/tirx/codegen/test_ptx_dialect.py` already use, so older toolchains skip it instead of failing in ptxas.

Test-only change; no table or codegen edits.
