### PR TITLE
[S-TIR][Test] Use tvm.testing.main() so schedule tests can run standalone

### DIFF
--- a/tests/python/s_tir/schedule/test_tir_schedule_read_write_at.py
+++ b/tests/python/s_tir/schedule/test_tir_schedule_read_write_at.py
@@ -37,6 +37,7 @@ import sys
 import pytest
 
 import tvm
+import tvm.testing
 from tvm import tirx
 from tvm.s_tir.schedule.testing import (
     assert_structural_equal_ignore_global_symbol,

--- a/tests/python/s_tir/schedule/test_tir_schedule_storage_align.py
+++ b/tests/python/s_tir/schedule/test_tir_schedule_storage_align.py
@@ -19,6 +19,7 @@
 import pytest
 
 import tvm
+import tvm.testing
 from tvm import tirx
 from tvm.s_tir.schedule.testing import (
     assert_structural_equal_ignore_global_symbol,
@@ -173,11 +174,4 @@ def test_storage_align_invalid_annotation():
 
 
 if __name__ == "__main__":
-    test_storage_align()
-    test_storage_align_update()
-    test_storage_align_invalid_factor1()
-    test_storage_align_invalid_factor2()
-    test_storage_align_invalid_buffer()
-    test_storage_align_invalid_buffer_index()
-    test_storage_align_invalid_axis()
-    test_storage_align_invalid_annotation()
+    tvm.testing.main()


### PR DESCRIPTION
## Problem

Two files under `tests/python/s_tir/schedule/` cannot be run standalone.

### 1. `tvm.testing` is used but never imported

Both `test_tir_schedule_storage_align.py` and `test_tir_schedule_read_write_at.py`
reference `tvm.testing` while importing only `import tvm`:

```python
import tvm
from tvm import tirx
```

`tvm/__init__.py` does not pull in `tvm.testing`, so the attribute only resolves
because pytest has already imported the submodule elsewhere in the session.
Running either file directly gives:

```
AttributeError: module 'tvm' has no attribute 'testing'
```

These are the only two files in the directory with that gap.

### 2. `test_tir_schedule_storage_align.py` has a broken `__main__` block

```python
use_block_name = tvm.testing.parameter(by_dict={"block_obj": False, "block_name": True})

def test_storage_align(use_block_name):
    ...

if __name__ == "__main__":
    test_storage_align()          # <-- no argument for the fixture
    test_storage_align_update()
    ...
```

`test_storage_align` takes the parametrized `use_block_name` fixture, so the
first line of the `__main__` block raises:

```
TypeError: test_storage_align() missing 1 required positional argument: 'use_block_name'
```

The hand-maintained list is also stale-prone — it has to be updated by hand
every time a test is added.

## Fix

Add the missing `import tvm.testing` to both files, and replace the
hand-written call list with `tvm.testing.main()`, which is what **36 of the 39**
files in `tests/python/s_tir/schedule/` already do (including
`test_tir_schedule_read_write_at.py`) and which handles parametrized tests
correctly.

Test behaviour under pytest is unchanged — this only affects direct
`python tests/python/s_tir/schedule/test_...py` invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
