### PR TITLE
[FFI][PERF] Typed expr and var checks read ty through a borrowed view

### DIFF
--- a/include/tvm/ir/base_expr.h
+++ b/include/tvm/ir/base_expr.h
@@ -485,10 +485,10 @@ struct TypeTraits<TypedExpr<ExpectedType>>
         !details::IsObjectInstance<ExprNode>(src->type_index)) {
       return false;
     }
-    // Non-owning: this only reads `ty`, and the owning form's incref/decref pair costs two
-    // atomics per check on a path every typed field assignment takes.
+    // Non-owning: this only reads `ty`, through a borrowed view. The owning form would build a
+    // temporary Any, an incref/decref pair on a path every typed descent takes.
     const auto* expr = details::ObjectUnsafe::RawObjectPtrFromUnowned<ExprNode>(src->v_obj);
-    return details::AnyUnsafe::CheckAnyStrict<ExpectedType>(expr->ty);
+    return details::AnyUnsafe::CheckAnyViewStrict<ExpectedType>(AnyView(expr->ty));
   }
 
   TVM_FFI_INLINE static std::optional<TypedExpr<ExpectedType>> TryCastFromAnyView(

--- a/include/tvm/tirx/buffer.h
+++ b/include/tvm/tirx/buffer.h
@@ -396,9 +396,10 @@ struct TypeTraits<tirx::BufferVar> : public ObjectRefTypeTraitsBase<tirx::Buffer
     if (src->type_index != tirx::VarNode::RuntimeTypeIndex()) {
       return false;
     }
-    const auto* var = static_cast<const tirx::VarNode*>(
-        details::ObjectUnsafe::ObjectPtrFromUnowned<Object>(src->v_obj).get());
-    return details::AnyUnsafe::CheckAnyStrict<tirx::BufferType>(var->ExprNode::ty);
+    // Non-owning: a raw pointer and a borrowed view of `ty`; the owning forms cost two
+    // incref/decref pairs per check.
+    const auto* var = details::ObjectUnsafe::RawObjectPtrFromUnowned<tirx::VarNode>(src->v_obj);
+    return details::AnyUnsafe::CheckAnyViewStrict<tirx::BufferType>(AnyView(var->ExprNode::ty));
   }
 
   TVM_FFI_INLINE static std::optional<tirx::BufferVar> TryCastFromAnyView(const TVMFFIAny* src) {

--- a/include/tvm/tirx/var.h
+++ b/include/tvm/tirx/var.h
@@ -257,9 +257,10 @@ struct TypeTraits<tirx::PrimVar> : public ObjectRefTypeTraitsBase<tirx::PrimVar>
     if (src->type_index != tirx::VarNode::RuntimeTypeIndex()) {
       return false;
     }
-    const auto* var = static_cast<const tirx::VarNode*>(
-        details::ObjectUnsafe::ObjectPtrFromUnowned<Object>(src->v_obj).get());
-    return details::AnyUnsafe::CheckAnyStrict<PrimType>(var->ExprNode::ty);
+    // Non-owning: a raw pointer and a borrowed view of `ty`; the owning forms cost two
+    // incref/decref pairs per check.
+    const auto* var = details::ObjectUnsafe::RawObjectPtrFromUnowned<tirx::VarNode>(src->v_obj);
+    return details::AnyUnsafe::CheckAnyViewStrict<PrimType>(AnyView(var->ExprNode::ty));
   }
 
   TVM_FFI_INLINE static std::optional<tirx::PrimVar> TryCastFromAnyView(const TVMFFIAny* src) {


### PR DESCRIPTION
`TypedExpr`, `TypedVar` and `BufferVar` `CheckAnyStrict` passed the `ty` field to `AnyUnsafe::CheckAnyStrict`, whose `const Any&` parameter builds a temporary owning `Any`: a refcount pair and about 40 instructions per check, on the changed path of every typed descent. The var and buffer traits also held the node through an owning `ObjectPtr` for the same read. Use the raw pointer and `AnyUnsafe::CheckAnyViewStrict(AnyView(ty))`.

Depends on apache/tvm-ffi#767 and a `3rdparty/tvm-ffi` bump that carries it; until then this does not compile. Measured with it: `TypeTraits<PrimExpr>::CheckAnyStrict` 79 → 44 instructions, 3 → 0 atomics; `TypeTraits<tirx::Var>::CheckAnyStrict` 15 instructions, no atomics. No behaviour change.