### PR TITLE
[FFI] Upgrade to latest tvm-ffi

### DIFF
--- a/include/tvm/ir/base_expr.h
+++ b/include/tvm/ir/base_expr.h
@@ -488,7 +488,7 @@ struct TypeTraits<TypedExpr<ExpectedType>>
     // Non-owning: this only reads `ty`, and the owning form's incref/decref pair costs two
     // atomics per check on a path every typed field assignment takes.
     const auto* expr = details::ObjectUnsafe::RawObjectPtrFromUnowned<ExprNode>(src->v_obj);
-    return details::AnyUnsafe::CheckAnyStrict<ExpectedType>(expr->ty);
+    return details::AnyUnsafe::CheckAnyViewStrict<ExpectedType>(AnyView(expr->ty));
   }
 
   TVM_FFI_INLINE static std::optional<TypedExpr<ExpectedType>> TryCastFromAnyView(

--- a/include/tvm/ir/expr.h
+++ b/include/tvm/ir/expr.h
@@ -116,7 +116,7 @@ class TensorLoadNode : public ExprNode {
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<TensorLoadNode>()
-        .def_ro("source", &TensorLoadNode::source, refl::AttachFieldFlag::SEqHashDefRecursive())
+        .def_ro("source", &TensorLoadNode::source, refl::AttachFieldFlag::SEqHashDefPattern())
         .def_ro("indices", &TensorLoadNode::indices);
   }
 

--- a/include/tvm/ir/prim/expr.h
+++ b/include/tvm/ir/prim/expr.h
@@ -545,7 +545,7 @@ class LetNode : public ExprNode {
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<LetNode>()
-        .def_ro("var", &LetNode::var, refl::AttachFieldFlag::SEqHashDefNonRecursive())
+        .def_ro("var", &LetNode::var, refl::AttachFieldFlag::SEqHashDefSimple())
         .def_ro("value", &LetNode::value)
         .def_ro("body", &LetNode::body);
   }

--- a/include/tvm/relax/expr.h
+++ b/include/tvm/relax/expr.h
@@ -199,8 +199,8 @@ class BindingNode : public ffi::Object {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<BindingNode>()
         .def_ro("span", &BindingNode::span, refl::AttachFieldFlag::SEqHashIgnore())
-        // TODO(tqchen): use SEqHashDefNonRecursive after the next pypi tvm-ffi release
-        .def_ro("var", &BindingNode::var, refl::AttachFieldFlag::SEqHashDefRecursive());
+        // TODO(tqchen): use SEqHashDefSimple after the next pypi tvm-ffi release
+        .def_ro("var", &BindingNode::var, refl::AttachFieldFlag::SEqHashDefPattern());
   }
 
   static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind = kTVMFFISEqHashKindTreeNode;
@@ -242,8 +242,8 @@ class MatchCastNode : public BindingNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<MatchCastNode>()
         .def_ro("value", &MatchCastNode::value)
-        // TODO(tqchen): use SEqHashDefNonRecursive after the next pypi tvm-ffi release
-        .def_ro("ty", &MatchCastNode::ty, refl::AttachFieldFlag::SEqHashDefRecursive());
+        // TODO(tqchen): use SEqHashDefSimple after the next pypi tvm-ffi release
+        .def_ro("ty", &MatchCastNode::ty, refl::AttachFieldFlag::SEqHashDefPattern());
   }
   TVM_FFI_DECLARE_OBJECT_INFO_FINAL("relax.expr.MatchCast", MatchCastNode, BindingNode);
 };
@@ -458,7 +458,7 @@ class FunctionNode : public BaseFuncNode {
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<FunctionNode>()
-        .def_ro("params", &FunctionNode::params, refl::AttachFieldFlag::SEqHashDefRecursive())
+        .def_ro("params", &FunctionNode::params, refl::AttachFieldFlag::SEqHashDefPattern())
         .def_ro("body", &FunctionNode::body)
         .def_ro("ret_ty", &FunctionNode::ret_ty)
         .def_ro("is_pure", &FunctionNode::is_pure);

--- a/include/tvm/relax/type.h
+++ b/include/tvm/relax/type.h
@@ -297,7 +297,7 @@ class FuncTypeNode : public TypeNode {
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<FuncTypeNode>()
-        .def_ro("params", &FuncTypeNode::params, refl::AttachFieldFlag::SEqHashDefRecursive())
+        .def_ro("params", &FuncTypeNode::params, refl::AttachFieldFlag::SEqHashDefPattern())
         .def_ro("ret", &FuncTypeNode::ret)
         .def_ro("derive_func", &FuncTypeNode::derive_func)
         .def_ro("purity", &FuncTypeNode::purity);

--- a/include/tvm/te/operation.h
+++ b/include/tvm/te/operation.h
@@ -71,8 +71,8 @@ class CommReducerNode : public ffi::Object {
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<CommReducerNode>()
-        .def_ro("lhs", &CommReducerNode::lhs, refl::AttachFieldFlag::SEqHashDefRecursive())
-        .def_ro("rhs", &CommReducerNode::rhs, refl::AttachFieldFlag::SEqHashDefRecursive())
+        .def_ro("lhs", &CommReducerNode::lhs, refl::AttachFieldFlag::SEqHashDefPattern())
+        .def_ro("rhs", &CommReducerNode::rhs, refl::AttachFieldFlag::SEqHashDefPattern())
         .def_ro("result", &CommReducerNode::result)
         .def_ro("identity_element", &CommReducerNode::identity_element)
         .def_ro("span", &CommReducerNode::span, refl::AttachFieldFlag::SEqHashIgnore());

--- a/include/tvm/tirx/buffer.h
+++ b/include/tvm/tirx/buffer.h
@@ -112,13 +112,13 @@ class BufferTypeNode : public TypeNode {
     refl::ObjectDef<BufferTypeNode>()
         .def_ro("dtype", &BufferTypeNode::dtype)
         .def_ro("storage_scope", &BufferTypeNode::storage_scope)
-        // TODO(tqchen): use SEqHashDefNonRecursive after the next pypi tvm-ffi release
-        .def_ro("shape", &BufferTypeNode::shape, refl::AttachFieldFlag::SEqHashDefRecursive())
-        // TODO(tqchen): use SEqHashDefNonRecursive after the next pypi tvm-ffi release
-        .def_ro("strides", &BufferTypeNode::strides, refl::AttachFieldFlag::SEqHashDefRecursive())
-        // TODO(tqchen): use SEqHashDefNonRecursive after the next pypi tvm-ffi release
+        // TODO(tqchen): use SEqHashDefSimple after the next pypi tvm-ffi release
+        .def_ro("shape", &BufferTypeNode::shape, refl::AttachFieldFlag::SEqHashDefPattern())
+        // TODO(tqchen): use SEqHashDefSimple after the next pypi tvm-ffi release
+        .def_ro("strides", &BufferTypeNode::strides, refl::AttachFieldFlag::SEqHashDefPattern())
+        // TODO(tqchen): use SEqHashDefSimple after the next pypi tvm-ffi release
         .def_ro("elem_offset", &BufferTypeNode::elem_offset,
-                refl::AttachFieldFlag::SEqHashDefRecursive())
+                refl::AttachFieldFlag::SEqHashDefPattern())
         .def_ro("data_alignment", &BufferTypeNode::data_alignment)
         .def_ro("offset_factor", &BufferTypeNode::offset_factor)
         .def_ro("layout", &BufferTypeNode::layout)

--- a/include/tvm/tirx/buffer_region.h
+++ b/include/tvm/tirx/buffer_region.h
@@ -54,7 +54,7 @@ class BufferRegionNode : public ExprNode {
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<BufferRegionNode>()
-        .def_ro("buffer", &BufferRegionNode::buffer, refl::AttachFieldFlag::SEqHashDefRecursive())
+        .def_ro("buffer", &BufferRegionNode::buffer, refl::AttachFieldFlag::SEqHashDefPattern())
         .def_ro("region", &BufferRegionNode::region);
   }
 

--- a/include/tvm/tirx/exec_scope.h
+++ b/include/tvm/tirx/exec_scope.h
@@ -124,8 +124,7 @@ class ScopeIdDefNode : public ffi::Object {
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<ScopeIdDefNode>()
-        .def_ro("def_ids", &ScopeIdDefNode::def_ids,
-                refl::AttachFieldFlag::SEqHashDefNonRecursive())
+        .def_ro("def_ids", &ScopeIdDefNode::def_ids, refl::AttachFieldFlag::SEqHashDefSimple())
         .def_ro("extents", &ScopeIdDefNode::extents)
         .def_ro("scope", &ScopeIdDefNode::scope)
         .def_ro("preferred_extents", &ScopeIdDefNode::preferred_extents);

--- a/include/tvm/tirx/function.h
+++ b/include/tvm/tirx/function.h
@@ -58,7 +58,7 @@ class PrimFuncNode : public BaseFuncNode {
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<PrimFuncNode>()
-        .def_ro("params", &PrimFuncNode::params, refl::AttachFieldFlag::SEqHashDefRecursive())
+        .def_ro("params", &PrimFuncNode::params, refl::AttachFieldFlag::SEqHashDefPattern())
         .def_ro("ret_type", &PrimFuncNode::ret_type)
         .def_ro("body", &PrimFuncNode::body);
     refl::TypeAttrDef<PrimFuncNode>()

--- a/include/tvm/tirx/index_map.h
+++ b/include/tvm/tirx/index_map.h
@@ -179,7 +179,7 @@ class IndexMapNode : public ffi::Object {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<IndexMapNode>()
         .def_ro("initial_indices", &IndexMapNode::initial_indices,
-                refl::AttachFieldFlag::SEqHashDefRecursive())
+                refl::AttachFieldFlag::SEqHashDefPattern())
         .def_ro("final_indices", &IndexMapNode::final_indices)
         .def_ro("inverse_index_map", &IndexMapNode::inverse_index_map,
                 refl::AttachFieldFlag::SEqHashIgnore());

--- a/include/tvm/tirx/stmt.h
+++ b/include/tvm/tirx/stmt.h
@@ -87,7 +87,7 @@ class BindNode : public StmtNode {
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<BindNode>()
-        .def_ro("var", &BindNode::var, refl::AttachFieldFlag::SEqHashDefNonRecursive())
+        .def_ro("var", &BindNode::var, refl::AttachFieldFlag::SEqHashDefSimple())
         .def_ro("value", &BindNode::value);
   }
   TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tirx.Bind", BindNode, StmtNode);
@@ -213,7 +213,7 @@ class BufferStoreNode : public StmtNode {
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<BufferStoreNode>()
-        .def_ro("buffer", &BufferStoreNode::buffer, refl::AttachFieldFlag::SEqHashDefRecursive())
+        .def_ro("buffer", &BufferStoreNode::buffer, refl::AttachFieldFlag::SEqHashDefPattern())
         .def_ro("value", &BufferStoreNode::value)
         .def_ro("indices", &BufferStoreNode::indices);
   }
@@ -244,7 +244,7 @@ class DeclBufferNode : public StmtNode {
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<DeclBufferNode>()
-        .def_ro("buffer", &DeclBufferNode::buffer, refl::AttachFieldFlag::SEqHashDefNonRecursive())
+        .def_ro("buffer", &DeclBufferNode::buffer, refl::AttachFieldFlag::SEqHashDefSimple())
         .def_ro("data", &DeclBufferNode::data);
   }
   TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tirx.DeclBuffer", DeclBufferNode, StmtNode);
@@ -274,7 +274,7 @@ class AllocBufferNode : public StmtNode {
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<AllocBufferNode>()
-        .def_ro("buffer", &AllocBufferNode::buffer, refl::AttachFieldFlag::SEqHashDefNonRecursive())
+        .def_ro("buffer", &AllocBufferNode::buffer, refl::AttachFieldFlag::SEqHashDefSimple())
         .def_ro("annotations", &AllocBufferNode::annotations);
   }
   TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tirx.AllocBuffer", AllocBufferNode, StmtNode);
@@ -620,7 +620,7 @@ class ForNode : public StmtNode {
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<ForNode>()
-        .def_ro("loop_var", &ForNode::loop_var, refl::AttachFieldFlag::SEqHashDefNonRecursive())
+        .def_ro("loop_var", &ForNode::loop_var, refl::AttachFieldFlag::SEqHashDefSimple())
         .def_ro("min", &ForNode::min)
         .def_ro("extent", &ForNode::extent)
         .def_ro("kind", &ForNode::kind)
@@ -786,8 +786,7 @@ class MatchBufferRegionNode : public ffi::Object {
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<MatchBufferRegionNode>()
-        .def_ro("buffer", &MatchBufferRegionNode::buffer,
-                refl::AttachFieldFlag::SEqHashDefNonRecursive())
+        .def_ro("buffer", &MatchBufferRegionNode::buffer, refl::AttachFieldFlag::SEqHashDefSimple())
         .def_ro("source", &MatchBufferRegionNode::source);
   }
 
@@ -864,7 +863,7 @@ class SBlockNode : public StmtNode {
         .def_ro("writes", &SBlockNode::writes)
         .def_ro("name_hint", &SBlockNode::name_hint, refl::AttachFieldFlag::SEqHashIgnore())
         .def_ro("alloc_buffers", &SBlockNode::alloc_buffers,
-                refl::AttachFieldFlag::SEqHashDefNonRecursive())
+                refl::AttachFieldFlag::SEqHashDefSimple())
         .def_ro("match_buffers", &SBlockNode::match_buffers)
         .def_ro("annotations", &SBlockNode::annotations)
         .def_ro("init", &SBlockNode::init)

--- a/include/tvm/tirx/tile_primitive.h
+++ b/include/tvm/tirx/tile_primitive.h
@@ -55,7 +55,7 @@ class LambdaExprNode : public ffi::Object {
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<LambdaExprNode>()
-        .def_ro("vars", &LambdaExprNode::vars, refl::AttachFieldFlag::SEqHashDefRecursive())
+        .def_ro("vars", &LambdaExprNode::vars, refl::AttachFieldFlag::SEqHashDefPattern())
         .def_ro("pred", &LambdaExprNode::pred);
   }
 

--- a/include/tvm/tirx/var.h
+++ b/include/tvm/tirx/var.h
@@ -174,7 +174,7 @@ class IterVarNode : public PrimExprConvertibleNode {
     namespace refl = tvm::ffi::reflection;
     refl::ObjectDef<IterVarNode>()
         .def_ro("dom", &IterVarNode::dom)
-        .def_ro("var", &IterVarNode::var, refl::AttachFieldFlag::SEqHashDefNonRecursive())
+        .def_ro("var", &IterVarNode::var, refl::AttachFieldFlag::SEqHashDefSimple())
         .def_ro("iter_type", &IterVarNode::iter_type)
         .def_ro("thread_tag", &IterVarNode::thread_tag)
         .def_ro("span", &IterVarNode::span, refl::DefaultValue(Span()),

--- a/src/ir/expr.cc
+++ b/src/ir/expr.cc
@@ -49,18 +49,19 @@ TVMFFIAny OpaqueExprVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const OpaqueExprNode>(value);
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->ty));
   // Any None is Expected<Optional<VisitInterrupt>>'s successful empty value.
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
 TVMFFIAny OpaqueExprMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
   const OpaqueExprNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const OpaqueExprNode>(value);
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Type, mapped_ty, mutator->MutateExpected(self->ty));
-  if (mapped_ty.same_as(self->ty)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Type>, mapped_ty,
+                                    mutator->MutateExpected(self->ty));
+  if (mapped_ty.UnchangedOrSameAs(self->ty)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
   ffi::ObjectPtr<OpaqueExprNode> copy = ffi::make_object<OpaqueExprNode>(*self);
-  copy->ty = std::move(mapped_ty);
+  copy->ty = std::move(mapped_ty).ValueOrUnchanged(std::move(copy->ty));
   return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
 }
 
@@ -68,13 +69,13 @@ TVMFFIAny OpaqueExprMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
                                        ffi::AnyView value) noexcept {
   OpaqueExprNode* self = const_cast<OpaqueExprNode*>(
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const OpaqueExprNode>(value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Type, mapped_ty,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Type>, mapped_ty,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->ty));
-  if (mapped_ty.same_as(self->ty)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_ty.UnchangedOrSameAs(self->ty)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
-  self->ty = std::move(mapped_ty);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (!mapped_ty.IsUnchanged()) self->ty = std::move(mapped_ty).ValueUnchecked();
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 TVMFFIAny TensorLoadVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
@@ -83,24 +84,26 @@ TVMFFIAny TensorLoadVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->ty));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->source));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->indices));
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
 TVMFFIAny TensorLoadMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
   const TensorLoadNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const TensorLoadNode>(value);
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Type, mapped_ty, mutator->MutateExpected(self->ty));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Expr, mapped_source, mutator->MutateExpected(self->source));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<PrimExpr>, mapped_indices,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Type>, mapped_ty,
+                                    mutator->MutateExpected(self->ty));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Expr>, mapped_source,
+                                    mutator->MutateExpected(self->source));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Array<PrimExpr>>, mapped_indices,
                                     mutator->MutateExpected(self->indices));
-  if (mapped_ty.same_as(self->ty) && mapped_source.same_as(self->source) &&
-      mapped_indices.same_as(self->indices)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_ty.UnchangedOrSameAs(self->ty) && mapped_source.UnchangedOrSameAs(self->source) &&
+      mapped_indices.UnchangedOrSameAs(self->indices)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
   ffi::ObjectPtr<TensorLoadNode> copy = ffi::make_object<TensorLoadNode>(*self);
-  copy->ty = std::move(mapped_ty);
-  copy->source = std::move(mapped_source);
-  copy->indices = std::move(mapped_indices);
+  copy->ty = std::move(mapped_ty).ValueOrUnchanged(std::move(copy->ty));
+  copy->source = std::move(mapped_source).ValueOrUnchanged(std::move(copy->source));
+  copy->indices = std::move(mapped_indices).ValueOrUnchanged(std::move(copy->indices));
   return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
 }
 
@@ -108,20 +111,20 @@ TVMFFIAny TensorLoadMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
                                        ffi::AnyView value) noexcept {
   TensorLoadNode* self = const_cast<TensorLoadNode*>(
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const TensorLoadNode>(value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Type, mapped_ty,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Type>, mapped_ty,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->ty));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Expr, mapped_source,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Expr>, mapped_source,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->source));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<PrimExpr>, mapped_indices,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Array<PrimExpr>>, mapped_indices,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->indices));
-  if (mapped_ty.same_as(self->ty) && mapped_source.same_as(self->source) &&
-      mapped_indices.same_as(self->indices)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_ty.UnchangedOrSameAs(self->ty) && mapped_source.UnchangedOrSameAs(self->source) &&
+      mapped_indices.UnchangedOrSameAs(self->indices)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
-  self->ty = std::move(mapped_ty);
-  self->source = std::move(mapped_source);
-  self->indices = std::move(mapped_indices);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (!mapped_ty.IsUnchanged()) self->ty = std::move(mapped_ty).ValueUnchecked();
+  if (!mapped_source.IsUnchanged()) self->source = std::move(mapped_source).ValueUnchecked();
+  if (!mapped_indices.IsUnchanged()) self->indices = std::move(mapped_indices).ValueUnchecked();
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 TVMFFIAny TupleVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
@@ -129,37 +132,38 @@ TVMFFIAny TupleVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noe
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const TupleNode>(value);
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->ty));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->fields));
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
 TVMFFIAny TupleMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
   const TupleNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const TupleNode>(value);
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Type, mapped_ty, mutator->MutateExpected(self->ty));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<Expr>, mapped_fields,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Type>, mapped_ty,
+                                    mutator->MutateExpected(self->ty));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Array<Expr>>, mapped_fields,
                                     mutator->MutateExpected(self->fields));
-  if (mapped_ty.same_as(self->ty) && mapped_fields.same_as(self->fields)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_ty.UnchangedOrSameAs(self->ty) && mapped_fields.UnchangedOrSameAs(self->fields)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
   ffi::ObjectPtr<TupleNode> copy = ffi::make_object<TupleNode>(*self);
-  copy->ty = std::move(mapped_ty);
-  copy->fields = std::move(mapped_fields);
+  copy->ty = std::move(mapped_ty).ValueOrUnchanged(std::move(copy->ty));
+  copy->fields = std::move(mapped_fields).ValueOrUnchanged(std::move(copy->fields));
   return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
 }
 
 TVMFFIAny TupleMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
   TupleNode* self = const_cast<TupleNode*>(
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const TupleNode>(value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Type, mapped_ty,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Type>, mapped_ty,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->ty));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<Expr>, mapped_fields,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Array<Expr>>, mapped_fields,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->fields));
-  if (mapped_ty.same_as(self->ty) && mapped_fields.same_as(self->fields)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_ty.UnchangedOrSameAs(self->ty) && mapped_fields.UnchangedOrSameAs(self->fields)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
-  self->ty = std::move(mapped_ty);
-  self->fields = std::move(mapped_fields);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (!mapped_ty.IsUnchanged()) self->ty = std::move(mapped_ty).ValueUnchecked();
+  if (!mapped_fields.IsUnchanged()) self->fields = std::move(mapped_fields).ValueUnchecked();
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 TVMFFIAny TupleGetItemVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
@@ -168,21 +172,23 @@ TVMFFIAny TupleGetItemVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView val
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const TupleGetItemNode>(value);
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->ty));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->tuple));
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
 TVMFFIAny TupleGetItemMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
   // skips: index
   const TupleGetItemNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const TupleGetItemNode>(value);
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Type, mapped_ty, mutator->MutateExpected(self->ty));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Expr, mapped_tuple, mutator->MutateExpected(self->tuple));
-  if (mapped_ty.same_as(self->ty) && mapped_tuple.same_as(self->tuple)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Type>, mapped_ty,
+                                    mutator->MutateExpected(self->ty));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Expr>, mapped_tuple,
+                                    mutator->MutateExpected(self->tuple));
+  if (mapped_ty.UnchangedOrSameAs(self->ty) && mapped_tuple.UnchangedOrSameAs(self->tuple)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
   ffi::ObjectPtr<TupleGetItemNode> copy = ffi::make_object<TupleGetItemNode>(*self);
-  copy->ty = std::move(mapped_ty);
-  copy->tuple = std::move(mapped_tuple);
+  copy->ty = std::move(mapped_ty).ValueOrUnchanged(std::move(copy->ty));
+  copy->tuple = std::move(mapped_tuple).ValueOrUnchanged(std::move(copy->tuple));
   return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
 }
 
@@ -191,54 +197,46 @@ TVMFFIAny TupleGetItemMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
   // skips: index
   TupleGetItemNode* self = const_cast<TupleGetItemNode*>(
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const TupleGetItemNode>(value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Type, mapped_ty,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Type>, mapped_ty,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->ty));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Expr, mapped_tuple,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Expr>, mapped_tuple,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->tuple));
-  if (mapped_ty.same_as(self->ty) && mapped_tuple.same_as(self->tuple)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_ty.UnchangedOrSameAs(self->ty) && mapped_tuple.UnchangedOrSameAs(self->tuple)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
-  self->ty = std::move(mapped_ty);
-  self->tuple = std::move(mapped_tuple);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (!mapped_ty.IsUnchanged()) self->ty = std::move(mapped_ty).ValueUnchecked();
+  if (!mapped_tuple.IsUnchanged()) self->tuple = std::move(mapped_tuple).ValueUnchecked();
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 TVMFFIAny IntImmVisit(ffi::StructuralVisitorObj*, ffi::AnyView) noexcept {
   // skips: value
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
-TVMFFIAny IntImmMutate(ffi::StructuralMutatorObj*, ffi::AnyView value) noexcept {
+TVMFFIAny IntImmMutate(ffi::StructuralMutatorObj*, ffi::AnyView) noexcept {
   // skips: value
-  const IntImmNode* self =
-      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const IntImmNode>(value);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
-TVMFFIAny IntImmMaybeInplaceMutate(ffi::StructuralMutatorObj*, ffi::AnyView value) noexcept {
+TVMFFIAny IntImmMaybeInplaceMutate(ffi::StructuralMutatorObj*, ffi::AnyView) noexcept {
   // skips: value
-  const IntImmNode* self =
-      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const IntImmNode>(value);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 TVMFFIAny FloatImmVisit(ffi::StructuralVisitorObj*, ffi::AnyView) noexcept {
   // skips: value
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
-TVMFFIAny FloatImmMutate(ffi::StructuralMutatorObj*, ffi::AnyView value) noexcept {
+TVMFFIAny FloatImmMutate(ffi::StructuralMutatorObj*, ffi::AnyView) noexcept {
   // skips: value
-  const FloatImmNode* self =
-      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const FloatImmNode>(value);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
-TVMFFIAny FloatImmMaybeInplaceMutate(ffi::StructuralMutatorObj*, ffi::AnyView value) noexcept {
+TVMFFIAny FloatImmMaybeInplaceMutate(ffi::StructuralMutatorObj*, ffi::AnyView) noexcept {
   // skips: value
-  const FloatImmNode* self =
-      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const FloatImmNode>(value);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 TVMFFIAny RangeVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
@@ -246,36 +244,38 @@ TVMFFIAny RangeVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noe
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const RangeNode>(value);
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->min));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->extent));
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
 TVMFFIAny RangeMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
   const RangeNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const RangeNode>(value);
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_min, mutator->MutateExpected(self->min));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_extent, mutator->MutateExpected(self->extent));
-  if (mapped_min.same_as(self->min) && mapped_extent.same_as(self->extent)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_min,
+                                    mutator->MutateExpected(self->min));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_extent,
+                                    mutator->MutateExpected(self->extent));
+  if (mapped_min.UnchangedOrSameAs(self->min) && mapped_extent.UnchangedOrSameAs(self->extent)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
   ffi::ObjectPtr<RangeNode> copy = ffi::make_object<RangeNode>(*self);
-  copy->min = std::move(mapped_min);
-  copy->extent = std::move(mapped_extent);
+  copy->min = std::move(mapped_min).ValueOrUnchanged(std::move(copy->min));
+  copy->extent = std::move(mapped_extent).ValueOrUnchanged(std::move(copy->extent));
   return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
 }
 
 TVMFFIAny RangeMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
   RangeNode* self = const_cast<RangeNode*>(
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const RangeNode>(value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_min,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_min,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->min));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_extent,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_extent,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->extent));
-  if (mapped_min.same_as(self->min) && mapped_extent.same_as(self->extent)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_min.UnchangedOrSameAs(self->min) && mapped_extent.UnchangedOrSameAs(self->extent)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
-  self->min = std::move(mapped_min);
-  self->extent = std::move(mapped_extent);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (!mapped_min.IsUnchanged()) self->min = std::move(mapped_min).ValueUnchecked();
+  if (!mapped_extent.IsUnchanged()) self->extent = std::move(mapped_extent).ValueUnchecked();
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 TVMFFIAny VarVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
@@ -285,16 +285,16 @@ TVMFFIAny VarVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexc
   // A PrimType carries only a dtype, so it has nothing to visit.  Broad callbacks do not see this
   // skipped field; dynamically typed Vars still descend through the Type value.
   if (!self->ty.as<PrimTypeNode>()) {
-    // Only NonRecursive is clamped: Recursive co-introduces type fields such as BufferType shape
+    // Only Simple is clamped: Pattern co-introduces type fields such as BufferType shape
     // variables, so that ambient region must continue through the dynamic type.
-    if (visitor->def_region_kind() == kTVMFFIDefRegionKindNonRecursive) {
+    if (visitor->def_region_kind() == kTVMFFIDefRegionKindSimple) {
       TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->WithDefRegionKind(
           kTVMFFIDefRegionKindNone, [&]() { return visitor->VisitExpected(self->ty); }));
     } else {
       TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->ty));
     }
   }
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
 TVMFFIAny VarMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
@@ -307,34 +307,37 @@ TVMFFIAny VarMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noex
       ffi::TypeIndex::kTVMFFINone) {
     return ffi::details::ExpectedUnsafe::MoveToTVMFFIAny(std::move(remap_result));
   }
-  auto return_mapped_var = [&](ffi::Any mapped_var) -> TVMFFIAny {
-    auto set_result = mutator->VarRemapSetExpected(value, mapped_var);
-    if (TVM_FFI_PREDICT_FALSE(set_result.is_err())) {
-      // Hooks propagate errors untouched; the engine names this node.
-      return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(set_result).error()));
-    }
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(std::move(mapped_var));
-  };
+  if (mutator->def_region_kind() == kTVMFFIDefRegionKindNone) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
+  }
+  ffi::UnchangedOr<ffi::Any> result = ffi::Unchanged();
+  ffi::Any mapped_value;
   // A PrimType carries only a dtype, so it has nothing to substitute.  Broad callbacks do not see
   // this skipped field; dynamically typed Vars still descend through the Type value.
-  if (self->ty.as<PrimTypeNode>()) {
-    return return_mapped_var(ffi::Any(self));
+  if (!self->ty.as<PrimTypeNode>()) {
+    // Pattern co-introduces type fields such as BufferType shape variables; Simple does not.
+    ffi::Expected<ffi::UnchangedOr<ffi::Any>> mapped_ty_result =
+        mutator->def_region_kind() == kTVMFFIDefRegionKindSimple
+            ? mutator->WithDefRegionKind(kTVMFFIDefRegionKindNone,
+                                         [&]() { return mutator->MutateExpected(self->ty); })
+            : mutator->MutateExpected(self->ty);
+    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Type>, mapped_ty,
+                                      std::move(mapped_ty_result));
+    if (!mapped_ty.UnchangedOrSameAs(self->ty)) {
+      ffi::ObjectPtr<VarNode> copy = ffi::make_object<VarNode>(*self);
+      copy->ty = std::move(mapped_ty).ValueUnchecked();
+      mapped_value = ffi::Any(std::move(copy));
+      result = mapped_value;
+    }
   }
-  // Only NonRecursive is clamped: Recursive co-introduces type fields such as BufferType shape
-  // variables, so that ambient region must continue through the dynamic type.
-  auto mutate_ty = [&]() { return mutator->MutateExpected(self->ty); };
-  ffi::Expected<ffi::Any> mapped_ty_result =
-      mutator->def_region_kind() == kTVMFFIDefRegionKindNonRecursive
-          ? mutator->WithDefRegionKind(kTVMFFIDefRegionKindNone, mutate_ty)
-          : mutate_ty();
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Type, mapped_ty, std::move(mapped_ty_result));
-  ffi::Any mapped_var = ffi::Any(self);
-  if (!mapped_ty.same_as(self->ty)) {
-    ffi::ObjectPtr<VarNode> copy = ffi::make_object<VarNode>(*self);
-    copy->ty = std::move(mapped_ty);
-    mapped_var = ffi::Any(std::move(copy));
+  if (!result.IsUnchanged() || mutator->def_region_kind() == kTVMFFIDefRegionKindPattern) {
+    ffi::AnyView value_to_store = result.IsUnchanged() ? value : ffi::AnyView(mapped_value);
+    auto set_result = mutator->VarRemapSetExpected(value, value_to_store);
+    if (TVM_FFI_PREDICT_FALSE(set_result.is_err())) {
+      return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(set_result).error()));
+    }
   }
-  return return_mapped_var(std::move(mapped_var));
+  return ffi::details::UnchangedOrUnsafe::MoveToTVMFFIAny(std::move(result));
 }
 
 TVMFFIAny VarMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
@@ -347,29 +350,37 @@ TVMFFIAny VarMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView
       ffi::TypeIndex::kTVMFFINone) {
     return ffi::details::ExpectedUnsafe::MoveToTVMFFIAny(std::move(remap_result));
   }
-  auto return_mapped_var = [&](ffi::Any mapped_var) -> TVMFFIAny {
-    auto set_result = mutator->VarRemapSetExpected(value, mapped_var);
-    if (TVM_FFI_PREDICT_FALSE(set_result.is_err())) {
-      // Hooks propagate errors untouched; the engine names this node.
-      return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(set_result).error()));
-    }
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(std::move(mapped_var));
-  };
+  if (mutator->def_region_kind() == kTVMFFIDefRegionKindNone) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
+  }
+  ffi::UnchangedOr<ffi::Any> result = ffi::Unchanged();
+  ffi::Any mapped_value;
   // A PrimType carries only a dtype, so it has nothing to substitute.  Broad callbacks do not see
   // this skipped field; dynamically typed Vars still descend through the Type value.
-  if (self->ty.as<PrimTypeNode>()) {
-    return return_mapped_var(ffi::Any(self));
+  if (!self->ty.as<PrimTypeNode>()) {
+    // Pattern co-introduces type fields such as BufferType shape variables; Simple does not.
+    ffi::Expected<ffi::UnchangedOr<ffi::Any>> mapped_ty_result =
+        mutator->def_region_kind() == kTVMFFIDefRegionKindSimple
+            ? mutator->WithDefRegionKind(
+                  kTVMFFIDefRegionKindNone,
+                  [&]() { return mutator->MaybeInplaceMutateIfUniqueExpected(self->ty); })
+            : mutator->MaybeInplaceMutateIfUniqueExpected(self->ty);
+    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Type>, mapped_ty,
+                                      std::move(mapped_ty_result));
+    if (!mapped_ty.UnchangedOrSameAs(self->ty)) {
+      self->ty = std::move(mapped_ty).ValueUnchecked();
+      mapped_value = ffi::Any(self);
+      result = mapped_value;
+    }
   }
-  // Only NonRecursive is clamped: Recursive co-introduces type fields such as BufferType shape
-  // variables, so that ambient region must continue through the dynamic type.
-  auto mutate_ty = [&]() { return mutator->MaybeInplaceMutateIfUniqueExpected(self->ty); };
-  ffi::Expected<ffi::Any> mapped_ty_result =
-      mutator->def_region_kind() == kTVMFFIDefRegionKindNonRecursive
-          ? mutator->WithDefRegionKind(kTVMFFIDefRegionKindNone, mutate_ty)
-          : mutate_ty();
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Type, mapped_ty, std::move(mapped_ty_result));
-  if (!mapped_ty.same_as(self->ty)) self->ty = std::move(mapped_ty);
-  return return_mapped_var(ffi::Any(self));
+  if (!result.IsUnchanged() || mutator->def_region_kind() == kTVMFFIDefRegionKindPattern) {
+    ffi::AnyView value_to_store = result.IsUnchanged() ? value : ffi::AnyView(mapped_value);
+    auto set_result = mutator->VarRemapSetExpected(value, value_to_store);
+    if (TVM_FFI_PREDICT_FALSE(set_result.is_err())) {
+      return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(set_result).error()));
+    }
+  }
+  return ffi::details::UnchangedOrUnsafe::MoveToTVMFFIAny(std::move(result));
 }
 
 TVMFFIAny CallVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
@@ -392,7 +403,7 @@ TVMFFIAny CallVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noex
   if (!self->ty_args.empty()) {
     TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->ty_args));
   }
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
 TVMFFIAny CallMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
@@ -401,38 +412,40 @@ TVMFFIAny CallMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noe
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const CallNode>(value);
   // A PrimType carries only a dtype, so it has nothing to substitute.  Broad callbacks do not see
   // this skipped field; dynamically typed Call results still descend through the Type value.
-  // Deliberate copy: avoids Any boxing on the dominant primitive skip path.
-  Type mapped_ty = self->ty;
+  ffi::UnchangedOr<Type> mapped_ty = ffi::Unchanged();
   if (!self->ty.as<PrimTypeNode>()) {
-    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Type, descended_ty, mutator->MutateExpected(self->ty));
+    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Type>, descended_ty,
+                                      mutator->MutateExpected(self->ty));
     mapped_ty = std::move(descended_ty);
   }
   // An Op is an interned registry singleton, so it has nothing to substitute.  Broad callbacks do
   // not see this skipped field; function-valued Call operators still descend through the Expr.
-  Expr mapped_op = self->op;
+  ffi::UnchangedOr<Expr> mapped_op = ffi::Unchanged();
   if (!self->op.as<OpNode>()) {
-    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Expr, descended_op, mutator->MutateExpected(self->op));
+    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Expr>, descended_op,
+                                      mutator->MutateExpected(self->op));
     mapped_op = std::move(descended_op);
   }
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<Expr>, mapped_args,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Array<Expr>>, mapped_args,
                                     mutator->MutateExpected(self->args));
   // An empty ty_args has no element to substitute.  Broad callbacks do not see the empty
   // container; nonempty type arguments retain normal container descent and callback behavior.
-  ffi::Array<Type> mapped_ty_args = self->ty_args;
+  ffi::UnchangedOr<ffi::Array<Type>> mapped_ty_args = ffi::Unchanged();
   if (!self->ty_args.empty()) {
-    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<Type>, descended_ty_args,
+    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Array<Type>>, descended_ty_args,
                                       mutator->MutateExpected(self->ty_args));
     mapped_ty_args = std::move(descended_ty_args);
   }
-  if (mapped_ty.same_as(self->ty) && mapped_op.same_as(self->op) &&
-      mapped_args.same_as(self->args) && mapped_ty_args.same_as(self->ty_args)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_ty.UnchangedOrSameAs(self->ty) && mapped_op.UnchangedOrSameAs(self->op) &&
+      mapped_args.UnchangedOrSameAs(self->args) &&
+      mapped_ty_args.UnchangedOrSameAs(self->ty_args)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
   ffi::ObjectPtr<CallNode> copy = ffi::make_object<CallNode>(*self);
-  copy->ty = std::move(mapped_ty);
-  copy->op = std::move(mapped_op);
-  copy->args = std::move(mapped_args);
-  copy->ty_args = std::move(mapped_ty_args);
+  copy->ty = std::move(mapped_ty).ValueOrUnchanged(std::move(copy->ty));
+  copy->op = std::move(mapped_op).ValueOrUnchanged(std::move(copy->op));
+  copy->args = std::move(mapped_args).ValueOrUnchanged(std::move(copy->args));
+  copy->ty_args = std::move(mapped_ty_args).ValueOrUnchanged(std::move(copy->ty_args));
   return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
 }
 
@@ -442,40 +455,40 @@ TVMFFIAny CallMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyVie
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const CallNode>(value));
   // A PrimType carries only a dtype, so it has nothing to substitute.  Broad callbacks do not see
   // this skipped field; dynamically typed Call results still descend through the Type value.
-  // Deliberate copy: avoids Any boxing on the dominant primitive skip path.
-  Type mapped_ty = self->ty;
+  ffi::UnchangedOr<Type> mapped_ty = ffi::Unchanged();
   if (!self->ty.as<PrimTypeNode>()) {
-    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Type, descended_ty,
+    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Type>, descended_ty,
                                       mutator->MaybeInplaceMutateIfUniqueExpected(self->ty));
     mapped_ty = std::move(descended_ty);
   }
   // An Op is an interned registry singleton, so it has nothing to substitute.  Broad callbacks do
   // not see this skipped field; function-valued Call operators still descend through the Expr.
-  Expr mapped_op = self->op;
+  ffi::UnchangedOr<Expr> mapped_op = ffi::Unchanged();
   if (!self->op.as<OpNode>()) {
-    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Expr, descended_op,
+    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Expr>, descended_op,
                                       mutator->MaybeInplaceMutateIfUniqueExpected(self->op));
     mapped_op = std::move(descended_op);
   }
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<Expr>, mapped_args,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Array<Expr>>, mapped_args,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->args));
   // An empty ty_args has no element to substitute.  Broad callbacks do not see the empty
   // container; nonempty type arguments retain normal container descent and callback behavior.
-  ffi::Array<Type> mapped_ty_args = self->ty_args;
+  ffi::UnchangedOr<ffi::Array<Type>> mapped_ty_args = ffi::Unchanged();
   if (!self->ty_args.empty()) {
-    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<Type>, descended_ty_args,
+    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Array<Type>>, descended_ty_args,
                                       mutator->MaybeInplaceMutateIfUniqueExpected(self->ty_args));
     mapped_ty_args = std::move(descended_ty_args);
   }
-  if (mapped_ty.same_as(self->ty) && mapped_op.same_as(self->op) &&
-      mapped_args.same_as(self->args) && mapped_ty_args.same_as(self->ty_args)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_ty.UnchangedOrSameAs(self->ty) && mapped_op.UnchangedOrSameAs(self->op) &&
+      mapped_args.UnchangedOrSameAs(self->args) &&
+      mapped_ty_args.UnchangedOrSameAs(self->ty_args)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
-  self->ty = std::move(mapped_ty);
-  self->op = std::move(mapped_op);
-  self->args = std::move(mapped_args);
-  self->ty_args = std::move(mapped_ty_args);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (!mapped_ty.IsUnchanged()) self->ty = std::move(mapped_ty).ValueUnchecked();
+  if (!mapped_op.IsUnchanged()) self->op = std::move(mapped_op).ValueUnchecked();
+  if (!mapped_args.IsUnchanged()) self->args = std::move(mapped_args).ValueUnchecked();
+  if (!mapped_ty_args.IsUnchanged()) self->ty_args = std::move(mapped_ty_args).ValueUnchecked();
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 }  // namespace

--- a/src/ir/prim/expr.cc
+++ b/src/ir/prim/expr.cc
@@ -55,7 +55,7 @@ TVMFFIAny BinaryVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) no
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const TNode>(value);
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->a));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->b));
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
 template <typename TNode>
@@ -63,17 +63,19 @@ TVMFFIAny BinaryMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) n
   // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
   const TNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const TNode>(value);
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, a, mutator->MutateExpected(self->a));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, b, mutator->MutateExpected(self->b));
-  if (a.same_as(self->a) && b.same_as(self->b)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, a,
+                                    mutator->MutateExpected(self->a));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, b,
+                                    mutator->MutateExpected(self->b));
+  if (a.UnchangedOrSameAs(self->a) && b.UnchangedOrSameAs(self->b)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
   ffi::ObjectPtr<TNode> copy = ffi::make_object<TNode>(*self);
   // StructuralMap preserves node types. A rewrite that changes operand dtypes must keep the
   // operands compatible and set the result type itself; a generic traversal cannot infer the
   // casts that would require.
-  copy->a = std::move(a);
-  copy->b = std::move(b);
+  copy->a = std::move(a).ValueOrUnchanged(std::move(copy->a));
+  copy->b = std::move(b).ValueOrUnchanged(std::move(copy->b));
   return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
 }
 
@@ -83,13 +85,16 @@ TVMFFIAny BinaryMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
   // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
   TNode* self = const_cast<TNode*>(
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const TNode>(value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, a,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, a,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->a));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, b,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, b,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->b));
-  if (!a.same_as(self->a)) self->a = std::move(a);
-  if (!b.same_as(self->b)) self->b = std::move(b);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (a.UnchangedOrSameAs(self->a) && b.UnchangedOrSameAs(self->b)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
+  }
+  if (!a.IsUnchanged()) self->a = std::move(a).ValueUnchecked();
+  if (!b.IsUnchanged()) self->b = std::move(b).ValueUnchecked();
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 TVMFFIAny RampVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
@@ -99,24 +104,27 @@ TVMFFIAny RampVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noex
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->base));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->stride));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->lanes));
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
 TVMFFIAny RampMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
   // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
   const RampNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const RampNode>(value);
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_base, mutator->MutateExpected(self->base));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_stride, mutator->MutateExpected(self->stride));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_lanes, mutator->MutateExpected(self->lanes));
-  if (mapped_base.same_as(self->base) && mapped_stride.same_as(self->stride) &&
-      mapped_lanes.same_as(self->lanes)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_base,
+                                    mutator->MutateExpected(self->base));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_stride,
+                                    mutator->MutateExpected(self->stride));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_lanes,
+                                    mutator->MutateExpected(self->lanes));
+  if (mapped_base.UnchangedOrSameAs(self->base) && mapped_stride.UnchangedOrSameAs(self->stride) &&
+      mapped_lanes.UnchangedOrSameAs(self->lanes)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
   ffi::ObjectPtr<RampNode> copy = ffi::make_object<RampNode>(*self);
-  copy->base = std::move(mapped_base);
-  copy->stride = std::move(mapped_stride);
-  copy->lanes = std::move(mapped_lanes);
+  copy->base = std::move(mapped_base).ValueOrUnchanged(std::move(copy->base));
+  copy->stride = std::move(mapped_stride).ValueOrUnchanged(std::move(copy->stride));
+  copy->lanes = std::move(mapped_lanes).ValueOrUnchanged(std::move(copy->lanes));
   return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
 }
 
@@ -124,20 +132,20 @@ TVMFFIAny RampMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyVie
   // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
   RampNode* self = const_cast<RampNode*>(
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const RampNode>(value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_base,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_base,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->base));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_stride,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_stride,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->stride));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_lanes,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_lanes,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->lanes));
-  if (mapped_base.same_as(self->base) && mapped_stride.same_as(self->stride) &&
-      mapped_lanes.same_as(self->lanes)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_base.UnchangedOrSameAs(self->base) && mapped_stride.UnchangedOrSameAs(self->stride) &&
+      mapped_lanes.UnchangedOrSameAs(self->lanes)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
-  self->base = std::move(mapped_base);
-  self->stride = std::move(mapped_stride);
-  self->lanes = std::move(mapped_lanes);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (!mapped_base.IsUnchanged()) self->base = std::move(mapped_base).ValueUnchecked();
+  if (!mapped_stride.IsUnchanged()) self->stride = std::move(mapped_stride).ValueUnchecked();
+  if (!mapped_lanes.IsUnchanged()) self->lanes = std::move(mapped_lanes).ValueUnchecked();
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 TVMFFIAny BroadcastVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
@@ -146,21 +154,23 @@ TVMFFIAny BroadcastVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value)
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const BroadcastNode>(value);
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->value));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->lanes));
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
 TVMFFIAny BroadcastMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
   // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
   const BroadcastNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const BroadcastNode>(value);
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_value, mutator->MutateExpected(self->value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_lanes, mutator->MutateExpected(self->lanes));
-  if (mapped_value.same_as(self->value) && mapped_lanes.same_as(self->lanes)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_value,
+                                    mutator->MutateExpected(self->value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_lanes,
+                                    mutator->MutateExpected(self->lanes));
+  if (mapped_value.UnchangedOrSameAs(self->value) && mapped_lanes.UnchangedOrSameAs(self->lanes)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
   ffi::ObjectPtr<BroadcastNode> copy = ffi::make_object<BroadcastNode>(*self);
-  copy->value = std::move(mapped_value);
-  copy->lanes = std::move(mapped_lanes);
+  copy->value = std::move(mapped_value).ValueOrUnchanged(std::move(copy->value));
+  copy->lanes = std::move(mapped_lanes).ValueOrUnchanged(std::move(copy->lanes));
   return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
 }
 
@@ -169,16 +179,16 @@ TVMFFIAny BroadcastMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
   // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
   BroadcastNode* self = const_cast<BroadcastNode*>(
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const BroadcastNode>(value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_value,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_value,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_lanes,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_lanes,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->lanes));
-  if (mapped_value.same_as(self->value) && mapped_lanes.same_as(self->lanes)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_value.UnchangedOrSameAs(self->value) && mapped_lanes.UnchangedOrSameAs(self->lanes)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
-  self->value = std::move(mapped_value);
-  self->lanes = std::move(mapped_lanes);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (!mapped_value.IsUnchanged()) self->value = std::move(mapped_value).ValueUnchecked();
+  if (!mapped_lanes.IsUnchanged()) self->lanes = std::move(mapped_lanes).ValueUnchecked();
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 TVMFFIAny ShuffleVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
@@ -187,23 +197,24 @@ TVMFFIAny ShuffleVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) n
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const ShuffleNode>(value);
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->vectors));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->indices));
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
 TVMFFIAny ShuffleMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
   // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
   const ShuffleNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const ShuffleNode>(value);
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<PrimExpr>, mapped_vectors,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Array<PrimExpr>>, mapped_vectors,
                                     mutator->MutateExpected(self->vectors));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<PrimExpr>, mapped_indices,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Array<PrimExpr>>, mapped_indices,
                                     mutator->MutateExpected(self->indices));
-  if (mapped_vectors.same_as(self->vectors) && mapped_indices.same_as(self->indices)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_vectors.UnchangedOrSameAs(self->vectors) &&
+      mapped_indices.UnchangedOrSameAs(self->indices)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
   ffi::ObjectPtr<ShuffleNode> copy = ffi::make_object<ShuffleNode>(*self);
-  copy->vectors = std::move(mapped_vectors);
-  copy->indices = std::move(mapped_indices);
+  copy->vectors = std::move(mapped_vectors).ValueOrUnchanged(std::move(copy->vectors));
+  copy->indices = std::move(mapped_indices).ValueOrUnchanged(std::move(copy->indices));
   return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
 }
 
@@ -212,41 +223,38 @@ TVMFFIAny ShuffleMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
   // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
   ShuffleNode* self = const_cast<ShuffleNode*>(
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const ShuffleNode>(value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<PrimExpr>, mapped_vectors,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Array<PrimExpr>>, mapped_vectors,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->vectors));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<PrimExpr>, mapped_indices,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Array<PrimExpr>>, mapped_indices,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->indices));
-  if (mapped_vectors.same_as(self->vectors) && mapped_indices.same_as(self->indices)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_vectors.UnchangedOrSameAs(self->vectors) &&
+      mapped_indices.UnchangedOrSameAs(self->indices)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
-  self->vectors = std::move(mapped_vectors);
-  self->indices = std::move(mapped_indices);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (!mapped_vectors.IsUnchanged()) self->vectors = std::move(mapped_vectors).ValueUnchecked();
+  if (!mapped_indices.IsUnchanged()) self->indices = std::move(mapped_indices).ValueUnchecked();
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 TVMFFIAny StringImmVisit(ffi::StructuralVisitorObj*, ffi::AnyView) noexcept {
   // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
   // value is a constant: reflected for StructuralEqual/Hash,
   // not traversed by the visitor/mutator contract.
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
-TVMFFIAny StringImmMutate(ffi::StructuralMutatorObj*, ffi::AnyView value) noexcept {
+TVMFFIAny StringImmMutate(ffi::StructuralMutatorObj*, ffi::AnyView) noexcept {
   // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
   // value is a constant: reflected for StructuralEqual/Hash,
   // not traversed by the visitor/mutator contract.
-  const StringImmNode* self =
-      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const StringImmNode>(value);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
-TVMFFIAny StringImmMaybeInplaceMutate(ffi::StructuralMutatorObj*, ffi::AnyView value) noexcept {
+TVMFFIAny StringImmMaybeInplaceMutate(ffi::StructuralMutatorObj*, ffi::AnyView) noexcept {
   // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
   // value is a constant: reflected for StructuralEqual/Hash,
   // not traversed by the visitor/mutator contract.
-  const StringImmNode* self =
-      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const StringImmNode>(value);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 TVMFFIAny CastVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
@@ -254,19 +262,20 @@ TVMFFIAny CastVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noex
   const CastNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const CastNode>(value);
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->value));
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
 TVMFFIAny CastMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
   // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
   const CastNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const CastNode>(value);
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_value, mutator->MutateExpected(self->value));
-  if (mapped_value.same_as(self->value)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_value,
+                                    mutator->MutateExpected(self->value));
+  if (mapped_value.UnchangedOrSameAs(self->value)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
   ffi::ObjectPtr<CastNode> copy = ffi::make_object<CastNode>(*self);
-  copy->value = std::move(mapped_value);
+  copy->value = std::move(mapped_value).ValueOrUnchanged(std::move(copy->value));
   return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
 }
 
@@ -274,13 +283,13 @@ TVMFFIAny CastMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyVie
   // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
   CastNode* self = const_cast<CastNode*>(
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const CastNode>(value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_value,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_value,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->value));
-  if (mapped_value.same_as(self->value)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_value.UnchangedOrSameAs(self->value)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
-  self->value = std::move(mapped_value);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (!mapped_value.IsUnchanged()) self->value = std::move(mapped_value).ValueUnchecked();
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 TVMFFIAny NotVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
@@ -288,19 +297,20 @@ TVMFFIAny NotVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexc
   const NotNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const NotNode>(value);
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->a));
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
 TVMFFIAny NotMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
   // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
   const NotNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const NotNode>(value);
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_a, mutator->MutateExpected(self->a));
-  if (mapped_a.same_as(self->a)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_a,
+                                    mutator->MutateExpected(self->a));
+  if (mapped_a.UnchangedOrSameAs(self->a)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
   ffi::ObjectPtr<NotNode> copy = ffi::make_object<NotNode>(*self);
-  copy->a = std::move(mapped_a);
+  copy->a = std::move(mapped_a).ValueOrUnchanged(std::move(copy->a));
   return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
 }
 
@@ -308,13 +318,13 @@ TVMFFIAny NotMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView
   // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
   NotNode* self = const_cast<NotNode*>(
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const NotNode>(value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_a,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_a,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->a));
-  if (mapped_a.same_as(self->a)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_a.UnchangedOrSameAs(self->a)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
-  self->a = std::move(mapped_a);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (!mapped_a.IsUnchanged()) self->a = std::move(mapped_a).ValueUnchecked();
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 TVMFFIAny SelectVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
@@ -324,27 +334,28 @@ TVMFFIAny SelectVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) no
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->condition));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->true_value));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->false_value));
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
 TVMFFIAny SelectMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
   // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
   const SelectNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const SelectNode>(value);
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_condition,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_condition,
                                     mutator->MutateExpected(self->condition));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_true_value,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_true_value,
                                     mutator->MutateExpected(self->true_value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_false_value,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_false_value,
                                     mutator->MutateExpected(self->false_value));
-  if (mapped_condition.same_as(self->condition) && mapped_true_value.same_as(self->true_value) &&
-      mapped_false_value.same_as(self->false_value)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_condition.UnchangedOrSameAs(self->condition) &&
+      mapped_true_value.UnchangedOrSameAs(self->true_value) &&
+      mapped_false_value.UnchangedOrSameAs(self->false_value)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
   ffi::ObjectPtr<SelectNode> copy = ffi::make_object<SelectNode>(*self);
-  copy->condition = std::move(mapped_condition);
-  copy->true_value = std::move(mapped_true_value);
-  copy->false_value = std::move(mapped_false_value);
+  copy->condition = std::move(mapped_condition).ValueOrUnchanged(std::move(copy->condition));
+  copy->true_value = std::move(mapped_true_value).ValueOrUnchanged(std::move(copy->true_value));
+  copy->false_value = std::move(mapped_false_value).ValueOrUnchanged(std::move(copy->false_value));
   return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
 }
 
@@ -353,20 +364,24 @@ TVMFFIAny SelectMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
   // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
   SelectNode* self = const_cast<SelectNode*>(
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const SelectNode>(value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_condition,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_condition,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->condition));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_true_value,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_true_value,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->true_value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_false_value,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_false_value,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->false_value));
-  if (mapped_condition.same_as(self->condition) && mapped_true_value.same_as(self->true_value) &&
-      mapped_false_value.same_as(self->false_value)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_condition.UnchangedOrSameAs(self->condition) &&
+      mapped_true_value.UnchangedOrSameAs(self->true_value) &&
+      mapped_false_value.UnchangedOrSameAs(self->false_value)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
-  self->condition = std::move(mapped_condition);
-  self->true_value = std::move(mapped_true_value);
-  self->false_value = std::move(mapped_false_value);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (!mapped_condition.IsUnchanged())
+    self->condition = std::move(mapped_condition).ValueUnchecked();
+  if (!mapped_true_value.IsUnchanged())
+    self->true_value = std::move(mapped_true_value).ValueUnchecked();
+  if (!mapped_false_value.IsUnchanged())
+    self->false_value = std::move(mapped_false_value).ValueUnchecked();
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 TVMFFIAny LetVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
@@ -374,30 +389,32 @@ TVMFFIAny LetVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexc
   const LetNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const LetNode>(value);
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->WithDefRegionKind(
-      kTVMFFIDefRegionKindNonRecursive, [&]() { return visitor->VisitExpected(self->var); }));
+      kTVMFFIDefRegionKindSimple, [&]() { return visitor->VisitExpected(self->var); }));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->value));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->body));
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
 TVMFFIAny LetMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
   // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
   const LetNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const LetNode>(value);
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(
-      Var, mapped_var, mutator->WithDefRegionKind(kTVMFFIDefRegionKindNonRecursive, [&]() {
-        return mutator->MutateExpected(self->var);
-      }));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_value, mutator->MutateExpected(self->value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_body, mutator->MutateExpected(self->body));
-  if (mapped_var.same_as(self->var) && mapped_value.same_as(self->value) &&
-      mapped_body.same_as(self->body)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Var>, mapped_var,
+                                    mutator->WithDefRegionKind(kTVMFFIDefRegionKindSimple, [&]() {
+                                      return mutator->MutateExpected(self->var);
+                                    }));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_value,
+                                    mutator->MutateExpected(self->value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_body,
+                                    mutator->MutateExpected(self->body));
+  if (mapped_var.UnchangedOrSameAs(self->var) && mapped_value.UnchangedOrSameAs(self->value) &&
+      mapped_body.UnchangedOrSameAs(self->body)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
   ffi::ObjectPtr<LetNode> copy = ffi::make_object<LetNode>(*self);
-  copy->var = std::move(mapped_var);
-  copy->value = std::move(mapped_value);
-  copy->body = std::move(mapped_body);
+  copy->var = std::move(mapped_var).ValueOrUnchanged(std::move(copy->var));
+  copy->value = std::move(mapped_value).ValueOrUnchanged(std::move(copy->value));
+  copy->body = std::move(mapped_body).ValueOrUnchanged(std::move(copy->body));
   return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
 }
 
@@ -405,22 +422,22 @@ TVMFFIAny LetMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView
   // skips: PrimExpr types are always PrimType and remain unchanged in normal mutation.
   LetNode* self = const_cast<LetNode*>(
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const LetNode>(value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(
-      Var, mapped_var, mutator->WithDefRegionKind(kTVMFFIDefRegionKindNonRecursive, [&]() {
-        return mutator->MaybeInplaceMutateIfUniqueExpected(self->var);
-      }));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_value,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Var>, mapped_var,
+                                    mutator->WithDefRegionKind(kTVMFFIDefRegionKindSimple, [&]() {
+                                      return mutator->MaybeInplaceMutateIfUniqueExpected(self->var);
+                                    }));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_value,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_body,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_body,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->body));
-  if (mapped_var.same_as(self->var) && mapped_value.same_as(self->value) &&
-      mapped_body.same_as(self->body)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_var.UnchangedOrSameAs(self->var) && mapped_value.UnchangedOrSameAs(self->value) &&
+      mapped_body.UnchangedOrSameAs(self->body)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
-  self->var = std::move(mapped_var);
-  self->value = std::move(mapped_value);
-  self->body = std::move(mapped_body);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (!mapped_var.IsUnchanged()) self->var = std::move(mapped_var).ValueUnchecked();
+  if (!mapped_value.IsUnchanged()) self->value = std::move(mapped_value).ValueUnchecked();
+  if (!mapped_body.IsUnchanged()) self->body = std::move(mapped_body).ValueUnchecked();
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 }  // namespace

--- a/src/ir/type.cc
+++ b/src/ir/type.cc
@@ -72,23 +72,19 @@ ffi::ObjectPtr<PrimTypeNode> GetCachedPrimTypeNode(DLDataType dtype) {
 TVMFFIAny PrimTypeVisit(ffi::StructuralVisitorObj*, ffi::AnyView) noexcept {
   // dtype is a constant: reflected for StructuralEqual/Hash,
   // not traversed by the visitor/mutator contract.
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
-TVMFFIAny PrimTypeMutate(ffi::StructuralMutatorObj*, ffi::AnyView value) noexcept {
+TVMFFIAny PrimTypeMutate(ffi::StructuralMutatorObj*, ffi::AnyView) noexcept {
   // dtype is a constant: reflected for StructuralEqual/Hash,
   // not traversed by the visitor/mutator contract.
-  const PrimTypeNode* self =
-      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const PrimTypeNode>(value);
-  return ffi::details::ExpectedUnsafe::MoveToTVMFFIAny(ffi::Expected<ffi::Any>(ffi::Any(self)));
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
-TVMFFIAny PrimTypeMaybeInplaceMutate(ffi::StructuralMutatorObj*, ffi::AnyView value) noexcept {
+TVMFFIAny PrimTypeMaybeInplaceMutate(ffi::StructuralMutatorObj*, ffi::AnyView) noexcept {
   // dtype is a constant: reflected for StructuralEqual/Hash,
   // not traversed by the visitor/mutator contract.
-  const PrimTypeNode* self =
-      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const PrimTypeNode>(value);
-  return ffi::details::ExpectedUnsafe::MoveToTVMFFIAny(ffi::Expected<ffi::Any>(ffi::Any(self)));
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 }  // namespace

--- a/src/tirx/ir/buffer.cc
+++ b/src/tirx/ir/buffer.cc
@@ -130,48 +130,53 @@ TVMFFIAny BufferTypeVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value
   if (!self->allocated_addr.empty()) {
     TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->allocated_addr));
   }
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
 TVMFFIAny BufferTypeMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
   // skips: storage_scope, data_alignment, offset_factor
   const BufferTypeNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const BufferTypeNode>(value);
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimType, mapped_dtype, mutator->MutateExpected(self->dtype));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<PrimExpr>, mapped_shape,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimType>, mapped_dtype,
+                                    mutator->MutateExpected(self->dtype));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Array<PrimExpr>>, mapped_shape,
                                     mutator->MutateExpected(self->shape));
   // Empty strides denote the common compact layout.  Broad callbacks do not see the empty
   // container; explicit strides retain normal container descent and callback behavior.
-  auto mapped_strides = self->strides;
+  ffi::UnchangedOr<ffi::Array<PrimExpr>> mapped_strides = ffi::Unchanged();
   if (!self->strides.empty()) {
-    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<PrimExpr>, descended_strides,
+    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Array<PrimExpr>>, descended_strides,
                                       mutator->MutateExpected(self->strides));
     mapped_strides = std::move(descended_strides);
   }
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_elem_offset,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_elem_offset,
                                     mutator->MutateExpected(self->elem_offset));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Optional<Layout>, mapped_layout,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Optional<Layout>>, mapped_layout,
                                     mutator->MutateExpected(self->layout));
   // allocated_addr is empty outside specialized storage scopes.  Broad callbacks do not see the
   // empty container; present addresses retain normal container descent and callback behavior.
-  auto mapped_allocated_addr = self->allocated_addr;
+  ffi::UnchangedOr<ffi::Array<PrimExpr>> mapped_allocated_addr = ffi::Unchanged();
   if (!self->allocated_addr.empty()) {
-    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<PrimExpr>, descended_allocated_addr,
+    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Array<PrimExpr>>,
+                                      descended_allocated_addr,
                                       mutator->MutateExpected(self->allocated_addr));
     mapped_allocated_addr = std::move(descended_allocated_addr);
   }
-  if (mapped_dtype.same_as(self->dtype) && mapped_shape.same_as(self->shape) &&
-      mapped_strides.same_as(self->strides) && mapped_elem_offset.same_as(self->elem_offset) &&
-      mapped_layout.same_as(self->layout) && mapped_allocated_addr.same_as(self->allocated_addr)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_dtype.UnchangedOrSameAs(self->dtype) && mapped_shape.UnchangedOrSameAs(self->shape) &&
+      mapped_strides.UnchangedOrSameAs(self->strides) &&
+      mapped_elem_offset.UnchangedOrSameAs(self->elem_offset) &&
+      mapped_layout.UnchangedOrSameAs(self->layout) &&
+      mapped_allocated_addr.UnchangedOrSameAs(self->allocated_addr)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
   ffi::ObjectPtr<BufferTypeNode> copy = ffi::make_object<BufferTypeNode>(*self);
-  copy->dtype = std::move(mapped_dtype);
-  copy->shape = std::move(mapped_shape);
-  copy->strides = std::move(mapped_strides);
-  copy->elem_offset = std::move(mapped_elem_offset);
-  copy->layout = std::move(mapped_layout);
-  copy->allocated_addr = std::move(mapped_allocated_addr);
+  copy->dtype = std::move(mapped_dtype).ValueOrUnchanged(std::move(copy->dtype));
+  copy->shape = std::move(mapped_shape).ValueOrUnchanged(std::move(copy->shape));
+  copy->strides = std::move(mapped_strides).ValueOrUnchanged(std::move(copy->strides));
+  copy->elem_offset = std::move(mapped_elem_offset).ValueOrUnchanged(std::move(copy->elem_offset));
+  copy->layout = std::move(mapped_layout).ValueOrUnchanged(std::move(copy->layout));
+  copy->allocated_addr =
+      std::move(mapped_allocated_addr).ValueOrUnchanged(std::move(copy->allocated_addr));
   return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
 }
 
@@ -180,43 +185,48 @@ TVMFFIAny BufferTypeMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
   // skips: storage_scope, data_alignment, offset_factor
   BufferTypeNode* self = const_cast<BufferTypeNode*>(
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const BufferTypeNode>(value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimType, mapped_dtype,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimType>, mapped_dtype,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->dtype));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<PrimExpr>, mapped_shape,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Array<PrimExpr>>, mapped_shape,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->shape));
   // Empty strides denote the common compact layout.  Broad callbacks do not see the empty
   // container; explicit strides retain normal container descent and callback behavior.
-  auto mapped_strides = self->strides;
+  ffi::UnchangedOr<ffi::Array<PrimExpr>> mapped_strides = ffi::Unchanged();
   if (!self->strides.empty()) {
-    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<PrimExpr>, descended_strides,
+    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Array<PrimExpr>>, descended_strides,
                                       mutator->MaybeInplaceMutateIfUniqueExpected(self->strides));
     mapped_strides = std::move(descended_strides);
   }
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_elem_offset,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_elem_offset,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->elem_offset));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Optional<Layout>, mapped_layout,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Optional<Layout>>, mapped_layout,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->layout));
   // allocated_addr is empty outside specialized storage scopes.  Broad callbacks do not see the
   // empty container; present addresses retain normal container descent and callback behavior.
-  auto mapped_allocated_addr = self->allocated_addr;
+  ffi::UnchangedOr<ffi::Array<PrimExpr>> mapped_allocated_addr = ffi::Unchanged();
   if (!self->allocated_addr.empty()) {
     TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(
-        ffi::Array<PrimExpr>, descended_allocated_addr,
+        ffi::UnchangedOr<ffi::Array<PrimExpr>>, descended_allocated_addr,
         mutator->MaybeInplaceMutateIfUniqueExpected(self->allocated_addr));
     mapped_allocated_addr = std::move(descended_allocated_addr);
   }
-  if (mapped_dtype.same_as(self->dtype) && mapped_shape.same_as(self->shape) &&
-      mapped_strides.same_as(self->strides) && mapped_elem_offset.same_as(self->elem_offset) &&
-      mapped_layout.same_as(self->layout) && mapped_allocated_addr.same_as(self->allocated_addr)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_dtype.UnchangedOrSameAs(self->dtype) && mapped_shape.UnchangedOrSameAs(self->shape) &&
+      mapped_strides.UnchangedOrSameAs(self->strides) &&
+      mapped_elem_offset.UnchangedOrSameAs(self->elem_offset) &&
+      mapped_layout.UnchangedOrSameAs(self->layout) &&
+      mapped_allocated_addr.UnchangedOrSameAs(self->allocated_addr)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
-  self->dtype = std::move(mapped_dtype);
-  self->shape = std::move(mapped_shape);
-  self->strides = std::move(mapped_strides);
-  self->elem_offset = std::move(mapped_elem_offset);
-  self->layout = std::move(mapped_layout);
-  self->allocated_addr = std::move(mapped_allocated_addr);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (!mapped_dtype.IsUnchanged()) self->dtype = std::move(mapped_dtype).ValueUnchecked();
+  if (!mapped_shape.IsUnchanged()) self->shape = std::move(mapped_shape).ValueUnchecked();
+  if (!mapped_strides.IsUnchanged()) self->strides = std::move(mapped_strides).ValueUnchecked();
+  if (!mapped_elem_offset.IsUnchanged())
+    self->elem_offset = std::move(mapped_elem_offset).ValueUnchecked();
+  if (!mapped_layout.IsUnchanged()) self->layout = std::move(mapped_layout).ValueUnchecked();
+  if (!mapped_allocated_addr.IsUnchanged()) {
+    self->allocated_addr = std::move(mapped_allocated_addr).ValueUnchecked();
+  }
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 }  // namespace

--- a/src/tirx/ir/iter_var.cc
+++ b/src/tirx/ir/iter_var.cc
@@ -41,25 +41,26 @@ TVMFFIAny IterVarVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) n
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const IterVarNode>(value);
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->dom));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->WithDefRegionKind(
-      kTVMFFIDefRegionKindNonRecursive, [&]() { return visitor->VisitExpected(self->var); }));
-  TVM_FFI_S_VISIT_RETURN_NONE();
+      kTVMFFIDefRegionKindSimple, [&]() { return visitor->VisitExpected(self->var); }));
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
 TVMFFIAny IterVarMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
   // skips: iter_type, thread_tag
   const IterVarNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const IterVarNode>(value);
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Range, mapped_dom, mutator->MutateExpected(self->dom));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(
-      PrimVar, mapped_var, mutator->WithDefRegionKind(kTVMFFIDefRegionKindNonRecursive, [&]() {
-        return mutator->MutateExpected(self->var);
-      }));
-  if (mapped_dom.same_as(self->dom) && mapped_var.same_as(self->var)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Range>, mapped_dom,
+                                    mutator->MutateExpected(self->dom));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimVar>, mapped_var,
+                                    mutator->WithDefRegionKind(kTVMFFIDefRegionKindSimple, [&]() {
+                                      return mutator->MutateExpected(self->var);
+                                    }));
+  if (mapped_dom.UnchangedOrSameAs(self->dom) && mapped_var.UnchangedOrSameAs(self->var)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
   ffi::ObjectPtr<IterVarNode> copy = ffi::make_object<IterVarNode>(*self);
-  copy->dom = std::move(mapped_dom);
-  copy->var = std::move(mapped_var);
+  copy->dom = std::move(mapped_dom).ValueOrUnchanged(std::move(copy->dom));
+  copy->var = std::move(mapped_var).ValueOrUnchanged(std::move(copy->var));
   return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
 }
 
@@ -68,18 +69,18 @@ TVMFFIAny IterVarMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
   // skips: iter_type, thread_tag
   IterVarNode* self = const_cast<IterVarNode*>(
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const IterVarNode>(value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Range, mapped_dom,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Range>, mapped_dom,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->dom));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(
-      PrimVar, mapped_var, mutator->WithDefRegionKind(kTVMFFIDefRegionKindNonRecursive, [&]() {
-        return mutator->MaybeInplaceMutateIfUniqueExpected(self->var);
-      }));
-  if (mapped_dom.same_as(self->dom) && mapped_var.same_as(self->var)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimVar>, mapped_var,
+                                    mutator->WithDefRegionKind(kTVMFFIDefRegionKindSimple, [&]() {
+                                      return mutator->MaybeInplaceMutateIfUniqueExpected(self->var);
+                                    }));
+  if (mapped_dom.UnchangedOrSameAs(self->dom) && mapped_var.UnchangedOrSameAs(self->var)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
-  self->dom = std::move(mapped_dom);
-  self->var = std::move(mapped_var);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  self->dom = std::move(mapped_dom).ValueOrUnchanged(std::move(self->dom));
+  self->var = std::move(mapped_var).ValueOrUnchanged(std::move(self->var));
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 }  // namespace

--- a/src/tirx/ir/layout/tile_core.cc
+++ b/src/tirx/ir/layout/tile_core.cc
@@ -45,43 +45,46 @@ TVMFFIAny IterVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noex
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->extent));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->stride));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->axis));
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
 TVMFFIAny IterMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
   const IterNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const IterNode>(value);
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_extent, mutator->MutateExpected(self->extent));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_stride, mutator->MutateExpected(self->stride));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Axis, mapped_axis, mutator->MutateExpected(self->axis));
-  if (mapped_extent.same_as(self->extent) && mapped_stride.same_as(self->stride) &&
-      mapped_axis.same_as(self->axis)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_extent,
+                                    mutator->MutateExpected(self->extent));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_stride,
+                                    mutator->MutateExpected(self->stride));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Axis>, mapped_axis,
+                                    mutator->MutateExpected(self->axis));
+  if (mapped_extent.UnchangedOrSameAs(self->extent) &&
+      mapped_stride.UnchangedOrSameAs(self->stride) && mapped_axis.UnchangedOrSameAs(self->axis)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
   ffi::ObjectPtr<IterNode> copy = ffi::make_object<IterNode>(*self);
-  copy->extent = std::move(mapped_extent);
-  copy->stride = std::move(mapped_stride);
-  copy->axis = std::move(mapped_axis);
+  copy->extent = std::move(mapped_extent).ValueOrUnchanged(std::move(copy->extent));
+  copy->stride = std::move(mapped_stride).ValueOrUnchanged(std::move(copy->stride));
+  copy->axis = std::move(mapped_axis).ValueOrUnchanged(std::move(copy->axis));
   return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
 }
 
 TVMFFIAny IterMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
   IterNode* self = const_cast<IterNode*>(
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const IterNode>(value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_extent,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_extent,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->extent));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_stride,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_stride,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->stride));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Axis, mapped_axis,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Axis>, mapped_axis,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->axis));
-  if (mapped_extent.same_as(self->extent) && mapped_stride.same_as(self->stride) &&
-      mapped_axis.same_as(self->axis)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_extent.UnchangedOrSameAs(self->extent) &&
+      mapped_stride.UnchangedOrSameAs(self->stride) && mapped_axis.UnchangedOrSameAs(self->axis)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
-  self->extent = std::move(mapped_extent);
-  self->stride = std::move(mapped_stride);
-  self->axis = std::move(mapped_axis);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  self->extent = std::move(mapped_extent).ValueOrUnchanged(std::move(self->extent));
+  self->stride = std::move(mapped_stride).ValueOrUnchanged(std::move(self->stride));
+  self->axis = std::move(mapped_axis).ValueOrUnchanged(std::move(self->axis));
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 TVMFFIAny TileLayoutVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
@@ -90,34 +93,28 @@ TVMFFIAny TileLayoutVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->shard));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->replica));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->offset));
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
 TVMFFIAny TileLayoutMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
   const TileLayoutNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const TileLayoutNode>(value);
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<Iter>, mapped_shard,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Array<Iter>>, mapped_shard,
                                     mutator->MutateExpected(self->shard));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<Iter>, mapped_replica,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Array<Iter>>, mapped_replica,
                                     mutator->MutateExpected(self->replica));
-  auto mapped_offset_result = mutator->MutateExpected(self->offset);
-  TVM_FFI_S_MUTATE_MAYBE_EARLY_RETURN(mapped_offset_result);
-  bool mapped_offset_type_ok = ffi::details::AnyUnsafe::CheckAnyStrict<ffi::Map<Axis, PrimExpr>>(
-      ffi::details::ExpectedUnsafe::GetData(mapped_offset_result));
-  if (TVM_FFI_PREDICT_FALSE(!mapped_offset_type_ok)) {
-    return ffi::details::ExpectedUnsafe::MoveToTVMFFIAny(ffi::details::SMutateDeclaredTypeError());
-  }
-  ffi::Map<Axis, PrimExpr> mapped_offset =
-      ffi::details::AnyUnsafe::MoveFromAnyAfterCheck<ffi::Map<Axis, PrimExpr>>(
-          std::move(ffi::details::ExpectedUnsafe::GetData(mapped_offset_result)));
-  if (mapped_shard.same_as(self->shard) && mapped_replica.same_as(self->replica) &&
-      mapped_offset.same_as(self->offset)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  using OffsetMap = ffi::Map<Axis, PrimExpr>;
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<OffsetMap>, mapped_offset,
+                                    mutator->MutateExpected(self->offset));
+  if (mapped_shard.UnchangedOrSameAs(self->shard) &&
+      mapped_replica.UnchangedOrSameAs(self->replica) &&
+      mapped_offset.UnchangedOrSameAs(self->offset)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
   ffi::ObjectPtr<TileLayoutNode> copy = ffi::make_object<TileLayoutNode>(*self);
-  copy->shard = std::move(mapped_shard);
-  copy->replica = std::move(mapped_replica);
-  copy->offset = std::move(mapped_offset);
+  copy->shard = std::move(mapped_shard).ValueOrUnchanged(std::move(copy->shard));
+  copy->replica = std::move(mapped_replica).ValueOrUnchanged(std::move(copy->replica));
+  copy->offset = std::move(mapped_offset).ValueOrUnchanged(std::move(copy->offset));
   return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
 }
 
@@ -125,28 +122,22 @@ TVMFFIAny TileLayoutMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
                                        ffi::AnyView value) noexcept {
   TileLayoutNode* self = const_cast<TileLayoutNode*>(
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const TileLayoutNode>(value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<Iter>, mapped_shard,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Array<Iter>>, mapped_shard,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->shard));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<Iter>, mapped_replica,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Array<Iter>>, mapped_replica,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->replica));
-  auto mapped_offset_result = mutator->MaybeInplaceMutateIfUniqueExpected(self->offset);
-  TVM_FFI_S_MUTATE_MAYBE_EARLY_RETURN(mapped_offset_result);
-  bool mapped_offset_type_ok = ffi::details::AnyUnsafe::CheckAnyStrict<ffi::Map<Axis, PrimExpr>>(
-      ffi::details::ExpectedUnsafe::GetData(mapped_offset_result));
-  if (TVM_FFI_PREDICT_FALSE(!mapped_offset_type_ok)) {
-    return ffi::details::ExpectedUnsafe::MoveToTVMFFIAny(ffi::details::SMutateDeclaredTypeError());
+  using OffsetMap = ffi::Map<Axis, PrimExpr>;
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<OffsetMap>, mapped_offset,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->offset));
+  if (mapped_shard.UnchangedOrSameAs(self->shard) &&
+      mapped_replica.UnchangedOrSameAs(self->replica) &&
+      mapped_offset.UnchangedOrSameAs(self->offset)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
-  ffi::Map<Axis, PrimExpr> mapped_offset =
-      ffi::details::AnyUnsafe::MoveFromAnyAfterCheck<ffi::Map<Axis, PrimExpr>>(
-          std::move(ffi::details::ExpectedUnsafe::GetData(mapped_offset_result)));
-  if (mapped_shard.same_as(self->shard) && mapped_replica.same_as(self->replica) &&
-      mapped_offset.same_as(self->offset)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
-  }
-  self->shard = std::move(mapped_shard);
-  self->replica = std::move(mapped_replica);
-  self->offset = std::move(mapped_offset);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  self->shard = std::move(mapped_shard).ValueOrUnchanged(std::move(self->shard));
+  self->replica = std::move(mapped_replica).ValueOrUnchanged(std::move(self->replica));
+  self->offset = std::move(mapped_offset).ValueOrUnchanged(std::move(self->offset));
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 }  // namespace

--- a/src/tirx/ir/stmt.cc
+++ b/src/tirx/ir/stmt.cc
@@ -31,7 +31,9 @@
 #include <tvm/tirx/op_attr_types.h>
 #include <tvm/tirx/stmt.h>
 
+#include <iterator>
 #include <utility>
+#include <vector>
 
 #include "buffer_common.h"
 
@@ -113,43 +115,44 @@ TVMFFIAny BindVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noex
   const BindNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const BindNode>(value);
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->WithDefRegionKind(
-      kTVMFFIDefRegionKindNonRecursive, [&]() { return visitor->VisitExpected(self->var); }));
+      kTVMFFIDefRegionKindSimple, [&]() { return visitor->VisitExpected(self->var); }));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->value));
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
 TVMFFIAny BindMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
   const BindNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const BindNode>(value);
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(
-      Var, mapped_var, mutator->WithDefRegionKind(kTVMFFIDefRegionKindNonRecursive, [&]() {
-        return mutator->MutateExpected(self->var);
-      }));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Expr, mapped_value, mutator->MutateExpected(self->value));
-  if (mapped_var.same_as(self->var) && mapped_value.same_as(self->value)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Var>, mapped_var,
+                                    mutator->WithDefRegionKind(kTVMFFIDefRegionKindSimple, [&]() {
+                                      return mutator->MutateExpected(self->var);
+                                    }));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Expr>, mapped_value,
+                                    mutator->MutateExpected(self->value));
+  if (mapped_var.UnchangedOrSameAs(self->var) && mapped_value.UnchangedOrSameAs(self->value)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
   ffi::ObjectPtr<BindNode> copy = ffi::make_object<BindNode>(*self);
-  copy->var = std::move(mapped_var);
-  copy->value = std::move(mapped_value);
+  copy->var = std::move(mapped_var).ValueOrUnchanged(std::move(copy->var));
+  copy->value = std::move(mapped_value).ValueOrUnchanged(std::move(copy->value));
   return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
 }
 
 TVMFFIAny BindMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
   BindNode* self = const_cast<BindNode*>(
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const BindNode>(value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(
-      Var, mapped_var, mutator->WithDefRegionKind(kTVMFFIDefRegionKindNonRecursive, [&]() {
-        return mutator->MaybeInplaceMutateIfUniqueExpected(self->var);
-      }));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Expr, mapped_value,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Var>, mapped_var,
+                                    mutator->WithDefRegionKind(kTVMFFIDefRegionKindSimple, [&]() {
+                                      return mutator->MaybeInplaceMutateIfUniqueExpected(self->var);
+                                    }));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Expr>, mapped_value,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->value));
-  if (mapped_var.same_as(self->var) && mapped_value.same_as(self->value)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_var.UnchangedOrSameAs(self->var) && mapped_value.UnchangedOrSameAs(self->value)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
-  self->var = std::move(mapped_var);
-  self->value = std::move(mapped_value);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (!mapped_var.IsUnchanged()) self->var = std::move(mapped_var).ValueUnchecked();
+  if (!mapped_value.IsUnchanged()) self->value = std::move(mapped_value).ValueUnchecked();
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 TVMFFIAny AttrStmtVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
@@ -159,24 +162,27 @@ TVMFFIAny AttrStmtVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) 
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->node));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->value));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->body));
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
 TVMFFIAny AttrStmtMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
   // skips: attr_key
   const AttrStmtNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const AttrStmtNode>(value);
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Any, mapped_node, mutator->MutateExpected(self->node));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_value, mutator->MutateExpected(self->value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Stmt, mapped_body, mutator->MutateExpected(self->body));
-  if (mapped_node.same_as(self->node) && mapped_value.same_as(self->value) &&
-      mapped_body.same_as(self->body)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Any>, mapped_node,
+                                    mutator->MutateExpected(self->node));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_value,
+                                    mutator->MutateExpected(self->value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Stmt>, mapped_body,
+                                    mutator->MutateExpected(self->body));
+  if (mapped_node.UnchangedOrSameAs(self->node) && mapped_value.UnchangedOrSameAs(self->value) &&
+      mapped_body.UnchangedOrSameAs(self->body)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
   ffi::ObjectPtr<AttrStmtNode> copy = ffi::make_object<AttrStmtNode>(*self);
-  copy->node = std::move(mapped_node);
-  copy->value = std::move(mapped_value);
-  copy->body = std::move(mapped_body);
+  copy->node = std::move(mapped_node).ValueOrUnchanged(std::move(copy->node));
+  copy->value = std::move(mapped_value).ValueOrUnchanged(std::move(copy->value));
+  copy->body = std::move(mapped_body).ValueOrUnchanged(std::move(copy->body));
   return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
 }
 
@@ -185,20 +191,20 @@ TVMFFIAny AttrStmtMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
   // skips: attr_key
   AttrStmtNode* self = const_cast<AttrStmtNode*>(
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const AttrStmtNode>(value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Any, mapped_node,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Any>, mapped_node,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->node));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_value,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_value,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Stmt, mapped_body,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Stmt>, mapped_body,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->body));
-  if (mapped_node.same_as(self->node) && mapped_value.same_as(self->value) &&
-      mapped_body.same_as(self->body)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_node.UnchangedOrSameAs(self->node) && mapped_value.UnchangedOrSameAs(self->value) &&
+      mapped_body.UnchangedOrSameAs(self->body)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
-  self->node = std::move(mapped_node);
-  self->value = std::move(mapped_value);
-  self->body = std::move(mapped_body);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (!mapped_node.IsUnchanged()) self->node = std::move(mapped_node).ValueUnchecked();
+  if (!mapped_value.IsUnchanged()) self->value = std::move(mapped_value).ValueUnchecked();
+  if (!mapped_body.IsUnchanged()) self->body = std::move(mapped_body).ValueUnchecked();
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 TVMFFIAny AssertStmtVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
@@ -206,20 +212,20 @@ TVMFFIAny AssertStmtVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value
   const AssertStmtNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const AssertStmtNode>(value);
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->condition));
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
 TVMFFIAny AssertStmtMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
   // skips: error_kind and message_parts, which are constant assertion metadata.
   const AssertStmtNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const AssertStmtNode>(value);
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_condition,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_condition,
                                     mutator->MutateExpected(self->condition));
-  if (mapped_condition.same_as(self->condition)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_condition.UnchangedOrSameAs(self->condition)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
   ffi::ObjectPtr<AssertStmtNode> copy = ffi::make_object<AssertStmtNode>(*self);
-  copy->condition = std::move(mapped_condition);
+  copy->condition = std::move(mapped_condition).ValueOrUnchanged(std::move(copy->condition));
   return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
 }
 
@@ -228,13 +234,14 @@ TVMFFIAny AssertStmtMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
   // skips: error_kind and message_parts, which are constant assertion metadata.
   AssertStmtNode* self = const_cast<AssertStmtNode*>(
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const AssertStmtNode>(value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_condition,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_condition,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->condition));
-  if (mapped_condition.same_as(self->condition)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_condition.UnchangedOrSameAs(self->condition)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
-  self->condition = std::move(mapped_condition);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (!mapped_condition.IsUnchanged())
+    self->condition = std::move(mapped_condition).ValueUnchecked();
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 TVMFFIAny ForVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
@@ -242,42 +249,48 @@ TVMFFIAny ForVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexc
   const ForNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const ForNode>(value);
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->WithDefRegionKind(
-      kTVMFFIDefRegionKindNonRecursive, [&]() { return visitor->VisitExpected(self->loop_var); }));
+      kTVMFFIDefRegionKindSimple, [&]() { return visitor->VisitExpected(self->loop_var); }));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->min));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->extent));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->body));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->thread_binding));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->step));
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
 TVMFFIAny ForMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
   // skips: kind and constant annotations; unlike SBlock annotations, these carry no expressions.
   const ForNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const ForNode>(value);
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(
-      PrimVar, mapped_loop_var, mutator->WithDefRegionKind(kTVMFFIDefRegionKindNonRecursive, [&]() {
-        return mutator->MutateExpected(self->loop_var);
-      }));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_min, mutator->MutateExpected(self->min));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_extent, mutator->MutateExpected(self->extent));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Stmt, mapped_body, mutator->MutateExpected(self->body));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Optional<IterVar>, mapped_thread_binding,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimVar>, mapped_loop_var,
+                                    mutator->WithDefRegionKind(kTVMFFIDefRegionKindSimple, [&]() {
+                                      return mutator->MutateExpected(self->loop_var);
+                                    }));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_min,
+                                    mutator->MutateExpected(self->min));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_extent,
+                                    mutator->MutateExpected(self->extent));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Stmt>, mapped_body,
+                                    mutator->MutateExpected(self->body));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Optional<IterVar>>, mapped_thread_binding,
                                     mutator->MutateExpected(self->thread_binding));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Optional<PrimExpr>, mapped_step,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Optional<PrimExpr>>, mapped_step,
                                     mutator->MutateExpected(self->step));
-  if (mapped_loop_var.same_as(self->loop_var) && mapped_min.same_as(self->min) &&
-      mapped_extent.same_as(self->extent) && mapped_body.same_as(self->body) &&
-      mapped_thread_binding.same_as(self->thread_binding) && mapped_step.same_as(self->step)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_loop_var.UnchangedOrSameAs(self->loop_var) &&
+      mapped_min.UnchangedOrSameAs(self->min) && mapped_extent.UnchangedOrSameAs(self->extent) &&
+      mapped_body.UnchangedOrSameAs(self->body) &&
+      mapped_thread_binding.UnchangedOrSameAs(self->thread_binding) &&
+      mapped_step.UnchangedOrSameAs(self->step)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
   ffi::ObjectPtr<ForNode> copy = ffi::make_object<ForNode>(*self);
-  copy->loop_var = std::move(mapped_loop_var);
-  copy->min = std::move(mapped_min);
-  copy->extent = std::move(mapped_extent);
-  copy->body = std::move(mapped_body);
-  copy->thread_binding = std::move(mapped_thread_binding);
-  copy->step = std::move(mapped_step);
+  copy->loop_var = std::move(mapped_loop_var).ValueOrUnchanged(std::move(copy->loop_var));
+  copy->min = std::move(mapped_min).ValueOrUnchanged(std::move(copy->min));
+  copy->extent = std::move(mapped_extent).ValueOrUnchanged(std::move(copy->extent));
+  copy->body = std::move(mapped_body).ValueOrUnchanged(std::move(copy->body));
+  copy->thread_binding =
+      std::move(mapped_thread_binding).ValueOrUnchanged(std::move(copy->thread_binding));
+  copy->step = std::move(mapped_step).ValueOrUnchanged(std::move(copy->step));
   return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
 }
 
@@ -286,32 +299,37 @@ TVMFFIAny ForMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView
   ForNode* self = const_cast<ForNode*>(
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const ForNode>(value));
   TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(
-      PrimVar, mapped_loop_var, mutator->WithDefRegionKind(kTVMFFIDefRegionKindNonRecursive, [&]() {
+      ffi::UnchangedOr<PrimVar>, mapped_loop_var,
+      mutator->WithDefRegionKind(kTVMFFIDefRegionKindSimple, [&]() {
         return mutator->MaybeInplaceMutateIfUniqueExpected(self->loop_var);
       }));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_min,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_min,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->min));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_extent,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_extent,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->extent));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Stmt, mapped_body,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Stmt>, mapped_body,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->body));
   TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(
-      ffi::Optional<IterVar>, mapped_thread_binding,
+      ffi::UnchangedOr<ffi::Optional<IterVar>>, mapped_thread_binding,
       mutator->MaybeInplaceMutateIfUniqueExpected(self->thread_binding));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Optional<PrimExpr>, mapped_step,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Optional<PrimExpr>>, mapped_step,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->step));
-  if (mapped_loop_var.same_as(self->loop_var) && mapped_min.same_as(self->min) &&
-      mapped_extent.same_as(self->extent) && mapped_body.same_as(self->body) &&
-      mapped_thread_binding.same_as(self->thread_binding) && mapped_step.same_as(self->step)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_loop_var.UnchangedOrSameAs(self->loop_var) &&
+      mapped_min.UnchangedOrSameAs(self->min) && mapped_extent.UnchangedOrSameAs(self->extent) &&
+      mapped_body.UnchangedOrSameAs(self->body) &&
+      mapped_thread_binding.UnchangedOrSameAs(self->thread_binding) &&
+      mapped_step.UnchangedOrSameAs(self->step)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
-  self->loop_var = std::move(mapped_loop_var);
-  self->min = std::move(mapped_min);
-  self->extent = std::move(mapped_extent);
-  self->body = std::move(mapped_body);
-  self->thread_binding = std::move(mapped_thread_binding);
-  self->step = std::move(mapped_step);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (!mapped_loop_var.IsUnchanged()) self->loop_var = std::move(mapped_loop_var).ValueUnchecked();
+  if (!mapped_min.IsUnchanged()) self->min = std::move(mapped_min).ValueUnchecked();
+  if (!mapped_extent.IsUnchanged()) self->extent = std::move(mapped_extent).ValueUnchecked();
+  if (!mapped_body.IsUnchanged()) self->body = std::move(mapped_body).ValueUnchecked();
+  if (!mapped_thread_binding.IsUnchanged()) {
+    self->thread_binding = std::move(mapped_thread_binding).ValueUnchecked();
+  }
+  if (!mapped_step.IsUnchanged()) self->step = std::move(mapped_step).ValueUnchecked();
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 TVMFFIAny WhileVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
@@ -319,55 +337,60 @@ TVMFFIAny WhileVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noe
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const WhileNode>(value);
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->condition));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->body));
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
 TVMFFIAny WhileMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
   const WhileNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const WhileNode>(value);
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_condition,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_condition,
                                     mutator->MutateExpected(self->condition));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Stmt, mapped_body, mutator->MutateExpected(self->body));
-  if (mapped_condition.same_as(self->condition) && mapped_body.same_as(self->body)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Stmt>, mapped_body,
+                                    mutator->MutateExpected(self->body));
+  if (mapped_condition.UnchangedOrSameAs(self->condition) &&
+      mapped_body.UnchangedOrSameAs(self->body)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
   ffi::ObjectPtr<WhileNode> copy = ffi::make_object<WhileNode>(*self);
-  copy->condition = std::move(mapped_condition);
-  copy->body = std::move(mapped_body);
+  copy->condition = std::move(mapped_condition).ValueOrUnchanged(std::move(copy->condition));
+  copy->body = std::move(mapped_body).ValueOrUnchanged(std::move(copy->body));
   return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
 }
 
 TVMFFIAny WhileMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
   WhileNode* self = const_cast<WhileNode*>(
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const WhileNode>(value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_condition,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_condition,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->condition));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Stmt, mapped_body,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Stmt>, mapped_body,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->body));
-  if (mapped_condition.same_as(self->condition) && mapped_body.same_as(self->body)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_condition.UnchangedOrSameAs(self->condition) &&
+      mapped_body.UnchangedOrSameAs(self->body)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
-  self->condition = std::move(mapped_condition);
-  self->body = std::move(mapped_body);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (!mapped_condition.IsUnchanged())
+    self->condition = std::move(mapped_condition).ValueUnchecked();
+  if (!mapped_body.IsUnchanged()) self->body = std::move(mapped_body).ValueUnchecked();
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 TVMFFIAny ReturnVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
   const ReturnNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const ReturnNode>(value);
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->value));
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
 TVMFFIAny ReturnMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
   const ReturnNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const ReturnNode>(value);
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Expr, mapped_value, mutator->MutateExpected(self->value));
-  if (mapped_value.same_as(self->value)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Expr>, mapped_value,
+                                    mutator->MutateExpected(self->value));
+  if (mapped_value.UnchangedOrSameAs(self->value)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
   ffi::ObjectPtr<ReturnNode> copy = ffi::make_object<ReturnNode>(*self);
-  copy->value = std::move(mapped_value);
+  copy->value = std::move(mapped_value).ValueOrUnchanged(std::move(copy->value));
   return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
 }
 
@@ -375,70 +398,63 @@ TVMFFIAny ReturnMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
                                    ffi::AnyView value) noexcept {
   ReturnNode* self = const_cast<ReturnNode*>(
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const ReturnNode>(value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Expr, mapped_value,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Expr>, mapped_value,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->value));
-  if (mapped_value.same_as(self->value)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_value.UnchangedOrSameAs(self->value)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
-  self->value = std::move(mapped_value);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (!mapped_value.IsUnchanged()) self->value = std::move(mapped_value).ValueUnchecked();
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 TVMFFIAny BreakVisit(ffi::StructuralVisitorObj*, ffi::AnyView) noexcept {
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
-TVMFFIAny BreakMutate(ffi::StructuralMutatorObj*, ffi::AnyView value) noexcept {
-  const BreakNode* self =
-      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const BreakNode>(value);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+TVMFFIAny BreakMutate(ffi::StructuralMutatorObj*, ffi::AnyView) noexcept {
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
-TVMFFIAny BreakMaybeInplaceMutate(ffi::StructuralMutatorObj*, ffi::AnyView value) noexcept {
-  const BreakNode* self =
-      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const BreakNode>(value);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+TVMFFIAny BreakMaybeInplaceMutate(ffi::StructuralMutatorObj*, ffi::AnyView) noexcept {
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 TVMFFIAny ContinueVisit(ffi::StructuralVisitorObj*, ffi::AnyView) noexcept {
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
-TVMFFIAny ContinueMutate(ffi::StructuralMutatorObj*, ffi::AnyView value) noexcept {
-  const ContinueNode* self =
-      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const ContinueNode>(value);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+TVMFFIAny ContinueMutate(ffi::StructuralMutatorObj*, ffi::AnyView) noexcept {
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
-TVMFFIAny ContinueMaybeInplaceMutate(ffi::StructuralMutatorObj*, ffi::AnyView value) noexcept {
-  const ContinueNode* self =
-      ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const ContinueNode>(value);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+TVMFFIAny ContinueMaybeInplaceMutate(ffi::StructuralMutatorObj*, ffi::AnyView) noexcept {
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 TVMFFIAny DeclBufferVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
   const DeclBufferNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const DeclBufferNode>(value);
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->WithDefRegionKind(
-      kTVMFFIDefRegionKindNonRecursive, [&]() { return visitor->VisitExpected(self->buffer); }));
+      kTVMFFIDefRegionKindSimple, [&]() { return visitor->VisitExpected(self->buffer); }));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->data));
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
 TVMFFIAny DeclBufferMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
   const DeclBufferNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const DeclBufferNode>(value);
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(
-      BufferVar, mapped_buffer, mutator->WithDefRegionKind(kTVMFFIDefRegionKindNonRecursive, [&]() {
-        return mutator->MutateExpected(self->buffer);
-      }));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Expr, mapped_data, mutator->MutateExpected(self->data));
-  if (mapped_buffer.same_as(self->buffer) && mapped_data.same_as(self->data)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<BufferVar>, mapped_buffer,
+                                    mutator->WithDefRegionKind(kTVMFFIDefRegionKindSimple, [&]() {
+                                      return mutator->MutateExpected(self->buffer);
+                                    }));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Expr>, mapped_data,
+                                    mutator->MutateExpected(self->data));
+  if (mapped_buffer.UnchangedOrSameAs(self->buffer) && mapped_data.UnchangedOrSameAs(self->data)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
   ffi::ObjectPtr<DeclBufferNode> copy = ffi::make_object<DeclBufferNode>(*self);
-  copy->buffer = std::move(mapped_buffer);
-  copy->data = std::move(mapped_data);
+  copy->buffer = std::move(mapped_buffer).ValueOrUnchanged(std::move(copy->buffer));
+  copy->data = std::move(mapped_data).ValueOrUnchanged(std::move(copy->data));
   return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
 }
 
@@ -447,17 +463,18 @@ TVMFFIAny DeclBufferMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
   DeclBufferNode* self = const_cast<DeclBufferNode*>(
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const DeclBufferNode>(value));
   TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(
-      BufferVar, mapped_buffer, mutator->WithDefRegionKind(kTVMFFIDefRegionKindNonRecursive, [&]() {
+      ffi::UnchangedOr<BufferVar>, mapped_buffer,
+      mutator->WithDefRegionKind(kTVMFFIDefRegionKindSimple, [&]() {
         return mutator->MaybeInplaceMutateIfUniqueExpected(self->buffer);
       }));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Expr, mapped_data,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Expr>, mapped_data,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->data));
-  if (mapped_buffer.same_as(self->buffer) && mapped_data.same_as(self->data)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_buffer.UnchangedOrSameAs(self->buffer) && mapped_data.UnchangedOrSameAs(self->data)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
-  self->buffer = std::move(mapped_buffer);
-  self->data = std::move(mapped_data);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (!mapped_buffer.IsUnchanged()) self->buffer = std::move(mapped_buffer).ValueUnchecked();
+  if (!mapped_data.IsUnchanged()) self->data = std::move(mapped_data).ValueUnchecked();
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 TVMFFIAny AllocBufferVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
@@ -465,23 +482,23 @@ TVMFFIAny AllocBufferVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView valu
   const AllocBufferNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const AllocBufferNode>(value);
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->WithDefRegionKind(
-      kTVMFFIDefRegionKindNonRecursive, [&]() { return visitor->VisitExpected(self->buffer); }));
-  TVM_FFI_S_VISIT_RETURN_NONE();
+      kTVMFFIDefRegionKindSimple, [&]() { return visitor->VisitExpected(self->buffer); }));
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
 TVMFFIAny AllocBufferMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
   // skips: constant annotations; unlike SBlock annotations, these carry no expressions.
   const AllocBufferNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const AllocBufferNode>(value);
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(
-      BufferVar, mapped_buffer, mutator->WithDefRegionKind(kTVMFFIDefRegionKindNonRecursive, [&]() {
-        return mutator->MutateExpected(self->buffer);
-      }));
-  if (mapped_buffer.same_as(self->buffer)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<BufferVar>, mapped_buffer,
+                                    mutator->WithDefRegionKind(kTVMFFIDefRegionKindSimple, [&]() {
+                                      return mutator->MutateExpected(self->buffer);
+                                    }));
+  if (mapped_buffer.UnchangedOrSameAs(self->buffer)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
   ffi::ObjectPtr<AllocBufferNode> copy = ffi::make_object<AllocBufferNode>(*self);
-  copy->buffer = std::move(mapped_buffer);
+  copy->buffer = std::move(mapped_buffer).ValueOrUnchanged(std::move(copy->buffer));
   return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
 }
 
@@ -491,153 +508,112 @@ TVMFFIAny AllocBufferMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
   AllocBufferNode* self = const_cast<AllocBufferNode*>(
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const AllocBufferNode>(value));
   TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(
-      BufferVar, mapped_buffer, mutator->WithDefRegionKind(kTVMFFIDefRegionKindNonRecursive, [&]() {
+      ffi::UnchangedOr<BufferVar>, mapped_buffer,
+      mutator->WithDefRegionKind(kTVMFFIDefRegionKindSimple, [&]() {
         return mutator->MaybeInplaceMutateIfUniqueExpected(self->buffer);
       }));
-  if (mapped_buffer.same_as(self->buffer)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_buffer.UnchangedOrSameAs(self->buffer)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
-  self->buffer = std::move(mapped_buffer);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (!mapped_buffer.IsUnchanged()) self->buffer = std::move(mapped_buffer).ValueUnchecked();
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 TVMFFIAny SeqStmtVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
   const SeqStmtNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const SeqStmtNode>(value);
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->seq));
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
-bool IsSeqStmtNoOp(const Stmt& stmt) {
+bool IsSeqStmtNoOp(ffi::AnyView stmt) {
   const auto* evaluate = stmt.as<EvaluateNode>();
   const auto* value = evaluate == nullptr ? nullptr : evaluate->value.as<IntImmNode>();
   return value != nullptr && value->value == 0;
 }
 
-void AppendSeqStmtResult(ffi::Array<Stmt>* output, Stmt mapped) {
-  if (IsSeqStmtNoOp(mapped)) {
-    return;
-  }
-  if (const auto* nested = mapped.as<SeqStmtNode>()) {
-    for (const Stmt& stmt : nested->seq) {
-      output->push_back(stmt);
+// Move the non-None slots to the front, preserving order; return the compacted size.
+size_t SeqStmtCompactNop(ffi::Any* begin, size_t current_size) {
+  size_t write = 0;
+  for (size_t read = 0; read < current_size; ++read) {
+    if (begin[read].type_index() == ffi::TypeIndex::kTVMFFINone) {
+      continue;
     }
-  } else {
-    output->push_back(std::move(mapped));
+    if (write != read) {
+      begin[write] = std::move(begin[read]);
+    }
+    ++write;
+  }
+  return write;
+}
+
+// Expand each nested SeqStmt in [0, current_size) into its final position in [0, target_size).
+// Walk backward so a destination is never below its source; requires every nested SeqStmt to be
+// non-empty and target_size slots to exist.
+void SeqStmtExpandNested(ffi::Any* begin, size_t current_size, size_t target_size) {
+  size_t write = target_size;
+  for (size_t read = current_size; read-- > 0;) {
+    if (const auto* nested = begin[read].as<SeqStmtNode>()) {
+      for (size_t i = nested->seq.size(); i-- > 0;) {
+        begin[--write] = ffi::Any(nested->seq[i]);
+      }
+    } else {
+      --write;
+      if (write != read) {
+        begin[write] = std::move(begin[read]);
+      }
+    }
   }
 }
 
 TVMFFIAny MutateSeqStmtChanged(ffi::StructuralMutatorObj* mutator, const SeqStmtNode* self,
-                               int64_t index, Stmt mapped) noexcept {
-  const int64_t size = static_cast<int64_t>(self->seq.size());
-  ffi::ObjectPtr<ffi::ArrayObj> output_obj = ffi::ArrayObj::CreateRepeated(size, ffi::Any());
-  output_obj->InitRange(0, self->seq.begin(), self->seq.begin() + index);
-  output_obj->resize(index);
-  ffi::Array<Stmt> output(std::move(output_obj));
-  AppendSeqStmtResult(&output, std::move(mapped));
-  for (int64_t i = index + 1; i < size; ++i) {
-    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Stmt, mapped, mutator->MutateExpected(self->seq[i]));
-    AppendSeqStmtResult(&output, std::move(mapped));
+                               size_t index, Stmt mapped) noexcept {
+  const size_t size = self->seq.size();
+  std::vector<Stmt> results;
+  results.reserve(size);
+  results.assign(self->seq.begin(), self->seq.begin() + index);
+  auto append = [&](Stmt stmt) {
+    if (IsSeqStmtNoOp(stmt)) {
+      return;
+    }
+    if (const auto* nested = stmt.as<SeqStmtNode>()) {
+      for (const Stmt& child : nested->seq) {
+        results.emplace_back(child);
+      }
+    } else {
+      results.emplace_back(std::move(stmt));
+    }
+  };
+  append(std::move(mapped));
+  for (size_t i = index + 1; i < size; ++i) {
+    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Stmt>, element,
+                                      mutator->MutateExpected(self->seq[i]));
+    append(element.IsUnchanged() ? self->seq[i] : std::move(element).ValueUnchecked());
   }
-  if (output.empty()) {
+  if (results.empty()) {
     return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(Evaluate(0)));
   }
-  if (output.size() == 1) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(output[0]));
+  if (results.size() == 1) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(results[0])));
   }
   ffi::ObjectPtr<SeqStmtNode> copy = ffi::make_object<SeqStmtNode>(*self);
-  copy->seq = std::move(output);
+  copy->seq = ffi::Array<Stmt>(std::make_move_iterator(results.begin()),
+                               std::make_move_iterator(results.end()));
   return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
 }
 
 TVMFFIAny MutateSeqStmtRaw(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
   const SeqStmtNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const SeqStmtNode>(value);
-  const int64_t size = static_cast<int64_t>(self->seq.size());
-  for (int64_t i = 0; i < size; ++i) {
-    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Stmt, mapped, mutator->MutateExpected(self->seq[i]));
-    if (!self->seq[i].same_as(mapped)) {
-      return MutateSeqStmtChanged(mutator, self, i, std::move(mapped));
+  const size_t size = self->seq.size();
+  for (size_t i = 0; i < size; ++i) {
+    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Stmt>, mapped,
+                                      mutator->MutateExpected(self->seq[i]));
+    if (!mapped.UnchangedOrSameAs(self->seq[i])) {
+      return MutateSeqStmtChanged(mutator, self, i, std::move(mapped).ValueUnchecked());
     }
   }
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
-}
-
-TVMFFIAny InplaceSplice(ffi::StructuralMutatorObj* mutator, SeqStmtNode* self, ffi::ArrayObj* seq,
-                        int64_t total, int64_t index, const SeqStmtNode* nested) noexcept {
-  const int64_t size = static_cast<int64_t>(seq->size());
-  ffi::Array<Stmt> output;
-  output.reserve(size + static_cast<int64_t>(nested->seq.size()) - 1);
-  for (int64_t i = 0; i < total; ++i) {
-    output.push_back(seq->begin()[i].cast<Stmt>());
-  }
-  for (const Stmt& stmt : nested->seq) {
-    output.push_back(stmt);
-  }
-  for (int64_t i = index + 1; i < size; ++i) {
-    const ffi::Any& item = seq->begin()[i];
-    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Stmt, mapped,
-                                      mutator->MaybeInplaceMutateIfUniqueExpected(item));
-    AppendSeqStmtResult(&output, std::move(mapped));
-  }
-  if (output.empty()) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(Evaluate(0)));
-  }
-  if (output.size() == 1) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(output[0]));
-  }
-  self->seq = std::move(output);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
-}
-
-TVMFFIAny MaybeInplaceMutateSeqStmtChanged(ffi::StructuralMutatorObj* mutator, SeqStmtNode* self,
-                                           ffi::ArrayObj* seq, int64_t index,
-                                           Stmt mapped) noexcept {
-  const int64_t size = static_cast<int64_t>(seq->size());
-  int64_t total = index;
-  if (IsSeqStmtNoOp(mapped)) {
-    // Drop Evaluate(0), matching SeqStmt::Flatten.
-  } else if (const auto* nested = mapped.as<SeqStmtNode>()) {
-    const int64_t nested_size = static_cast<int64_t>(nested->seq.size());
-    if (total + nested_size > index + 1) {
-      return InplaceSplice(mutator, self, seq, total, index, nested);
-    }
-    for (const Stmt& stmt : nested->seq) {
-      seq->SetItemAfterCheck(total++, ffi::Any(stmt));
-    }
-  } else {
-    seq->SetItemAfterCheck(total++, ffi::Any(std::move(mapped)));
-  }
-  for (int64_t i = index + 1; i < size; ++i) {
-    const ffi::Any& item = seq->begin()[i];
-    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Stmt, mapped,
-                                      mutator->MaybeInplaceMutateIfUniqueExpected(item));
-    if (IsSeqStmtNoOp(mapped)) {
-      continue;
-    }
-    if (const auto* nested = mapped.as<SeqStmtNode>()) {
-      const int64_t nested_size = static_cast<int64_t>(nested->seq.size());
-      if (total + nested_size > i + 1) {
-        return InplaceSplice(mutator, self, seq, total, i, nested);
-      }
-      for (const Stmt& stmt : nested->seq) {
-        seq->SetItemAfterCheck(total++, ffi::Any(stmt));
-      }
-      continue;
-    }
-    if (total != i || !item.same_as(mapped)) {
-      seq->SetItemAfterCheck(total, ffi::Any(std::move(mapped)));
-    }
-    ++total;
-  }
-  seq->resize(total);
-  if (total == 0) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(Evaluate(0)));
-  }
-  if (total == 1) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(seq->begin()[0].cast<Stmt>()));
-  }
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 TVMFFIAny MaybeInplaceMutateSeqStmtRaw(ffi::StructuralMutatorObj* mutator,
@@ -649,17 +625,72 @@ TVMFFIAny MaybeInplaceMutateSeqStmtRaw(ffi::StructuralMutatorObj* mutator,
     return MutateSeqStmtRaw(mutator, value);
   }
   ffi::ArrayObj* seq = self->seq.GetArrayObj();
-  const int64_t size = static_cast<int64_t>(seq->size());
-  for (int64_t i = 0; i < size; ++i) {
-    // Borrow the storage slot so the element stays unique during in-place dispatch.
-    const ffi::Any& item = seq->begin()[i];
-    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Stmt, mapped,
-                                      mutator->MaybeInplaceMutateIfUniqueExpected(item));
-    if (!item.same_as(mapped)) {
-      return MaybeInplaceMutateSeqStmtChanged(mutator, self, seq, i, std::move(mapped));
+  ffi::Any* slots = const_cast<ffi::Any*>(seq->begin());
+  const size_t size = seq->size();
+  size_t delete_count = 0;
+  size_t nested_extra = 0;
+
+  // Pass 1: rebuild each element in place and classify the final slot contents.
+  for (size_t i = 0; i < size; ++i) {
+    TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Stmt>, mapped,
+                                      mutator->MaybeInplaceMutateIfUniqueExpected(slots[i]));
+    if (!mapped.UnchangedOrSameAs(slots[i].cast<Stmt>())) {
+      slots[i] = ffi::Any(std::move(mapped).ValueUnchecked());
+    }
+    if (IsSeqStmtNoOp(slots[i])) {
+      slots[i] = ffi::Any();  // A None slot is the delete marker consumed by compaction.
+      ++delete_count;
+      continue;
+    }
+    if (const auto* nested = slots[i].as<SeqStmtNode>()) {
+      if (nested->seq.empty()) {
+        slots[i] = ffi::Any();
+        ++delete_count;
+      } else {
+        nested_extra += nested->seq.size() - 1;
+      }
     }
   }
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+
+  const size_t final_size = size - delete_count + nested_extra;
+  if (delete_count == 0 && nested_extra == 0) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
+  }
+
+  // Splice in place when the result fits: compact out None slots, resize once, then expand.
+  if (final_size <= seq->SeqBaseObj::capacity()) {
+    size_t compacted = SeqStmtCompactNop(slots, size);
+    seq->resize(final_size);
+    SeqStmtExpandNested(slots, compacted, final_size);
+  } else {
+    // Splice beyond capacity: flatten into one exact-size array with pointer moves.
+    std::vector<Stmt> results;
+    results.reserve(final_size);
+    for (size_t i = 0; i < size; ++i) {
+      if (slots[i].type_index() == ffi::TypeIndex::kTVMFFINone) {
+        continue;
+      }
+      if (const auto* nested = slots[i].as<SeqStmtNode>()) {
+        for (const Stmt& child : nested->seq) {
+          results.emplace_back(child);
+        }
+      } else {
+        results.emplace_back(
+            ffi::details::AnyUnsafe::MoveFromAnyAfterCheck<Stmt>(std::move(slots[i])));
+      }
+    }
+    self->seq = ffi::Array<Stmt>(std::make_move_iterator(results.begin()),
+                                 std::make_move_iterator(results.end()));
+    seq = self->seq.GetArrayObj();
+  }
+
+  if (final_size == 0) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(Evaluate(0)));
+  }
+  if (final_size == 1) {
+    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(seq->begin()[0].cast<Stmt>()));
+  }
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 TVMFFIAny SeqStmtMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
@@ -677,26 +708,27 @@ TVMFFIAny IfThenElseVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->condition));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->then_case));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->else_case));
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
 TVMFFIAny IfThenElseMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
   const IfThenElseNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const IfThenElseNode>(value);
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_condition,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_condition,
                                     mutator->MutateExpected(self->condition));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Stmt, mapped_then_case,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Stmt>, mapped_then_case,
                                     mutator->MutateExpected(self->then_case));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Optional<Stmt>, mapped_else_case,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Optional<Stmt>>, mapped_else_case,
                                     mutator->MutateExpected(self->else_case));
-  if (mapped_condition.same_as(self->condition) && mapped_then_case.same_as(self->then_case) &&
-      mapped_else_case.same_as(self->else_case)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_condition.UnchangedOrSameAs(self->condition) &&
+      mapped_then_case.UnchangedOrSameAs(self->then_case) &&
+      mapped_else_case.UnchangedOrSameAs(self->else_case)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
   ffi::ObjectPtr<IfThenElseNode> copy = ffi::make_object<IfThenElseNode>(*self);
-  copy->condition = std::move(mapped_condition);
-  copy->then_case = std::move(mapped_then_case);
-  copy->else_case = std::move(mapped_else_case);
+  copy->condition = std::move(mapped_condition).ValueOrUnchanged(std::move(copy->condition));
+  copy->then_case = std::move(mapped_then_case).ValueOrUnchanged(std::move(copy->then_case));
+  copy->else_case = std::move(mapped_else_case).ValueOrUnchanged(std::move(copy->else_case));
   return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
 }
 
@@ -704,38 +736,43 @@ TVMFFIAny IfThenElseMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
                                        ffi::AnyView value) noexcept {
   IfThenElseNode* self = const_cast<IfThenElseNode*>(
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const IfThenElseNode>(value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_condition,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_condition,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->condition));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Stmt, mapped_then_case,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Stmt>, mapped_then_case,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->then_case));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Optional<Stmt>, mapped_else_case,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Optional<Stmt>>, mapped_else_case,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->else_case));
-  if (mapped_condition.same_as(self->condition) && mapped_then_case.same_as(self->then_case) &&
-      mapped_else_case.same_as(self->else_case)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_condition.UnchangedOrSameAs(self->condition) &&
+      mapped_then_case.UnchangedOrSameAs(self->then_case) &&
+      mapped_else_case.UnchangedOrSameAs(self->else_case)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
-  self->condition = std::move(mapped_condition);
-  self->then_case = std::move(mapped_then_case);
-  self->else_case = std::move(mapped_else_case);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (!mapped_condition.IsUnchanged())
+    self->condition = std::move(mapped_condition).ValueUnchecked();
+  if (!mapped_then_case.IsUnchanged())
+    self->then_case = std::move(mapped_then_case).ValueUnchecked();
+  if (!mapped_else_case.IsUnchanged())
+    self->else_case = std::move(mapped_else_case).ValueUnchecked();
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 TVMFFIAny EvaluateVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
   const EvaluateNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const EvaluateNode>(value);
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->value));
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
 TVMFFIAny EvaluateMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
   const EvaluateNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const EvaluateNode>(value);
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Expr, mapped_value, mutator->MutateExpected(self->value));
-  if (mapped_value.same_as(self->value)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Expr>, mapped_value,
+                                    mutator->MutateExpected(self->value));
+  if (mapped_value.UnchangedOrSameAs(self->value)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
   ffi::ObjectPtr<EvaluateNode> copy = ffi::make_object<EvaluateNode>(*self);
-  copy->value = std::move(mapped_value);
+  copy->value = std::move(mapped_value).ValueOrUnchanged(std::move(copy->value));
   return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
 }
 
@@ -743,13 +780,13 @@ TVMFFIAny EvaluateMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
                                      ffi::AnyView value) noexcept {
   EvaluateNode* self = const_cast<EvaluateNode*>(
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const EvaluateNode>(value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Expr, mapped_value,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Expr>, mapped_value,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->value));
-  if (mapped_value.same_as(self->value)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_value.UnchangedOrSameAs(self->value)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
-  self->value = std::move(mapped_value);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (!mapped_value.IsUnchanged()) self->value = std::move(mapped_value).ValueUnchecked();
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 TVMFFIAny BufferStoreVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
@@ -758,25 +795,27 @@ TVMFFIAny BufferStoreVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView valu
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->buffer));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->value));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->indices));
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
 TVMFFIAny BufferStoreMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
   const BufferStoreNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const BufferStoreNode>(value);
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(BufferVar, mapped_buffer,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<BufferVar>, mapped_buffer,
                                     mutator->MutateExpected(self->buffer));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_value, mutator->MutateExpected(self->value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<PrimExpr>, mapped_indices,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_value,
+                                    mutator->MutateExpected(self->value));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Array<PrimExpr>>, mapped_indices,
                                     mutator->MutateExpected(self->indices));
-  if (mapped_buffer.same_as(self->buffer) && mapped_value.same_as(self->value) &&
-      mapped_indices.same_as(self->indices)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_buffer.UnchangedOrSameAs(self->buffer) &&
+      mapped_value.UnchangedOrSameAs(self->value) &&
+      mapped_indices.UnchangedOrSameAs(self->indices)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
   ffi::ObjectPtr<BufferStoreNode> copy = ffi::make_object<BufferStoreNode>(*self);
-  copy->buffer = std::move(mapped_buffer);
-  copy->value = std::move(mapped_value);
-  copy->indices = std::move(mapped_indices);
+  copy->buffer = std::move(mapped_buffer).ValueOrUnchanged(std::move(copy->buffer));
+  copy->value = std::move(mapped_value).ValueOrUnchanged(std::move(copy->value));
+  copy->indices = std::move(mapped_indices).ValueOrUnchanged(std::move(copy->indices));
   return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
 }
 
@@ -784,20 +823,21 @@ TVMFFIAny BufferStoreMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
                                         ffi::AnyView value) noexcept {
   BufferStoreNode* self = const_cast<BufferStoreNode*>(
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const BufferStoreNode>(value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(BufferVar, mapped_buffer,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<BufferVar>, mapped_buffer,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->buffer));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_value,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_value,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<PrimExpr>, mapped_indices,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Array<PrimExpr>>, mapped_indices,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->indices));
-  if (mapped_buffer.same_as(self->buffer) && mapped_value.same_as(self->value) &&
-      mapped_indices.same_as(self->indices)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_buffer.UnchangedOrSameAs(self->buffer) &&
+      mapped_value.UnchangedOrSameAs(self->value) &&
+      mapped_indices.UnchangedOrSameAs(self->indices)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
-  self->buffer = std::move(mapped_buffer);
-  self->value = std::move(mapped_value);
-  self->indices = std::move(mapped_indices);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (!mapped_buffer.IsUnchanged()) self->buffer = std::move(mapped_buffer).ValueUnchecked();
+  if (!mapped_value.IsUnchanged()) self->value = std::move(mapped_value).ValueUnchecked();
+  if (!mapped_indices.IsUnchanged()) self->indices = std::move(mapped_indices).ValueUnchecked();
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 TVMFFIAny BufferRegionVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
@@ -805,22 +845,23 @@ TVMFFIAny BufferRegionVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView val
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const BufferRegionNode>(value);
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->buffer));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->region));
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
 TVMFFIAny BufferRegionMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
   const BufferRegionNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const BufferRegionNode>(value);
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(BufferVar, mapped_buffer,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<BufferVar>, mapped_buffer,
                                     mutator->MutateExpected(self->buffer));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<Range>, mapped_region,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Array<Range>>, mapped_region,
                                     mutator->MutateExpected(self->region));
-  if (mapped_buffer.same_as(self->buffer) && mapped_region.same_as(self->region)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_buffer.UnchangedOrSameAs(self->buffer) &&
+      mapped_region.UnchangedOrSameAs(self->region)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
   ffi::ObjectPtr<BufferRegionNode> copy = ffi::make_object<BufferRegionNode>(*self);
-  copy->buffer = std::move(mapped_buffer);
-  copy->region = std::move(mapped_region);
+  copy->buffer = std::move(mapped_buffer).ValueOrUnchanged(std::move(copy->buffer));
+  copy->region = std::move(mapped_region).ValueOrUnchanged(std::move(copy->region));
   return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
 }
 
@@ -828,16 +869,17 @@ TVMFFIAny BufferRegionMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
                                          ffi::AnyView value) noexcept {
   BufferRegionNode* self = const_cast<BufferRegionNode*>(
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const BufferRegionNode>(value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(BufferVar, mapped_buffer,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<BufferVar>, mapped_buffer,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->buffer));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<Range>, mapped_region,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Array<Range>>, mapped_region,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->region));
-  if (mapped_buffer.same_as(self->buffer) && mapped_region.same_as(self->region)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_buffer.UnchangedOrSameAs(self->buffer) &&
+      mapped_region.UnchangedOrSameAs(self->region)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
-  self->buffer = std::move(mapped_buffer);
-  self->region = std::move(mapped_region);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (!mapped_buffer.IsUnchanged()) self->buffer = std::move(mapped_buffer).ValueUnchecked();
+  if (!mapped_region.IsUnchanged()) self->region = std::move(mapped_region).ValueUnchecked();
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 TVMFFIAny MatchBufferRegionVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
@@ -845,27 +887,28 @@ TVMFFIAny MatchBufferRegionVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyVie
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const MatchBufferRegionNode>(
           value);
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->WithDefRegionKind(
-      kTVMFFIDefRegionKindNonRecursive, [&]() { return visitor->VisitExpected(self->buffer); }));
+      kTVMFFIDefRegionKindSimple, [&]() { return visitor->VisitExpected(self->buffer); }));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->source));
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
 TVMFFIAny MatchBufferRegionMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
   const MatchBufferRegionNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const MatchBufferRegionNode>(
           value);
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(
-      BufferVar, mapped_buffer, mutator->WithDefRegionKind(kTVMFFIDefRegionKindNonRecursive, [&]() {
-        return mutator->MutateExpected(self->buffer);
-      }));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(BufferRegion, mapped_source,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<BufferVar>, mapped_buffer,
+                                    mutator->WithDefRegionKind(kTVMFFIDefRegionKindSimple, [&]() {
+                                      return mutator->MutateExpected(self->buffer);
+                                    }));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<BufferRegion>, mapped_source,
                                     mutator->MutateExpected(self->source));
-  if (mapped_buffer.same_as(self->buffer) && mapped_source.same_as(self->source)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_buffer.UnchangedOrSameAs(self->buffer) &&
+      mapped_source.UnchangedOrSameAs(self->source)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
   ffi::ObjectPtr<MatchBufferRegionNode> copy = ffi::make_object<MatchBufferRegionNode>(*self);
-  copy->buffer = std::move(mapped_buffer);
-  copy->source = std::move(mapped_source);
+  copy->buffer = std::move(mapped_buffer).ValueOrUnchanged(std::move(copy->buffer));
+  copy->source = std::move(mapped_source).ValueOrUnchanged(std::move(copy->source));
   return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
 }
 
@@ -875,17 +918,19 @@ TVMFFIAny MatchBufferRegionMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const MatchBufferRegionNode>(
           value));
   TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(
-      BufferVar, mapped_buffer, mutator->WithDefRegionKind(kTVMFFIDefRegionKindNonRecursive, [&]() {
+      ffi::UnchangedOr<BufferVar>, mapped_buffer,
+      mutator->WithDefRegionKind(kTVMFFIDefRegionKindSimple, [&]() {
         return mutator->MaybeInplaceMutateIfUniqueExpected(self->buffer);
       }));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(BufferRegion, mapped_source,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<BufferRegion>, mapped_source,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->source));
-  if (mapped_buffer.same_as(self->buffer) && mapped_source.same_as(self->source)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_buffer.UnchangedOrSameAs(self->buffer) &&
+      mapped_source.UnchangedOrSameAs(self->source)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
-  self->buffer = std::move(mapped_buffer);
-  self->source = std::move(mapped_source);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (!mapped_buffer.IsUnchanged()) self->buffer = std::move(mapped_buffer).ValueUnchecked();
+  if (!mapped_source.IsUnchanged()) self->source = std::move(mapped_source).ValueUnchecked();
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 TVMFFIAny SBlockVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
@@ -895,62 +940,59 @@ TVMFFIAny SBlockVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) no
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->iter_vars));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->reads));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->writes));
-  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(
-      visitor->WithDefRegionKind(kTVMFFIDefRegionKindNonRecursive,
-                                 [&]() { return visitor->VisitExpected(self->alloc_buffers); }));
+  TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->WithDefRegionKind(
+      kTVMFFIDefRegionKindSimple, [&]() { return visitor->VisitExpected(self->alloc_buffers); }));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->match_buffers));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->annotations));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->init));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->body));
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
 TVMFFIAny SBlockMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
   // skips: name_hint
   const SBlockNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const SBlockNode>(value);
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<IterVar>, mapped_iter_vars,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Array<IterVar>>, mapped_iter_vars,
                                     mutator->MutateExpected(self->iter_vars));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<BufferRegion>, mapped_reads,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Array<BufferRegion>>, mapped_reads,
                                     mutator->MutateExpected(self->reads));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<BufferRegion>, mapped_writes,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Array<BufferRegion>>, mapped_writes,
                                     mutator->MutateExpected(self->writes));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(
-      ffi::Array<BufferVar>, mapped_alloc_buffers,
-      mutator->WithDefRegionKind(kTVMFFIDefRegionKindNonRecursive,
-                                 [&]() { return mutator->MutateExpected(self->alloc_buffers); }));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<MatchBufferRegion>, mapped_match_buffers,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Array<BufferVar>>, mapped_alloc_buffers,
+                                    mutator->WithDefRegionKind(kTVMFFIDefRegionKindSimple, [&]() {
+                                      return mutator->MutateExpected(self->alloc_buffers);
+                                    }));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Array<MatchBufferRegion>>,
+                                    mapped_match_buffers,
                                     mutator->MutateExpected(self->match_buffers));
-  auto mapped_annotations_result = mutator->MutateExpected(self->annotations);
-  TVM_FFI_S_MUTATE_MAYBE_EARLY_RETURN(mapped_annotations_result);
-  bool mapped_annotations_type_ok =
-      ffi::details::AnyUnsafe::CheckAnyStrict<ffi::Map<ffi::String, ffi::Any>>(
-          ffi::details::ExpectedUnsafe::GetData(mapped_annotations_result));
-  if (TVM_FFI_PREDICT_FALSE(!mapped_annotations_type_ok)) {
-    return ffi::details::ExpectedUnsafe::MoveToTVMFFIAny(ffi::details::SMutateDeclaredTypeError());
-  }
-  ffi::Map<ffi::String, ffi::Any> mapped_annotations =
-      ffi::details::AnyUnsafe::MoveFromAnyAfterCheck<ffi::Map<ffi::String, ffi::Any>>(
-          std::move(ffi::details::ExpectedUnsafe::GetData(mapped_annotations_result)));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Optional<Stmt>, mapped_init,
+  using AnnotationMap = ffi::Map<ffi::String, ffi::Any>;
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<AnnotationMap>, mapped_annotations,
+                                    mutator->MutateExpected(self->annotations));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Optional<Stmt>>, mapped_init,
                                     mutator->MutateExpected(self->init));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Stmt, mapped_body, mutator->MutateExpected(self->body));
-  if (mapped_iter_vars.same_as(self->iter_vars) && mapped_reads.same_as(self->reads) &&
-      mapped_writes.same_as(self->writes) && mapped_alloc_buffers.same_as(self->alloc_buffers) &&
-      mapped_match_buffers.same_as(self->match_buffers) &&
-      mapped_annotations.same_as(self->annotations) && mapped_init.same_as(self->init) &&
-      mapped_body.same_as(self->body)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Stmt>, mapped_body,
+                                    mutator->MutateExpected(self->body));
+  if (mapped_iter_vars.UnchangedOrSameAs(self->iter_vars) &&
+      mapped_reads.UnchangedOrSameAs(self->reads) &&
+      mapped_writes.UnchangedOrSameAs(self->writes) &&
+      mapped_alloc_buffers.UnchangedOrSameAs(self->alloc_buffers) &&
+      mapped_match_buffers.UnchangedOrSameAs(self->match_buffers) &&
+      mapped_annotations.UnchangedOrSameAs(self->annotations) &&
+      mapped_init.UnchangedOrSameAs(self->init) && mapped_body.UnchangedOrSameAs(self->body)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
   ffi::ObjectPtr<SBlockNode> copy = ffi::make_object<SBlockNode>(*self);
-  copy->iter_vars = std::move(mapped_iter_vars);
-  copy->reads = std::move(mapped_reads);
-  copy->writes = std::move(mapped_writes);
-  copy->alloc_buffers = std::move(mapped_alloc_buffers);
-  copy->match_buffers = std::move(mapped_match_buffers);
-  copy->annotations = std::move(mapped_annotations);
-  copy->init = std::move(mapped_init);
-  copy->body = std::move(mapped_body);
+  copy->iter_vars = std::move(mapped_iter_vars).ValueOrUnchanged(std::move(copy->iter_vars));
+  copy->reads = std::move(mapped_reads).ValueOrUnchanged(std::move(copy->reads));
+  copy->writes = std::move(mapped_writes).ValueOrUnchanged(std::move(copy->writes));
+  copy->alloc_buffers =
+      std::move(mapped_alloc_buffers).ValueOrUnchanged(std::move(copy->alloc_buffers));
+  copy->match_buffers =
+      std::move(mapped_match_buffers).ValueOrUnchanged(std::move(copy->match_buffers));
+  copy->annotations = std::move(mapped_annotations).ValueOrUnchanged(std::move(copy->annotations));
+  copy->init = std::move(mapped_init).ValueOrUnchanged(std::move(copy->init));
+  copy->body = std::move(mapped_body).ValueOrUnchanged(std::move(copy->body));
   return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
 }
 
@@ -959,51 +1001,51 @@ TVMFFIAny SBlockMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
   // skips: name_hint
   SBlockNode* self = const_cast<SBlockNode*>(
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const SBlockNode>(value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<IterVar>, mapped_iter_vars,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Array<IterVar>>, mapped_iter_vars,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->iter_vars));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<BufferRegion>, mapped_reads,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Array<BufferRegion>>, mapped_reads,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->reads));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<BufferRegion>, mapped_writes,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Array<BufferRegion>>, mapped_writes,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->writes));
   TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(
-      ffi::Array<BufferVar>, mapped_alloc_buffers,
-      mutator->WithDefRegionKind(kTVMFFIDefRegionKindNonRecursive, [&]() {
+      ffi::UnchangedOr<ffi::Array<BufferVar>>, mapped_alloc_buffers,
+      mutator->WithDefRegionKind(kTVMFFIDefRegionKindSimple, [&]() {
         return mutator->MaybeInplaceMutateIfUniqueExpected(self->alloc_buffers);
       }));
   TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(
-      ffi::Array<MatchBufferRegion>, mapped_match_buffers,
+      ffi::UnchangedOr<ffi::Array<MatchBufferRegion>>, mapped_match_buffers,
       mutator->MaybeInplaceMutateIfUniqueExpected(self->match_buffers));
-  auto mapped_annotations_result = mutator->MaybeInplaceMutateIfUniqueExpected(self->annotations);
-  TVM_FFI_S_MUTATE_MAYBE_EARLY_RETURN(mapped_annotations_result);
-  bool mapped_annotations_type_ok =
-      ffi::details::AnyUnsafe::CheckAnyStrict<ffi::Map<ffi::String, ffi::Any>>(
-          ffi::details::ExpectedUnsafe::GetData(mapped_annotations_result));
-  if (TVM_FFI_PREDICT_FALSE(!mapped_annotations_type_ok)) {
-    return ffi::details::ExpectedUnsafe::MoveToTVMFFIAny(ffi::details::SMutateDeclaredTypeError());
-  }
-  ffi::Map<ffi::String, ffi::Any> mapped_annotations =
-      ffi::details::AnyUnsafe::MoveFromAnyAfterCheck<ffi::Map<ffi::String, ffi::Any>>(
-          std::move(ffi::details::ExpectedUnsafe::GetData(mapped_annotations_result)));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Optional<Stmt>, mapped_init,
+  using AnnotationMap = ffi::Map<ffi::String, ffi::Any>;
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<AnnotationMap>, mapped_annotations,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->annotations));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Optional<Stmt>>, mapped_init,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->init));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(Stmt, mapped_body,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<Stmt>, mapped_body,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->body));
-  if (mapped_iter_vars.same_as(self->iter_vars) && mapped_reads.same_as(self->reads) &&
-      mapped_writes.same_as(self->writes) && mapped_alloc_buffers.same_as(self->alloc_buffers) &&
-      mapped_match_buffers.same_as(self->match_buffers) &&
-      mapped_annotations.same_as(self->annotations) && mapped_init.same_as(self->init) &&
-      mapped_body.same_as(self->body)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_iter_vars.UnchangedOrSameAs(self->iter_vars) &&
+      mapped_reads.UnchangedOrSameAs(self->reads) &&
+      mapped_writes.UnchangedOrSameAs(self->writes) &&
+      mapped_alloc_buffers.UnchangedOrSameAs(self->alloc_buffers) &&
+      mapped_match_buffers.UnchangedOrSameAs(self->match_buffers) &&
+      mapped_annotations.UnchangedOrSameAs(self->annotations) &&
+      mapped_init.UnchangedOrSameAs(self->init) && mapped_body.UnchangedOrSameAs(self->body)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
-  self->iter_vars = std::move(mapped_iter_vars);
-  self->reads = std::move(mapped_reads);
-  self->writes = std::move(mapped_writes);
-  self->alloc_buffers = std::move(mapped_alloc_buffers);
-  self->match_buffers = std::move(mapped_match_buffers);
-  self->annotations = std::move(mapped_annotations);
-  self->init = std::move(mapped_init);
-  self->body = std::move(mapped_body);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (!mapped_iter_vars.IsUnchanged())
+    self->iter_vars = std::move(mapped_iter_vars).ValueUnchecked();
+  if (!mapped_reads.IsUnchanged()) self->reads = std::move(mapped_reads).ValueUnchecked();
+  if (!mapped_writes.IsUnchanged()) self->writes = std::move(mapped_writes).ValueUnchecked();
+  if (!mapped_alloc_buffers.IsUnchanged()) {
+    self->alloc_buffers = std::move(mapped_alloc_buffers).ValueUnchecked();
+  }
+  if (!mapped_match_buffers.IsUnchanged()) {
+    self->match_buffers = std::move(mapped_match_buffers).ValueUnchecked();
+  }
+  if (!mapped_annotations.IsUnchanged())
+    self->annotations = std::move(mapped_annotations).ValueUnchecked();
+  if (!mapped_init.IsUnchanged()) self->init = std::move(mapped_init).ValueUnchecked();
+  if (!mapped_body.IsUnchanged()) self->body = std::move(mapped_body).ValueUnchecked();
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 TVMFFIAny ScopeIdDefStmtVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
@@ -1011,18 +1053,19 @@ TVMFFIAny ScopeIdDefStmtVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView v
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const ScopeIdDefStmtNode>(value);
   // ScopeIdDef reflection marks only def_ids as definitions; its extent fields remain uses.
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->def));
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
 TVMFFIAny ScopeIdDefStmtMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
   const ScopeIdDefStmtNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const ScopeIdDefStmtNode>(value);
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ScopeIdDef, mapped_def, mutator->MutateExpected(self->def));
-  if (mapped_def.same_as(self->def)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ScopeIdDef>, mapped_def,
+                                    mutator->MutateExpected(self->def));
+  if (mapped_def.UnchangedOrSameAs(self->def)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
   ffi::ObjectPtr<ScopeIdDefStmtNode> copy = ffi::make_object<ScopeIdDefStmtNode>(*self);
-  copy->def = std::move(mapped_def);
+  copy->def = std::move(mapped_def).ValueOrUnchanged(std::move(copy->def));
   return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
 }
 
@@ -1030,13 +1073,13 @@ TVMFFIAny ScopeIdDefStmtMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
                                            ffi::AnyView value) noexcept {
   ScopeIdDefStmtNode* self = const_cast<ScopeIdDefStmtNode*>(
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const ScopeIdDefStmtNode>(value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ScopeIdDef, mapped_def,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ScopeIdDef>, mapped_def,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->def));
-  if (mapped_def.same_as(self->def)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_def.UnchangedOrSameAs(self->def)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
-  self->def = std::move(mapped_def);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (!mapped_def.IsUnchanged()) self->def = std::move(mapped_def).ValueUnchecked();
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 TVMFFIAny SBlockRealizeVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView value) noexcept {
@@ -1045,25 +1088,27 @@ TVMFFIAny SBlockRealizeVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyView va
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->iter_values));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->predicate));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->block));
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
 TVMFFIAny SBlockRealizeMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
   const SBlockRealizeNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const SBlockRealizeNode>(value);
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<PrimExpr>, mapped_iter_values,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Array<PrimExpr>>, mapped_iter_values,
                                     mutator->MutateExpected(self->iter_values));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_predicate,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_predicate,
                                     mutator->MutateExpected(self->predicate));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(SBlock, mapped_block, mutator->MutateExpected(self->block));
-  if (mapped_iter_values.same_as(self->iter_values) && mapped_predicate.same_as(self->predicate) &&
-      mapped_block.same_as(self->block)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<SBlock>, mapped_block,
+                                    mutator->MutateExpected(self->block));
+  if (mapped_iter_values.UnchangedOrSameAs(self->iter_values) &&
+      mapped_predicate.UnchangedOrSameAs(self->predicate) &&
+      mapped_block.UnchangedOrSameAs(self->block)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
   ffi::ObjectPtr<SBlockRealizeNode> copy = ffi::make_object<SBlockRealizeNode>(*self);
-  copy->iter_values = std::move(mapped_iter_values);
-  copy->predicate = std::move(mapped_predicate);
-  copy->block = std::move(mapped_block);
+  copy->iter_values = std::move(mapped_iter_values).ValueOrUnchanged(std::move(copy->iter_values));
+  copy->predicate = std::move(mapped_predicate).ValueOrUnchanged(std::move(copy->predicate));
+  copy->block = std::move(mapped_block).ValueOrUnchanged(std::move(copy->block));
   return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
 }
 
@@ -1071,20 +1116,23 @@ TVMFFIAny SBlockRealizeMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator,
                                           ffi::AnyView value) noexcept {
   SBlockRealizeNode* self = const_cast<SBlockRealizeNode*>(
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const SBlockRealizeNode>(value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<PrimExpr>, mapped_iter_values,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Array<PrimExpr>>, mapped_iter_values,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->iter_values));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(PrimExpr, mapped_predicate,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<PrimExpr>, mapped_predicate,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->predicate));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(SBlock, mapped_block,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<SBlock>, mapped_block,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->block));
-  if (mapped_iter_values.same_as(self->iter_values) && mapped_predicate.same_as(self->predicate) &&
-      mapped_block.same_as(self->block)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_iter_values.UnchangedOrSameAs(self->iter_values) &&
+      mapped_predicate.UnchangedOrSameAs(self->predicate) &&
+      mapped_block.UnchangedOrSameAs(self->block)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
-  self->iter_values = std::move(mapped_iter_values);
-  self->predicate = std::move(mapped_predicate);
-  self->block = std::move(mapped_block);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (!mapped_iter_values.IsUnchanged())
+    self->iter_values = std::move(mapped_iter_values).ValueUnchecked();
+  if (!mapped_predicate.IsUnchanged())
+    self->predicate = std::move(mapped_predicate).ValueUnchecked();
+  if (!mapped_block.IsUnchanged()) self->block = std::move(mapped_block).ValueUnchecked();
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 }  // namespace

--- a/src/tirx/ir/tirx_stmt.cc
+++ b/src/tirx/ir/tirx_stmt.cc
@@ -59,7 +59,7 @@ TVMFFIAny TilePrimitiveCallVisit(ffi::StructuralVisitorObj* visitor, ffi::AnyVie
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->args));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->workspace));
   TVM_FFI_S_VISIT_MAYBE_EARLY_RETURN(visitor->VisitExpected(self->config));
-  TVM_FFI_S_VISIT_RETURN_NONE();
+  return ffi::AnyView(nullptr).CopyToTVMFFIAny();
 }
 
 TVMFFIAny TilePrimitiveCallMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyView value) noexcept {
@@ -67,41 +67,25 @@ TVMFFIAny TilePrimitiveCallMutate(ffi::StructuralMutatorObj* mutator, ffi::AnyVi
   const TilePrimitiveCallNode* self =
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const TilePrimitiveCallNode>(
           value);
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<ffi::Any>, mapped_args,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Array<ffi::Any>>, mapped_args,
                                     mutator->MutateExpected(self->args));
 
-  auto mapped_workspace_result = mutator->MutateExpected(self->workspace);
-  TVM_FFI_S_MUTATE_MAYBE_EARLY_RETURN(mapped_workspace_result);
-  bool mapped_workspace_type_ok =
-      ffi::details::AnyUnsafe::CheckAnyStrict<ffi::Map<ffi::String, BufferVar>>(
-          ffi::details::ExpectedUnsafe::GetData(mapped_workspace_result));
-  if (TVM_FFI_PREDICT_FALSE(!mapped_workspace_type_ok)) {
-    return ffi::details::ExpectedUnsafe::MoveToTVMFFIAny(ffi::details::SMutateDeclaredTypeError());
-  }
-  ffi::Map<ffi::String, BufferVar> mapped_workspace =
-      ffi::details::AnyUnsafe::MoveFromAnyAfterCheck<ffi::Map<ffi::String, BufferVar>>(
-          std::move(ffi::details::ExpectedUnsafe::GetData(mapped_workspace_result)));
+  using WorkspaceMap = ffi::Map<ffi::String, BufferVar>;
+  using ConfigMap = ffi::Map<ffi::String, ffi::Any>;
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<WorkspaceMap>, mapped_workspace,
+                                    mutator->MutateExpected(self->workspace));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ConfigMap>, mapped_config,
+                                    mutator->MutateExpected(self->config));
 
-  auto mapped_config_result = mutator->MutateExpected(self->config);
-  TVM_FFI_S_MUTATE_MAYBE_EARLY_RETURN(mapped_config_result);
-  bool mapped_config_type_ok =
-      ffi::details::AnyUnsafe::CheckAnyStrict<ffi::Map<ffi::String, ffi::Any>>(
-          ffi::details::ExpectedUnsafe::GetData(mapped_config_result));
-  if (TVM_FFI_PREDICT_FALSE(!mapped_config_type_ok)) {
-    return ffi::details::ExpectedUnsafe::MoveToTVMFFIAny(ffi::details::SMutateDeclaredTypeError());
-  }
-  ffi::Map<ffi::String, ffi::Any> mapped_config =
-      ffi::details::AnyUnsafe::MoveFromAnyAfterCheck<ffi::Map<ffi::String, ffi::Any>>(
-          std::move(ffi::details::ExpectedUnsafe::GetData(mapped_config_result)));
-
-  if (mapped_args.same_as(self->args) && mapped_workspace.same_as(self->workspace) &&
-      mapped_config.same_as(self->config)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  if (mapped_args.UnchangedOrSameAs(self->args) &&
+      mapped_workspace.UnchangedOrSameAs(self->workspace) &&
+      mapped_config.UnchangedOrSameAs(self->config)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
   ffi::ObjectPtr<TilePrimitiveCallNode> copy = ffi::make_object<TilePrimitiveCallNode>(*self);
-  copy->args = std::move(mapped_args);
-  copy->workspace = std::move(mapped_workspace);
-  copy->config = std::move(mapped_config);
+  copy->args = std::move(mapped_args).ValueOrUnchanged(std::move(copy->args));
+  copy->workspace = std::move(mapped_workspace).ValueOrUnchanged(std::move(copy->workspace));
+  copy->config = std::move(mapped_config).ValueOrUnchanged(std::move(copy->config));
   return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(std::move(copy)));
 }
 
@@ -111,41 +95,25 @@ TVMFFIAny TilePrimitiveCallMaybeInplaceMutate(ffi::StructuralMutatorObj* mutator
   TilePrimitiveCallNode* self = const_cast<TilePrimitiveCallNode*>(
       ffi::details::AnyUnsafe::RawObjectPtrFromAnyViewAfterCheck<const TilePrimitiveCallNode>(
           value));
-  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::Array<ffi::Any>, mapped_args,
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ffi::Array<ffi::Any>>, mapped_args,
                                     mutator->MaybeInplaceMutateIfUniqueExpected(self->args));
 
-  auto mapped_workspace_result = mutator->MaybeInplaceMutateIfUniqueExpected(self->workspace);
-  TVM_FFI_S_MUTATE_MAYBE_EARLY_RETURN(mapped_workspace_result);
-  bool mapped_workspace_type_ok =
-      ffi::details::AnyUnsafe::CheckAnyStrict<ffi::Map<ffi::String, BufferVar>>(
-          ffi::details::ExpectedUnsafe::GetData(mapped_workspace_result));
-  if (TVM_FFI_PREDICT_FALSE(!mapped_workspace_type_ok)) {
-    return ffi::details::ExpectedUnsafe::MoveToTVMFFIAny(ffi::details::SMutateDeclaredTypeError());
-  }
-  ffi::Map<ffi::String, BufferVar> mapped_workspace =
-      ffi::details::AnyUnsafe::MoveFromAnyAfterCheck<ffi::Map<ffi::String, BufferVar>>(
-          std::move(ffi::details::ExpectedUnsafe::GetData(mapped_workspace_result)));
+  using WorkspaceMap = ffi::Map<ffi::String, BufferVar>;
+  using ConfigMap = ffi::Map<ffi::String, ffi::Any>;
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<WorkspaceMap>, mapped_workspace,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->workspace));
+  TVM_FFI_S_MUTATE_ASSIGN_OR_RETURN(ffi::UnchangedOr<ConfigMap>, mapped_config,
+                                    mutator->MaybeInplaceMutateIfUniqueExpected(self->config));
 
-  auto mapped_config_result = mutator->MaybeInplaceMutateIfUniqueExpected(self->config);
-  TVM_FFI_S_MUTATE_MAYBE_EARLY_RETURN(mapped_config_result);
-  bool mapped_config_type_ok =
-      ffi::details::AnyUnsafe::CheckAnyStrict<ffi::Map<ffi::String, ffi::Any>>(
-          ffi::details::ExpectedUnsafe::GetData(mapped_config_result));
-  if (TVM_FFI_PREDICT_FALSE(!mapped_config_type_ok)) {
-    return ffi::details::ExpectedUnsafe::MoveToTVMFFIAny(ffi::details::SMutateDeclaredTypeError());
+  if (mapped_args.UnchangedOrSameAs(self->args) &&
+      mapped_workspace.UnchangedOrSameAs(self->workspace) &&
+      mapped_config.UnchangedOrSameAs(self->config)) {
+    return ffi::Unchanged().CopyToTVMFFIAny();
   }
-  ffi::Map<ffi::String, ffi::Any> mapped_config =
-      ffi::details::AnyUnsafe::MoveFromAnyAfterCheck<ffi::Map<ffi::String, ffi::Any>>(
-          std::move(ffi::details::ExpectedUnsafe::GetData(mapped_config_result)));
-
-  if (mapped_args.same_as(self->args) && mapped_workspace.same_as(self->workspace) &&
-      mapped_config.same_as(self->config)) {
-    return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
-  }
-  self->args = std::move(mapped_args);
-  self->workspace = std::move(mapped_workspace);
-  self->config = std::move(mapped_config);
-  return ffi::details::AnyUnsafe::MoveAnyToTVMFFIAny(ffi::Any(self));
+  self->args = std::move(mapped_args).ValueOrUnchanged(std::move(self->args));
+  self->workspace = std::move(mapped_workspace).ValueOrUnchanged(std::move(self->workspace));
+  self->config = std::move(mapped_config).ValueOrUnchanged(std::move(self->config));
+  return ffi::Unchanged().CopyToTVMFFIAny();
 }
 
 }  // namespace

--- a/tests/cpp/ir_functor_test.cc
+++ b/tests/cpp/ir_functor_test.cc
@@ -375,9 +375,11 @@ TEST(IRF, StructuralMapSplicesMappedSeqStmtChild) {
   {
     Stmt input = make_input();
     const auto* original = input.get();
+    const auto* original_array = input.as<SeqStmtNode>()->seq.GetArrayObj();
     Stmt mapped =
         ffi::StructuralMap<ffi::WalkOrder::kPostOrder>(std::move(input), expand_one).cast<Stmt>();
     EXPECT_EQ(mapped.get(), original);
+    EXPECT_NE(mapped.as<SeqStmtNode>()->seq.GetArrayObj(), original_array);
     check_values(mapped, {5, 2, 3, 4});
   }
 
@@ -420,6 +422,20 @@ TEST(IRF, StructuralMapSplicesMappedSeqStmtChild) {
   };
   check_differential(shrink_first_grow_last, {2, 3, 30, 31}, true);
 
+  auto empty_first_grow_last = [](const Evaluate& evaluate) -> Stmt {
+    const auto* value = evaluate->value.as<IntImmNode>();
+    if (value != nullptr && value->value == 1) {
+      auto empty = ffi::make_object<SeqStmtNode>();
+      empty->seq = {};
+      return Stmt(std::move(empty));
+    }
+    if (value != nullptr && value->value == 4) {
+      return SeqStmt({Evaluate(IntImm::Int32(30)), Evaluate(IntImm::Int32(31))});
+    }
+    return evaluate;
+  };
+  check_differential(empty_first_grow_last, {2, 3, 30, 31}, true);
+
   int overflow_callback_count = 0;
   auto grow_first_shrink_last = [&overflow_callback_count](const Evaluate& evaluate) -> Stmt {
     ++overflow_callback_count;
@@ -432,8 +448,17 @@ TEST(IRF, StructuralMapSplicesMappedSeqStmtChild) {
     }
     return evaluate;
   };
-  check_differential(grow_first_shrink_last, {10, 11, 2, 3}, false);
+  check_differential(grow_first_shrink_last, {10, 11, 2, 3}, true);
   EXPECT_EQ(overflow_callback_count, 8);
+
+  auto grow_last_over_capacity = [](const Evaluate& evaluate) -> Stmt {
+    const auto* value = evaluate->value.as<IntImmNode>();
+    if (value != nullptr && value->value == 4) {
+      return SeqStmt({Evaluate(IntImm::Int32(40)), Evaluate(IntImm::Int32(41))});
+    }
+    return evaluate;
+  };
+  check_differential(grow_last_over_capacity, {1, 2, 3, 40, 41}, false);
 
   auto replace_middle_with_one = [](const Evaluate& evaluate) -> Stmt {
     const auto* value = evaluate->value.as<IntImmNode>();
@@ -543,7 +568,7 @@ TEST(IRF, StructuralHooksPreserveScopeIdDefRegions) {
                                      ffi::Array<PrimExpr>{PrimVar("preferred")}));
   };
   auto check_kinds = [](int binder, int extent, int preferred) {
-    EXPECT_EQ(binder, kTVMFFIDefRegionKindNonRecursive);
+    EXPECT_EQ(binder, kTVMFFIDefRegionKindSimple);
     EXPECT_EQ(extent, kTVMFFIDefRegionKindNone);
     EXPECT_EQ(preferred, kTVMFFIDefRegionKindNone);
   };


### PR DESCRIPTION
[FFI] Upgrade to latest tvm-ffi

Bump tvm-ffi to 39d593e, absorbing inlined `ObjectPtr::reset` (apache/tvm-ffi#764), `UnchangedOr` structural mutation results (apache/tvm-ffi#768), and the `DefRegionKind` rename (apache/tvm-ffi#769). Adopt the `UnchangedOr` protocol across TVM structural mutation hooks.
