### PR TITLE
[REFACTOR][TIR] Use StructuralMap in place of Substitute

### DIFF
--- a/src/s_tir/analysis/sblock_access_region_detector.cc
+++ b/src/s_tir/analysis/sblock_access_region_detector.cc
@@ -24,6 +24,7 @@
 
 #include <tvm/arith/analyzer.h>
 #include <tvm/ffi/cast.h>
+#include <tvm/ffi/extra/structural_mutate.h>
 #include <tvm/ffi/reflection/registry.h>
 #include <tvm/tirx/op.h>
 #include <tvm/tirx/stmt_functor.h>
@@ -164,10 +165,28 @@ void BlockReadWriteDetector::VisitExpr_(const VarNode* op) { UpdateOpaque(ffi::G
 void BlockReadWriteDetector::VisitExpr_(const TensorLoadNode* op) {
   std::vector<arith::IntSet> relaxed_region;
   for (PrimExpr index : op->indices) {
-    PrimExpr remapped_index = Substitute(index, let_bindings_);
+    PrimExpr remapped_index =
+        ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+            index,
+            [this](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+              if (auto it = let_bindings_.find(var.get()); it != let_bindings_.end()) {
+                return ffi::Any(it->second);
+              }
+              return ffi::Unchanged();
+            })
+            .cast<PrimExpr>();
     while (!remapped_index.same_as(index)) {
       index = remapped_index;
-      remapped_index = Substitute(index, let_bindings_);
+      remapped_index =
+          ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+              index,
+              [this](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                if (auto it = let_bindings_.find(var.get()); it != let_bindings_.end()) {
+                  return ffi::Any(it->second);
+                }
+                return ffi::Unchanged();
+              })
+              .cast<PrimExpr>();
     }
     relaxed_region.push_back(arith::EvalSet(arith::IntSet::Vector(remapped_index), dom_map_));
   }
@@ -216,10 +235,28 @@ void BlockReadWriteDetector::VisitExpr_(const CallNode* op) {
                                      std::vector<std::vector<arith::IntSet>>* regions) {
     std::vector<arith::IntSet> relaxed_region;
     for (PrimExpr index : indices) {
-      PrimExpr remapped_index = Substitute(index, let_bindings_);
+      PrimExpr remapped_index =
+          ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+              index,
+              [this](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                if (auto it = let_bindings_.find(var.get()); it != let_bindings_.end()) {
+                  return ffi::Any(it->second);
+                }
+                return ffi::Unchanged();
+              })
+              .cast<PrimExpr>();
       while (!remapped_index.same_as(index)) {
         index = remapped_index;
-        remapped_index = Substitute(index, let_bindings_);
+        remapped_index =
+            ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+                index,
+                [this](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                  if (auto it = let_bindings_.find(var.get()); it != let_bindings_.end()) {
+                    return ffi::Any(it->second);
+                  }
+                  return ffi::Unchanged();
+                })
+                .cast<PrimExpr>();
       }
       relaxed_region.push_back(arith::EvalSet(arith::IntSet::Vector(remapped_index), dom_map_));
     }
@@ -293,10 +330,28 @@ void BlockReadWriteDetector::VisitExpr_(const CallNode* op) {
 void BlockReadWriteDetector::VisitStmt_(const BufferStoreNode* op) {
   std::vector<arith::IntSet> relaxed_region;
   for (PrimExpr index : op->indices) {
-    PrimExpr remapped_index = Substitute(index, let_bindings_);
+    PrimExpr remapped_index =
+        ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+            index,
+            [this](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+              if (auto it = let_bindings_.find(var.get()); it != let_bindings_.end()) {
+                return ffi::Any(it->second);
+              }
+              return ffi::Unchanged();
+            })
+            .cast<PrimExpr>();
     while (!remapped_index.same_as(index)) {
       index = remapped_index;
-      remapped_index = Substitute(index, let_bindings_);
+      remapped_index =
+          ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+              index,
+              [this](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                if (auto it = let_bindings_.find(var.get()); it != let_bindings_.end()) {
+                  return ffi::Any(it->second);
+                }
+                return ffi::Unchanged();
+              })
+              .cast<PrimExpr>();
     }
     relaxed_region.push_back(arith::EvalSet(arith::IntSet::Vector(remapped_index), dom_map_));
   }
@@ -313,20 +368,52 @@ void BlockReadWriteDetector::VisitStmt_(const SBlockRealizeNode* op) {
   for (const auto& read : op->block->reads) {
     std::vector<arith::IntSet> relaxed_region;
     for (const auto& range : read->region) {
+      PrimExpr min = ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+                         range->min,
+                         [&vmap](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                           if (auto it = vmap.find(var.get()); it != vmap.end()) {
+                             return ffi::Any(it->second);
+                           }
+                           return ffi::Unchanged();
+                         })
+                         .cast<PrimExpr>();
+      PrimExpr extent = ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+                            range->extent,
+                            [&vmap](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                              if (auto it = vmap.find(var.get()); it != vmap.end()) {
+                                return ffi::Any(it->second);
+                              }
+                              return ffi::Unchanged();
+                            })
+                            .cast<PrimExpr>();
       relaxed_region.push_back(
-          arith::EvalSet(arith::IntSet::FromRange(Range::FromMinExtent(
-                             Substitute(range->min, vmap), Substitute(range->extent, vmap))),
-                         dom_map_));
+          arith::EvalSet(arith::IntSet::FromRange(Range::FromMinExtent(min, extent)), dom_map_));
     }
     Update(&read_buffers_, &read_regions_, read->buffer, relaxed_region);
   }
   for (const auto& write : op->block->writes) {
     std::vector<arith::IntSet> relaxed_region;
     for (const auto& range : write->region) {
+      PrimExpr min = ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+                         range->min,
+                         [&vmap](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                           if (auto it = vmap.find(var.get()); it != vmap.end()) {
+                             return ffi::Any(it->second);
+                           }
+                           return ffi::Unchanged();
+                         })
+                         .cast<PrimExpr>();
+      PrimExpr extent = ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+                            range->extent,
+                            [&vmap](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                              if (auto it = vmap.find(var.get()); it != vmap.end()) {
+                                return ffi::Any(it->second);
+                              }
+                              return ffi::Unchanged();
+                            })
+                            .cast<PrimExpr>();
       relaxed_region.push_back(
-          arith::EvalSet(arith::IntSet::FromRange(Range::FromMinExtent(
-                             Substitute(range->min, vmap), Substitute(range->extent, vmap))),
-                         dom_map_));
+          arith::EvalSet(arith::IntSet::FromRange(Range::FromMinExtent(min, extent)), dom_map_));
     }
     Update(&writes_buffers_, &write_regions_, write->buffer, relaxed_region);
   }

--- a/src/s_tir/schedule/concrete_schedule.cc
+++ b/src/s_tir/schedule/concrete_schedule.cc
@@ -1028,14 +1028,15 @@ void ConcreteScheduleNode::TransformLayout(const SBlockRV& block_rv, int buffer_
                                            const ffi::Optional<IndexMap>& pad_value,
                                            bool assume_injective_transform) {
   TVM_TIR_SCHEDULE_BEGIN();
-  auto f_subst = [&](const Var& var) -> ffi::Optional<PrimExpr> {
-    if (auto opt_expr = symbol_table_.Get(var)) {
-      return opt_expr.value().as_or_throw<PrimExpr>();
-    } else {
-      return std::nullopt;
-    }
-  };
-  auto new_index_map = Substitute(index_map, f_subst);
+  auto new_index_map = ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+                           index_map,
+                           [this](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                             if (auto opt_expr = symbol_table_.Get(var)) {
+                               return ffi::Any(opt_expr.value().as_or_throw<PrimExpr>());
+                             }
+                             return ffi::Unchanged();
+                           })
+                           .cast<IndexMap>();
   s_tir::TransformLayout(state_, this->GetSRef(block_rv), buffer_index, buffer_index_type,
                          new_index_map, pad_value, assume_injective_transform);
   this->state_->DebugVerify();

--- a/src/s_tir/schedule/concrete_schedule.h
+++ b/src/s_tir/schedule/concrete_schedule.h
@@ -20,6 +20,7 @@
 #define TVM_S_TIR_SCHEDULE_CONCRETE_SCHEDULE_H_
 
 #include <tvm/ffi/cast.h>
+#include <tvm/ffi/extra/structural_mutate.h>
 #include <tvm/ir/prim/expr.h>
 
 #include <memory>
@@ -260,15 +261,19 @@ inline For ConcreteScheduleNode::Get(const LoopRV& loop_rv) const {
 }
 
 inline PrimExpr ConcreteScheduleNode::Get(const ExprRV& expr_rv) const {
-  PrimExpr transformed = Substitute(expr_rv, [this](const Var& var) -> ffi::Optional<Expr> {
-    auto it = this->symbol_table_.find(var);
-    if (it == this->symbol_table_.end()) {
-      TVM_FFI_THROW(IndexError) << "Cannot find corresponding ExprRV: " << var;
-    }
-    const ffi::ObjectRef& obj = (*it).second;
-    const auto* int_imm = TVM_TYPE_AS(obj, IntImmNode);
-    return IntImm::Int32(int_imm->value);
-  });
+  PrimExpr transformed = ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+                             expr_rv,
+                             [this](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                               auto it = this->symbol_table_.find(var);
+                               if (it == this->symbol_table_.end()) {
+                                 TVM_FFI_THROW(IndexError)
+                                     << "Cannot find corresponding ExprRV: " << var;
+                               }
+                               const ffi::ObjectRef& obj = (*it).second;
+                               const auto* int_imm = TVM_TYPE_AS(obj, IntImmNode);
+                               return ffi::Any(IntImm::Int32(int_imm->value));
+                             })
+                             .cast<PrimExpr>();
   return this->analyzer_->Simplify(transformed);
 }
 

--- a/src/s_tir/schedule/instruction.cc
+++ b/src/s_tir/schedule/instruction.cc
@@ -17,6 +17,7 @@
  * under the License.
  */
 #include <tvm/ffi/cast.h>
+#include <tvm/ffi/extra/structural_mutate.h>
 #include <tvm/ffi/reflection/registry.h>
 
 #include "./utils.h"
@@ -81,9 +82,13 @@ ffi::String InstructionAsPythonRepr(const InstructionNode* self) {
     } else if (obj.as<IntImmNode>() || obj.as<FloatImmNode>()) {
       inputs.push_back(obj);
     } else if (auto expr = obj.as<PrimExpr>()) {
-      PrimExpr new_expr = Substitute(expr.value(), [](const Var& var) -> ffi::Optional<Expr> {
-        return Var("_", var->ty, var->span).as_or_throw<PrimExpr>();
-      });
+      PrimExpr new_expr =
+          ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+              expr.value(),
+              [](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                return ffi::Any(Var("_", var->ty, var->span).as_or_throw<PrimExpr>());
+              })
+              .cast<PrimExpr>();
       std::ostringstream os;
       os << new_expr;
       inputs.push_back(ffi::String(os.str()));

--- a/src/s_tir/schedule/primitive/blockize_tensorize.cc
+++ b/src/s_tir/schedule/primitive/blockize_tensorize.cc
@@ -18,6 +18,7 @@
  */
 
 #include <tvm/ffi/cast.h>
+#include <tvm/ffi/extra/structural_mutate.h>
 #include <tvm/runtime/logging.h>
 
 #include <functional>
@@ -373,19 +374,27 @@ Stmt GenerateOuterInit(const Stmt& block_init, const SBlockRealize& inner_realiz
     }
   }
   // Step 4: Substitute the iter vars and loop vars
-  return Substitute(stmt, subst_map);
+  return ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+             stmt,
+             [&subst_map](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+               if (auto replacement = subst_map.Get(var)) {
+                 return ffi::Any(replacement.value());
+               }
+               return ffi::Unchanged();
+             })
+      .cast<Stmt>();
 }
 
 /*!
- * \brief Substitute variables in the stmt, do simplification and track block substitution
+ * \brief Replace variables in the stmt, do simplification and track block replacement
  * \param stmt The stmt to be substituted.
  * \param sub The substitution map.
  * \param block_sref_reuse The block substitution happens during the substitution.
  * \param analyzer The analyzer for arithmetic simplification.
  * \return The substituted stmt.
  */
-Stmt Substitute(const Stmt& stmt, const ffi::Map<Var, PrimExpr>& sub,
-                ffi::Map<SBlock, SBlock>* block_sref_reuse, arith::AnalyzerObj* analyzer) {
+Stmt ReplaceAndSimplify(const Stmt& stmt, const ffi::Map<Var, PrimExpr>& sub,
+                        ffi::Map<SBlock, SBlock>* block_sref_reuse, arith::AnalyzerObj* analyzer) {
   struct Replacer : public StmtExprMutator {
     explicit Replacer(const ffi::Map<Var, PrimExpr>& sub,
                       ffi::Map<SBlock, SBlock>* block_sref_reuse, arith::AnalyzerObj* analyzer)
@@ -528,7 +537,7 @@ SBlockRealize BlockizeImpl(const ScheduleState& self, const StmtSRef& loop_sref,
     analyzer->Bind(iter->var, iter->dom);
   }
   SBlock block_subst =
-      Substitute(block, block_var_subst, block_sref_reuse, analyzer).as_or_throw<SBlock>();
+      ReplaceAndSimplify(block, block_var_subst, block_sref_reuse, analyzer).as_or_throw<SBlock>();
   // Step 5: Generate the inner block. The write regions of the inner blocks will be reduction if
   // 1. The original block has init stmt.
   // 2. There are outer reduction iter vars.
@@ -618,12 +627,33 @@ SBlockRealize BlockizeBlocks(const ScheduleState& self, const ffi::Array<StmtSRe
     }
     ffi::Map<Var, arith::IntSet> inner_iter_dom;
     for (const IterVar& iter : inner_iter_vars) {
-      Range dom = tirx::Substitute(iter->dom, loop_var_subst);
+      PrimExpr min =
+          ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+              iter->dom->min,
+              [&loop_var_subst](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                if (auto replacement = loop_var_subst.Get(var)) {
+                  return ffi::Any(replacement.value());
+                }
+                return ffi::Unchanged();
+              })
+              .cast<PrimExpr>();
+      PrimExpr extent =
+          ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+              iter->dom->extent,
+              [&loop_var_subst](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                if (auto replacement = loop_var_subst.Get(var)) {
+                  return ffi::Any(replacement.value());
+                }
+                return ffi::Unchanged();
+              })
+              .cast<PrimExpr>();
+      Range dom = Range::FromMinExtent(min, extent);
       inner_iter_dom.Set(iter->var, arith::IntSet::FromRange(dom));
       analyzer->Bind(iter->var, dom);
     }
     SBlock block_subst =
-        Substitute(block, block_var_subst, block_sref_reuse, analyzer.get()).as_or_throw<SBlock>();
+        ReplaceAndSimplify(block, block_var_subst, block_sref_reuse, analyzer.get())
+            .as_or_throw<SBlock>();
     auto reads = EvalSetRegions(block_subst->reads, inner_iter_dom);
     auto writes = EvalSetRegions(block_subst->writes, inner_iter_dom);
     read_regions.insert(read_regions.end(), reads.begin(), reads.end());
@@ -651,7 +681,16 @@ SBlockRealize BlockizeBlocks(const ScheduleState& self, const ffi::Array<StmtSRe
     for (const ForNode* loop : loops) {
       ffi::ObjectPtr<ForNode> new_loop = ffi::make_object<ForNode>(*loop);
       new_loop->body = std::move(stmt);
-      new_loop->extent = tirx::Substitute(new_loop->extent, loop_var_subst);
+      new_loop->extent =
+          ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+              new_loop->extent,
+              [&loop_var_subst](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                if (auto replacement = loop_var_subst.Get(var)) {
+                  return ffi::Any(replacement.value());
+                }
+                return ffi::Unchanged();
+              })
+              .cast<PrimExpr>();
       stmt = For(new_loop);
     }
     seq_body.push_back(stmt);

--- a/src/s_tir/schedule/primitive/cache_index.cc
+++ b/src/s_tir/schedule/primitive/cache_index.cc
@@ -18,6 +18,7 @@
  */
 #include <tvm/arith/int_set.h>
 #include <tvm/ffi/cast.h>
+#include <tvm/ffi/extra/structural_mutate.h>
 
 #include "../../../tirx/transform/replace_selected_expr.h"
 #include "../utils.h"
@@ -284,7 +285,16 @@ ffi::Array<SBlock> MakeIndexCacheStage(IndexInfo* info, const ffi::String& stora
     // Create iter_values from the original block.
     std::vector<PrimExpr> iter_values;
     for (const Var& it : info->origin_block_vars[expr_index]) {
-      iter_values.push_back(Substitute(info->var_binding.at(it), replace_table));
+      iter_values.push_back(
+          ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+              info->var_binding.at(it),
+              [&replace_table](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                if (auto replacement = replace_table.Get(var)) {
+                  return ffi::Any(replacement.value());
+                }
+                return ffi::Unchanged();
+              })
+              .cast<PrimExpr>());
     }
     // block variables
     ffi::Array<IterVar> block_vars;
@@ -310,7 +320,16 @@ ffi::Array<SBlock> MakeIndexCacheStage(IndexInfo* info, const ffi::String& stora
     }
 
     // Create the index computing block
-    PrimExpr new_expr = Substitute(index_expr, block_var_map);
+    PrimExpr new_expr =
+        ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+            index_expr,
+            [&block_var_map](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+              if (auto replacement = block_var_map.Get(var)) {
+                return ffi::Any(replacement.value());
+              }
+              return ffi::Unchanged();
+            })
+            .cast<PrimExpr>();
     SBlock block(
         /*iter_vars=*/std::move(block_vars),
         /*reads=*/{},

--- a/src/s_tir/schedule/primitive/cache_read_write.cc
+++ b/src/s_tir/schedule/primitive/cache_read_write.cc
@@ -18,6 +18,7 @@
  */
 
 #include <tvm/ffi/cast.h>
+#include <tvm/ffi/extra/structural_mutate.h>
 
 #include <unordered_set>
 
@@ -179,7 +180,16 @@ SBlock MakeReindexCacheStage(const BufferRegion& cache_region, ReindexCacheStage
         /*IterVarType=*/kDataPar);
     var_map.Set(original_block_var->var, block_var->var);
     block_vars.push_back(block_var);
-    iter_values.push_back(Substitute(original_iter_value, var_map));
+    iter_values.push_back(
+        ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+            original_iter_value,
+            [&var_map](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+              if (auto replacement = var_map.Get(var)) {
+                return ffi::Any(replacement.value());
+              }
+              return ffi::Unchanged();
+            })
+            .template cast<PrimExpr>());
   }
 
   // block access region for read/write buffers
@@ -189,13 +199,31 @@ SBlock MakeReindexCacheStage(const BufferRegion& cache_region, ReindexCacheStage
   ffi::Array<PrimExpr>& old_indices = (is_cache_read) ? read_access_indices : write_access_indices;
   Region& old_region = (is_cache_read) ? read_access_region : write_access_region;
   for (const Range& range : cache_region->region) {
-    old_indices.push_back(Substitute(range->min, var_map));
+    old_indices.push_back(
+        ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+            range->min,
+            [&var_map](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+              if (auto replacement = var_map.Get(var)) {
+                return ffi::Any(replacement.value());
+              }
+              return ffi::Unchanged();
+            })
+            .template cast<PrimExpr>());
     old_region.push_back(Range::FromMinExtent(old_indices.back(), IntImm::Int32(1)));
   }
   ffi::Array<PrimExpr>& new_indices = (is_cache_read) ? write_access_indices : read_access_indices;
   Region& new_region = (is_cache_read) ? write_access_region : read_access_region;
   for (const PrimExpr& idx : info->indices) {
-    new_indices.push_back(Substitute((idx), var_map));
+    new_indices.push_back(
+        ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+            idx,
+            [&var_map](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+              if (auto replacement = var_map.Get(var)) {
+                return ffi::Any(replacement.value());
+              }
+              return ffi::Unchanged();
+            })
+            .template cast<PrimExpr>());
     new_region.push_back(Range::FromMinExtent(new_indices.back(), IntImm::Int32(1)));
   }
 
@@ -379,7 +407,16 @@ SBlock MakeReIndexStage(const SBlock& block, CacheStageInfo* info,
 
   // Step 2: Replace the original block iters with the new block iters
   for (const PrimExpr& index : original_indices) {
-    target_indices.push_back(Substitute(index, block_var_replace_map));
+    target_indices.push_back(
+        ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+            index,
+            [&block_var_replace_map](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+              if (auto it = block_var_replace_map.find(var); it != block_var_replace_map.end()) {
+                return ffi::Any(it->second);
+              }
+              return ffi::Unchanged();
+            })
+            .cast<PrimExpr>());
   }
 
   // Step 3: Create the reindex block
@@ -582,7 +619,18 @@ static PrimExpr CollectNestedBlockPredicates(const Stmt& body, const BufferVar& 
         for (size_t i = 0; i < block->iter_vars.size(); ++i) {
           subst.Set(block->iter_vars[i]->var, realize->iter_values[i]);
         }
-        PrimExpr pred = subst.empty() ? realize->predicate : Substitute(realize->predicate, subst);
+        PrimExpr pred =
+            subst.empty()
+                ? realize->predicate
+                : ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+                      realize->predicate,
+                      [&subst](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                        if (auto replacement = subst.Get(var)) {
+                          return ffi::Any(replacement.value());
+                        }
+                        return ffi::Unchanged();
+                      })
+                      .cast<PrimExpr>();
         // OR the predicates across all accessing nested blocks: each such block is an
         // independent alternative access path (sibling blocks in a SeqStmt), so the
         // cache must cover the *union* of their access regions, not the intersection.
@@ -627,10 +675,26 @@ BufferRegion RelaxBufferRegion(ScheduleState self, const BufferRegion& buffer_re
   ffi::Map<Var, PrimExpr> binding = GetBindings(realize);
   const BufferVar& buffer = buffer_region->buffer;
   arith::Analyzer analyzer;
-  BufferRegion subst_region = BufferRegion(buffer, Substitute(buffer_region->region, binding));
+  auto map_binding = [&binding](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+    if (auto replacement = binding.Get(var)) {
+      return ffi::Any(replacement.value());
+    }
+    return ffi::Unchanged();
+  };
+  ffi::Array<Range> mapped_region = buffer_region->region.Map([&map_binding](const Range& range) {
+    PrimExpr min =
+        ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(range->min, map_binding).cast<PrimExpr>();
+    PrimExpr extent =
+        ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(range->extent, map_binding).cast<PrimExpr>();
+    return Range::FromMinExtent(min, extent);
+  });
+  BufferRegion subst_region = BufferRegion(buffer, mapped_region);
   ffi::Array<arith::IntSet> int_sets = AnalyzeRegionUpperBound(
       /*region=*/subst_region,
-      /*predicate=*/Substitute(realize->predicate && extra_predicate, binding),
+      /*predicate=*/
+      ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(realize->predicate && extra_predicate,
+                                                    map_binding)
+          .cast<PrimExpr>(),
       /*dom_low_inclusive=*/dom_low_inclusive,
       /*dom_high_exclusive=*/dom_high_exclusive,
       /*analyzer=*/analyzer.get());

--- a/src/s_tir/schedule/primitive/compute_at.cc
+++ b/src/s_tir/schedule/primitive/compute_at.cc
@@ -17,6 +17,7 @@
  * under the License.
  */
 #include <tvm/ffi/cast.h>
+#include <tvm/ffi/extra/structural_mutate.h>
 
 #include "../utils.h"
 
@@ -394,8 +395,29 @@ void RelaxBufferRegions(const ffi::Map<Var, PrimExpr>& binding,
           /*extra_relax_scope=*/scope));
     }
     // Relax the region
-    ffi::Array<arith::IntSet> relaxed_region =
-        arith::EvalSet(Substitute(region, binding), var_dom.value());
+    ffi::Array<Range> mapped_region = region.Map([&binding](const Range& range) {
+      PrimExpr min = ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+                         range->min,
+                         [&binding](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                           if (auto replacement = binding.Get(var)) {
+                             return ffi::Any(replacement.value());
+                           }
+                           return ffi::Unchanged();
+                         })
+                         .template cast<PrimExpr>();
+      PrimExpr extent =
+          ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+              range->extent,
+              [&binding](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                if (auto replacement = binding.Get(var)) {
+                  return ffi::Any(replacement.value());
+                }
+                return ffi::Unchanged();
+              })
+              .template cast<PrimExpr>();
+      return Range::FromMinExtent(min, extent);
+    });
+    ffi::Array<arith::IntSet> relaxed_region = arith::EvalSet(mapped_region, var_dom.value());
     relaxed_regions.push_back({relaxed_region.begin(), relaxed_region.end()});
   }
 }

--- a/src/s_tir/schedule/primitive/compute_inline.cc
+++ b/src/s_tir/schedule/primitive/compute_inline.cc
@@ -17,6 +17,7 @@
  * under the License.
  */
 #include <tvm/ffi/cast.h>
+#include <tvm/ffi/extra/structural_mutate.h>
 #include <tvm/s_tir/stmt.h>
 
 #include "../utils.h"
@@ -527,7 +528,16 @@ class ComputeInliner : public BaseInliner {
         inverse_iter_map.Set(iter->var, iter->dom->min);
       }
     }
-    store_value_ = Substitute(store_value_, inverse_iter_map);
+    store_value_ =
+        ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+            store_value_,
+            [&inverse_iter_map](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+              if (auto replacement = inverse_iter_map.Get(var)) {
+                return ffi::Any(replacement.value());
+              }
+              return ffi::Unchanged();
+            })
+            .cast<PrimExpr>();
     return true;
   }
 
@@ -545,7 +555,15 @@ class ComputeInliner : public BaseInliner {
 
   PrimExpr ReplaceInlinedBuffer(TensorLoad load) {
     SetIndexSubstitution(load->indices);
-    return Substitute(store_value_, idx_sub_);
+    return ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+               store_value_,
+               [this](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                 if (auto it = idx_sub_.find(var.get()); it != idx_sub_.end()) {
+                   return ffi::Any(it->second);
+                 }
+                 return ffi::Unchanged();
+               })
+        .cast<PrimExpr>();
   }
 
   /*!
@@ -757,7 +775,16 @@ class ReverseComputeInliner : public BaseInliner {
         }
       }
     }
-    PrimExpr outer_predicate = Substitute(predicate, subst_map);
+    PrimExpr outer_predicate =
+        ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+            predicate,
+            [&subst_map](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+              if (auto replacement = subst_map.Get(var)) {
+                return ffi::Any(replacement.value());
+              }
+              return ffi::Unchanged();
+            })
+            .cast<PrimExpr>();
     auto n = producer_block_realize.CopyOnWrite();
     n->block = producer_block;
     n->predicate = analyzer_->Simplify(outer_predicate);
@@ -1273,6 +1300,12 @@ SBlock ReductionEpilogueFuser::CreateFusedReductionBlock(
   for (size_t i = 0; i < reduction_data_vars.size(); ++i) {
     var_map[epilogue_data_vars[i]] = reduction_data_vars[i];
   }
+  auto map_epilogue_var = [&var_map](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+    if (auto it = var_map.find(var); it != var_map.end()) {
+      return ffi::Any(it->second);
+    }
+    return ffi::Unchanged();
+  };
 
   // 2. Generalized init transformation: substitute reduction buffer load with identity element (0)
   // Create a substituter to replace reduction_buffer_load_ with identity element
@@ -1302,14 +1335,18 @@ SBlock ReductionEpilogueFuser::CreateFusedReductionBlock(
   PrimExpr init_epilogue = init_subst(epilogue_expression_).as_or_throw<PrimExpr>();
 
   // Apply index mapping
-  init_epilogue = Substitute(init_epilogue, var_map);
+  init_epilogue = ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(init_epilogue, map_epilogue_var)
+                      .cast<PrimExpr>();
 
   // Simplify the expression (e.g., 0 + C[vi, vj] -> C[vi, vj])
   arith::Analyzer analyzer;
   init_epilogue = analyzer->Simplify(init_epilogue);
 
-  BufferStore new_init_store = BufferStore(epilogue_output_buffer_, init_epilogue,
-                                           Substitute(epilogue_output_indices_, var_map));
+  ffi::Array<PrimExpr> init_indices = epilogue_output_indices_.Map([&map_epilogue_var](
+                                                                       const PrimExpr& index) {
+    return ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(index, map_epilogue_var).cast<PrimExpr>();
+  });
+  BufferStore new_init_store = BufferStore(epilogue_output_buffer_, init_epilogue, init_indices);
   new_block->init = new_init_store;
 
   // 3. Generalized update transformation: apply epilogue expression with reduction buffer replaced
@@ -1432,7 +1469,15 @@ SBlock ReductionEpilogueFuser::CreateFusedReductionBlock(
         PrimExpr new_value = applier(epilogue_expression_).as_or_throw<PrimExpr>();
 
         // Apply index mapping
-        new_value = Substitute(new_value, var_map_);
+        new_value = ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+                        new_value,
+                        [this](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                          if (auto it = var_map_.find(var); it != var_map_.end()) {
+                            return ffi::Any(it->second);
+                          }
+                          return ffi::Unchanged();
+                        })
+                        .cast<PrimExpr>();
 
         return BufferStore(new_buffer_, new_value, store->indices);
       }
@@ -1456,7 +1501,9 @@ SBlock ReductionEpilogueFuser::CreateFusedReductionBlock(
   };
 
   // Apply index mapping to epilogue expression first
-  PrimExpr epilogue_expr_mapped = Substitute(epilogue_expression_, var_map);
+  PrimExpr epilogue_expr_mapped =
+      ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(epilogue_expression_, map_epilogue_var)
+          .cast<PrimExpr>();
 
   UpdateSubstituter replacer(inlined_buffer_, epilogue_output_buffer_, inlined_buffer_,
                              epilogue_expr_mapped, var_map);
@@ -1466,8 +1513,15 @@ SBlock ReductionEpilogueFuser::CreateFusedReductionBlock(
   ffi::Array<BufferRegion> new_writes;
   for (const BufferRegion& write : reduction_block->writes) {
     if (write->buffer.same_as(inlined_buffer_)) {
-      new_writes.push_back(
-          BufferRegion(epilogue_output_buffer_, Substitute(write->region, var_map)));
+      ffi::Array<Range> mapped_region = write->region.Map([&map_epilogue_var](const Range& range) {
+        PrimExpr min = ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(range->min, map_epilogue_var)
+                           .cast<PrimExpr>();
+        PrimExpr extent =
+            ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(range->extent, map_epilogue_var)
+                .cast<PrimExpr>();
+        return Range::FromMinExtent(min, extent);
+      });
+      new_writes.push_back(BufferRegion(epilogue_output_buffer_, mapped_region));
     } else {
       new_writes.push_back(write);
     }
@@ -1481,7 +1535,15 @@ SBlock ReductionEpilogueFuser::CreateFusedReductionBlock(
   // Add all non-reduction buffers from epilogue expression
   for (const BufferRegion& read : epilogue_block_->reads) {
     if (!read->buffer.same_as(inlined_buffer_)) {
-      new_reads.push_back(BufferRegion(read->buffer, Substitute(read->region, var_map)));
+      ffi::Array<Range> mapped_region = read->region.Map([&map_epilogue_var](const Range& range) {
+        PrimExpr min = ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(range->min, map_epilogue_var)
+                           .cast<PrimExpr>();
+        PrimExpr extent =
+            ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(range->extent, map_epilogue_var)
+                .cast<PrimExpr>();
+        return Range::FromMinExtent(min, extent);
+      });
+      new_reads.push_back(BufferRegion(read->buffer, mapped_region));
       read_bufs.insert(read->buffer.get());
     }
   }

--- a/src/s_tir/schedule/primitive/decompose_padding.cc
+++ b/src/s_tir/schedule/primitive/decompose_padding.cc
@@ -17,6 +17,7 @@
  * under the License.
  */
 #include <tvm/ffi/cast.h>
+#include <tvm/ffi/extra/structural_mutate.h>
 #include <tvm/ffi/reflection/registry.h>
 
 #include "../../../tirx/transform/ir_utils.h"
@@ -103,7 +104,16 @@ class PaddingInfoAnalyzer {
       SetError("Value of BufferStore expect to be constrained by a padding predicate");
       return false;
     }
-    PrimExpr pad_predicate = Substitute(if_then_else->args[0].as_or_throw<PrimExpr>(), iter_values);
+    PrimExpr pad_predicate =
+        ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+            if_then_else->args[0].as_or_throw<PrimExpr>(),
+            [&iter_values](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+              if (auto it = iter_values.find(var.get()); it != iter_values.end()) {
+                return ffi::Any(it->second);
+              }
+              return ffi::Unchanged();
+            })
+            .cast<PrimExpr>();
     PrimExpr in_bound_value = if_then_else->args[1].as_or_throw<PrimExpr>();
     PrimExpr pad_value = if_then_else->args[2].as_or_throw<PrimExpr>();
     if (!is_const_number(pad_value)) {
@@ -217,7 +227,16 @@ static std::pair<Stmt, SBlockRealize> CreateConstBlock(const SBlockRealizeNode* 
 
   // rewrite expr helper
   auto rewrite_expr = [&repl_dict, analyzer](const PrimExpr& e) {
-    return analyzer->Simplify(Substitute(e, repl_dict));
+    return analyzer->Simplify(
+        ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+            e,
+            [&repl_dict](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+              if (auto replacement = repl_dict.Get(var)) {
+                return ffi::Any(replacement.value());
+              }
+              return ffi::Unchanged();
+            })
+            .cast<PrimExpr>());
   };
 
   // create new write region
@@ -313,7 +332,16 @@ static std::pair<Stmt, SBlockRealize> CreateInBoundBlock(const SBlockRealizeNode
 
   // rewrite helpers
   auto rewrite_expr = [&repl_dict, analyzer](const PrimExpr& e) {
-    return analyzer->Simplify(Substitute(e, repl_dict));
+    return analyzer->Simplify(
+        ffi::StructuralMap<ffi::WalkOrder::kPostOrder>(
+            e,
+            [&repl_dict](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+              if (auto replacement = repl_dict.Get(var)) {
+                return ffi::Any(replacement.value());
+              }
+              return ffi::Unchanged();
+            })
+            .cast<PrimExpr>());
   };
   auto rewrite_region = [rewrite_expr](const Region& region) {
     return region.Map([rewrite_expr](const Range& r) {

--- a/src/s_tir/schedule/primitive/layout_transformation.cc
+++ b/src/s_tir/schedule/primitive/layout_transformation.cc
@@ -19,6 +19,7 @@
 
 #include <tvm/arith/analyzer.h>
 #include <tvm/ffi/cast.h>
+#include <tvm/ffi/extra/structural_mutate.h>
 #include <tvm/runtime/logging.h>
 
 #include <optional>
@@ -186,7 +187,16 @@ class TransformLayoutPlanner : private StmtExprVisitor {
       for (size_t i = 0; i < loopnest.size(); i++) {
         const For& loop = loopnest[i];
         const PrimExpr& buffer_dim = old_buffer_->shape[i];
-        PrimExpr index = Substitute(op->indices[i], active_var_bindings_);
+        PrimExpr index = ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+                             op->indices[i],
+                             [this](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                               if (auto it = active_var_bindings_.find(var.get());
+                                   it != active_var_bindings_.end()) {
+                                 return ffi::Any(it->second);
+                               }
+                               return ffi::Unchanged();
+                             })
+                             .cast<PrimExpr>();
         bool is_loop_over_axis = index.same_as(loop->loop_var) && is_const_int(loop->min, 0) &&
                                  ExprDeepEqual()(loop->extent, buffer_dim) &&
                                  loop->kind == ForKind::kSerial;
@@ -329,11 +339,29 @@ class TransformLayoutPlanner : private StmtExprVisitor {
       TVM_FFI_ICHECK_EQ(inverse->final_indices.size(), old_indices.size());
       for (size_t i = 0; i < old_indices.size(); i++) {
         Var var = old_indices[i].as_or_throw<Var>();
-        PrimExpr expr = Substitute(inverse->final_indices[i], loop_var_to_virtual_var);
+        PrimExpr expr = ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+                            inverse->final_indices[i],
+                            [&loop_var_to_virtual_var](
+                                const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                              if (auto replacement = loop_var_to_virtual_var.Get(var)) {
+                                return ffi::Any(replacement.value());
+                              }
+                              return ffi::Unchanged();
+                            })
+                            .cast<PrimExpr>();
         var_remap.Set(var, expr);
       }
 
-      padding_predicate = Substitute(padding_predicate, loop_var_to_virtual_var);
+      padding_predicate = ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+                              padding_predicate,
+                              [&loop_var_to_virtual_var](
+                                  const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                                if (auto replacement = loop_var_to_virtual_var.Get(var)) {
+                                  return ffi::Any(replacement.value());
+                                }
+                                return ffi::Unchanged();
+                              })
+                              .cast<PrimExpr>();
 
       this->new_iter_vars = new_iter_vars;
       this->new_iter_values = new_iter_values;
@@ -487,7 +515,16 @@ class TransformLayoutPlanner : private StmtExprVisitor {
       iter_vars.push_back(iter_var);
       iter_values.push_back(loop_var);
     }
-    padding_predicate = Substitute(std::move(padding_predicate), loop_indices_to_block_indices);
+    padding_predicate = ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+                            std::move(padding_predicate),
+                            [&loop_indices_to_block_indices](
+                                const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                              if (auto replacement = loop_indices_to_block_indices.Get(var)) {
+                                return ffi::Any(replacement.value());
+                              }
+                              return ffi::Unchanged();
+                            })
+                            .cast<PrimExpr>();
 
     PrimExpr pad_value_at_index =
         pad_value.value()->MapIndices(indices, ffi::GetRef<arith::Analyzer>(analyzer))[0];
@@ -646,7 +683,16 @@ class TransformLayoutPlanner : private StmtExprVisitor {
       if (auto loop_depth = self->LoopDependencyRange(prim_value.value()); loop_depth.has_value()) {
         self->loop_depth_lookup_[var.get()] = loop_depth.value();
         self->active_var_bindings_[var.get()] =
-            Substitute(prim_value.value(), self->active_var_bindings_);
+            ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+                prim_value.value(),
+                [self](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                  if (auto it = self->active_var_bindings_.find(var.get());
+                      it != self->active_var_bindings_.end()) {
+                    return ffi::Any(it->second);
+                  }
+                  return ffi::Unchanged();
+                })
+                .cast<PrimExpr>();
       }
     }
     ~BindVariableDefinition() {}
@@ -1469,8 +1515,19 @@ void TransformBlockLayout(ScheduleState self, const StmtSRef& block_sref,
       inverse_subst_map.Set(block_vars[i].as_or_throw<Var>(), inversed_new_block_vars[i]);
     }
   }
-  SBlock new_block =
-      Substitute(ffi::GetRef<SBlock>(block_ptr), inverse_subst_map).as_or_throw<SBlock>();
+  SBlock new_block = ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+                         ffi::GetRef<SBlock>(block_ptr),
+                         [&inverse_subst_map](const Var& var, TVMFFIDefRegionKind kind)
+                             -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                           if (kind != kTVMFFIDefRegionKindNone) {
+                             return ffi::Unchanged();
+                           }
+                           if (auto replacement = inverse_subst_map.Get(var)) {
+                             return ffi::Any(replacement.value());
+                           }
+                           return ffi::Unchanged();
+                         })
+                         .cast<SBlock>();
   new_block.CopyOnWrite()->iter_vars = new_block_iters;
   new_block = BlockBufferAccessSimplifier::Simplify(new_block, analyzer).as_or_throw<SBlock>();
 

--- a/src/s_tir/schedule/primitive/loop_transformation.cc
+++ b/src/s_tir/schedule/primitive/loop_transformation.cc
@@ -17,6 +17,7 @@
  * under the License.
  */
 #include <tvm/ffi/cast.h>
+#include <tvm/ffi/extra/structural_mutate.h>
 
 #include "../utils.h"
 
@@ -607,7 +608,15 @@ class BlockMutator : public StmtExprMutator {
     }
 
     // Update all instances of old iter_vars in the block with new iter_vars
-    auto block_stmt = tirx::Substitute(new_block, var_map);
+    auto block_stmt = ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+                          new_block,
+                          [&var_map](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                            if (auto replacement = var_map.Get(var)) {
+                              return ffi::Any(replacement.value());
+                            }
+                            return ffi::Unchanged();
+                          })
+                          .cast<SBlock>();
     return block_stmt;
   }
 
@@ -630,7 +639,15 @@ class BlockMutator : public StmtExprMutator {
 
     if (!op->loop_var.same_as(new_var)) {
       // If the partioned loop contains nested for loop, then create new iteration variable instance
-      res.CopyOnWrite()->body = tirx::Substitute(res->body, {{op->loop_var, new_var}});
+      res.CopyOnWrite()->body =
+          ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+              res->body,
+              [old_var = op->loop_var,
+               &new_var](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                if (var.same_as(old_var)) return ffi::Any(new_var);
+                return ffi::Unchanged();
+              })
+              .cast<Stmt>();
       res.CopyOnWrite()->loop_var = new_var.as_or_throw<PrimVar>();
     }
     return res;
@@ -679,7 +696,14 @@ ffi::Array<StmtSRef> LoopPartition(ScheduleState self, const StmtSRef& loop_sref
   for (int i = 0; i < n; i++) {
     extent_value = analyzer->Simplify(factors[i]);
     Var new_loop_var = loop->loop_var.CopyWithSuffix(std::to_string(i)).CopyWithDType(dtype);
-    Stmt loop_body = tirx::Substitute(loop->body, {{loop->loop_var, new_loop_var}});
+    Stmt loop_body = ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+                         loop->body,
+                         [old_var = loop->loop_var, &new_loop_var](
+                             const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                           if (var.same_as(old_var)) return ffi::Any(new_loop_var);
+                           return ffi::Unchanged();
+                         })
+                         .cast<Stmt>();
 
     // Create new block with new reference to each variable/stmt/expr in the existing block
     loop_body = BlockMutator(new_loop_var, min_value, extent_value)(std::move(loop_body));
@@ -744,7 +768,15 @@ class LoopReconstructor : private StmtMutator {
         }
         var_map.Set(loops_[i][j]->loop_var, new_loop_vars[j].as_or_throw<PrimExpr>());
       }
-      auto new_stmt = Substitute(loops_[i][0]->body, var_map);
+      auto new_stmt = ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+                          loops_[i][0]->body,
+                          [&var_map](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                            if (auto replacement = var_map.Get(var)) {
+                              return ffi::Any(replacement.value());
+                            }
+                            return ffi::Unchanged();
+                          })
+                          .cast<Stmt>();
       new_stmts.push_back(new_stmt);
       this->need_remove_loop_.push_back(loops_[i].back());
     }

--- a/src/s_tir/schedule/primitive/read_write_at.cc
+++ b/src/s_tir/schedule/primitive/read_write_at.cc
@@ -18,6 +18,7 @@
  */
 
 #include <tvm/ffi/cast.h>
+#include <tvm/ffi/extra/structural_mutate.h>
 #include <tvm/s_tir/stmt.h>
 
 #include <string>
@@ -47,8 +48,30 @@ void RelaxBufferRegions(const ffi::Array<BufferRegion>& buffer_regions,
                         std::vector<NDIntSet>* relaxed_regions) {
   for (const BufferRegion& buffer_region : buffer_regions) {
     if (buffer_region->buffer.same_as(buffer)) {
-      ffi::Array<arith::IntSet> relaxed_region =
-          arith::EvalSet(Substitute(buffer_region->region, bindings), var_dom);
+      ffi::Array<Range> mapped_region = buffer_region->region.Map([&bindings](const Range& range) {
+        PrimExpr min =
+            ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+                range->min,
+                [&bindings](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                  if (auto replacement = bindings.Get(var)) {
+                    return ffi::Any(replacement.value());
+                  }
+                  return ffi::Unchanged();
+                })
+                .cast<PrimExpr>();
+        PrimExpr extent =
+            ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+                range->extent,
+                [&bindings](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                  if (auto replacement = bindings.Get(var)) {
+                    return ffi::Any(replacement.value());
+                  }
+                  return ffi::Unchanged();
+                })
+                .cast<PrimExpr>();
+        return Range::FromMinExtent(min, extent);
+      });
+      ffi::Array<arith::IntSet> relaxed_region = arith::EvalSet(mapped_region, var_dom);
       relaxed_regions->push_back({relaxed_region.begin(), relaxed_region.end()});
     }
   }
@@ -281,22 +304,25 @@ struct ReadWriteAtImpl {
     iter_values.reserve(n);
     indices.reserve(n);
     for (int i = 0; i < n; ++i) {
-      auto f_substitute = [&loop_domain, &bindings, &iter_vars,
-                           &iter_values](const Var& var) -> ffi::Optional<Expr> {
+      auto f_substitute = [&loop_domain, &bindings, &iter_vars, &iter_values](
+                              const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
         auto it = bindings.find(var);
         if (it != bindings.end()) {
-          return (*it).second;
+          return ffi::Any((*it).second);
         }
         Range range = loop_domain.at(var);
         Var v("v" + std::to_string(iter_vars.size()), var->ty, var->span);
         bindings.Set(var, v.as_or_throw<PrimExpr>());
         iter_values.push_back(var.as_or_throw<PrimExpr>());
         iter_vars.push_back(IterVar(range, v.as_or_throw<PrimVar>(), IterVarType::kDataPar));
-        return v.as_or_throw<PrimExpr>();
+        return ffi::Any(v.as_or_throw<PrimExpr>());
       };
       ffi::ObjectPtr<RangeNode> dom = ffi::make_object<RangeNode>(*domain[i].get());
-      dom->min = Substitute(std::move(dom->min), f_substitute);
-      dom->extent = Substitute(std::move(dom->extent), f_substitute);
+      dom->min = ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(std::move(dom->min), f_substitute)
+                     .cast<PrimExpr>();
+      dom->extent =
+          ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(std::move(dom->extent), f_substitute)
+              .cast<PrimExpr>();
       domain.Set(i, Range(dom));
     }
     for (int i = 0; i < n; ++i) {

--- a/src/s_tir/schedule/primitive/reduction.cc
+++ b/src/s_tir/schedule/primitive/reduction.cc
@@ -17,6 +17,7 @@
  * under the License.
  */
 #include <tvm/ffi/cast.h>
+#include <tvm/ffi/extra/structural_mutate.h>
 #include <tvm/ffi/reflection/registry.h>
 #include <tvm/te/operation.h>
 
@@ -231,10 +232,25 @@ StmtSRef DecomposeReduction(ScheduleState self, const StmtSRef& block_sref,
     block_var_map[iter_var->var] = new_iter_var->var;
   }
   // Step 2. After copying block vars, substitute them in init block
-  init_block->body = Substitute(block->init.value(), block_var_map);
+  auto map_block_var =
+      [&block_var_map](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+    if (auto it = block_var_map.find(var); it != block_var_map.end()) {
+      return ffi::Any(it->second);
+    }
+    return ffi::Unchanged();
+  };
+  init_block->body =
+      ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(block->init.value(), map_block_var)
+          .cast<Stmt>();
   for (const BufferRegion& write : block->writes) {
-    init_block->writes.push_back(
-        BufferRegion(write->buffer, Substitute(write->region, block_var_map)));
+    ffi::Array<Range> mapped_region = write->region.Map([&map_block_var](const Range& range) {
+      PrimExpr min =
+          ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(range->min, map_block_var).cast<PrimExpr>();
+      PrimExpr extent = ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(range->extent, map_block_var)
+                            .cast<PrimExpr>();
+      return Range::FromMinExtent(min, extent);
+    });
+    init_block->writes.push_back(BufferRegion(write->buffer, mapped_region));
   }
   // Step 3. Scan loops not higher than the specified loop above the reduction block.
   //         If the loop is used in the init block binding, then it is chosen.
@@ -286,7 +302,15 @@ StmtSRef DecomposeReduction(ScheduleState self, const StmtSRef& block_sref,
     new_loop->body = body;
     body = ffi::GetRef<For>(new_loop);
   }
-  body = Substitute(body, loop_var_map);
+  body = ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+             body,
+             [&loop_var_map](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+               if (auto it = loop_var_map.find(var); it != loop_var_map.end()) {
+                 return ffi::Any(it->second);
+               }
+               return ffi::Unchanged();
+             })
+             .cast<Stmt>();
   // Step 6. Mutate IR
   const SBlockNode* old_scope_root = TVM_SREF_TO_SBLOCK(scope_root_sref);
   auto [new_scope_root, new_reduction_block] = DecomposeReductionBlockReplacer::Replace(
@@ -713,10 +737,19 @@ class BaseBlockCreator {
     // The pre-processing finds out the buffers written in the block, the indices of the buffer
     // accesses, and the reduction LHS and RHS of the stored values.
     PreProcess();
-    Stmt block_body = Substitute(CreateBlockBody(has_reduce_iter), var_map_);
+    auto map_block_var = [this](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+      if (auto replacement = var_map_.Get(var)) {
+        return ffi::Any(replacement.value());
+      }
+      return ffi::Unchanged();
+    };
+    Stmt block_body = ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+                          CreateBlockBody(has_reduce_iter), map_block_var)
+                          .cast<Stmt>();
     ffi::Optional<Stmt> block_init = CreateBlockInit(has_reduce_iter);
     if (block_init.has_value()) {
-      block_init = Substitute(block_init.value(), var_map_);
+      block_init = ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(block_init.value(), map_block_var)
+                       .cast<Stmt>();
     }
     CreateReadWriteRegions();
 
@@ -929,7 +962,17 @@ class RFactorBlockCreator : public BaseBlockCreator {
     }
     // Substitute the original binding with new block iters. Store the result expression
     // in `rf_var_map` for future substitution.
-    var_map_.Set(old_iter->var, Substitute(old_binding, loop_var2block_binding_));
+    var_map_.Set(old_iter->var,
+                 ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+                     old_binding,
+                     [this](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                       if (auto it = loop_var2block_binding_.find(var.get());
+                           it != loop_var2block_binding_.end()) {
+                         return ffi::Any(it->second);
+                       }
+                       return ffi::Unchanged();
+                     })
+                     .cast<PrimExpr>());
   }
 
   void PreProcess() final {
@@ -951,10 +994,23 @@ class RFactorBlockCreator : public BaseBlockCreator {
       buffer_map.Set(old_reduction_updates_[i]->buffer, rf_buffers_[i]);
     }
     const SBlock& old_block = old_block_realize_->block;
+    auto map_block_var = [this](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+      if (auto replacement = var_map_.Get(var)) {
+        return ffi::Any(replacement.value());
+      }
+      return ffi::Unchanged();
+    };
     read_regions_.reserve(old_block->reads.size());
     for (const BufferRegion& read_region : old_block->reads) {
-      read_regions_.push_back(
-          BufferRegion(read_region->buffer, Substitute(read_region->region, var_map_)));
+      ffi::Array<Range> region = read_region->region.Map([&map_block_var](const Range& range) {
+        PrimExpr min = ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(range->min, map_block_var)
+                           .cast<PrimExpr>();
+        PrimExpr extent =
+            ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(range->extent, map_block_var)
+                .cast<PrimExpr>();
+        return Range::FromMinExtent(min, extent);
+      });
+      read_regions_.push_back(BufferRegion(read_region->buffer, region));
     }
     write_regions_.reserve(old_block->writes.size());
     for (const BufferRegion& write_region : old_block->writes) {
@@ -964,7 +1020,15 @@ class RFactorBlockCreator : public BaseBlockCreator {
           Range::FromMinExtent(additional_iter_->var, IntImm(additional_iter_->var.ty(), 1)));
       ffi::Optional<BufferVar> rf_buffer = buffer_map.Get(write_region->buffer);
       TVM_FFI_ICHECK(rf_buffer.has_value());
-      write_regions_.push_back(BufferRegion(rf_buffer.value(), Substitute(region, var_map_)));
+      region.MutateByApply([&map_block_var](const Range& range) {
+        PrimExpr min = ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(range->min, map_block_var)
+                           .cast<PrimExpr>();
+        PrimExpr extent =
+            ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(range->extent, map_block_var)
+                .cast<PrimExpr>();
+        return Range::FromMinExtent(min, extent);
+      });
+      write_regions_.push_back(BufferRegion(rf_buffer.value(), region));
     }
   }
 
@@ -1032,12 +1096,22 @@ class WriteBackBlockCreator : public BaseBlockCreator {
   }
 
   void PreProcess() final {
+    auto map_block_var = [this](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+      if (auto replacement = var_map_.Get(var)) {
+        return ffi::Any(replacement.value());
+      }
+      return ffi::Unchanged();
+    };
     for (int i = 0; i < n_buffers_; ++i) {
       PrimExpr rhs = BufferLoad(rf_buffers_[i], rf_buf_access_indices_);
       update_buffers_.push_back(old_reduction_updates_[i]->buffer);
       update_indices_.push_back(old_reduction_updates_[i]->indices);
-      update_lhs_.push_back(Substitute(combiner_lhs_[i], var_map_));
-      update_rhs_.push_back(Substitute(std::move(rhs), var_map_));
+      update_lhs_.push_back(
+          ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(combiner_lhs_[i], map_block_var)
+              .cast<PrimExpr>());
+      update_rhs_.push_back(
+          ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(std::move(rhs), map_block_var)
+              .cast<PrimExpr>());
     }
   }
 
@@ -1089,15 +1163,25 @@ Stmt CreateLoopOutsideRfactorBlock(SBlockRealize rf_block_realize, const ffi::Ar
   }
 
   // Step 2. Update the iter bindings and predicate of the rfactor block.
+  auto map_loop_var =
+      [&new_loop_var_map](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+    if (auto it = new_loop_var_map.find(var.get()); it != new_loop_var_map.end()) {
+      return ffi::Any(it->second);
+    }
+    return ffi::Unchanged();
+  };
   ffi::Array<PrimExpr> new_bindings;
   new_bindings.reserve(rf_block_realize->iter_values.size());
   for (const PrimExpr& old_binding : rf_block_realize->iter_values) {
-    new_bindings.push_back(Substitute(old_binding, new_loop_var_map));
+    new_bindings.push_back(
+        ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(old_binding, map_loop_var).cast<PrimExpr>());
   }
   {
     SBlockRealizeNode* p_rf_block_realize = rf_block_realize.CopyOnWrite();
     p_rf_block_realize->iter_values = new_bindings;
-    p_rf_block_realize->predicate = Substitute(rf_block_realize->predicate, new_loop_var_map);
+    p_rf_block_realize->predicate =
+        ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(rf_block_realize->predicate, map_loop_var)
+            .cast<PrimExpr>();
   }
 
   // Step 3. Wrap `rf_block_realize` with outer loops.

--- a/src/s_tir/schedule/primitive/rolling_buffer.cc
+++ b/src/s_tir/schedule/primitive/rolling_buffer.cc
@@ -17,6 +17,7 @@
  * under the License.
  */
 #include <tvm/ffi/cast.h>
+#include <tvm/ffi/extra/structural_mutate.h>
 
 #include <functional>
 
@@ -43,8 +44,29 @@ struct RollingBufferInfo {
 
 BufferRegion GetRelaxedBufferRegion(const SBlockRealize& realize, const BufferRegion& buffer_region,
                                     const ffi::Map<Var, arith::IntSet>& dom_map) {
-  ffi::Array<arith::IntSet> relaxed_intsets =
-      arith::EvalSet(Substitute(buffer_region->region, GetBindings(realize)), dom_map);
+  ffi::Map<Var, PrimExpr> bindings = GetBindings(realize);
+  ffi::Array<Range> mapped_region = buffer_region->region.Map([&bindings](const Range& range) {
+    PrimExpr min = ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+                       range->min,
+                       [&bindings](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                         if (auto replacement = bindings.Get(var)) {
+                           return ffi::Any(replacement.value());
+                         }
+                         return ffi::Unchanged();
+                       })
+                       .cast<PrimExpr>();
+    PrimExpr extent = ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+                          range->extent,
+                          [&bindings](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                            if (auto replacement = bindings.Get(var)) {
+                              return ffi::Any(replacement.value());
+                            }
+                            return ffi::Unchanged();
+                          })
+                          .cast<PrimExpr>();
+    return Range::FromMinExtent(min, extent);
+  });
+  ffi::Array<arith::IntSet> relaxed_intsets = arith::EvalSet(mapped_region, dom_map);
   Region relaxed_region;
   relaxed_region.reserve(relaxed_intsets.size());
   for (size_t i = 0; i < relaxed_intsets.size(); ++i) {

--- a/src/s_tir/schedule/state.cc
+++ b/src/s_tir/schedule/state.cc
@@ -18,6 +18,7 @@
  */
 #include <tvm/arith/int_set.h>
 #include <tvm/ffi/cast.h>
+#include <tvm/ffi/extra/structural_mutate.h>
 #include <tvm/ffi/reflection/registry.h>
 
 #include "./utils.h"
@@ -218,14 +219,60 @@ class SBlockInfoCollector : private StmtVisitor {
       ffi::Array<BufferRegion> reads;
       reads.reserve(block->reads.size());
       for (const BufferRegion& region : block->reads) {
-        reads.push_back(BufferRegion(region->buffer, Substitute(region->region, binding)));
+        ffi::Array<Range> mapped_region = region->region.Map([&binding](const Range& range) {
+          PrimExpr min =
+              ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+                  range->min,
+                  [&binding](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                    if (auto replacement = binding.Get(var)) {
+                      return ffi::Any(replacement.value());
+                    }
+                    return ffi::Unchanged();
+                  })
+                  .cast<PrimExpr>();
+          PrimExpr extent =
+              ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+                  range->extent,
+                  [&binding](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                    if (auto replacement = binding.Get(var)) {
+                      return ffi::Any(replacement.value());
+                    }
+                    return ffi::Unchanged();
+                  })
+                  .cast<PrimExpr>();
+          return Range::FromMinExtent(min, extent);
+        });
+        reads.push_back(BufferRegion(region->buffer, mapped_region));
       }
       block_reads_unbound.emplace(block_sref.get(), std::move(reads));
       // Step 1.2. Unbind write regions
       ffi::Array<BufferRegion> writes;
       writes.reserve(block->writes.size());
       for (const BufferRegion& region : block->writes) {
-        writes.push_back(BufferRegion(region->buffer, Substitute(region->region, binding)));
+        ffi::Array<Range> mapped_region = region->region.Map([&binding](const Range& range) {
+          PrimExpr min =
+              ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+                  range->min,
+                  [&binding](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                    if (auto replacement = binding.Get(var)) {
+                      return ffi::Any(replacement.value());
+                    }
+                    return ffi::Unchanged();
+                  })
+                  .cast<PrimExpr>();
+          PrimExpr extent =
+              ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+                  range->extent,
+                  [&binding](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                    if (auto replacement = binding.Get(var)) {
+                      return ffi::Any(replacement.value());
+                    }
+                    return ffi::Unchanged();
+                  })
+                  .cast<PrimExpr>();
+          return Range::FromMinExtent(min, extent);
+        });
+        writes.push_back(BufferRegion(region->buffer, mapped_region));
       }
       block_writes_unbound.emplace(block_sref.get(), std::move(writes));
     }

--- a/src/s_tir/schedule/trace.cc
+++ b/src/s_tir/schedule/trace.cc
@@ -17,6 +17,7 @@
  * under the License.
  */
 #include <tvm/ffi/cast.h>
+#include <tvm/ffi/extra/structural_mutate.h>
 #include <tvm/ffi/reflection/registry.h>
 
 #include <sstream>
@@ -95,9 +96,27 @@ ffi::Array<Any> TranslateInputRVs(
       TVM_FFI_CHECK(it != rv_map.end(), IndexError) << "Random variable doesn't exist: " << input;
       result.push_back(ffi::GetRef<ffi::ObjectRef>(it->second));
     } else if (auto expr = input.try_cast<PrimExpr>()) {  // RV: Expr
-      result.push_back(Substitute(expr.value(), f_subst_with_rv_map));
+      result.push_back(
+          ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+              expr.value(),
+              [&f_subst_with_rv_map](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                if (auto replacement = f_subst_with_rv_map(var)) {
+                  return ffi::Any(replacement.value());
+                }
+                return ffi::Unchanged();
+              })
+              .cast<PrimExpr>());
     } else if (auto index_map = input.as<IndexMap>()) {
-      result.push_back(Substitute(index_map.value(), f_subst_with_rv_map_prim));
+      result.push_back(ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+                           index_map.value(),
+                           [&f_subst_with_rv_map_prim](
+                               const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                             if (auto replacement = f_subst_with_rv_map_prim(var)) {
+                               return ffi::Any(replacement.value());
+                             }
+                             return ffi::Unchanged();
+                           })
+                           .cast<IndexMap>());
     } else if (auto arr = input.as<ffi::Array<Any>>()) {
       // Recursively convert elements of the array into a new list of ObjectRefs.
       result.push_back(TranslateInputRVs(arr.value(), rv_map));
@@ -205,13 +224,16 @@ ffi::Array<Any> TranslateInputRVs(
       // Case 6. IndexMap
       if (obj.as<IndexMapNode>()) {
         IndexMap index_map = obj.as_or_throw<IndexMap>();
-        index_map = Substitute(index_map, [&named_rvs](const Var& var) -> ffi::Optional<PrimExpr> {
-          auto it = named_rvs.find(var->name);
-          if (it != named_rvs.end()) {
-            return it->second.as_or_throw<Var>().as_or_throw<PrimExpr>();
-          }
-          return std::nullopt;
-        });
+        index_map = ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+                        index_map,
+                        [&named_rvs](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                          auto it = named_rvs.find(var->name);
+                          if (it != named_rvs.end()) {
+                            return ffi::Any(it->second.as_or_throw<Var>().as_or_throw<PrimExpr>());
+                          }
+                          return ffi::Unchanged();
+                        })
+                        .cast<IndexMap>();
         results.push_back(index_map);
         continue;
       } else {

--- a/src/te/operation/create_primfunc.cc
+++ b/src/te/operation/create_primfunc.cc
@@ -21,6 +21,7 @@
 
 #include <tvm/arith/analyzer.h>
 #include <tvm/ffi/cast.h>
+#include <tvm/ffi/extra/structural_mutate.h>
 #include <tvm/ffi/extra/structural_visit.h>
 #include <tvm/ffi/function.h>
 #include <tvm/ffi/reflection/registry.h>
@@ -395,7 +396,15 @@ Stmt GenerateInitStmt(const ffi::Array<PrimExpr>& indices, const ffi::Array<Buff
                       CreateFuncInfo* info) {
   // helper to transform the expr and remap iters to the block domain
   auto f_transform_and_remap = [&](const PrimExpr& e) {
-    return Substitute(info->transformer(e).as_or_throw<PrimExpr>(), var_map);
+    return ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+               info->transformer(e).as_or_throw<PrimExpr>(),
+               [&var_map](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                 if (auto replacement = var_map.Get(var)) {
+                   return ffi::Any(replacement.value());
+                 }
+                 return ffi::Unchanged();
+               })
+        .cast<PrimExpr>();
   };
   ffi::Optional<Stmt> init = std::nullopt;
   Stmt body;
@@ -425,7 +434,15 @@ Stmt GenerateBodyStmt(const ffi::Array<PrimExpr>& indices, const ffi::Array<Buff
                       CreateFuncInfo* info, arith::AnalyzerObj* analyzer) {
   // helper to transform the expr and remap iters to the block domain
   auto f_transform_and_remap = [&](const PrimExpr& e) {
-    return Substitute(info->transformer(e).as_or_throw<PrimExpr>(), var_map);
+    return ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+               info->transformer(e).as_or_throw<PrimExpr>(),
+               [&var_map](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                 if (auto replacement = var_map.Get(var)) {
+                   return ffi::Any(replacement.value());
+                 }
+                 return ffi::Unchanged();
+               })
+        .cast<PrimExpr>();
   };
   Stmt body;
   if (const auto* reduce = expr_body.as<te::ReduceNode>()) {
@@ -567,8 +584,24 @@ Stmt GenerateStmtFromCompute(const te::ComputeOp& compute_op, CreateFuncInfo* in
         PrimExpr extent = axis->dom->extent;
         if (i > 0) {
           const auto& scope_repl = scopes[i - 1].axes_remap;
-          min = Substitute(min, scope_repl);
-          extent = Substitute(extent, scope_repl);
+          min = ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+                    min,
+                    [&scope_repl](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                      if (auto replacement = scope_repl.Get(var)) {
+                        return ffi::Any(replacement.value());
+                      }
+                      return ffi::Unchanged();
+                    })
+                    .cast<PrimExpr>();
+          extent = ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+                       extent,
+                       [&scope_repl](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                         if (auto replacement = scope_repl.Get(var)) {
+                           return ffi::Any(replacement.value());
+                         }
+                         return ffi::Unchanged();
+                       })
+                       .cast<PrimExpr>();
         }
         Range dom = Range::FromMinExtent(analyzer->Simplify(min), analyzer->Simplify(extent));
         IterVar new_block_iter(dom, block_var.as_or_throw<PrimVar>(), axis->iter_type,

--- a/src/te/operation/reduce.cc
+++ b/src/te/operation/reduce.cc
@@ -21,6 +21,7 @@
  * \file reduce.cc
  * \brief TE reduction expression definitions.
  */
+#include <tvm/ffi/extra/structural_mutate.h>
 #include <tvm/ffi/function.h>
 #include <tvm/ffi/reflection/registry.h>
 #include <tvm/te/operation.h>
@@ -69,7 +70,16 @@ CommReducer::CommReducer(ffi::Array<PrimVar> lhs, ffi::Array<PrimVar> rhs,
 
   ffi::ArrayObj* p_result = result.CopyOnWrite();
   for (int i = 0; i < static_cast<int>(n_group); ++i) {
-    p_result->SetItem(i, Substitute(result[i], var_map));
+    p_result->SetItem(i,
+                      ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+                          result[i],
+                          [&var_map](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                            if (auto it = var_map.find(var.get()); it != var_map.end()) {
+                              return ffi::Any(it->second);
+                            }
+                            return ffi::Unchanged();
+                          })
+                          .cast<PrimExpr>());
   }
 
   auto node = ffi::make_object<CommReducerNode>();
@@ -91,7 +101,17 @@ ffi::Array<PrimExpr> CommReducerNode::operator()(ffi::Array<PrimExpr> a,
     value_map.Set(lhs[i], a[i]);
     value_map.Set(rhs[i], b[i]);
   }
-  return Substitute(this->result, value_map);
+  return this->result.Map([&value_map](const PrimExpr& expr) {
+    return ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+               expr,
+               [&value_map](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                 if (auto replacement = value_map.Get(var)) {
+                   return ffi::Any(replacement.value());
+                 }
+                 return ffi::Unchanged();
+               })
+        .cast<PrimExpr>();
+  });
 }
 
 TVM_FFI_STATIC_INIT_BLOCK() {

--- a/src/tirx/ir/index_map.cc
+++ b/src/tirx/ir/index_map.cc
@@ -25,6 +25,7 @@
 #include <tvm/arith/int_set.h>
 #include <tvm/arith/iter_affine_map.h>
 #include <tvm/ffi/cast.h>
+#include <tvm/ffi/extra/structural_mutate.h>
 #include <tvm/ffi/reflection/registry.h>
 #include <tvm/ir/unique_name_supply.h>
 #include <tvm/tirx/index_map.h>
@@ -133,7 +134,16 @@ std::pair<IndexMap, PrimExpr> IndexMapInverseImpl(const IndexMap& self,
 
   PrimExpr padding_predicate = padded_iter_map->padding_predicate;
   padding_predicate = arith::NormalizeIterMapToExpr(padding_predicate);
-  padding_predicate = Substitute(padding_predicate, inverse_exprs_map);
+  padding_predicate =
+      ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+          padding_predicate,
+          [&inverse_exprs_map](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+            if (auto replacement = inverse_exprs_map.Get(var)) {
+              return ffi::Any(replacement.value());
+            }
+            return ffi::Unchanged();
+          })
+          .cast<PrimExpr>();
 
   auto output_ranges = self->MapRanges(initial_ranges, analyzer_ref);
   {
@@ -393,10 +403,28 @@ IndexMap IndexMap::RenameVariables(
     }
   }
 
-  auto new_initial_indices = n->initial_indices.Map(
-      [&](const PrimVar& var) { return Substitute(var, var_remap).as_or_throw<PrimVar>(); });
-  auto new_final_indices =
-      n->final_indices.Map([&](const PrimExpr& expr) { return Substitute(expr, var_remap); });
+  auto new_initial_indices = n->initial_indices.Map([&](const PrimVar& var) {
+    return ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+               var,
+               [&var_remap](const Var& value) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                 if (auto replacement = var_remap.Get(value)) {
+                   return ffi::Any(replacement.value());
+                 }
+                 return ffi::Unchanged();
+               })
+        .cast<PrimVar>();
+  });
+  auto new_final_indices = n->final_indices.Map([&](const PrimExpr& expr) {
+    return ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+               expr,
+               [&var_remap](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                 if (auto replacement = var_remap.Get(var)) {
+                   return ffi::Any(replacement.value());
+                 }
+                 return ffi::Unchanged();
+               })
+        .cast<PrimExpr>();
+  });
   ffi::Optional<IndexMap> new_inverse_index_map = std::nullopt;
   if (n->inverse_index_map.has_value()) {
     new_inverse_index_map =
@@ -462,12 +490,17 @@ ffi::String IndexMapNode::ToPythonString(
 
 IndexMap Substitute(const IndexMap& index_map,
                     std::function<ffi::Optional<PrimExpr>(const Var& var)> f_subst) {
-  auto general_subst = [&](const Var& var) -> ffi::Optional<Expr> {
-    if (auto replacement = f_subst(var)) return replacement.value();
-    return std::nullopt;
-  };
-  ffi::Array<PrimExpr> new_output = index_map->final_indices.Map(
-      [&](const PrimExpr& expr) { return Substitute(expr, general_subst); });
+  ffi::Array<PrimExpr> new_output = index_map->final_indices.Map([&](const PrimExpr& expr) {
+    return ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+               expr,
+               [&f_subst](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+                 if (auto replacement = f_subst(var)) {
+                   return ffi::Any(replacement.value());
+                 }
+                 return ffi::Unchanged();
+               })
+        .cast<PrimExpr>();
+  });
   ffi::Optional<IndexMap> new_inverse_map = std::nullopt;
   if (index_map->inverse_index_map.has_value()) {
     new_inverse_map =

--- a/src/tirx/ir/lambdaexpr.cc
+++ b/src/tirx/ir/lambdaexpr.cc
@@ -22,7 +22,7 @@
  * \brief Implementation of LambdaExpr, a reified lambda used by tile primitive ops.
  */
 
-#include "tvm/tirx/stmt_functor.h"
+#include "tvm/ffi/extra/structural_mutate.h"
 #include "tvm/tirx/tile_primitive.h"
 
 namespace tvm {
@@ -39,7 +39,15 @@ PrimExpr LambdaExprNode::Apply(const ffi::Array<PrimExpr>& indices) const {
     vmap.Set(vars[i], indices[i]);
   }
 
-  return Substitute(std::move(pred), vmap);
+  return ffi::StructuralMap<ffi::WalkOrder::kPreOrder>(
+             std::move(pred),
+             [&vmap](const Var& var) -> ffi::Expected<ffi::UnchangedOr<ffi::Any>> {
+               if (auto replacement = vmap.Get(var)) {
+                 return ffi::Any(replacement.value());
+               }
+               return ffi::Unchanged();
+             })
+      .cast<PrimExpr>();
 }
 
 LambdaExpr::LambdaExpr(ffi::Array<Var> vars, PrimExpr pred) {


### PR DESCRIPTION
Replace the remaining TIR substitution adapters with direct `StructuralMap` calls and named local callbacks. Map callbacks return a lookup hit or `Unchanged`; single-variable replacements compare identities with `same_as`. Post-order traversal preserves replacements that contain their own lookup keys.

Buffer stores and tensor loads now refer to previously defined buffer identities. Tensor-memory address roundtrips preserve explicit aliases and use the normal expression printer for scalar and indexed loads.

This completes removal of `tirx::Substitute`, `IRSubstitute`, and the IndexMap adapter; the FFI global and Python wrapper have already been removed upstream.
