### PR TITLE
[Fix][Codegen] Avoid extraneous parentheses in if_then_else generated code

### DIFF
--- a/src/target/source/codegen_c.cc
+++ b/src/target/source/codegen_c.cc
@@ -743,7 +743,11 @@ void CodeGenC::VisitExpr_(const CallNode* op, std::ostream& os) {  // NOLINT(*)
       PrintType(op->ty, this->stream);
       this->stream << " " << result << ";\n";
       this->PrintIndent();
-      this->stream << "if (" << cond << ") {\n";
+      if (cond[0] == '(' && cond[cond.length() - 1] == ')') {
+        this->stream << "if " << cond << " {\n";
+      } else {
+        this->stream << "if (" << cond << ") {\n";
+      }
       {
         int then_scope = this->BeginScope();
         std::string true_val = PrintExpr(op->args[1]);

--- a/tests/python/codegen/test_target_codegen_c_host.py
+++ b/tests/python/codegen/test_target_codegen_c_host.py
@@ -293,5 +293,33 @@ def test_vector_access_ptr_address_uses_ramp_base():
     assert " + 4" in call
 
 
+def test_if_then_else_avoids_extraneous_parentheses():
+    @I.ir_module
+    class Module:
+        @T.prim_func
+        def main(A: T.Buffer((8,), "int32"), B: T.Buffer((8,), "int32")):
+            for i in range(8):
+                B[i] = T.if_then_else(i == 0, 1, A[i])
+
+    built = tvm.tirx.build(Module, target="c")
+    source = built.inspect_source()
+    assert "if ((" not in source, (
+        "Generated code contains extraneous parentheses in the if condition, "
+        "which triggers clang's -Wparentheses-equality warning"
+    )
+
+    temp = utils.tempdir()
+    path_dso = temp.relpath("if_then_else.so")
+    built.export_library(path_dso)
+    loaded = tvm.runtime.load_module(path_dso)
+
+    a = tvm.runtime.tensor(np.arange(8, dtype="int32"))
+    b = tvm.runtime.tensor(np.zeros(8, dtype="int32"))
+    loaded["main"](a, b)
+    tvm.testing.assert_allclose(
+        b.numpy(), np.where(np.arange(8) == 0, 1, np.arange(8)).astype("int32")
+    )
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
## Problem

Since #16242, the `if_then_else` builtin call is expanded into an if/else statement. When printing the condition, the codegen wraps it in another pair of parentheses even though it is already parenthesized, producing `if ((i == 0))`.

## Impact

The doubled parentheses trigger clang's `-Wparentheses-equality` warning under `-Wall`/`-Wparentheses`, which is noisy for downstream users who compile TVM-generated C sources with strict warning settings. Correctness is not affected — the issue is cosmetic.

## Solution

Reuse the same leading/trailing parenthesis check as the existing `IfThenElseNode` handling in `CodeGenC`, so a condition that already starts and ends with parentheses is printed as-is. The generated code now reads `if (i == 0)`.

Since `CodeGenC` is the shared base of all C-style backends (CUDA, Metal, ROCm, Vulkan, WebGPU, Hexagon), this fix covers them all at once.

## Testing

- Added a regression test `test_if_then_else_avoids_extraneous_parentheses` in `tests/python/codegen/test_target_codegen_c_host.py`, which asserts the generated C source contains no `if ((` and validates the runtime result.
- Ran the full `test_target_codegen_c_host.py` suite on aarch64 Linux with a local build: 10/10 passed.
- `pre-commit` (clang-format, ruff-check, ruff-format) passed on the changed files.