### PR TITLE
[Fix][TIRx] Reject int64 overflow in AllocBuffer allocation-size analysis

### DIFF
--- a/include/tvm/tirx/stmt.h
+++ b/include/tvm/tirx/stmt.h
@@ -31,6 +31,7 @@
 #include <tvm/tirx/exec_scope.h>
 #include <tvm/tirx/layout.h>
 
+#include <limits>
 #include <optional>
 #include <string>
 #include <type_traits>
@@ -289,16 +290,34 @@ class AllocBuffer : public Stmt {
       Span span = Span());
   /*!
    * \brief If the buffer's shape is constant, return the total number of elements.
-   * \return The product of all shape extents if all are constant, std::nullopt otherwise.
+   *
+   * The extents are multiplied together with an overflow check before each
+   * multiplication, so the result is never taken from a value that has already
+   * overflowed. Signed integer overflow is undefined behavior in C++, so the
+   * product must be range-checked before it is computed, not sanity-checked
+   * after the fact.
+   *
+   * \return The product of all shape extents if all are constant and the product
+   *         is representable in int64_t, std::nullopt otherwise (non-constant
+   *         extent, negative extent, or a product that would overflow).
    */
   std::optional<int64_t> ConstantAllocationSize() const {
     int64_t result = 1;
     for (const PrimExpr& extent : (*this)->buffer->shape) {
-      if (const auto* int_size = extent.as<IntImmNode>()) {
-        result *= int_size->value;
-      } else {
+      const auto* int_size = extent.as<IntImmNode>();
+      if (!int_size) {
         return std::nullopt;
       }
+      int64_t value = int_size->value;
+      if (value < 0) {
+        // A negative extent is never a valid allocation size.
+        return std::nullopt;
+      }
+      if (value != 0 && result > std::numeric_limits<int64_t>::max() / value) {
+        // result * value would overflow int64_t.
+        return std::nullopt;
+      }
+      result *= value;
     }
     return result;
   }

--- a/src/s_tir/analysis/calculate_allocated_memory.cc
+++ b/src/s_tir/analysis/calculate_allocated_memory.cc
@@ -32,8 +32,11 @@
 #include <tvm/tirx/transform.h>
 
 #include <algorithm>
+#include <limits>
 #include <map>
 #include <unordered_map>
+
+#include "../../arith/int_operator.h"
 
 namespace tvm {
 namespace s_tir {
@@ -68,17 +71,51 @@ class AllocBufferCalculator : public StmtExprVisitor {
       _current_size[storage_scope] = 0;
       _max_size[storage_scope] = 0;
     }
-    int64_t size = 1;
+
+    // Multiply the shape extents in the same overflow-checked way as
+    // AllocBuffer::ConstantAllocationSize() (include/tvm/tirx/stmt.h). This is kept
+    // as a separate loop, rather than calling ConstantAllocationSize() directly,
+    // because that function's std::optional<int64_t> cannot distinguish "shape has
+    // a non-constant extent" (size genuinely unknown here, contributes 0 bytes as
+    // before) from "shape is constant but the element count overflows" (below,
+    // rejected outright rather than silently treated as 0 bytes).
+    bool is_constant_shape = true;
+    int64_t num_elements = 1;
     for (const PrimExpr& e : op->buffer->shape) {
-      if (auto* imm = e.as<IntImmNode>()) {
-        size *= imm->value;
-      } else {
-        size = 0;
+      const auto* imm = e.as<IntImmNode>();
+      if (!imm) {
+        is_constant_shape = false;
         break;
       }
+      TVM_FFI_ICHECK_GE(imm->value, 0)
+          << "Buffer " << op->buffer.name() << " in scope \"" << storage_scope
+          << "\" has a negative shape extent (" << imm->value << "), which is not a valid "
+          << "allocation size";
+      TVM_FFI_ICHECK(!arith::WillOverflow<prim::MulNode>(num_elements, imm->value, 0,
+                                                         std::numeric_limits<int64_t>::max()))
+          << "Allocation shape of buffer " << op->buffer.name() << " in scope \"" << storage_scope
+          << "\" has an element count that overflows int64_t";
+      num_elements *= imm->value;
     }
-    size *= static_cast<int64_t>(op->buffer->dtype.StorageBytes());
-    _current_size[storage_scope] += size;
+
+    if (is_constant_shape) {
+      int64_t bytes_per_element = static_cast<int64_t>(op->buffer->dtype.StorageBytes());
+      TVM_FFI_ICHECK(!arith::WillOverflow<prim::MulNode>(num_elements, bytes_per_element, 0,
+                                                         std::numeric_limits<int64_t>::max()))
+          << "Allocation of buffer " << op->buffer.name() << " in scope \"" << storage_scope
+          << "\" (" << num_elements << " elements of " << bytes_per_element
+          << " bytes each) overflows int64_t when converted to a byte size";
+      int64_t size = num_elements * bytes_per_element;
+
+      TVM_FFI_ICHECK(!arith::WillOverflow<prim::AddNode>(_current_size[storage_scope], size, 0,
+                                                         std::numeric_limits<int64_t>::max()))
+          << "Accumulated allocation size for scope \"" << storage_scope
+          << "\" overflows int64_t after adding buffer " << op->buffer.name();
+      _current_size[storage_scope] += size;
+    }
+    // Else: the shape has a non-constant extent, so its byte size cannot be
+    // determined here; it contributes 0 to _current_size, as before this fix.
+
     _max_size[storage_scope] = std::max(_current_size[storage_scope], _max_size[storage_scope]);
     StmtExprVisitor::VisitStmt_(op);
   }

--- a/tests/python/s_tir/analysis/test_s_tir_analysis_calculate_allocated_memory.py
+++ b/tests/python/s_tir/analysis/test_s_tir_analysis_calculate_allocated_memory.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=missing-module-docstring,missing-function-docstring,missing-class-docstring
-# ruff: noqa: F401
 import pytest
 
 import tvm

--- a/tests/python/s_tir/analysis/test_s_tir_analysis_calculate_allocated_memory.py
+++ b/tests/python/s_tir/analysis/test_s_tir_analysis_calculate_allocated_memory.py
@@ -137,5 +137,37 @@ def test_full_mod_calculator():
     assert scale_by_two_three_sizes["global.vtcm"] == 256, "Expected the calculated size to be 256"
 
 
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (2**62, 4),
+        (2**62, 5),
+        (2**32, 2**32),
+    ],
+)
+def test_constant_allocation_size_overflow_is_rejected(shape):
+    """A constant AllocBuffer shape whose element count overflows int64_t must be
+    rejected rather than silently wrapped. See https://github.com/apache/tvm/issues/20268:
+    before this fix, calculate_allocated_bytes() returned a wrapped (and sometimes
+    negative or zero) byte count computed via undefined-behavior signed overflow.
+    """
+    buf = tirx.decl_buffer(shape, dtype="int8", scope="global.vtcm")
+    func = tirx.PrimFunc([], tirx.AllocBuffer(buf))
+    with pytest.raises(tvm.error.InternalError):
+        tvm.s_tir.analysis.calculate_allocated_bytes(func)
+
+
+def test_constant_allocation_size_large_but_valid():
+    """A large allocation whose byte size is still representable in int64_t must
+    continue to be calculated correctly and must not be rejected by the overflow
+    check added for #20268.
+    """
+    shape = (2**20, 2**10)  # 2**30 elements, well within int64_t as int8 bytes
+    buf = tirx.decl_buffer(shape, dtype="int8", scope="global.vtcm")
+    func = tirx.PrimFunc([], tirx.AllocBuffer(buf))
+    sizes = tvm.s_tir.analysis.calculate_allocated_bytes(func)
+    assert sizes["main"]["global.vtcm"] == 2**30
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
Fixes #20268.

## The bug

`AllocBuffer::ConstantAllocationSize()` (`include/tvm/tirx/stmt.h`, the
`ConstantAllocationSize()` member) multiplies constant shape extents together
in `int64_t` with no overflow check. When the product exceeds `INT64_MAX` the
multiplication wraps, which is signed integer overflow, undefined behavior in
C++, not merely a wrong number. `AllocBufferCalculator::VisitStmt_()` in
`src/s_tir/analysis/calculate_allocated_memory.cc` repeated the same unchecked
shape multiplication and then did an unchecked byte-size multiply and add, so
a wrapped (and sometimes negative or zero) result could reach the two
`CalculateAllocatedBytes()` overloads and, through them, `VerifyVTCMLimit()`.

I confirmed this still matches current `main` before fixing it. Current line
numbers: `ConstantAllocationSize()` at `include/tvm/tirx/stmt.h` L294-304,
`VisitStmt_()` at `src/s_tir/analysis/calculate_allocated_memory.cc` L64-84,
the two `CalculateAllocatedBytes()` overloads at L104-123 of the same file
(the reporter's line numbers, pinned to `v0.25.0.post1`, have drifted slightly
on `main` but the code is unchanged in substance).

## Why `std::nullopt`, not a post-hoc check

`ConstantAllocationSize()` already returns `std::optional<int64_t>`, so the
API already has a way to say "unknown." Overflow should produce
`std::nullopt`, not a value obtained by computing something the C++ standard
says is never validly obtained. That means the multiplication has to be
range-checked *before* each multiply, not sanity-checked on the result
afterward, since by the time you have a wrapped result the behavior that
produced it was already undefined. The fix does a division-based bounds
check (`result > INT64_MAX / value`) ahead of each `result *= value`, and
also rejects a negative extent the same way, since a negative extent is
never a valid allocation size either.

## The two call sites

`AllocBufferCalculator::VisitStmt_()` keeps its own loop rather than calling
`ConstantAllocationSize()` directly. That function's `std::optional` cannot
distinguish "this extent is not a compile-time constant" (size genuinely
unknown at this point; the calculator has always treated that as contributing
0 bytes, and this PR does not change that) from "the shape is fully constant
but the element count overflows" (the actual bug: silently treating that as 0
bytes would just move the danger from "wraps to a wrong number" to "silently
reports the worst possible wrong number for a safety check", since
`VerifyVTCMLimit()` treats 0 bytes as trivially within any limit). So the
overflow case is now rejected outright via `TVM_FFI_ICHECK`, and the
non-constant-shape case is unchanged.

The byte-size multiply (element count × bytes per element) and the
accumulation add (`_current_size[storage_scope] += size`, called out in the
issue as also unchecked) are both now guarded the same way, using
`tvm::arith::WillOverflow<prim::MulNode>` / `WillOverflow<prim::AddNode>`
from `src/arith/int_operator.h`. This is the codebase's own existing
overflow-check primitive (used in `src/arith/const_int_bound.cc`, and already
reachable from `src/tirx` via the same relative include in
`src/tirx/transform/storage_rewrite.cc`), so this PR reuses it rather than
inventing a new mechanism. `include/tvm/tirx/stmt.h` is a public header, so
its fix does not reach into that private `src/arith` header; it does its own
self-contained division-based check instead, matching the same logic.

Because every value that reaches `_current_size` / `_max_size` is now
rejected via `TVM_FFI_ICHECK` before it is ever computed, a negative or
wrapped value can no longer survive the `std::max(_current_size[...],
_max_size[...])` against the zero-initialized `_max_size` map entry.

## Distinct from #20125

#20125 is a separate bug: an `int64_t`-to-`int32_t` narrowing truncation in
the LLVM codegen backend (`CodeGenLLVM::VisitStmt_(const AllocBufferNode*)`
and its NVPTX/AMDGPU overrides), which happens after codegen has already
taken over. This PR is about TIR analysis and allocation planning before
codegen: `ConstantAllocationSize()` and `CalculateAllocatedBytes()`. Fixing
one does not fix the other; both are real.

## Verification

I could not build TVM in this environment (LLVM toolchain, full CMake
configure and build were not feasible here), so I did not run `pytest` or
the C++ test suite against a built `libtvm`. What I did verify:

- Both changed files pass `clang++ -std=c++20 -fsyntax-only` against the
  real headers (`include/`, `src/`, the `tvm-ffi` and `dlpack` submodules
  checked out locally), which caught and let me fix a real compile error
  (`op->buffer->var` does not exist on `BufferVar`; the diagnostic name is
  `op->buffer.name()`).
- Both files pass `clang-format --style=file` with zero replacements.
- I extracted the exact overflow-checked multiplication logic now in
  `stmt.h`, and the exact `tvm::arith::WillOverflow` logic now used in
  `calculate_allocated_memory.cc`, into small standalone C++ programs
  compiled with `-fsanitize=undefined,signed-integer-overflow
  -fno-sanitize-recover=all`, and ran them against the reporter's three
  cases plus valid large and small allocations:
  - The unfixed logic reproduces the reporter's exact reported values
    (`(2**62,4)` -> `0`, `(2**62,5)` -> `4611686018427387904`,
    `(2**32,2**32)` -> `0`) and UBSan aborts on it with "signed integer
    overflow ... cannot be represented in type 'int64_t'" at the
    multiplication, confirming this is genuine UB and not just a surprising
    number.
  - The fixed logic rejects all three cases (`nullopt` / rejected) with zero
    UB under UBSan, while still correctly computing valid allocations
    (`1024x1024x1024` float32 -> `1073741824`, `16x16` int8 -> `256`), and
    correctly rejects an accumulation that overflows on the *second*
    allocation into the same scope even when neither allocation alone
    would.
- I added Python tests to
  `tests/python/s_tir/analysis/test_s_tir_analysis_calculate_allocated_memory.py`,
  following that file's existing style, covering the reporter's three cases
  (expecting `tvm.error.InternalError`, matching how this codebase's other
  `TVM_FFI_ICHECK` failures surface in Python, e.g.
  `tests/python/s_tir/transform/test_s_tir_transform_canonicalize_loop.py`)
  and a large-but-valid allocation (`2**20 x 2**10` int8, expecting `2**30`
  bytes) so the fix does not over-reject. I could not run these against a
  built TVM; I'm reporting that plainly rather than claiming a test run I
  did not perform.

No PR template file was found in this repository (`.github/` has no
`PULL_REQUEST_TEMPLATE.md`, and none exists elsewhere in the tree).