### PR TITLE
[REFACTOR][IR] Rename the uniform dispatch table to ObjectFunctor

### DIFF
--- a/include/tvm/ir/object_functor.h
+++ b/include/tvm/ir/object_functor.h
@@ -17,11 +17,11 @@
  * under the License.
  */
 /*!
- * \file tvm/ir/node_functor.h
+ * \file tvm/ir/object_functor.h
  * \brief Defines the Functor data structures.
  */
-#ifndef TVM_IR_NODE_FUNCTOR_H_
-#define TVM_IR_NODE_FUNCTOR_H_
+#ifndef TVM_IR_OBJECT_FUNCTOR_H_
+#define TVM_IR_OBJECT_FUNCTOR_H_
 
 #include <tvm/ffi/error.h>
 
@@ -35,53 +35,62 @@ namespace tvm {
 /*!
  * \brief A dynamically dispatched functor on the type of the first argument.
  *
- * This is a class that is useful to construct polymorphic dispatching
- * base on the AST/IR node's type.
+ * Dispatch is based on the runtime type of the first object argument.
  *
  * \code
- *   NodeFunctor<std::string (const ffi::ObjectRef& n, std::string prefix)> tostr;
- *   tostr.set_dispatch<Add>([](const ffi::ObjectRef& op, std::string prefix) {
+ *   ObjectFunctor<std::string(const ffi::ObjectRef& n, std::string prefix)> tostr;
+ *   tostr.SetDispatch<prim::AddNode>([](const ffi::ObjectRef& op, std::string prefix) {
  *     return prefix + "Add";
  *   });
- *   tostr.set_dispatch<IntImm>([](const ffi::ObjectRef& op, std::string prefix) {
- *     return prefix + "IntImm"
+ *   tostr.SetDispatch<IntImmNode>([](const ffi::ObjectRef& op, std::string prefix) {
+ *     return prefix + "IntImm";
  *   });
  *
- *   Expr x = MakeConst(1);
- *   Expr y = x + x;
+ *   tirx::PrimVar x("x");
+ *   PrimExpr y = x + 1;
  *   // dispatch to IntImm, outputs "MyIntImm"
- *   LOG(INFO) << tostr(x, "My");
- *   // dispatch to IntImm, outputs "MyAdd"
+ *   LOG(INFO) << tostr(IntImm::Int32(1), "My");
+ *   // dispatch to Add, outputs "MyAdd"
  *   LOG(INFO) << tostr(y, "My");
  * \endcode
  *
- * \tparam FType function signiture
- *  This type if only defined for FType with function signature
+ * A shared table can register dispatch functions during static initialization:
+ *
+ * \code
+ *   class Printer {
+ *    public:
+ *     using FType = ObjectFunctor<std::string(const ffi::ObjectRef&)>;
+ *     static FType& vtable();
+ *   };
+ *
+ *   Printer::FType& Printer::vtable() {
+ *     static FType inst;
+ *     return inst;
+ *   }
+ *
+ *   TVM_FFI_STATIC_INIT_BLOCK() {
+ *     Printer::vtable()
+ *         .SetDispatch<prim::AddNode>([](const ffi::ObjectRef&) { return std::string("Add"); })
+ *         .SetDispatch<IntImmNode>([](const ffi::ObjectRef&) { return std::string("IntImm"); });
+ *   }
+ * \endcode
+ *
+ * \tparam FType Function signature, with const ffi::ObjectRef& as its first argument.
  */
 template <typename FType>
-class NodeFunctor;
+class ObjectFunctor;
 
 template <typename R, typename... Args>
-class NodeFunctor<R(const ffi::ObjectRef& n, Args...)> {
- private:
-  /*! \brief internal function pointer type */
-  typedef R (*FPointer)(const ffi::ObjectRef& n, Args...);
-  /*! \brief refer to itself. */
-  using TSelf = NodeFunctor<R(const ffi::ObjectRef& n, Args...)>;
-  /*! \brief internal function table */
-  std::vector<FPointer> func_;
-  /*! \brief start range of func index */
-  uint32_t begin_type_index_{0};
-
+class ObjectFunctor<R(const ffi::ObjectRef& n, Args...)> {
  public:
   /*! \brief the result type of this functor */
   using result_type = R;
   /*!
-   * \brief Whether the functor can dispatch the corresponding Node
-   * \param n The node to be dispatched
-   * \return Whether dispatching function is registered for n's type.
+   * \brief Whether a dispatch function is registered for the exact runtime type.
+   * \param n The object to be dispatched.
+   * \return Whether a dispatch function is registered for n's type, excluding ancestors.
    */
-  bool can_dispatch(const ffi::ObjectRef& n) const {
+  bool CanDispatch(const ffi::ObjectRef& n) const {
     uint32_t type_index = n->type_index();
     if (type_index < begin_type_index_) return false;
     type_index -= begin_type_index_;
@@ -89,7 +98,7 @@ class NodeFunctor<R(const ffi::ObjectRef& n, Args...)> {
   }
   /*!
    * \brief invoke the functor, dispatch on type of n
-   * \param n The Node argument
+   * \param n The object argument
    * \param args The additional arguments
    * \return The result.
    */
@@ -112,7 +121,7 @@ class NodeFunctor<R(const ffi::ObjectRef& n, Args...)> {
         }
       }
     }
-    TVM_FFI_THROW(InternalError) << "NodeFunctor calls un-registered function on type "
+    TVM_FFI_THROW(InternalError) << "ObjectFunctor calls un-registered function on type "
                                  << n->GetTypeKey();
     throw;
   }
@@ -123,14 +132,14 @@ class NodeFunctor<R(const ffi::ObjectRef& n, Args...)> {
    * \return reference to self.
    */
   template <typename TNode>
-  TSelf& set_dispatch(FPointer f) {  // NOLINT(*)
+  ObjectFunctor& SetDispatch(R (*f)(const ffi::ObjectRef& n, Args...)) {
     uint32_t tindex = TNode::RuntimeTypeIndex();
     if (func_.size() <= tindex) {
       func_.resize(tindex + 1, nullptr);
     }
     TVM_FFI_ICHECK(func_[tindex] == nullptr)
         << "Dispatch for " << TNode::_type_key << " is already set";
-    TVM_FFI_ICHECK_EQ(begin_type_index_, 0) << " Cannot call set_dispatch after calling Finalize";
+    TVM_FFI_ICHECK_EQ(begin_type_index_, 0) << " Cannot call SetDispatch after calling Finalize";
     func_[tindex] = f;
     return *this;
   }
@@ -141,15 +150,15 @@ class NodeFunctor<R(const ffi::ObjectRef& n, Args...)> {
    * \return reference to self.
    */
   template <typename TNode>
-  TSelf& clear_dispatch() {  // NOLINT(*)
+  ObjectFunctor& ClearDispatch() {
     uint32_t tindex = TNode::RuntimeTypeIndex();
-    TVM_FFI_ICHECK_LT(tindex, func_.size()) << "clear_dispatch: index out of range";
-    TVM_FFI_ICHECK_EQ(begin_type_index_, 0) << " Cannot call clear_dispatch after calling Finalize";
+    TVM_FFI_ICHECK_LT(tindex, func_.size()) << "ClearDispatch: index out of range";
+    TVM_FFI_ICHECK_EQ(begin_type_index_, 0) << " Cannot call ClearDispatch after calling Finalize";
     func_[tindex] = nullptr;
     return *this;
   }
   /*!
-   * \brief Finalize the functor after calling sequence of set_dispatch
+   * \brief Finalize the functor after calling sequence of SetDispatch
    * This function will attempt to find the min type index that is not null
    * and optimize the space of the func table so it is more compact
    */
@@ -167,46 +176,15 @@ class NodeFunctor<R(const ffi::ObjectRef& n, Args...)> {
     func_.resize(new_ftable_size);
     func_.shrink_to_fit();
   }
+
+ private:
+  /*! \brief internal function pointer type */
+  using FPointer = R (*)(const ffi::ObjectRef& n, Args...);
+  /*! \brief internal function table */
+  std::vector<FPointer> func_;
+  /*! \brief start range of func index */
+  uint32_t begin_type_index_{0};
 };
 
-#define TVM_REG_FUNC_VAR_DEF(ClsName) [[maybe_unused]] static auto& __make_functor##_##ClsName
-
-/*!
- * \brief Useful macro to set NodeFunctor dispatch in a global static field.
- *
- * \code
- *  // Use NodeFunctor to implement TVMScriptPrinter similar to Visitor Pattern.
- *  // vtable allows easy patch of new Node types, without changing
- *  // the interface of TVMScriptPrinter.
- *
- *  class TVMScriptPrinter {
- *   public:
- *    // the dispatch function.
- *    static std::string Script(const ffi::ObjectRef& node, const PrinterConfig& cfg) {
- *      return vtable()(node, cfg);
- *    }
- *    using FType = NodeFunctor<std::string(const ffi::ObjectRef&, const PrinterConfig&)>;
- *    // function to return global function table
- *    static FType& vtable();
- *  };
- *
- *  // in cpp/cc file
- *  TVMScriptPrinter::FType& TVMScriptPrinter::vtable() {
- *    static FType inst; return inst;
- *  }
- *
- *  TVM_STATIC_IR_FUNCTOR(TVMScriptPrinter, vtable)
- *  .set_dispatch<AddNode>([](const ffi::ObjectRef& ref, const PrinterConfig& cfg) {
- *    auto* n = static_cast<const AddNode*>(ref.get());
- *    return Script(n->a, cfg) + " + " + Script(n->b, cfg);
- *  });
- *
- * \endcode
- *
- * \param ClsName The name of the class
- * \param FField The static function that returns a singleton of NodeFunctor.
- */
-#define TVM_STATIC_IR_FUNCTOR(ClsName, FField) \
-  TVM_FFI_STR_CONCAT(TVM_REG_FUNC_VAR_DEF(ClsName), __COUNTER__) = ClsName::FField()
 }  // namespace tvm
-#endif  // TVM_IR_NODE_FUNCTOR_H_
+#endif  // TVM_IR_OBJECT_FUNCTOR_H_

--- a/include/tvm/ir/prim/expr.h
+++ b/include/tvm/ir/prim/expr.h
@@ -32,7 +32,7 @@
 #include <tvm/ir/attrs.h>
 #include <tvm/ir/cow.h>
 #include <tvm/ir/expr.h>
-#include <tvm/ir/node_functor.h>
+#include <tvm/ir/object_functor.h>
 #include <tvm/ir/prim/vector_expr.h>
 #include <tvm/runtime/base.h>
 

--- a/include/tvm/relax/dataflow_pattern_functor.h
+++ b/include/tvm/relax/dataflow_pattern_functor.h
@@ -49,7 +49,7 @@ class DFPatternFunctor;
   }
 
 #define RELAX_DFPATTERN_FUNCTOR_DISPATCH(OP)                                                    \
-  vtable.template set_dispatch<OP>([](const ffi::ObjectRef& n, TSelf* self, Args... args) {     \
+  vtable.template SetDispatch<OP>([](const ffi::ObjectRef& n, TSelf* self, Args... args) {      \
     return self->VisitDFPattern_(static_cast<const OP*>(n.get()), std::forward<Args>(args)...); \
   });
 
@@ -57,7 +57,7 @@ template <typename R, typename... Args>
 class DFPatternFunctor<R(const DFPattern& n, Args...)> {
  private:
   using TSelf = DFPatternFunctor<R(const DFPattern& n, Args...)>;
-  using FType = tvm::NodeFunctor<R(const ffi::ObjectRef& n, TSelf* self, Args...)>;
+  using FType = tvm::ObjectFunctor<R(const ffi::ObjectRef& n, TSelf* self, Args...)>;
 
  public:
   /*! \brief virtual destructor */

--- a/include/tvm/relax/expr_functor.h
+++ b/include/tvm/relax/expr_functor.h
@@ -25,7 +25,7 @@
 #ifndef TVM_RELAX_EXPR_FUNCTOR_H_
 #define TVM_RELAX_EXPR_FUNCTOR_H_
 
-#include <tvm/ir/node_functor.h>
+#include <tvm/ir/object_functor.h>
 #include <tvm/relax/block_builder.h>
 #include <tvm/relax/expr.h>
 #include <tvm/relax/type.h>
@@ -63,9 +63,9 @@ class ExprFunctor;
     throw;                                                                                       \
   }
 
-#define RELAX_EXPR_FUNCTOR_DISPATCH(OP)                                                     \
-  vtable.template set_dispatch<OP>([](const ffi::ObjectRef& n, TSelf* self, Args... args) { \
-    return self->VisitExpr_(static_cast<const OP*>(n.get()), std::forward<Args>(args)...);  \
+#define RELAX_EXPR_FUNCTOR_DISPATCH(OP)                                                    \
+  vtable.template SetDispatch<OP>([](const ffi::ObjectRef& n, TSelf* self, Args... args) { \
+    return self->VisitExpr_(static_cast<const OP*>(n.get()), std::forward<Args>(args)...); \
   });
 
 #define PY_EXPR_VISITOR_DEFAULT(N, PY_FUNC, DEFAULT_FUNC) \
@@ -86,34 +86,34 @@ class ExprFunctor;
     }                                                               \
   }
 
-#define PY_EXPR_VISITOR_DISPATCH(OP, PY_FUNC)                                 \
-  vtable.template set_dispatch<OP>([](const ffi::ObjectRef& n, TSelf* self) { \
-    if (self->PY_FUNC != nullptr)                                             \
-      self->PY_FUNC(n);                                                       \
-    else                                                                      \
-      self->VisitExpr_(static_cast<const OP*>(n.get()));                      \
+#define PY_EXPR_VISITOR_DISPATCH(OP, PY_FUNC)                                \
+  vtable.template SetDispatch<OP>([](const ffi::ObjectRef& n, TSelf* self) { \
+    if (self->PY_FUNC != nullptr)                                            \
+      self->PY_FUNC(n);                                                      \
+    else                                                                     \
+      self->VisitExpr_(static_cast<const OP*>(n.get()));                     \
   });
 
-#define PY_EXPR_MUTATOR_DISPATCH(OP, PY_FUNC)                                 \
-  vtable.template set_dispatch<OP>([](const ffi::ObjectRef& n, TSelf* self) { \
-    if (self->PY_FUNC != nullptr) {                                           \
-      Expr expr = self->PY_FUNC(n).cast<Expr>();                              \
-      return expr;                                                            \
-    } else {                                                                  \
-      return self->VisitExpr_(static_cast<const OP*>(n.get()));               \
-    }                                                                         \
+#define PY_EXPR_MUTATOR_DISPATCH(OP, PY_FUNC)                                \
+  vtable.template SetDispatch<OP>([](const ffi::ObjectRef& n, TSelf* self) { \
+    if (self->PY_FUNC != nullptr) {                                          \
+      Expr expr = self->PY_FUNC(n).cast<Expr>();                             \
+      return expr;                                                           \
+    } else {                                                                 \
+      return self->VisitExpr_(static_cast<const OP*>(n.get()));              \
+    }                                                                        \
   });
 
-#define PY_EXPR_MUTATOR_VISIT_EXPR_POST_ORDER_DISPATCH(OP)                               \
-  post_order_vtable.template set_dispatch<OP>([](const ffi::ObjectRef& n, TSelf* self) { \
-    return self->VisitExprPostOrder_(static_cast<const OP*>(n.get()));                   \
+#define PY_EXPR_MUTATOR_VISIT_EXPR_POST_ORDER_DISPATCH(OP)                              \
+  post_order_vtable.template SetDispatch<OP>([](const ffi::ObjectRef& n, TSelf* self) { \
+    return self->VisitExprPostOrder_(static_cast<const OP*>(n.get()));                  \
   });
 
 template <typename R, typename... Args>
 class ExprFunctor<R(const Expr& n, Args...)> {
  private:
   using TSelf = ExprFunctor<R(const Expr& n, Args...)>;
-  using FType = tvm::NodeFunctor<R(const ffi::ObjectRef& n, TSelf* self, Args...)>;
+  using FType = tvm::ObjectFunctor<R(const ffi::ObjectRef& n, TSelf* self, Args...)>;
 
  public:
   /*! \brief the result type of this functor */
@@ -138,7 +138,7 @@ class ExprFunctor<R(const Expr& n, Args...)> {
         << "Found null pointer node while traversing AST. The previous pass may "
            "have generated invalid data.";
     static FType vtable = InitVTable();
-    if (vtable.can_dispatch(n)) {
+    if (vtable.CanDispatch(n)) {
       return vtable(n, this, std::forward<Args>(args)...);
     }
     return VisitExprFallback_(n.get(), std::forward<Args>(args)...);
@@ -372,8 +372,8 @@ class ExprVisitor : public ExprFunctor<void(const Expr&)> {
 
  private:
   using TSelf = ExprVisitor;
-  using VisitBindingVTable = tvm::NodeFunctor<void(const ffi::ObjectRef& n, ExprVisitor* self,
-                                                   const VarBindingNode* binding)>;
+  using VisitBindingVTable = tvm::ObjectFunctor<void(const ffi::ObjectRef& n, ExprVisitor* self,
+                                                     const VarBindingNode* binding)>;
   // initialize the vtable.
   static VisitBindingVTable InitVisitBindingVTable();
   /*!
@@ -682,8 +682,8 @@ class ExprMutator : public ExprMutatorBase {
 
  private:
   using TSelf = ExprMutator;
-  using VisitBindingVTable = tvm::NodeFunctor<void(const ffi::ObjectRef& n, ExprMutator* self,
-                                                   const VarBindingNode* binding)>;
+  using VisitBindingVTable = tvm::ObjectFunctor<void(const ffi::ObjectRef& n, ExprMutator* self,
+                                                     const VarBindingNode* binding)>;
   // initialize the vtable.
   static VisitBindingVTable InitVisitBindingVTable();
 };

--- a/include/tvm/relax/type_functor.h
+++ b/include/tvm/relax/type_functor.h
@@ -24,7 +24,7 @@
 #ifndef TVM_RELAX_TYPE_FUNCTOR_H_
 #define TVM_RELAX_TYPE_FUNCTOR_H_
 
-#include <tvm/ir/node_functor.h>
+#include <tvm/ir/object_functor.h>
 #include <tvm/relax/distributed/type.h>
 #include <tvm/relax/type.h>
 
@@ -42,16 +42,16 @@ class TypeFunctor;
     return VisitTypeDefault_(op, std::forward<Args>(args)...); \
   }
 
-#define TVM_RELAX_TYPE_FUNCTOR_DISPATCH(OP)                                                 \
-  vtable.template set_dispatch<OP>([](const ffi::ObjectRef& n, TSelf* self, Args... args) { \
-    return self->VisitType_(static_cast<const OP*>(n.get()), std::forward<Args>(args)...);  \
+#define TVM_RELAX_TYPE_FUNCTOR_DISPATCH(OP)                                                \
+  vtable.template SetDispatch<OP>([](const ffi::ObjectRef& n, TSelf* self, Args... args) { \
+    return self->VisitType_(static_cast<const OP*>(n.get()), std::forward<Args>(args)...); \
   });
 
 template <typename R, typename... Args>
 class TypeFunctor<R(const Type& n, Args...)> {
  private:
   using TSelf = TypeFunctor<R(const Type& n, Args...)>;
-  using FType = tvm::NodeFunctor<R(const ffi::ObjectRef& n, TSelf* self, Args...)>;
+  using FType = tvm::ObjectFunctor<R(const ffi::ObjectRef& n, TSelf* self, Args...)>;
 
  public:
   /*! \brief the result type of this functor */

--- a/include/tvm/script/ir_builder/base.h
+++ b/include/tvm/script/ir_builder/base.h
@@ -22,7 +22,7 @@
 #include <tvm/ffi/reflection/registry.h>
 #include <tvm/ir/expr.h>
 #include <tvm/ir/function.h>
-#include <tvm/ir/node_functor.h>
+#include <tvm/ir/object_functor.h>
 
 #include <vector>
 
@@ -269,7 +269,7 @@ namespace details {
 
 class Namer {
  public:
-  using FType = NodeFunctor<void(const ffi::ObjectRef&, ffi::String)>;
+  using FType = ObjectFunctor<void(const ffi::ObjectRef&, ffi::String)>;
   static FType& vtable();
   static void Name(ffi::ObjectRef node, ffi::String name);
 };

--- a/include/tvm/script/printer/printer.h
+++ b/include/tvm/script/printer/printer.h
@@ -28,7 +28,7 @@
 #ifndef TVM_SCRIPT_PRINTER_PRINTER_H_
 #define TVM_SCRIPT_PRINTER_PRINTER_H_
 
-#include <tvm/ir/node_functor.h>
+#include <tvm/ir/object_functor.h>
 #include <tvm/script/printer/config.h>
 
 namespace tvm {
@@ -46,7 +46,7 @@ TVM_DLL std::string Script(const ffi::ObjectRef& node,
  */
 class TVMScriptPrinter {
  public:
-  using FType = NodeFunctor<std::string(const ffi::ObjectRef&, const PrinterConfig&)>;
+  using FType = ObjectFunctor<std::string(const ffi::ObjectRef&, const PrinterConfig&)>;
   TVM_DLL static FType& vtable();
 };
 
@@ -64,8 +64,8 @@ class TVMScriptPrinter {
                                         [](ffi::ObjectRef obj, ffi::Function) -> ffi::String { \
                                           return RedirectedReprPrinterMethod(obj);             \
                                         });                                                    \
-  }                                                                                            \
-  TVM_STATIC_IR_FUNCTOR(TVMScriptPrinter, vtable).set_dispatch<ObjectType>(Method)
+    TVMScriptPrinter::vtable().SetDispatch<ObjectType>(Method);                                \
+  }
 
 }  // namespace tvm
 #endif  // TVM_SCRIPT_PRINTER_PRINTER_H_

--- a/include/tvm/tirx/expr_functor.h
+++ b/include/tvm/tirx/expr_functor.h
@@ -25,7 +25,7 @@
 #ifndef TVM_TIR_EXPR_FUNCTOR_H_
 #define TVM_TIR_EXPR_FUNCTOR_H_
 
-#include <tvm/ir/node_functor.h>
+#include <tvm/ir/object_functor.h>
 #include <tvm/ir/prim/expr.h>
 #include <tvm/tirx/buffer_region.h>
 
@@ -81,16 +81,16 @@ class ExprFunctor;
     return VisitExprDefault_(op, std::forward<Args>(args)...); \
   }
 
-#define IR_EXPR_FUNCTOR_DISPATCH(OP)                                                        \
-  vtable.template set_dispatch<OP>([](const ffi::ObjectRef& n, TSelf* self, Args... args) { \
-    return self->VisitExpr_(static_cast<const OP*>(n.get()), std::forward<Args>(args)...);  \
+#define IR_EXPR_FUNCTOR_DISPATCH(OP)                                                       \
+  vtable.template SetDispatch<OP>([](const ffi::ObjectRef& n, TSelf* self, Args... args) { \
+    return self->VisitExpr_(static_cast<const OP*>(n.get()), std::forward<Args>(args)...); \
   });
 
 template <typename R, typename... Args>
 class ExprFunctor<R(const Expr& n, Args...)> {
  private:
   using TSelf = ExprFunctor<R(const Expr& n, Args...)>;
-  using FType = NodeFunctor<R(const ffi::ObjectRef& n, TSelf* self, Args...)>;
+  using FType = ObjectFunctor<R(const ffi::ObjectRef& n, TSelf* self, Args...)>;
 
  public:
   /*! \brief the result type of this functor */

--- a/include/tvm/tirx/stmt_functor.h
+++ b/include/tvm/tirx/stmt_functor.h
@@ -26,7 +26,7 @@
 #ifndef TVM_TIRX_STMT_FUNCTOR_H_
 #define TVM_TIRX_STMT_FUNCTOR_H_
 
-#include <tvm/ir/node_functor.h>
+#include <tvm/ir/object_functor.h>
 #include <tvm/ir/prim/expr.h>
 #include <tvm/tirx/expr_functor.h>
 #include <tvm/tirx/function.h>
@@ -51,16 +51,16 @@ class StmtFunctor;
     return VisitStmtDefault_(op, std::forward<Args>(args)...); \
   }
 
-#define IR_STMT_FUNCTOR_DISPATCH(OP)                                                        \
-  vtable.template set_dispatch<OP>([](const ffi::ObjectRef& n, TSelf* self, Args... args) { \
-    return self->VisitStmt_(static_cast<const OP*>(n.get()), std::forward<Args>(args)...);  \
+#define IR_STMT_FUNCTOR_DISPATCH(OP)                                                       \
+  vtable.template SetDispatch<OP>([](const ffi::ObjectRef& n, TSelf* self, Args... args) { \
+    return self->VisitStmt_(static_cast<const OP*>(n.get()), std::forward<Args>(args)...); \
   });
 
 template <typename R, typename... Args>
 class StmtFunctor<R(const Stmt& n, Args... args)> {
  private:
   using TSelf = StmtFunctor<R(const Stmt& n, Args... args)>;
-  using FType = NodeFunctor<R(const ffi::ObjectRef& n, TSelf* self, Args... args)>;
+  using FType = ObjectFunctor<R(const ffi::ObjectRef& n, TSelf* self, Args... args)>;
 
  public:
   /*! \brief the result type of this functor */

--- a/src/relax/ir/expr_functor.cc
+++ b/src/relax/ir/expr_functor.cc
@@ -33,7 +33,7 @@
 
 // functions to be overriden.
 #define RELAX_VISIT_BINDING_DISPATCH(OP)                                        \
-  vtable.template set_dispatch<OP>(                                             \
+  vtable.template SetDispatch<OP>(                                              \
       [](const ffi::ObjectRef& n, TSelf* self, const VarBindingNode* binding) { \
         self->VisitBinding_(binding, static_cast<const OP*>(n.get()));          \
       });
@@ -62,7 +62,7 @@
     static VisitBindingVTable vtable = InitVisitBindingVTable();                        \
     const Expr& value = binding->value;                                                 \
     TVM_FFI_ICHECK(value.defined()) << "Found null pointer node while traversing AST."; \
-    if (vtable.can_dispatch(value)) {                                                   \
+    if (vtable.CanDispatch(value)) {                                                    \
       vtable(value, this, binding);                                                     \
     } else {                                                                            \
       VisitBinding_(binding, value.get());                                              \

--- a/src/relax/ir/py_expr_functor.cc
+++ b/src/relax/ir/py_expr_functor.cc
@@ -34,7 +34,7 @@ namespace relax {
 class PyExprVisitorNode : public ffi::Object, public ExprVisitor {
  private:
   using TSelf = PyExprVisitorNode;
-  using FType = tvm::NodeFunctor<void(const ffi::ObjectRef& n, TSelf* self)>;
+  using FType = tvm::ObjectFunctor<void(const ffi::ObjectRef& n, TSelf* self)>;
 
  public:
   /*! \brief The packed function to the `VisitExpr(const Expr& expr)` function. */
@@ -103,7 +103,7 @@ class PyExprVisitorNode : public ffi::Object, public ExprVisitor {
     } else {
       // Need to init the overwrite VTable
       static FType vtable = InitVTable();
-      if (vtable.can_dispatch(expr)) {
+      if (vtable.CanDispatch(expr)) {
         vtable(expr, this);
       } else {
         ExprVisitor::VisitExpr(expr);
@@ -279,7 +279,7 @@ class PyExprVisitor : public ffi::ObjectRef {
 class PyExprMutatorNode : public ffi::Object, public ExprMutator {
  private:
   using TSelf = PyExprMutatorNode;
-  using FType = tvm::NodeFunctor<Expr(const ffi::ObjectRef& n, TSelf* self)>;
+  using FType = tvm::ObjectFunctor<Expr(const ffi::ObjectRef& n, TSelf* self)>;
 
  public:
   /*! \brief The packed function to the `VisitExpr(const Expr& expr)` function. */
@@ -347,7 +347,7 @@ class PyExprMutatorNode : public ffi::Object, public ExprMutator {
       return builder_->Normalize(f_visit_expr(expr).cast<Expr>());
     } else {
       static FType vtable = InitVTable();
-      if (vtable.can_dispatch(expr)) {
+      if (vtable.CanDispatch(expr)) {
         return builder_->Normalize(vtable(expr, this));
       }
       return ExprMutator::VisitExpr(expr);
@@ -406,7 +406,7 @@ class PyExprMutatorNode : public ffi::Object, public ExprMutator {
    */
   Expr VisitExprPostOrder(const Expr& expr) {
     static FType post_order_vtable = InitPostOrderVTable();
-    if (post_order_vtable.can_dispatch(expr)) {
+    if (post_order_vtable.CanDispatch(expr)) {
       return post_order_vtable(expr, this);
     }
     return builder_->Normalize(ExprMutator::VisitExprFallback_(expr.get()));

--- a/src/relax/script/builder/ir.cc
+++ b/src/relax/script/builder/ir.cc
@@ -33,13 +33,14 @@ namespace relax {
 
 using tvm::script::ir_builder::details::Namer;
 
-TVM_STATIC_IR_FUNCTOR(Namer, vtable)
-    .set_dispatch<tvm::relax::DataflowVarNode>([](const ffi::ObjectRef& node,
-                                                  ffi::String name) -> void {
-      using tvm::relax::DataflowVarNode;
-      DataflowVarNode* var = const_cast<DataflowVarNode*>(node.as<DataflowVarNode>());
-      var->name = name;
-    });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  Namer::vtable().SetDispatch<tvm::relax::DataflowVarNode>(
+      [](const ffi::ObjectRef& node, ffi::String name) -> void {
+        using tvm::relax::DataflowVarNode;
+        DataflowVarNode* var = const_cast<DataflowVarNode*>(node.as<DataflowVarNode>());
+        var->name = name;
+      });
+}
 
 /////////////////////////////// Function ////////////////////////////////
 

--- a/src/relax/script/printer/binding.cc
+++ b/src/relax/script/printer/binding.cc
@@ -42,58 +42,62 @@ IfDoc PrintIfExpr(const relax::If& n, const AccessPath& n_p,
   return IfDoc(cond, branches[0], branches[1]);
 }
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<relax::MatchCast>(
-        "", [](relax::MatchCast n, AccessPath n_p, IRDocsifier d) -> Doc {
-          using tvm::Type;
-          using relax::MatchType;
-          ffi::Optional<ExprDoc> ann = std::nullopt;
-          if (d->cfg->GetExtraConfig<bool>("relax.show_all_ty", true)) {
-            ann = TypeAsAnn(n->var, n_p->Attr("var"), d, n->value);
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<relax::MatchCast>(
+      "", [](relax::MatchCast n, AccessPath n_p, IRDocsifier d) -> Doc {
+        using tvm::Type;
+        using relax::MatchType;
+        ffi::Optional<ExprDoc> ann = std::nullopt;
+        if (d->cfg->GetExtraConfig<bool>("relax.show_all_ty", true)) {
+          ann = TypeAsAnn(n->var, n_p->Attr("var"), d, n->value);
+        }
+        ExprDoc rhs = Relax(d, "match_cast")
+                          ->Call({d->AsDoc<ExprDoc>(n->value, n_p->Attr("value")),
+                                  d->AsDoc<ExprDoc>(n->ty, n_p->Attr("ty"))});
+        ExprDoc lhs = DefineRelaxVar(n->var, d->frames.back(), d);
+        return AssignDoc(lhs, rhs, ann);
+      });
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<relax::VarBinding>(  //
+      "", [](relax::VarBinding n, AccessPath n_p, IRDocsifier d) -> Doc {
+        if (const auto if_ = n->value.as<relax::IfNode>()) {
+          ffi::Optional<ExprDoc> ann = TypeAsAnn(n->var, n_p->Attr("var"), d, n->value);
+          if (!ann.has_value() && n->var->ty.as<PrimTypeNode>()) {
+            ann = d->AsDoc<ExprDoc>(n->var->ty, n_p->Attr("var")->Attr("ty"));
           }
-          ExprDoc rhs = Relax(d, "match_cast")
-                            ->Call({d->AsDoc<ExprDoc>(n->value, n_p->Attr("value")),
-                                    d->AsDoc<ExprDoc>(n->ty, n_p->Attr("ty"))});
+          ExprDoc lhs = DefineRelaxVar(n->var, d->frames.back(), d);
+          return PrintIfExpr(ffi::GetRef<relax::If>(if_), n_p->Attr("value"), d, lhs, ann);
+        } else if (n->value->IsInstance<tvm::BaseFuncNode>() &&
+                   !n->value->IsInstance<relax::ExternFuncNode>()) {
+          IdDoc lhs = DefineRelaxVar(n->var, d->frames.back(), d);
+          d->cfg->binding_names.push_back(lhs->name);
+          Doc ret = d->AsDoc(n->value, n_p->Attr("value"));
+          d->cfg->binding_names.pop_back();
+          return ret;
+        } else if (d->cfg->syntax_sugar && relax::HasVoidType(n->value) &&
+                   relax::HasVoidType(n->var)) {
+          ExprDoc rhs = d->AsDoc<ExprDoc>(n->value, n_p->Attr("value"));
+          return ExprStmtDoc(rhs);
+        } else {
+          ExprDoc rhs = d->AsDoc<ExprDoc>(n->value, n_p->Attr("value"));
+          ffi::Optional<ExprDoc> ann = TypeAsAnn(n->var, n_p->Attr("var"), d, n->value);
+          if (!ann.has_value() && n->var->ty.as<PrimTypeNode>()) {
+            ann = d->AsDoc<ExprDoc>(n->var->ty, n_p->Attr("var")->Attr("ty"));
+          }
           ExprDoc lhs = DefineRelaxVar(n->var, d->frames.back(), d);
           return AssignDoc(lhs, rhs, ann);
-        });
+        }
+      });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<relax::VarBinding>(  //
-        "", [](relax::VarBinding n, AccessPath n_p, IRDocsifier d) -> Doc {
-          if (const auto if_ = n->value.as<relax::IfNode>()) {
-            ffi::Optional<ExprDoc> ann = TypeAsAnn(n->var, n_p->Attr("var"), d, n->value);
-            if (!ann.has_value() && n->var->ty.as<PrimTypeNode>()) {
-              ann = d->AsDoc<ExprDoc>(n->var->ty, n_p->Attr("var")->Attr("ty"));
-            }
-            ExprDoc lhs = DefineRelaxVar(n->var, d->frames.back(), d);
-            return PrintIfExpr(ffi::GetRef<relax::If>(if_), n_p->Attr("value"), d, lhs, ann);
-          } else if (n->value->IsInstance<tvm::BaseFuncNode>() &&
-                     !n->value->IsInstance<relax::ExternFuncNode>()) {
-            IdDoc lhs = DefineRelaxVar(n->var, d->frames.back(), d);
-            d->cfg->binding_names.push_back(lhs->name);
-            Doc ret = d->AsDoc(n->value, n_p->Attr("value"));
-            d->cfg->binding_names.pop_back();
-            return ret;
-          } else if (d->cfg->syntax_sugar && relax::HasVoidType(n->value) &&
-                     relax::HasVoidType(n->var)) {
-            ExprDoc rhs = d->AsDoc<ExprDoc>(n->value, n_p->Attr("value"));
-            return ExprStmtDoc(rhs);
-          } else {
-            ExprDoc rhs = d->AsDoc<ExprDoc>(n->value, n_p->Attr("value"));
-            ffi::Optional<ExprDoc> ann = TypeAsAnn(n->var, n_p->Attr("var"), d, n->value);
-            if (!ann.has_value() && n->var->ty.as<PrimTypeNode>()) {
-              ann = d->AsDoc<ExprDoc>(n->var->ty, n_p->Attr("var")->Attr("ty"));
-            }
-            ExprDoc lhs = DefineRelaxVar(n->var, d->frames.back(), d);
-            return AssignDoc(lhs, rhs, ann);
-          }
-        });
-
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<relax::If>("", [](relax::If n, AccessPath n_p, IRDocsifier d) -> Doc {
-      return PrintIfExpr(n, n_p, d, std::nullopt, std::nullopt);
-    });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<relax::If>(
+      "", [](relax::If n, AccessPath n_p, IRDocsifier d) -> Doc {
+        return PrintIfExpr(n, n_p, d, std::nullopt, std::nullopt);
+      });
+}
 
 TVM_REGISTER_SCRIPT_AS_REPR(relax::MatchCastNode, ReprPrintRelax);
 TVM_REGISTER_SCRIPT_AS_REPR(relax::VarBindingNode, ReprPrintRelax);

--- a/src/relax/script/printer/call.cc
+++ b/src/relax/script/printer/call.cc
@@ -253,95 +253,96 @@ bool ShouldPrintAsTIR(const Call& call) {
   return true;
 }
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<Call>(  //
-        "", [](Call call, AccessPath n_p, IRDocsifier d) -> Doc {
-          if (ShouldPrintAsTIR(call)) {
-            return PrintTIRCall(call, n_p, d);
-          }
-          Call n = call;
-          // Special case: call_tir, call_dps_packed, call_tir_with_grad
-          if (ffi::Optional<ExprDoc> doc = PrintCallTIRDPSPacked(n, n_p, d)) {
-            return doc.value();
-          }
-          // Special case: assert_op
-          if (ffi::Optional<ExprDoc> doc = PrintAssertOp(n, n_p, d)) {
-            return doc.value();
-          }
-          // Special case: hint_on_device
-          if (ffi::Optional<ExprDoc> doc = PrintHintOnDevice(n, n_p, d)) {
-            return doc.value();
-          }
-          // Special case: to_vdevice
-          if (ffi::Optional<ExprDoc> doc = PrintToVDevice(n, n_p, d)) {
-            return doc.value();
-          }
-          // Special case: print
-          if (ffi::Optional<ExprDoc> doc = PrintRelaxPrint(n, n_p, d)) {
-            return doc.value();
-          }
-          ExprDoc prefix{ffi::UnsafeInit()};
-          ffi::Array<ExprDoc> args;
-          ffi::Array<ffi::String> kwargs_keys;
-          ffi::Array<ExprDoc> kwargs_values;
-          // Step 1. Print op
-          if (const auto* op = n->op.as<relax::ExternFuncNode>()) {
-            prefix = Relax(d, "call_packed");
-            args.push_back(LiteralDoc::Str(op->global_symbol, n_p->Attr("op")));
-          } else if (const auto* op = n->op.as<tvm::OpNode>()) {
-            std::string name = op->name;
-            if (name.rfind("relax.", 0) == 0) {
-              prefix = Relax(d, name.substr(6));
-            } else {
-              prefix = IdDoc(name);
-            }
-            prefix->source_paths.push_back(n_p->Attr("op"));
-          } else if (n->op->IsInstance<tvm::VarNode>() || n->op->IsInstance<tvm::GlobalVarNode>()) {
-            prefix = d->AsDoc<ExprDoc>(n->op, n_p->Attr("op"));
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<Call>(  //
+      "", [](Call call, AccessPath n_p, IRDocsifier d) -> Doc {
+        if (ShouldPrintAsTIR(call)) {
+          return PrintTIRCall(call, n_p, d);
+        }
+        Call n = call;
+        // Special case: call_tir, call_dps_packed, call_tir_with_grad
+        if (ffi::Optional<ExprDoc> doc = PrintCallTIRDPSPacked(n, n_p, d)) {
+          return doc.value();
+        }
+        // Special case: assert_op
+        if (ffi::Optional<ExprDoc> doc = PrintAssertOp(n, n_p, d)) {
+          return doc.value();
+        }
+        // Special case: hint_on_device
+        if (ffi::Optional<ExprDoc> doc = PrintHintOnDevice(n, n_p, d)) {
+          return doc.value();
+        }
+        // Special case: to_vdevice
+        if (ffi::Optional<ExprDoc> doc = PrintToVDevice(n, n_p, d)) {
+          return doc.value();
+        }
+        // Special case: print
+        if (ffi::Optional<ExprDoc> doc = PrintRelaxPrint(n, n_p, d)) {
+          return doc.value();
+        }
+        ExprDoc prefix{ffi::UnsafeInit()};
+        ffi::Array<ExprDoc> args;
+        ffi::Array<ffi::String> kwargs_keys;
+        ffi::Array<ExprDoc> kwargs_values;
+        // Step 1. Print op
+        if (const auto* op = n->op.as<relax::ExternFuncNode>()) {
+          prefix = Relax(d, "call_packed");
+          args.push_back(LiteralDoc::Str(op->global_symbol, n_p->Attr("op")));
+        } else if (const auto* op = n->op.as<tvm::OpNode>()) {
+          std::string name = op->name;
+          if (name.rfind("relax.", 0) == 0) {
+            prefix = Relax(d, name.substr(6));
           } else {
-            TVM_FFI_THROW(TypeError) << "Unsupported op: " << n->op->GetTypeKey();
+            prefix = IdDoc(name);
           }
-          // Step 2. Print args
-          if (!n->args.empty()) {
-            args.push_back(PrintCallee(n->args[0], n_p->Attr("args")->ArrayItem(0), d));
+          prefix->source_paths.push_back(n_p->Attr("op"));
+        } else if (n->op->IsInstance<tvm::VarNode>() || n->op->IsInstance<tvm::GlobalVarNode>()) {
+          prefix = d->AsDoc<ExprDoc>(n->op, n_p->Attr("op"));
+        } else {
+          TVM_FFI_THROW(TypeError) << "Unsupported op: " << n->op->GetTypeKey();
+        }
+        // Step 2. Print args
+        if (!n->args.empty()) {
+          args.push_back(PrintCallee(n->args[0], n_p->Attr("args")->ArrayItem(0), d));
+        }
+        for (int i = 1, l = n->args.size(); i < l; ++i) {
+          args.push_back(d->AsDoc<ExprDoc>(n->args[i], n_p->Attr("args")->ArrayItem(i)));
+        }
+        // Step 3. Print attrs
+        if (n->attrs.defined()) {
+          if (n->op->IsInstance<relax::ExternFuncNode>()) {
+            kwargs_keys.push_back("attrs_type_key");
+            kwargs_values.push_back(LiteralDoc::Str(n->attrs->GetTypeKey(), n_p->Attr("attrs")));
           }
-          for (int i = 1, l = n->args.size(); i < l; ++i) {
-            args.push_back(d->AsDoc<ExprDoc>(n->args[i], n_p->Attr("args")->ArrayItem(i)));
-          }
-          // Step 3. Print attrs
-          if (n->attrs.defined()) {
-            if (n->op->IsInstance<relax::ExternFuncNode>()) {
-              kwargs_keys.push_back("attrs_type_key");
-              kwargs_values.push_back(LiteralDoc::Str(n->attrs->GetTypeKey(), n_p->Attr("attrs")));
+          if (const auto* attrs = n->attrs.as<tvm::DictAttrsNode>()) {
+            std::vector<std::pair<ffi::String, ffi::Any>> sorted;
+            for (const auto& kv : attrs->dict) {
+              sorted.push_back(kv);
             }
-            if (const auto* attrs = n->attrs.as<tvm::DictAttrsNode>()) {
-              std::vector<std::pair<ffi::String, ffi::Any>> sorted;
-              for (const auto& kv : attrs->dict) {
-                sorted.push_back(kv);
-              }
-              std::sort(sorted.begin(), sorted.end(),
-                        [](const auto& a, const auto& b) { return a.first < b.first; });
-              for (const auto& kv : sorted) {
-                kwargs_keys.push_back(kv.first);
-                kwargs_values.push_back(
-                    d->AsDoc<ExprDoc>(kv.second, n_p->Attr("attrs")->Attr(kv.first)));
-              }
-            } else {
-              AttrPrinter(n_p->Attr("attrs"), d, &kwargs_keys, &kwargs_values)(n->attrs);
+            std::sort(sorted.begin(), sorted.end(),
+                      [](const auto& a, const auto& b) { return a.first < b.first; });
+            for (const auto& kv : sorted) {
+              kwargs_keys.push_back(kv.first);
+              kwargs_values.push_back(
+                  d->AsDoc<ExprDoc>(kv.second, n_p->Attr("attrs")->Attr(kv.first)));
             }
+          } else {
+            AttrPrinter(n_p->Attr("attrs"), d, &kwargs_keys, &kwargs_values)(n->attrs);
           }
-          // Step 4. Print type_args
-          if (n->ty_args.size() > 0) {
-            AccessPath ty_args_p = n_p->Attr("ty_args");
-            ffi::Array<ExprDoc> ty_args;
-            for (int i = 0, l = n->ty_args.size(); i < l; ++i) {
-              ty_args.push_back(d->AsDoc<ExprDoc>(n->ty_args[i], ty_args_p->ArrayItem(i)));
-            }
-            kwargs_keys.push_back("ty_args");
-            kwargs_values.push_back(TupleDoc(ty_args));
+        }
+        // Step 4. Print type_args
+        if (n->ty_args.size() > 0) {
+          AccessPath ty_args_p = n_p->Attr("ty_args");
+          ffi::Array<ExprDoc> ty_args;
+          for (int i = 0, l = n->ty_args.size(); i < l; ++i) {
+            ty_args.push_back(d->AsDoc<ExprDoc>(n->ty_args[i], ty_args_p->ArrayItem(i)));
           }
-          return prefix->Call(args, kwargs_keys, kwargs_values);
-        });
+          kwargs_keys.push_back("ty_args");
+          kwargs_values.push_back(TupleDoc(ty_args));
+        }
+        return prefix->Call(args, kwargs_keys, kwargs_values);
+      });
+}
 
 std::string ReprPrintCall(const ffi::ObjectRef& obj, const PrinterConfig& cfg) {
   Call call = obj.as_or_throw<Call>();

--- a/src/relax/script/printer/dependent_type.cc
+++ b/src/relax/script/printer/dependent_type.cc
@@ -26,9 +26,10 @@ namespace tvm {
 namespace script {
 namespace printer {
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<relax::AnyType>(  //
-        "", [](relax::AnyType n, AccessPath n_p, IRDocsifier d) -> Doc { return Relax(d, "Any"); });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<relax::AnyType>(  //
+      "", [](relax::AnyType n, AccessPath n_p, IRDocsifier d) -> Doc { return Relax(d, "Any"); });
+}
 
 ExprDoc PrintShapeVar(const PrimExpr& e, const AccessPath& e_p, const IRDocsifier& d) {
   ExprDoc expr_doc = d->AsDoc<ExprDoc>(e, e_p);
@@ -70,100 +71,101 @@ ExprDoc PrintShapeVar(const PrimExpr& e, const AccessPath& e_p, const IRDocsifie
   return expr_doc;
 }
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<relax::ShapeType>(
-        "", [](relax::ShapeType n, AccessPath n_p, IRDocsifier d) -> Doc {
-          if (n->values.has_value()) {
-            ffi::Array<PrimExpr> shape = n->values.value();
-            AccessPath shape_p = n_p->Attr("values");
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<relax::ShapeType>(
+      "", [](relax::ShapeType n, AccessPath n_p, IRDocsifier d) -> Doc {
+        if (n->values.has_value()) {
+          ffi::Array<PrimExpr> shape = n->values.value();
+          AccessPath shape_p = n_p->Attr("values");
+          ffi::Array<ExprDoc> shape_docs;
+          for (int i = 0, ndim = shape.size(); i < ndim; ++i) {
+            shape_docs.push_back(PrintShapeVar(shape[i], shape_p->ArrayItem(i), d));
+          }
+          return Relax(d, "Shape")->Call({ListDoc(shape_docs)});
+        }
+        return Relax(d, "Shape")->Call({}, {"ndim"}, {LiteralDoc::Int(n->ndim, n_p->Attr("ndim"))});
+      });
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<relax::TensorType>(  //
+      "", [](relax::TensorType n, AccessPath n_p, IRDocsifier d) -> Doc {
+        ffi::Array<ExprDoc> args;
+        ffi::Array<ffi::String> kwargs_keys;
+        ffi::Array<ExprDoc> kwargs_values;
+        if (n->shape.has_value()) {
+          // Need to dig into ShapeExpr to preserve the `R.shape` prefix
+          if (const auto* shape = n->shape.value().as<relax::ShapeExprNode>()) {
+            auto shape_expr = ffi::GetRef<relax::ShapeExpr>(shape);
+            AccessPath shape_p = n_p->Attr("shape")->Attr("values");
             ffi::Array<ExprDoc> shape_docs;
-            for (int i = 0, ndim = shape.size(); i < ndim; ++i) {
-              shape_docs.push_back(PrintShapeVar(shape[i], shape_p->ArrayItem(i), d));
+            for (int i = 0, ndim = shape_expr->values.size(); i < ndim; ++i) {
+              shape_docs.push_back(PrintShapeVar(shape_expr->values[i], shape_p->ArrayItem(i), d));
             }
-            return Relax(d, "Shape")->Call({ListDoc(shape_docs)});
+            args.push_back(TupleDoc(shape_docs));
+          } else {
+            args.push_back(d->AsDoc<ExprDoc>(n->shape.value(), n_p->Attr("shape")));
           }
-          return Relax(d, "Shape")
-              ->Call({}, {"ndim"}, {LiteralDoc::Int(n->ndim, n_p->Attr("ndim"))});
-        });
+        }
+        if (!n->IsUnknownDtype()) {
+          kwargs_keys.push_back("dtype");
+          kwargs_values.push_back(
+              LiteralDoc::DataType(n->dtype.value()->dtype, n_p->Attr("dtype")));
+        }
+        if (!n->shape.has_value() && !n->IsUnknownNdim()) {
+          kwargs_keys.push_back("ndim");
+          kwargs_values.push_back(LiteralDoc::Int(n->ndim, n_p->Attr("ndim")));
+        }
+        if (n->vdevice.has_value() && n->vdevice.value()->target.defined()) {
+          kwargs_keys.push_back("vdevice");
+          std::string dev_kind = n->vdevice.value()->target->kind->name;
+          int dev_index = FindVDeviceIndexByTargetKind(n->vdevice.value(), d);
+          kwargs_values.push_back(LiteralDoc::Str(
+              dev_kind + ":" + std::to_string(dev_index) + ":" + n->vdevice.value()->memory_scope,
+              n_p->Attr("vdevice")));
+        }
+        if (args.empty() && kwargs_keys.empty()) {
+          return Relax(d, "Tensor");
+        }
+        return Relax(d, "Tensor")->Call(args, kwargs_keys, kwargs_values);
+      });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<relax::TensorType>(  //
-        "", [](relax::TensorType n, AccessPath n_p, IRDocsifier d) -> Doc {
-          ffi::Array<ExprDoc> args;
-          ffi::Array<ffi::String> kwargs_keys;
-          ffi::Array<ExprDoc> kwargs_values;
-          if (n->shape.has_value()) {
-            // Need to dig into ShapeExpr to preserve the `R.shape` prefix
-            if (const auto* shape = n->shape.value().as<relax::ShapeExprNode>()) {
-              auto shape_expr = ffi::GetRef<relax::ShapeExpr>(shape);
-              AccessPath shape_p = n_p->Attr("shape")->Attr("values");
-              ffi::Array<ExprDoc> shape_docs;
-              for (int i = 0, ndim = shape_expr->values.size(); i < ndim; ++i) {
-                shape_docs.push_back(
-                    PrintShapeVar(shape_expr->values[i], shape_p->ArrayItem(i), d));
-              }
-              args.push_back(TupleDoc(shape_docs));
-            } else {
-              args.push_back(d->AsDoc<ExprDoc>(n->shape.value(), n_p->Attr("shape")));
-            }
-          }
-          if (!n->IsUnknownDtype()) {
-            kwargs_keys.push_back("dtype");
-            kwargs_values.push_back(
-                LiteralDoc::DataType(n->dtype.value()->dtype, n_p->Attr("dtype")));
-          }
-          if (!n->shape.has_value() && !n->IsUnknownNdim()) {
-            kwargs_keys.push_back("ndim");
-            kwargs_values.push_back(LiteralDoc::Int(n->ndim, n_p->Attr("ndim")));
-          }
-          if (n->vdevice.has_value() && n->vdevice.value()->target.defined()) {
-            kwargs_keys.push_back("vdevice");
-            std::string dev_kind = n->vdevice.value()->target->kind->name;
-            int dev_index = FindVDeviceIndexByTargetKind(n->vdevice.value(), d);
-            kwargs_values.push_back(LiteralDoc::Str(
-                dev_kind + ":" + std::to_string(dev_index) + ":" + n->vdevice.value()->memory_scope,
-                n_p->Attr("vdevice")));
-          }
-          if (args.empty() && kwargs_keys.empty()) {
-            return Relax(d, "Tensor");
-          }
-          return Relax(d, "Tensor")->Call(args, kwargs_keys, kwargs_values);
-        });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<relax::FuncType>(  //
+      "", [](relax::FuncType n, AccessPath n_p, IRDocsifier d) -> Doc {
+        auto ret_doc = d->AsDoc<ExprDoc>(n->ret, n_p->Attr("ret"));
+        auto purity_doc = LiteralDoc::Boolean(n->purity, n_p->Attr("purity"));
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<relax::FuncType>(  //
-        "", [](relax::FuncType n, AccessPath n_p, IRDocsifier d) -> Doc {
-          auto ret_doc = d->AsDoc<ExprDoc>(n->ret, n_p->Attr("ret"));
-          auto purity_doc = LiteralDoc::Boolean(n->purity, n_p->Attr("purity"));
+        if (n->IsOpaque()) {
+          ffi::Array<ffi::String> keys;
+          ffi::Array<ExprDoc, void> values;
 
-          if (n->IsOpaque()) {
-            ffi::Array<ffi::String> keys;
-            ffi::Array<ExprDoc, void> values;
-
-            if (!n->ret->IsInstance<relax::AnyTypeNode>()) {
-              keys.push_back("ret");
-              values.push_back(ret_doc);
-            }
-            if (n->purity) {
-              keys.push_back("purity");
-              values.push_back(purity_doc);
-            }
-
-            if (keys.size()) {
-              return Relax(d, "Callable")->Call({}, keys, values);
-            } else {
-              return Relax(d, "Callable");
-            }
+          if (!n->ret->IsInstance<relax::AnyTypeNode>()) {
+            keys.push_back("ret");
+            values.push_back(ret_doc);
           }
-          // TODO(@junrushao): track symbolic shape relation
-          ffi::Array<ExprDoc> params_doc;
-          ffi::Array<tvm::Type> params = n->params.value();
-          AccessPath params_p = n_p->Attr("params");
-          for (int i = 0, n_params = params.size(); i < n_params; ++i) {
-            params_doc.push_back(d->AsDoc<ExprDoc>(params[i], params_p->ArrayItem(i)));
+          if (n->purity) {
+            keys.push_back("purity");
+            values.push_back(purity_doc);
           }
-          return Relax(d, "Callable")->Call({TupleDoc(params_doc), ret_doc, purity_doc});
-        });
+
+          if (keys.size()) {
+            return Relax(d, "Callable")->Call({}, keys, values);
+          } else {
+            return Relax(d, "Callable");
+          }
+        }
+        // TODO(@junrushao): track symbolic shape relation
+        ffi::Array<ExprDoc> params_doc;
+        ffi::Array<tvm::Type> params = n->params.value();
+        AccessPath params_p = n_p->Attr("params");
+        for (int i = 0, n_params = params.size(); i < n_params; ++i) {
+          params_doc.push_back(d->AsDoc<ExprDoc>(params[i], params_p->ArrayItem(i)));
+        }
+        return Relax(d, "Callable")->Call({TupleDoc(params_doc), ret_doc, purity_doc});
+      });
+}
 
 TVM_REGISTER_SCRIPT_AS_REPR(relax::AnyTypeNode, ReprPrintRelax);
 TVM_REGISTER_SCRIPT_AS_REPR(relax::ShapeTypeNode, ReprPrintRelax);

--- a/src/relax/script/printer/distributed.cc
+++ b/src/relax/script/printer/distributed.cc
@@ -28,104 +28,105 @@ namespace script {
 namespace printer {
 
 // distributed::Placement
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<relax::distributed::Placement>("",
-                                                 [](relax::distributed::Placement n, AccessPath n_p,
-                                                    IRDocsifier d) -> Doc {
-                                                   return d->AsDoc<Doc>(n->ToString(), n_p);
-                                                 });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<relax::distributed::Placement>(
+      "", [](relax::distributed::Placement n, AccessPath n_p, IRDocsifier d) -> Doc {
+        return d->AsDoc<Doc>(n->ToString(), n_p);
+      });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<relax::distributed::DTensorType>(
-        "", [](relax::distributed::DTensorType n, AccessPath n_p, IRDocsifier d) -> Doc {
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<relax::distributed::DTensorType>(
+      "", [](relax::distributed::DTensorType n, AccessPath n_p, IRDocsifier d) -> Doc {
+        ffi::Array<ExprDoc> args;
+        ffi::Array<ffi::String> kwargs_keys;
+        ffi::Array<ExprDoc> kwargs_values;
+        bool require_kwargs = false;
+        if (n->tensor_ty->shape.has_value()) {
+          // Need to dig into ShapeExpr to preserve the `R.shape` prefix
+          if (const auto* shape = n->tensor_ty->shape.value().as<relax::ShapeExprNode>()) {
+            auto shape_expr = ffi::GetRef<relax::ShapeExpr>(shape);
+            AccessPath shape_p = n_p->Attr("shape")->Attr("values");
+            ffi::Array<ExprDoc> shape_docs;
+            for (int i = 0, ndim = shape_expr->values.size(); i < ndim; ++i) {
+              shape_docs.push_back(PrintShapeVar(shape_expr->values[i], shape_p->ArrayItem(i), d));
+            }
+            args.push_back(TupleDoc(shape_docs));
+          } else {
+            args.push_back(d->AsDoc<ExprDoc>(n->tensor_ty->shape.value(), n_p->Attr("shape")));
+          }
+        } else {
+          require_kwargs = true;
+        }
+        if (!n->tensor_ty->IsUnknownDtype()) {
+          if (!require_kwargs) {
+            args.push_back(
+                LiteralDoc::DataType(n->tensor_ty->dtype.value()->dtype, n_p->Attr("dtype")));
+          } else {
+            kwargs_keys.push_back("dtype");
+            kwargs_values.push_back(
+                LiteralDoc::DataType(n->tensor_ty->dtype.value()->dtype, n_p->Attr("dtype")));
+          }
+        } else {
+          require_kwargs = true;
+        }
+        if (!require_kwargs) {
+          args.push_back(d->AsDoc<ExprDoc>(n->device_mesh, n_p->Attr("device_mesh")));
+        } else {
+          kwargs_keys.push_back("device_mesh");
+          kwargs_values.push_back(d->AsDoc<ExprDoc>(n->device_mesh, n_p->Attr("device_mesh")));
+        }
+        if (!require_kwargs) {
+          args.push_back(d->AsDoc<ExprDoc>(n->placement, n_p->Attr("placement")));
+        } else {
+          kwargs_keys.push_back("placement");
+          kwargs_values.push_back(d->AsDoc<ExprDoc>(n->placement, n_p->Attr("placement")));
+        }
+        if (!n->tensor_ty->shape.has_value() && !n->tensor_ty->IsUnknownNdim()) {
+          kwargs_keys.push_back("ndim");
+          kwargs_values.push_back(LiteralDoc::Int(n->tensor_ty->ndim, n_p->Attr("ndim")));
+        }
+        return Relax(d, "DTensor")->Call(args, kwargs_keys, kwargs_values);
+      });
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<relax::distributed::DeviceMesh>(
+      "", [](relax::distributed::DeviceMesh n, AccessPath n_p, IRDocsifier d) -> Doc {
+        bool has_relax_frame = false;
+        const IRFrameNode* f = nullptr;
+        for (const Frame& frame : d->frames) {
+          if (frame.as<RelaxFrameNode>()) {
+            has_relax_frame = true;
+            break;
+          } else if (const auto* ir_frame = frame.as<IRFrameNode>()) {
+            f = ir_frame;
+          }
+        }
+        if (!has_relax_frame || !f) {
           ffi::Array<ExprDoc> args;
-          ffi::Array<ffi::String> kwargs_keys;
-          ffi::Array<ExprDoc> kwargs_values;
-          bool require_kwargs = false;
-          if (n->tensor_ty->shape.has_value()) {
-            // Need to dig into ShapeExpr to preserve the `R.shape` prefix
-            if (const auto* shape = n->tensor_ty->shape.value().as<relax::ShapeExprNode>()) {
-              auto shape_expr = ffi::GetRef<relax::ShapeExpr>(shape);
-              AccessPath shape_p = n_p->Attr("shape")->Attr("values");
-              ffi::Array<ExprDoc> shape_docs;
-              for (int i = 0, ndim = shape_expr->values.size(); i < ndim; ++i) {
-                shape_docs.push_back(
-                    PrintShapeVar(shape_expr->values[i], shape_p->ArrayItem(i), d));
-              }
-              args.push_back(TupleDoc(shape_docs));
-            } else {
-              args.push_back(d->AsDoc<ExprDoc>(n->tensor_ty->shape.value(), n_p->Attr("shape")));
-            }
+          args.push_back(d->AsDoc<ExprDoc>(n->shape, n_p->Attr("shape")));
+          if (n->device_range.has_value()) {
+            args.push_back(d->AsDoc<ExprDoc>(n->device_range, n_p->Attr("device_range")));
           } else {
-            require_kwargs = true;
+            args.push_back(d->AsDoc<ExprDoc>(n->device_ids, n_p->Attr("device_ids")));
           }
-          if (!n->tensor_ty->IsUnknownDtype()) {
-            if (!require_kwargs) {
-              args.push_back(
-                  LiteralDoc::DataType(n->tensor_ty->dtype.value()->dtype, n_p->Attr("dtype")));
-            } else {
-              kwargs_keys.push_back("dtype");
-              kwargs_values.push_back(
-                  LiteralDoc::DataType(n->tensor_ty->dtype.value()->dtype, n_p->Attr("dtype")));
-            }
-          } else {
-            require_kwargs = true;
-          }
-          if (!require_kwargs) {
-            args.push_back(d->AsDoc<ExprDoc>(n->device_mesh, n_p->Attr("device_mesh")));
-          } else {
-            kwargs_keys.push_back("device_mesh");
-            kwargs_values.push_back(d->AsDoc<ExprDoc>(n->device_mesh, n_p->Attr("device_mesh")));
-          }
-          if (!require_kwargs) {
-            args.push_back(d->AsDoc<ExprDoc>(n->placement, n_p->Attr("placement")));
-          } else {
-            kwargs_keys.push_back("placement");
-            kwargs_values.push_back(d->AsDoc<ExprDoc>(n->placement, n_p->Attr("placement")));
-          }
-          if (!n->tensor_ty->shape.has_value() && !n->tensor_ty->IsUnknownNdim()) {
-            kwargs_keys.push_back("ndim");
-            kwargs_values.push_back(LiteralDoc::Int(n->tensor_ty->ndim, n_p->Attr("ndim")));
-          }
-          return Relax(d, "DTensor")->Call(args, kwargs_keys, kwargs_values);
-        });
-
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<relax::distributed::DeviceMesh>(
-        "", [](relax::distributed::DeviceMesh n, AccessPath n_p, IRDocsifier d) -> Doc {
-          bool has_relax_frame = false;
-          const IRFrameNode* f = nullptr;
-          for (const Frame& frame : d->frames) {
-            if (frame.as<RelaxFrameNode>()) {
-              has_relax_frame = true;
-              break;
-            } else if (const auto* ir_frame = frame.as<IRFrameNode>()) {
-              f = ir_frame;
-            }
-          }
-          if (!has_relax_frame || !f) {
-            ffi::Array<ExprDoc> args;
-            args.push_back(d->AsDoc<ExprDoc>(n->shape, n_p->Attr("shape")));
-            if (n->device_range.has_value()) {
-              args.push_back(d->AsDoc<ExprDoc>(n->device_range, n_p->Attr("device_range")));
-            } else {
-              args.push_back(d->AsDoc<ExprDoc>(n->device_ids, n_p->Attr("device_ids")));
-            }
-            return Relax(d, "device_mesh")->Call(args);
-          } else {
-            for (const auto& kv : *f->global_infos) {
-              for (int i = 0; i < static_cast<int>(kv.second.size()); i++) {
-                if (kv.second[i].same_as(n)) {
-                  std::stringstream ss;
-                  ss << kv.first << "[" << i << "]";
-                  return d->AsDoc<Doc>(ffi::String(ss.str()), n_p);
-                }
+          return Relax(d, "device_mesh")->Call(args);
+        } else {
+          for (const auto& kv : *f->global_infos) {
+            for (int i = 0; i < static_cast<int>(kv.second.size()); i++) {
+              if (kv.second[i].same_as(n)) {
+                std::stringstream ss;
+                ss << kv.first << "[" << i << "]";
+                return d->AsDoc<Doc>(ffi::String(ss.str()), n_p);
               }
             }
-            TVM_FFI_THROW(InternalError) << "Cannot find device mesh in global infos";
-            TVM_FFI_UNREACHABLE();
           }
-        });
+          TVM_FFI_THROW(InternalError) << "Cannot find device mesh in global infos";
+          TVM_FFI_UNREACHABLE();
+        }
+      });
+}
 
 TVM_REGISTER_SCRIPT_AS_REPR(relax::distributed::DeviceMeshNode, ReprPrintRelax);
 TVM_REGISTER_SCRIPT_AS_REPR(relax::distributed::PlacementNode, ReprPrintRelax);

--- a/src/relax/script/printer/expr.cc
+++ b/src/relax/script/printer/expr.cc
@@ -29,50 +29,55 @@ namespace tvm {
 namespace script {
 namespace printer {
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<relax::StringImm>(  //
-        "", [](relax::StringImm n, AccessPath n_p, IRDocsifier d) -> Doc {
-          return Relax(d, "str")->Call({LiteralDoc::Str(n->value, n_p->Attr("value"))});
-        });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<relax::StringImm>(  //
+      "", [](relax::StringImm n, AccessPath n_p, IRDocsifier d) -> Doc {
+        return Relax(d, "str")->Call({LiteralDoc::Str(n->value, n_p->Attr("value"))});
+      });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<relax::DataTypeImm>(  //
-        "", [](relax::DataTypeImm n, AccessPath n_p, IRDocsifier d) -> Doc {
-          return Relax(d, "dtype")->Call({LiteralDoc::DataType(n->value, n_p->Attr("value"))});
-        });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<relax::DataTypeImm>(  //
+      "", [](relax::DataTypeImm n, AccessPath n_p, IRDocsifier d) -> Doc {
+        return Relax(d, "dtype")->Call({LiteralDoc::DataType(n->value, n_p->Attr("value"))});
+      });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<relax::Tuple>(  //
-        "", [](relax::Tuple n, AccessPath n_p, IRDocsifier d) -> Doc {
-          // TODO(@junrushao): revisit tuple printing
-          if (n->fields.empty()) {
-            return Relax(d, "tuple")->Call({});
-          }
-          ffi::Array<ExprDoc> fields_doc;
-          AccessPath fields_p = n_p->Attr("fields");
-          for (int i = 0, l = n->fields.size(); i < l; ++i) {
-            fields_doc.push_back(d->AsDoc<ExprDoc>(n->fields[i], fields_p->ArrayItem(i)));
-          }
-          return TupleDoc(fields_doc);
-        });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<relax::Tuple>(  //
+      "", [](relax::Tuple n, AccessPath n_p, IRDocsifier d) -> Doc {
+        // TODO(@junrushao): revisit tuple printing
+        if (n->fields.empty()) {
+          return Relax(d, "tuple")->Call({});
+        }
+        ffi::Array<ExprDoc> fields_doc;
+        AccessPath fields_p = n_p->Attr("fields");
+        for (int i = 0, l = n->fields.size(); i < l; ++i) {
+          fields_doc.push_back(d->AsDoc<ExprDoc>(n->fields[i], fields_p->ArrayItem(i)));
+        }
+        return TupleDoc(fields_doc);
+      });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<relax::TupleGetItem>(  //
-        "", [](relax::TupleGetItem n, AccessPath n_p, IRDocsifier d) -> Doc {
-          ExprDoc idx = LiteralDoc::Int(n->index, n_p->Attr("index"));
-          return d->AsDoc<ExprDoc>(n->tuple, n_p->Attr("tuple"))[{idx}];
-        });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<relax::TupleGetItem>(  //
+      "", [](relax::TupleGetItem n, AccessPath n_p, IRDocsifier d) -> Doc {
+        ExprDoc idx = LiteralDoc::Int(n->index, n_p->Attr("index"));
+        return d->AsDoc<ExprDoc>(n->tuple, n_p->Attr("tuple"))[{idx}];
+      });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<relax::ShapeExpr>(  //
-        "", [](relax::ShapeExpr n, AccessPath n_p, IRDocsifier d) -> Doc {
-          ffi::Array<ExprDoc> values_doc;
-          AccessPath values_p = n_p->Attr("values");
-          for (int i = 0, l = n->values.size(); i < l; ++i) {
-            values_doc.push_back(PrintShapeVar(n->values[i], values_p->ArrayItem(i), d));
-          }
-          return Relax(d, "shape")->Call({ListDoc(values_doc)});
-        });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<relax::ShapeExpr>(  //
+      "", [](relax::ShapeExpr n, AccessPath n_p, IRDocsifier d) -> Doc {
+        ffi::Array<ExprDoc> values_doc;
+        AccessPath values_p = n_p->Attr("values");
+        for (int i = 0, l = n->values.size(); i < l; ++i) {
+          values_doc.push_back(PrintShapeVar(n->values[i], values_p->ArrayItem(i), d));
+        }
+        return Relax(d, "shape")->Call({ListDoc(values_doc)});
+      });
+}
 
 ffi::Optional<ExprDoc> SpecialScalar(const runtime::Tensor& n, const AccessPath& p) {
   DLDataType dtype = n.DataType();
@@ -127,22 +132,23 @@ ffi::Optional<ExprDoc> SpecialScalar(const runtime::Tensor& n, const AccessPath&
   }
 }
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<relax::Constant>(  //
-        "", [](relax::Constant n, AccessPath n_p, IRDocsifier d) -> Doc {
-          if (ffi::Optional<ExprDoc> s = SpecialScalar(n->data, n_p->Attr("data"))) {
-            if (n->ty.as<relax::distributed::DTensorTypeNode>()) {
-              ExprDoc ann = d->AsDoc<ExprDoc>(n->ty, n_p->Attr("ty"));
-              return Relax(d, "dist.const")->Call({s.value(), ann});
-            }
-            return Relax(d, "const")
-                ->Call({
-                    s.value(),
-                    LiteralDoc::DataType(n->data.DataType(), n_p->Attr("data")->Attr("dtype")),
-                });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<relax::Constant>(  //
+      "", [](relax::Constant n, AccessPath n_p, IRDocsifier d) -> Doc {
+        if (ffi::Optional<ExprDoc> s = SpecialScalar(n->data, n_p->Attr("data"))) {
+          if (n->ty.as<relax::distributed::DTensorTypeNode>()) {
+            ExprDoc ann = d->AsDoc<ExprDoc>(n->ty, n_p->Attr("ty"));
+            return Relax(d, "dist.const")->Call({s.value(), ann});
           }
-          return d->AddMetadata(n);
-        });
+          return Relax(d, "const")
+              ->Call({
+                  s.value(),
+                  LiteralDoc::DataType(n->data.DataType(), n_p->Attr("data")->Attr("dtype")),
+              });
+        }
+        return d->AddMetadata(n);
+      });
+}
 
 Doc PrintRelaxVar(tvm::Var n, AccessPath p, IRDocsifier d) {
   if (!d->IsVarDefined(n)) {
@@ -154,7 +160,9 @@ Doc PrintRelaxVar(tvm::Var n, AccessPath p, IRDocsifier d) {
   return d->GetVarDoc(n).value();
 }
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable).set_dispatch<relax::DataflowVar>("relax", PrintRelaxVar);
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<relax::DataflowVar>("relax", PrintRelaxVar);
+}
 
 std::string ReprPrintVar(const ffi::ObjectRef& obj, const PrinterConfig& cfg) {
   Var var = obj.as_or_throw<Var>();

--- a/src/relax/script/printer/function.cc
+++ b/src/relax/script/printer/function.cc
@@ -50,100 +50,103 @@ bool AtTopLevelFunction(const IRDocsifier& d) {
 
 TVM_FFI_STATIC_INIT_BLOCK() { RelaxFrameNode::RegisterReflection(); }
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<relax::Function>("", [](relax::Function n, AccessPath n_p, IRDocsifier d) -> Doc {
-      std::unordered_set<const VarNode*> func_vars;
-      std::unordered_set<const VarNode*> type_vars;
-      std::unordered_set<const VarNode*> prim_params;
-      With<RelaxFrame> f(d);
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<relax::Function>(
+      "", [](relax::Function n, AccessPath n_p, IRDocsifier d) -> Doc {
+        std::unordered_set<const VarNode*> func_vars;
+        std::unordered_set<const VarNode*> type_vars;
+        std::unordered_set<const VarNode*> prim_params;
+        With<RelaxFrame> f(d);
 
-      IdDoc func_name("");
-      // if we are binding a local definition, then calling d->Define
-      // will result in a repeated definition and an incorrect displayed name
-      if (ffi::Optional<ffi::String> name = GetBindingName(d)) {
-        func_name = IdDoc(name.value());
-      } else {
-        func_name = IdDoc(FindFunctionName(d, n).value_or("main"));
-      }
-      (*f)->AddDispatchToken(d, "relax");
-      (*f)->is_func = true;
-      (*f)->func_vars = &func_vars;
-      (*f)->type_vars = &type_vars;
-      (*f)->prim_params = &prim_params;
-      for (const Var& param : n->params) {
-        if (param->ty.as<PrimTypeNode>()) {
-          prim_params.insert(param.get());
+        IdDoc func_name("");
+        // if we are binding a local definition, then calling d->Define
+        // will result in a repeated definition and an incorrect displayed name
+        if (ffi::Optional<ffi::String> name = GetBindingName(d)) {
+          func_name = IdDoc(name.value());
+        } else {
+          func_name = IdDoc(FindFunctionName(d, n).value_or("main"));
         }
-      }
-      // Step 1. Print params
-      ffi::Array<AssignDoc> params;
-      {
-        AccessPath params_p = n_p->Attr("params");
-        for (int i = 0, l = n->params.size(); i < l; ++i) {
-          params.push_back(AssignDoc(
-              /*lhs=*/DefineRelaxVar(n->params[i], *f, d),
-              /*rhs=*/std::nullopt,
-              TypeAsAnn(n->params[i], params_p->ArrayItem(i), d, std::nullopt)));
-        }
-      }
-      // Step 2. Print the return type
-      ffi::Optional<ExprDoc> ret_type = d->AsDoc<ExprDoc>(n->ret_ty, n_p->Attr("ret_ty"));
-      // Step 3. Clean up func variables
-      (*f)->func_vars = nullptr;
-      (*f)->type_vars = nullptr;
-      (*f)->prim_params = nullptr;
-      // Step 4. Print attributes
-      ffi::Map<ffi::String, Any> printable_attrs;
-      for (const auto& [key, value] : n->attrs->dict) {
-        // A matching global symbol is implicit for a top-level function.
-        if (key == tvm::attr::kGlobalSymbol && AtTopLevelFunction(d) &&
-            value.as_or_throw<ffi::String>() == func_name->name) {
-          continue;
-        }
-        printable_attrs.Set(key, value);
-      }
-      if (!printable_attrs.empty()) {
-        (*f)->stmts.push_back(ExprStmtDoc(
-            Relax(d, "func_attr")  //
-                ->Call({d->AsDoc<ExprDoc>(DictAttrs(printable_attrs), n_p->Attr("attrs"))})));
-      }
-      // Step 5. Prepare the decorator (include purity if it's impure)
-      ExprDoc decorator = Relax(d, "function");
-      ffi::Array<ExprDoc, void> pos_args = {};
-      ffi::Array<ffi::String, void> dec_keys;
-      ffi::Array<ExprDoc, void> dec_values;
-      if (!n->is_pure) {
-        dec_keys.push_back("pure");
-        dec_values.push_back(LiteralDoc::Boolean(false, ffi::Optional<AccessPath>()));
-      }
-      // if the function is global or is not in a module and does not have a global symbol,
-      // indicate that it's private
-      if (AtTopLevelFunction(d) && !n->attrs->dict.count(tvm::attr::kGlobalSymbol)) {
-        dec_keys.push_back("private");
-        dec_values.push_back(LiteralDoc::Boolean(true, ffi::Optional<AccessPath>()));
-      }
-      if (dec_keys.size()) {
-        decorator = decorator->Call(pos_args, dec_keys, dec_values);
-      }
-
-      // Step 6. Print body
-      ffi::Array<StmtDoc> body = PrintSeqExpr(n->body, n_p->Attr("body"), d, /*use_ret=*/true);
-      (*f)->stmts.insert((*f)->stmts.end(), body.begin(), body.end());
-      auto type_var_docs = DefineTypeVarDocs(type_vars, ffi::GetRef<Frame>((*f).get()), d);
-      return WrapFunctionDocWithTypeVars(
-          d, FunctionDoc(func_name, params, {decorator}, ret_type, (*f)->stmts), type_var_docs);
-    });
-
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<relax::ExternFunc>(  //
-        "", [](relax::ExternFunc n, AccessPath n_p, IRDocsifier d) -> Doc {
-          ffi::Array<ExprDoc> args;
-          args.push_back(LiteralDoc::Str(n->global_symbol, n_p->Attr("global_symbol")));
-          if (!HasDefaultExternFuncType(n)) {
-            args.push_back(d->AsDoc<ExprDoc>(n->ty, n_p->Attr("ty")));
+        (*f)->AddDispatchToken(d, "relax");
+        (*f)->is_func = true;
+        (*f)->func_vars = &func_vars;
+        (*f)->type_vars = &type_vars;
+        (*f)->prim_params = &prim_params;
+        for (const Var& param : n->params) {
+          if (param->ty.as<PrimTypeNode>()) {
+            prim_params.insert(param.get());
           }
-          return Relax(d, "ExternFunc")->Call(args);
-        });
+        }
+        // Step 1. Print params
+        ffi::Array<AssignDoc> params;
+        {
+          AccessPath params_p = n_p->Attr("params");
+          for (int i = 0, l = n->params.size(); i < l; ++i) {
+            params.push_back(AssignDoc(
+                /*lhs=*/DefineRelaxVar(n->params[i], *f, d),
+                /*rhs=*/std::nullopt,
+                TypeAsAnn(n->params[i], params_p->ArrayItem(i), d, std::nullopt)));
+          }
+        }
+        // Step 2. Print the return type
+        ffi::Optional<ExprDoc> ret_type = d->AsDoc<ExprDoc>(n->ret_ty, n_p->Attr("ret_ty"));
+        // Step 3. Clean up func variables
+        (*f)->func_vars = nullptr;
+        (*f)->type_vars = nullptr;
+        (*f)->prim_params = nullptr;
+        // Step 4. Print attributes
+        ffi::Map<ffi::String, Any> printable_attrs;
+        for (const auto& [key, value] : n->attrs->dict) {
+          // A matching global symbol is implicit for a top-level function.
+          if (key == tvm::attr::kGlobalSymbol && AtTopLevelFunction(d) &&
+              value.as_or_throw<ffi::String>() == func_name->name) {
+            continue;
+          }
+          printable_attrs.Set(key, value);
+        }
+        if (!printable_attrs.empty()) {
+          (*f)->stmts.push_back(ExprStmtDoc(
+              Relax(d, "func_attr")  //
+                  ->Call({d->AsDoc<ExprDoc>(DictAttrs(printable_attrs), n_p->Attr("attrs"))})));
+        }
+        // Step 5. Prepare the decorator (include purity if it's impure)
+        ExprDoc decorator = Relax(d, "function");
+        ffi::Array<ExprDoc, void> pos_args = {};
+        ffi::Array<ffi::String, void> dec_keys;
+        ffi::Array<ExprDoc, void> dec_values;
+        if (!n->is_pure) {
+          dec_keys.push_back("pure");
+          dec_values.push_back(LiteralDoc::Boolean(false, ffi::Optional<AccessPath>()));
+        }
+        // if the function is global or is not in a module and does not have a global symbol,
+        // indicate that it's private
+        if (AtTopLevelFunction(d) && !n->attrs->dict.count(tvm::attr::kGlobalSymbol)) {
+          dec_keys.push_back("private");
+          dec_values.push_back(LiteralDoc::Boolean(true, ffi::Optional<AccessPath>()));
+        }
+        if (dec_keys.size()) {
+          decorator = decorator->Call(pos_args, dec_keys, dec_values);
+        }
+
+        // Step 6. Print body
+        ffi::Array<StmtDoc> body = PrintSeqExpr(n->body, n_p->Attr("body"), d, /*use_ret=*/true);
+        (*f)->stmts.insert((*f)->stmts.end(), body.begin(), body.end());
+        auto type_var_docs = DefineTypeVarDocs(type_vars, ffi::GetRef<Frame>((*f).get()), d);
+        return WrapFunctionDocWithTypeVars(
+            d, FunctionDoc(func_name, params, {decorator}, ret_type, (*f)->stmts), type_var_docs);
+      });
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<relax::ExternFunc>(  //
+      "", [](relax::ExternFunc n, AccessPath n_p, IRDocsifier d) -> Doc {
+        ffi::Array<ExprDoc> args;
+        args.push_back(LiteralDoc::Str(n->global_symbol, n_p->Attr("global_symbol")));
+        if (!HasDefaultExternFuncType(n)) {
+          args.push_back(d->AsDoc<ExprDoc>(n->ty, n_p->Attr("ty")));
+        }
+        return Relax(d, "ExternFunc")->Call(args);
+      });
+}
 
 TVM_REGISTER_SCRIPT_AS_REPR(relax::FunctionNode, ReprPrintRelax);
 TVM_REGISTER_SCRIPT_AS_REPR(relax::ExternFuncNode, ReprPrintRelax);

--- a/src/relax/script/printer/region.cc
+++ b/src/relax/script/printer/region.cc
@@ -49,10 +49,12 @@ ffi::Array<StmtDoc> PrintSeqExpr(const relax::SeqExpr& n, const AccessPath& n_p,
   return *stmts;
 }
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<relax::SeqExpr>("", [](relax::SeqExpr n, AccessPath n_p, IRDocsifier d) -> Doc {
-      return StmtBlockDoc(PrintSeqExpr(n, n_p, d, false));
-    });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<relax::SeqExpr>(
+      "", [](relax::SeqExpr n, AccessPath n_p, IRDocsifier d) -> Doc {
+        return StmtBlockDoc(PrintSeqExpr(n, n_p, d, false));
+      });
+}
 
 ffi::Array<StmtDoc> PrintBindingBlock(const relax::BindingBlock& n, const AccessPath& n_p,
                                       const IRDocsifier& d,
@@ -79,20 +81,22 @@ ffi::Array<StmtDoc> PrintBindingBlock(const relax::BindingBlock& n, const Access
   return stmts;
 }
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<relax::BindingBlock>(  //
-        "", [](relax::BindingBlock n, AccessPath n_p, IRDocsifier d) -> Doc {
-          return StmtBlockDoc(PrintBindingBlock(n, n_p, d, nullptr));
-        });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<relax::BindingBlock>(  //
+      "", [](relax::BindingBlock n, AccessPath n_p, IRDocsifier d) -> Doc {
+        return StmtBlockDoc(PrintBindingBlock(n, n_p, d, nullptr));
+      });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<relax::DataflowBlock>(  //
-        "", [](relax::DataflowBlock n, AccessPath n_p, IRDocsifier d) -> Doc {
-          ffi::Array<ExprDoc> non_dataflow_vars;
-          ffi::Array<StmtDoc> stmts = PrintBindingBlock(n, n_p, d, &non_dataflow_vars);
-          stmts.push_back(ExprStmtDoc(Relax(d, "output")->Call(non_dataflow_vars)));
-          return ScopeDoc(std::nullopt, Relax(d, "dataflow")->Call({}), stmts);
-        });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<relax::DataflowBlock>(  //
+      "", [](relax::DataflowBlock n, AccessPath n_p, IRDocsifier d) -> Doc {
+        ffi::Array<ExprDoc> non_dataflow_vars;
+        ffi::Array<StmtDoc> stmts = PrintBindingBlock(n, n_p, d, &non_dataflow_vars);
+        stmts.push_back(ExprStmtDoc(Relax(d, "output")->Call(non_dataflow_vars)));
+        return ScopeDoc(std::nullopt, Relax(d, "dataflow")->Call({}), stmts);
+      });
+}
 
 TVM_REGISTER_SCRIPT_AS_REPR(relax::SeqExprNode, ReprPrintRelax);
 TVM_REGISTER_SCRIPT_AS_REPR(relax::BindingBlockNode, ReprPrintRelax);

--- a/src/relax/script/printer/tir.cc
+++ b/src/relax/script/printer/tir.cc
@@ -78,60 +78,65 @@ Doc PrintCanonicalVar(Var n, AccessPath n_p, IRDocsifier d) {
   TVM_FFI_UNREACHABLE();
 }
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable).set_dispatch<Var>("relax", PrintCanonicalVar);
+TVM_FFI_STATIC_INIT_BLOCK() { IRDocsifier::vtable().set_dispatch<Var>("relax", PrintCanonicalVar); }
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<tvm::IntImm>(                                             //
-        "relax", [](tvm::IntImm n, AccessPath n_p, IRDocsifier d) -> Doc {  //
-          // TODO(@junrushao): support non-int64 cases
-          if (n->ty.as_or_throw<PrimType>().MatchesElementType(DLDataTypeCode::kDLBool, 8)) {
-            return LiteralDoc::Boolean(n->value, n_p);
-          } else {
-            return LiteralDoc::Int(n->value, n_p);
-          }
-        });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<tvm::IntImm>(                        //
+      "relax", [](tvm::IntImm n, AccessPath n_p, IRDocsifier d) -> Doc {  //
+        // TODO(@junrushao): support non-int64 cases
+        if (n->ty.as_or_throw<PrimType>().MatchesElementType(DLDataTypeCode::kDLBool, 8)) {
+          return LiteralDoc::Boolean(n->value, n_p);
+        } else {
+          return LiteralDoc::Int(n->value, n_p);
+        }
+      });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<tvm::GlobalVar>(                                             //
-        "relax", [](tvm::GlobalVar n, AccessPath n_p, IRDocsifier d) -> Doc {  //
-          if (ffi::Optional<ExprDoc> doc = d->GetVarDoc(n)) {
-            return doc.value();
-          } else {
-            IdDoc ret(n->name_hint);
-            ret->source_paths.push_back(n_p);
-            return ret;
-          }
-        });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<tvm::GlobalVar>(                        //
+      "relax", [](tvm::GlobalVar n, AccessPath n_p, IRDocsifier d) -> Doc {  //
+        if (ffi::Optional<ExprDoc> doc = d->GetVarDoc(n)) {
+          return doc.value();
+        } else {
+          IdDoc ret(n->name_hint);
+          ret->source_paths.push_back(n_p);
+          return ret;
+        }
+      });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<tvm::IRModule>(                                               //
-        "relax", [](tvm::IRModule mod, AccessPath n_p, IRDocsifier d) -> Doc {  //
-          ffi::Optional<ExprDoc> doc = d->GetVarDoc(mod);
-          TVM_FFI_ICHECK(doc) << "Unable to print IRModule before definition in Relax.";
-          if (d->cfg->module_alias.empty()) {
-            // Use Module Name directly
-            return doc.value();
-          }
-          RelaxFrameNode* f = GetRelaxFrame(d);
-          TVM_FFI_CHECK(f != nullptr && f->is_func, IndexError)
-              << "No relax environment is found when printing a module alias var "
-                 "under relax's dispatch token";
-          if (!f->module_alias_printed) {
-            // If the module_alias is not defined before, define it.
-            f->stmts.push_back(AssignDoc(IdDoc(d->cfg->module_alias), doc.value(), std::nullopt));
-            f->module_alias_printed = true;
-          }
-          return IdDoc(d->cfg->module_alias);
-        });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<tvm::IRModule>(                          //
+      "relax", [](tvm::IRModule mod, AccessPath n_p, IRDocsifier d) -> Doc {  //
+        ffi::Optional<ExprDoc> doc = d->GetVarDoc(mod);
+        TVM_FFI_ICHECK(doc) << "Unable to print IRModule before definition in Relax.";
+        if (d->cfg->module_alias.empty()) {
+          // Use Module Name directly
+          return doc.value();
+        }
+        RelaxFrameNode* f = GetRelaxFrame(d);
+        TVM_FFI_CHECK(f != nullptr && f->is_func, IndexError)
+            << "No relax environment is found when printing a module alias var "
+               "under relax's dispatch token";
+        if (!f->module_alias_printed) {
+          // If the module_alias is not defined before, define it.
+          f->stmts.push_back(AssignDoc(IdDoc(d->cfg->module_alias), doc.value(), std::nullopt));
+          f->module_alias_printed = true;
+        }
+        return IdDoc(d->cfg->module_alias);
+      });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<Range>("relax", [](Range range, AccessPath p, IRDocsifier d) -> Doc {
-      return Relax(d, "Range")
-          ->Call({
-              d->AsDoc<ExprDoc>(range->min, p->Attr("min")),
-              d->AsDoc<ExprDoc>(range->extent + range->min, p->Attr("extent")),
-          });
-    });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<Range>(
+      "relax", [](Range range, AccessPath p, IRDocsifier d) -> Doc {
+        return Relax(d, "Range")
+            ->Call({
+                d->AsDoc<ExprDoc>(range->min, p->Attr("min")),
+                d->AsDoc<ExprDoc>(range->extent + range->min, p->Attr("extent")),
+            });
+      });
+}
 
 }  // namespace printer
 }  // namespace script

--- a/src/relax/script/printer/type.cc
+++ b/src/relax/script/printer/type.cc
@@ -24,39 +24,42 @@ namespace tvm {
 namespace script {
 namespace printer {
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<relax::PackedFuncType>(  //
-        "", [](relax::PackedFuncType n, AccessPath n_p, IRDocsifier d) -> Doc {
-          return Relax(d, "PackedFunc");  // TODO(@junrushao): verify if this is correct
-        });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<relax::PackedFuncType>(  //
+      "", [](relax::PackedFuncType n, AccessPath n_p, IRDocsifier d) -> Doc {
+        return Relax(d, "PackedFunc");  // TODO(@junrushao): verify if this is correct
+      });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<tvm::TupleType>(  //
-        "relax", [](tvm::TupleType n, AccessPath n_p, IRDocsifier d) -> Doc {
-          if (n->fields.empty()) {
-            return Relax(d, "Tuple");
-          }
-          ffi::Array<ExprDoc> fields_doc;
-          AccessPath fields_p = n_p->Attr("fields");
-          for (int i = 0, l = n->fields.size(); i < l; ++i) {
-            fields_doc.push_back(d->AsDoc<ExprDoc>(n->fields[i], fields_p->ArrayItem(i)));
-          }
-          return Relax(d, "Tuple")->Call(fields_doc);
-        });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<tvm::TupleType>(  //
+      "relax", [](tvm::TupleType n, AccessPath n_p, IRDocsifier d) -> Doc {
+        if (n->fields.empty()) {
+          return Relax(d, "Tuple");
+        }
+        ffi::Array<ExprDoc> fields_doc;
+        AccessPath fields_p = n_p->Attr("fields");
+        for (int i = 0, l = n->fields.size(); i < l; ++i) {
+          fields_doc.push_back(d->AsDoc<ExprDoc>(n->fields[i], fields_p->ArrayItem(i)));
+        }
+        return Relax(d, "Tuple")->Call(fields_doc);
+      });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<tvm::FuncType>(
-        "relax", [](tvm::FuncType n, AccessPath n_p, IRDocsifier d) -> Doc {
-          ffi::Array<ExprDoc> arg_types_doc;
-          ffi::Array<Type> arg_types = n->arg_types;
-          AccessPath arg_types_p = n_p->Attr("arg_types");
-          for (int i = 0, n_params = arg_types.size(); i < n_params; ++i) {
-            arg_types_doc.push_back(d->AsDoc<ExprDoc>(arg_types[i], arg_types_p->ArrayItem(i)));
-          }
-          return Relax(d, "Callable")
-              ->Call({TupleDoc(arg_types_doc),  //
-                      d->AsDoc<ExprDoc>(n->ret_type, n_p->Attr("ret_type"))});
-        });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<tvm::FuncType>(
+      "relax", [](tvm::FuncType n, AccessPath n_p, IRDocsifier d) -> Doc {
+        ffi::Array<ExprDoc> arg_types_doc;
+        ffi::Array<Type> arg_types = n->arg_types;
+        AccessPath arg_types_p = n_p->Attr("arg_types");
+        for (int i = 0, n_params = arg_types.size(); i < n_params; ++i) {
+          arg_types_doc.push_back(d->AsDoc<ExprDoc>(arg_types[i], arg_types_p->ArrayItem(i)));
+        }
+        return Relax(d, "Callable")
+            ->Call({TupleDoc(arg_types_doc),  //
+                    d->AsDoc<ExprDoc>(n->ret_type, n_p->Attr("ret_type"))});
+      });
+}
 
 TVM_REGISTER_SCRIPT_AS_REPR(relax::PackedFuncTypeNode, ReprPrintRelax);
 TVM_FFI_STATIC_INIT_BLOCK() {

--- a/src/relax/transform/attach_global_symbol.cc
+++ b/src/relax/transform/attach_global_symbol.cc
@@ -70,7 +70,7 @@ struct TirxGvarMutator : tirx::StmtExprMutator {
 };
 
 // Replace GlobalVar references across all functions in the module.
-// Direct dispatch on function type — no NodeFunctor indirection needed
+// Direct dispatch on function type — no ObjectFunctor indirection needed
 // since this file already includes the relax + tirx headers.
 IRModule ReplaceGlobalVarsInModule(IRModule mod, ffi::Map<GlobalVar, GlobalVar> replacements) {
   if (replacements.empty()) {

--- a/src/s_tir/meta_schedule/cost_model/cost_model.cc
+++ b/src/s_tir/meta_schedule/cost_model/cost_model.cc
@@ -64,8 +64,6 @@ CostModel CostModel::PyCostModel(PyCostModelNode::FLoad f_load,      //
 
 // Pattern A (RM): auto-default repr from reflection.
 // Ensure the type index is allocated for Python registration to work.
-// (Previously, TVM_STATIC_IR_FUNCTOR(ReprPrinter).set_dispatch<PyCostModelNode> had
-// a side-effect of calling PyCostModelNode::RuntimeTypeIndex() which registered the type.)
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;

--- a/src/script/ir_builder/base.cc
+++ b/src/script/ir_builder/base.cc
@@ -180,7 +180,7 @@ Namer::FType& Namer::vtable() {
 void Namer::Name(ffi::ObjectRef node, ffi::String name) {
   static const FType& f = vtable();
   TVM_FFI_CHECK(node.defined(), ValueError) << "ValueError: Cannot name nullptr with: " << name;
-  TVM_FFI_CHECK(f.can_dispatch(node), ValueError)
+  TVM_FFI_CHECK(f.CanDispatch(node), ValueError)
       << "ValueError: Do not know how to name type \"" << node->GetTypeKey() << "\"";
   f(node, name);
 }

--- a/src/script/ir_builder/ir/ir.cc
+++ b/src/script/ir_builder/ir/ir.cc
@@ -31,11 +31,13 @@ namespace ir {
 
 using tvm::script::ir_builder::details::Namer;
 
-TVM_STATIC_IR_FUNCTOR(Namer, vtable)
-    .set_dispatch<tvm::VarNode>([](const ffi::ObjectRef& node, ffi::String name) -> void {
-      VarNode* var = const_cast<VarNode*>(node.as<VarNode>());
-      var->name = name;
-    });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  Namer::vtable().SetDispatch<tvm::VarNode>(
+      [](const ffi::ObjectRef& node, ffi::String name) -> void {
+        VarNode* var = const_cast<VarNode*>(node.as<VarNode>());
+        var->name = name;
+      });
+}
 
 IRModuleFrame IRModule() {
   ffi::ObjectPtr<IRModuleFrameNode> n = ffi::make_object<IRModuleFrameNode>();

--- a/src/script/printer/ir/distributed.cc
+++ b/src/script/printer/ir/distributed.cc
@@ -24,16 +24,18 @@ namespace tvm {
 namespace script {
 namespace printer {
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<ffi::Shape>("", [](ffi::Shape n, AccessPath n_p, IRDocsifier d) -> Doc {
-      int s = n.size();
-      ffi::Array<ExprDoc> results;
-      results.reserve(s);
-      for (int i = 0; i < s; ++i) {
-        results.push_back(d->AsDoc<ExprDoc>(IntImm::Int32(n[i]), n_p->ArrayItem(i)));
-      }
-      return TupleDoc(results);
-    });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<ffi::Shape>(
+      "", [](ffi::Shape n, AccessPath n_p, IRDocsifier d) -> Doc {
+        int s = n.size();
+        ffi::Array<ExprDoc> results;
+        results.reserve(s);
+        for (int i = 0; i < s; ++i) {
+          results.push_back(d->AsDoc<ExprDoc>(IntImm::Int32(n[i]), n_p->ArrayItem(i)));
+        }
+        return TupleDoc(results);
+      });
+}
 
 }  // namespace printer
 }  // namespace script

--- a/src/script/printer/ir/ir.cc
+++ b/src/script/printer/ir/ir.cc
@@ -81,125 +81,141 @@ ffi::Optional<ffi::String> GetTypeVarDeclarationName(const StmtDoc& stmt) {
   return lhs->name;
 }
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<IRModule>("", [](IRModule mod, AccessPath p, IRDocsifier d) -> Doc {
-      std::vector<SortableFunction> functions;
-      ffi::Array<StmtDoc> type_var_decls;
-      std::unordered_set<ffi::String> declared_type_vars;
-      for (const auto& kv : mod->functions) {
-        functions.push_back(SortableFunction(kv));
-      }
-      std::sort(functions.begin(), functions.end());
-      With<IRFrame> f(d);
-      (*f)->AddDispatchToken(d, "ir");
-      IdDoc module_doc = d->Define(mod, f(), GetBindingName(d).value_or("Module"));
-      (*f)->global_infos = &mod->global_infos;
-      if (!mod->attrs->dict.empty()) {
-        (*f)->stmts.push_back(
-            ExprStmtDoc(IR(d, "module_attrs")  //
-                            ->Call({d->AsDoc<ExprDoc>(mod->attrs, p->Attr("attrs"))})));
-      }
-      if (mod->global_infos.defined() && !mod->global_infos.empty()) {
-        (*f)->stmts.push_back(ExprStmtDoc(
-            IR(d, "module_global_infos")  //
-                ->Call({d->AsDoc<ExprDoc>(mod->global_infos, p->Attr("global_infos"))})));
-      }
-      // Declare GlobalVars first
-      IdDoc module_alias = d->cfg->module_alias.empty() ? module_doc : IdDoc(d->cfg->module_alias);
-      for (const auto& entry : functions) {
-        const GlobalVar& gv = entry.gv;
-        d->Define(gv, f(), [=]() {
-          return d->AsDoc<ExprDoc>(mod, p->Attr("global_vars"))->Attr(gv->name_hint);
-        });
-      }
-      // Print functions
-      for (const auto& entry : functions) {
-        const GlobalVar& gv = entry.gv;
-        const BaseFunc& base_func = entry.func;
-        d->cfg->binding_names.push_back(gv->name_hint);
-        Doc doc = d->AsDoc(base_func, p->Attr("functions")->MapItem(gv));
-        d->cfg->binding_names.pop_back();
-        if (const auto* stmt_block = doc.as<StmtBlockDocNode>()) {
-          for (const StmtDoc& stmt : stmt_block->stmts) {
-            if (ffi::Optional<ffi::String> name = GetTypeVarDeclarationName(stmt)) {
-              if (!declared_type_vars.count(name.value())) {
-                declared_type_vars.insert(name.value());
-                type_var_decls.push_back(stmt);
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<IRModule>(
+      "", [](IRModule mod, AccessPath p, IRDocsifier d) -> Doc {
+        std::vector<SortableFunction> functions;
+        ffi::Array<StmtDoc> type_var_decls;
+        std::unordered_set<ffi::String> declared_type_vars;
+        for (const auto& kv : mod->functions) {
+          functions.push_back(SortableFunction(kv));
+        }
+        std::sort(functions.begin(), functions.end());
+        With<IRFrame> f(d);
+        (*f)->AddDispatchToken(d, "ir");
+        IdDoc module_doc = d->Define(mod, f(), GetBindingName(d).value_or("Module"));
+        (*f)->global_infos = &mod->global_infos;
+        if (!mod->attrs->dict.empty()) {
+          (*f)->stmts.push_back(
+              ExprStmtDoc(IR(d, "module_attrs")  //
+                              ->Call({d->AsDoc<ExprDoc>(mod->attrs, p->Attr("attrs"))})));
+        }
+        if (mod->global_infos.defined() && !mod->global_infos.empty()) {
+          (*f)->stmts.push_back(ExprStmtDoc(
+              IR(d, "module_global_infos")  //
+                  ->Call({d->AsDoc<ExprDoc>(mod->global_infos, p->Attr("global_infos"))})));
+        }
+        // Declare GlobalVars first
+        IdDoc module_alias =
+            d->cfg->module_alias.empty() ? module_doc : IdDoc(d->cfg->module_alias);
+        for (const auto& entry : functions) {
+          const GlobalVar& gv = entry.gv;
+          d->Define(gv, f(), [=]() {
+            return d->AsDoc<ExprDoc>(mod, p->Attr("global_vars"))->Attr(gv->name_hint);
+          });
+        }
+        // Print functions
+        for (const auto& entry : functions) {
+          const GlobalVar& gv = entry.gv;
+          const BaseFunc& base_func = entry.func;
+          d->cfg->binding_names.push_back(gv->name_hint);
+          Doc doc = d->AsDoc(base_func, p->Attr("functions")->MapItem(gv));
+          d->cfg->binding_names.pop_back();
+          if (const auto* stmt_block = doc.as<StmtBlockDocNode>()) {
+            for (const StmtDoc& stmt : stmt_block->stmts) {
+              if (ffi::Optional<ffi::String> name = GetTypeVarDeclarationName(stmt)) {
+                if (!declared_type_vars.count(name.value())) {
+                  declared_type_vars.insert(name.value());
+                  type_var_decls.push_back(stmt);
+                }
               }
             }
+            (*f)->stmts.push_back(stmt_block->stmts.back());
+            (*f)->stmts.back()->source_paths = std::move(doc->source_paths);
+          } else if (auto stmt = doc.as<StmtDoc>()) {
+            (*f)->stmts.push_back(stmt.value());
+          } else if (auto func = doc.as<FunctionDoc>()) {
+            (*f)->stmts.push_back(func.value());
+          } else if (auto expr = doc.as<ExprDoc>()) {
+            ExprDoc lhs = IdDoc(gv->name_hint);
+            AssignDoc assignment(lhs, expr.value(), std::nullopt);
+            (*f)->stmts.push_back(assignment);
+          } else {
+            TVM_FFI_THROW(TypeError)
+                << "Expected IRModule to only contain functions, "
+                << " but mod[" << gv->name_hint << "] with type  " << base_func->GetTypeKey()
+                << " produced Doc type of " << doc->GetTypeKey();
           }
-          (*f)->stmts.push_back(stmt_block->stmts.back());
-          (*f)->stmts.back()->source_paths = std::move(doc->source_paths);
-        } else if (auto stmt = doc.as<StmtDoc>()) {
-          (*f)->stmts.push_back(stmt.value());
-        } else if (auto func = doc.as<FunctionDoc>()) {
-          (*f)->stmts.push_back(func.value());
-        } else if (auto expr = doc.as<ExprDoc>()) {
-          ExprDoc lhs = IdDoc(gv->name_hint);
-          AssignDoc assignment(lhs, expr.value(), std::nullopt);
-          (*f)->stmts.push_back(assignment);
-        } else {
-          TVM_FFI_THROW(TypeError)
-              << "Expected IRModule to only contain functions, "
-              << " but mod[" << gv->name_hint << "] with type  " << base_func->GetTypeKey()
-              << " produced Doc type of " << doc->GetTypeKey();
         }
-      }
-      ClassDoc class_doc(module_doc, {IR(d, "ir_module")}, (*f)->stmts);
-      if (type_var_decls.empty()) {
-        return HeaderWrapper(d, class_doc);
-      }
-      type_var_decls.push_back(class_doc);
-      return HeaderWrapper(d, StmtBlockDoc(type_var_decls));
-    });
+        ClassDoc class_doc(module_doc, {IR(d, "ir_module")}, (*f)->stmts);
+        if (type_var_decls.empty()) {
+          return HeaderWrapper(d, class_doc);
+        }
+        type_var_decls.push_back(class_doc);
+        return HeaderWrapper(d, StmtBlockDoc(type_var_decls));
+      });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<DictAttrs>("", [](DictAttrs attrs, AccessPath p, IRDocsifier d) -> Doc {
-      return d->AsDoc(attrs->dict, p->Attr("dict"));
-    });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<DictAttrs>(
+      "", [](DictAttrs attrs, AccessPath p, IRDocsifier d) -> Doc {
+        return d->AsDoc(attrs->dict, p->Attr("dict"));
+      });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<GlobalVar>("", [](GlobalVar gv, AccessPath p, IRDocsifier d) -> Doc {
-      return IR(d, "GlobalVar")->Call({LiteralDoc::Str(gv->name_hint, p->Attr("name_hint"))});
-    });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<GlobalVar>(
+      "", [](GlobalVar gv, AccessPath p, IRDocsifier d) -> Doc {
+        return IR(d, "GlobalVar")->Call({LiteralDoc::Str(gv->name_hint, p->Attr("name_hint"))});
+      });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<DummyGlobalInfo>("", [](GlobalInfo ginfo, AccessPath p, IRDocsifier d) -> Doc {
-      return IR(d, "dummy_global_info")->Call({});
-    });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<DummyGlobalInfo>(
+      "", [](GlobalInfo ginfo, AccessPath p, IRDocsifier d) -> Doc {
+        return IR(d, "dummy_global_info")->Call({});
+      });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<VDevice>("", [](VDevice vdev, AccessPath p, IRDocsifier d) -> Doc {
-      d->AddGlobalInfo("vdevice", vdev);
-      ffi::Map<ffi::String, ffi::Any> config = vdev->target->ToConfig();
-      return IR(d, "vdevice")
-          ->Call({d->AsDoc<ExprDoc>(config, p),
-                  LiteralDoc::Int(vdev->vdevice_id, p->Attr("vdevice_id")),
-                  LiteralDoc::Str(vdev->memory_scope, p->Attr("memory_scope"))});
-    });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<VDevice>(
+      "", [](VDevice vdev, AccessPath p, IRDocsifier d) -> Doc {
+        d->AddGlobalInfo("vdevice", vdev);
+        ffi::Map<ffi::String, ffi::Any> config = vdev->target->ToConfig();
+        return IR(d, "vdevice")
+            ->Call({d->AsDoc<ExprDoc>(config, p),
+                    LiteralDoc::Int(vdev->vdevice_id, p->Attr("vdevice_id")),
+                    LiteralDoc::Str(vdev->memory_scope, p->Attr("memory_scope"))});
+      });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<Op>("", [](Op op, AccessPath p, IRDocsifier d) -> Doc {
-      return IR(d, "Op")->Call({LiteralDoc::Str(op->name, p->Attr("name"))});
-    });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<Op>("", [](Op op, AccessPath p, IRDocsifier d) -> Doc {
+    return IR(d, "Op")->Call({LiteralDoc::Str(op->name, p->Attr("name"))});
+  });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<FuncType>("", [](FuncType func_type, AccessPath p, IRDocsifier d) -> Doc {
-      return IR(d, "FuncType")
-          ->Call({
-              d->AsDoc<ExprDoc>(func_type->arg_types, p->Attr("arg_types")),
-              d->AsDoc<ExprDoc>(func_type->ret_type, p->Attr("ret_type")),
-          });
-    });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<FuncType>(
+      "", [](FuncType func_type, AccessPath p, IRDocsifier d) -> Doc {
+        return IR(d, "FuncType")
+            ->Call({
+                d->AsDoc<ExprDoc>(func_type->arg_types, p->Attr("arg_types")),
+                d->AsDoc<ExprDoc>(func_type->ret_type, p->Attr("ret_type")),
+            });
+      });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<Range>("ir", [](Range range, AccessPath p, IRDocsifier d) -> Doc {
-      return IR(d, "Range")
-          ->Call({
-              d->AsDoc<ExprDoc>(range->min, p->Attr("min")),
-              d->AsDoc<ExprDoc>(range->extent + range->min, p->Attr("extent")),
-          });
-    });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<Range>(
+      "ir", [](Range range, AccessPath p, IRDocsifier d) -> Doc {
+        return IR(d, "Range")
+            ->Call({
+                d->AsDoc<ExprDoc>(range->min, p->Attr("min")),
+                d->AsDoc<ExprDoc>(range->extent + range->min, p->Attr("extent")),
+            });
+      });
+}
 
 std::string ReprPrintIRModule(const ffi::ObjectRef& mod, const PrinterConfig& cfg) {
   return ReprPrintIR(mod, cfg);

--- a/src/script/printer/ir/misc.cc
+++ b/src/script/printer/ir/misc.cc
@@ -22,46 +22,48 @@ namespace tvm {
 namespace script {
 namespace printer {
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<ffi::Array<Any>>(  //
-        "", [](ffi::Array<Any> array, AccessPath p, IRDocsifier d) -> Doc {
-          int n = array.size();
-          ffi::Array<ExprDoc> results;
-          results.reserve(n);
-          for (int i = 0; i < n; ++i) {
-            results.push_back(d->AsDoc<ExprDoc>(array[i], p->ArrayItem(i)));
-          }
-          return ListDoc(results);
-        });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<ffi::Array<Any>>(  //
+      "", [](ffi::Array<Any> array, AccessPath p, IRDocsifier d) -> Doc {
+        int n = array.size();
+        ffi::Array<ExprDoc> results;
+        results.reserve(n);
+        for (int i = 0; i < n; ++i) {
+          results.push_back(d->AsDoc<ExprDoc>(array[i], p->ArrayItem(i)));
+        }
+        return ListDoc(results);
+      });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<ffi::Map<Any, Any>>(  //
-        "", [](ffi::Map<Any, Any> dict, AccessPath p, IRDocsifier d) -> Doc {
-          using POO = std::pair<Any, Any>;
-          std::vector<POO> items{dict.begin(), dict.end()};
-          bool is_str_map = true;
-          for (const auto& kv : items) {
-            if (!kv.first.as<ffi::String>()) {
-              is_str_map = false;
-              break;
-            }
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<ffi::Map<Any, Any>>(  //
+      "", [](ffi::Map<Any, Any> dict, AccessPath p, IRDocsifier d) -> Doc {
+        using POO = std::pair<Any, Any>;
+        std::vector<POO> items{dict.begin(), dict.end()};
+        bool is_str_map = true;
+        for (const auto& kv : items) {
+          if (!kv.first.as<ffi::String>()) {
+            is_str_map = false;
+            break;
           }
-          if (is_str_map) {
-            std::sort(items.begin(), items.end(), [](const POO& lhs, const POO& rhs) {
-              return lhs.first.as_or_throw<ffi::String>() < rhs.first.as_or_throw<ffi::String>();
-            });
-          }
-          int n = dict.size();
-          ffi::Array<ExprDoc> ks;
-          ffi::Array<ExprDoc> vs;
-          ks.reserve(n);
-          vs.reserve(n);
-          for (int i = 0; i < n; ++i) {
-            ks.push_back(d->AsDoc<ExprDoc>(items[i].first, p->MapItemMissing(items[i].first)));
-            vs.push_back(d->AsDoc<ExprDoc>(items[i].second, p->MapItem(items[i].first)));
-          }
-          return DictDoc(ks, vs);
-        });
+        }
+        if (is_str_map) {
+          std::sort(items.begin(), items.end(), [](const POO& lhs, const POO& rhs) {
+            return lhs.first.as_or_throw<ffi::String>() < rhs.first.as_or_throw<ffi::String>();
+          });
+        }
+        int n = dict.size();
+        ffi::Array<ExprDoc> ks;
+        ffi::Array<ExprDoc> vs;
+        ks.reserve(n);
+        vs.reserve(n);
+        for (int i = 0; i < n; ++i) {
+          ks.push_back(d->AsDoc<ExprDoc>(items[i].first, p->MapItemMissing(items[i].first)));
+          vs.push_back(d->AsDoc<ExprDoc>(items[i].second, p->MapItem(items[i].first)));
+        }
+        return DictDoc(ks, vs);
+      });
+}
 
 }  // namespace printer
 }  // namespace script

--- a/src/script/printer/ir_docsifier.cc
+++ b/src/script/printer/ir_docsifier.cc
@@ -208,10 +208,10 @@ IRDocsifier::FType& IRDocsifier::vtable() {
   return inst;
 }
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_fallback([](ffi::ObjectRef obj, AccessPath p, IRDocsifier d) -> Doc {
-      return d->AddMetadata(obj);
-    });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_fallback(
+      [](ffi::ObjectRef obj, AccessPath p, IRDocsifier d) -> Doc { return d->AddMetadata(obj); });
+}
 
 }  // namespace printer
 }  // namespace script

--- a/src/script/printer/script_printer.cc
+++ b/src/script/printer/script_printer.cc
@@ -56,7 +56,7 @@ TVMScriptPrinter::FType& TVMScriptPrinter::vtable() {
 
 std::string Script(const ffi::ObjectRef& node, const ffi::Optional<PrinterConfig>& cfg) {
   PrinterConfig config = cfg.value_or(PrinterConfig());
-  if (!TVMScriptPrinter::vtable().can_dispatch(node)) {
+  if (!TVMScriptPrinter::vtable().CanDispatch(node)) {
     // Fall back to ffi::ReprPrint for types not registered with TVMScriptPrinter.
     return RenderFallbackWithInvisiblePathInfo(ffi::ReprPrint(ffi::Any(node)), config);
   }

--- a/src/tirx/script/builder/ir.cc
+++ b/src/tirx/script/builder/ir.cc
@@ -921,25 +921,30 @@ Var Ptr(PrimType dtype, ffi::String storage_scope = "global") {
 
 using tvm::script::ir_builder::details::Namer;
 
-TVM_STATIC_IR_FUNCTOR(Namer, vtable)
-    .set_dispatch<TensorLoadNode>([](const ffi::ObjectRef& node, ffi::String name) -> void {
-      using namespace tvm::tirx;
-      TensorLoadNode* buffer = const_cast<TensorLoadNode*>(node.as<TensorLoadNode>());
-      Namer::Name(buffer->source.as_or_throw<tvm::tirx::BufferVar>(), name);
-    });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  Namer::vtable().SetDispatch<TensorLoadNode>(
+      [](const ffi::ObjectRef& node, ffi::String name) -> void {
+        using namespace tvm::tirx;
+        TensorLoadNode* buffer = const_cast<TensorLoadNode*>(node.as<TensorLoadNode>());
+        Namer::Name(buffer->source.as_or_throw<tvm::tirx::BufferVar>(), name);
+      });
+}
 
-TVM_STATIC_IR_FUNCTOR(Namer, vtable)
-    .set_dispatch<tvm::tirx::TileLayoutNode>([](const ffi::ObjectRef& node,
-                                                ffi::String name) -> void {
+TVM_FFI_STATIC_INIT_BLOCK() {
+  Namer::vtable().SetDispatch<tvm::tirx::TileLayoutNode>(
+      [](const ffi::ObjectRef& node, ffi::String name) -> void {
 
-    });
+      });
+}
 
-TVM_STATIC_IR_FUNCTOR(Namer, vtable)
-    .set_dispatch<tvm::tirx::IterVarNode>([](const ffi::ObjectRef& node, ffi::String name) -> void {
-      using namespace tvm::tirx;
-      IterVarNode* var = const_cast<IterVarNode*>(node.as<IterVarNode>());
-      Namer::Name(var->var, name);
-    });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  Namer::vtable().SetDispatch<tvm::tirx::IterVarNode>(
+      [](const ffi::ObjectRef& node, ffi::String name) -> void {
+        using namespace tvm::tirx;
+        IterVarNode* var = const_cast<IterVarNode*>(node.as<IterVarNode>());
+        Namer::Name(var->var, name);
+      });
+}
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;

--- a/src/tirx/script/printer/block.cc
+++ b/src/tirx/script/printer/block.cc
@@ -216,90 +216,95 @@ Doc PrintBlock(IRDocsifier d, tirx::SBlock block, AccessPath block_p,  //
                   (*frame)->stmts);
 }
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<tirx::SBlockRealize>(
-        "", [](tirx::SBlockRealize realize, AccessPath p, IRDocsifier d) -> Doc {
-          Doc doc = PrintBlock(d, realize->block, p->Attr("block"), realize, p);
-          // since we do not have d->AsDoc for realize->block,
-          // we should add possible doc decoration manually.
-          AddDocDecoration<ScopeDoc>(doc, realize->block, p->Attr("block"), d->cfg);
-          return doc;
-        });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<tirx::SBlockRealize>(
+      "", [](tirx::SBlockRealize realize, AccessPath p, IRDocsifier d) -> Doc {
+        Doc doc = PrintBlock(d, realize->block, p->Attr("block"), realize, p);
+        // since we do not have d->AsDoc for realize->block,
+        // we should add possible doc decoration manually.
+        AddDocDecoration<ScopeDoc>(doc, realize->block, p->Attr("block"), d->cfg);
+        return doc;
+      });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<tirx::SBlock>("", [](tirx::SBlock block, AccessPath p, IRDocsifier d) -> Doc {
-      return PrintBlock(d, block, p, std::nullopt, std::nullopt);
-    });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<tirx::SBlock>(
+      "", [](tirx::SBlock block, AccessPath p, IRDocsifier d) -> Doc {
+        return PrintBlock(d, block, p, std::nullopt, std::nullopt);
+      });
+}
 
 TVM_REGISTER_SCRIPT_AS_REPR(tirx::SBlockNode, ReprPrintTIR);
 TVM_REGISTER_SCRIPT_AS_REPR(tirx::SBlockRealizeNode, ReprPrintTIR);
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<tirx::ScopeIdDefStmt>(
-        "", [](tirx::ScopeIdDefStmt stmt, AccessPath p, IRDocsifier d) -> Doc {
-          // Render as ``(var1, var2, ...) = T.cta_id([ext], preferred=[...])``
-          // (or the appropriate API name for the binding).
-          TVM_FFI_ICHECK(!d->frames.empty());
-          tirx::ScopeIdDef def = stmt->def;
-          AccessPath def_p = p->Attr("def");
-          ffi::Array<ExprDoc> lhs;
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<tirx::ScopeIdDefStmt>(
+      "", [](tirx::ScopeIdDefStmt stmt, AccessPath p, IRDocsifier d) -> Doc {
+        // Render as ``(var1, var2, ...) = T.cta_id([ext], preferred=[...])``
+        // (or the appropriate API name for the binding).
+        TVM_FFI_ICHECK(!d->frames.empty());
+        tirx::ScopeIdDef def = stmt->def;
+        AccessPath def_p = p->Attr("def");
+        ffi::Array<ExprDoc> lhs;
+        for (auto scope_id : def->def_ids) {
+          lhs.push_back(DefineVar(scope_id, d->frames.back(), d));
+        }
+        ffi::Array<ExprDoc> rhs_args;
+        if (def->scope != tirx::ScopeBinding::kClusterCtaPair && def->extents.has_value()) {
+          rhs_args.push_back(d->AsDoc<ExprDoc>(def->extents.value(), def_p->Attr("extents")));
+        }
+        ffi::Array<ffi::String> kwarg_keys;
+        ffi::Array<ExprDoc> kwarg_vals;
+        if (def->preferred_extents.has_value()) {
+          kwarg_keys.push_back("preferred");
+          kwarg_vals.push_back(
+              d->AsDoc<ExprDoc>(def->preferred_extents.value(), def_p->Attr("preferred_extents")));
+        }
+        // The scope-id dtype is independent of the extents, so it has to be printed
+        // explicitly whenever it is not the int32 default in order to round-trip.
+        if (!def->def_ids.empty()) {
+          PrimType scope_id_ty = def->def_ids[0].ty();
           for (auto scope_id : def->def_ids) {
-            lhs.push_back(DefineVar(scope_id, d->frames.back(), d));
+            TVM_FFI_ICHECK(scope_id.ty() == scope_id_ty)
+                << "mixed scope-id dtypes are unsupported, got " << scope_id_ty << " and "
+                << scope_id.ty();
           }
-          ffi::Array<ExprDoc> rhs_args;
-          if (def->scope != tirx::ScopeBinding::kClusterCtaPair && def->extents.has_value()) {
-            rhs_args.push_back(d->AsDoc<ExprDoc>(def->extents.value(), def_p->Attr("extents")));
+          if (scope_id_ty != PrimType::Int(32)) {
+            kwarg_keys.push_back("dtype");
+            kwarg_vals.push_back(
+                LiteralDoc::Str(DType2Str(scope_id_ty->dtype), def_p->Attr("def_ids")));
           }
-          ffi::Array<ffi::String> kwarg_keys;
-          ffi::Array<ExprDoc> kwarg_vals;
-          if (def->preferred_extents.has_value()) {
-            kwarg_keys.push_back("preferred");
-            kwarg_vals.push_back(d->AsDoc<ExprDoc>(def->preferred_extents.value(),
-                                                   def_p->Attr("preferred_extents")));
-          }
-          // The scope-id dtype is independent of the extents, so it has to be printed
-          // explicitly whenever it is not the int32 default in order to round-trip.
-          if (!def->def_ids.empty()) {
-            PrimType scope_id_ty = def->def_ids[0].ty();
-            for (auto scope_id : def->def_ids) {
-              TVM_FFI_ICHECK(scope_id.ty() == scope_id_ty)
-                  << "mixed scope-id dtypes are unsupported, got " << scope_id_ty << " and "
-                  << scope_id.ty();
-            }
-            if (scope_id_ty != PrimType::Int(32)) {
-              kwarg_keys.push_back("dtype");
-              kwarg_vals.push_back(
-                  LiteralDoc::Str(DType2Str(scope_id_ty->dtype), def_p->Attr("def_ids")));
-            }
-          }
-          ExprDoc rhs = TIR(d, ScopeIdApiName(def->scope))->Call(rhs_args, kwarg_keys, kwarg_vals);
-          return AssignDoc(TupleDoc(lhs), rhs, std::nullopt);
-        });
+        }
+        ExprDoc rhs = TIR(d, ScopeIdApiName(def->scope))->Call(rhs_args, kwarg_keys, kwarg_vals);
+        return AssignDoc(TupleDoc(lhs), rhs, std::nullopt);
+      });
+}
 
 TVM_SCRIPT_REPR(tirx::ScopeIdDefStmtNode, ReprPrintTIR);
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<tirx::ExecScope>(
-        "", [](tirx::ExecScope exec_scope, AccessPath p, IRDocsifier d) -> Doc {
-          Doc doc =
-              TIR(d, "ExecScope")->Call({LiteralDoc::Str(exec_scope->name(), p->Attr("name"))});
-          return doc;
-        });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<tirx::ExecScope>(
+      "", [](tirx::ExecScope exec_scope, AccessPath p, IRDocsifier d) -> Doc {
+        Doc doc = TIR(d, "ExecScope")->Call({LiteralDoc::Str(exec_scope->name(), p->Attr("name"))});
+        return doc;
+      });
+}
 TVM_SCRIPT_REPR(tirx::ExecScopeNode, ReprPrintTIR);
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<tirx::ScopeIdDef>(
-        "", [](tirx::ScopeIdDef def, AccessPath p, IRDocsifier d) -> Doc {
-          auto [parent, cur] = tirx::ScopeBindingToStringPair(def->scope);
-          ExprDoc extents_doc = def->extents.has_value()
-                                    ? d->AsDoc<ExprDoc>(def->extents.value(), p->Attr("extents"))
-                                    : LiteralDoc::None(p->Attr("extents"));
-          Doc doc = TIR(d, "ScopeIdDef")
-                        ->Call({d->AsDoc<ExprDoc>(def->def_ids, p->Attr("def_ids")), extents_doc,
-                                LiteralDoc::Str(parent, p->Attr("parent")),
-                                LiteralDoc::Str(cur, p->Attr("cur"))});
-          return doc;
-        });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<tirx::ScopeIdDef>(
+      "", [](tirx::ScopeIdDef def, AccessPath p, IRDocsifier d) -> Doc {
+        auto [parent, cur] = tirx::ScopeBindingToStringPair(def->scope);
+        ExprDoc extents_doc = def->extents.has_value()
+                                  ? d->AsDoc<ExprDoc>(def->extents.value(), p->Attr("extents"))
+                                  : LiteralDoc::None(p->Attr("extents"));
+        Doc doc = TIR(d, "ScopeIdDef")
+                      ->Call({d->AsDoc<ExprDoc>(def->def_ids, p->Attr("def_ids")), extents_doc,
+                              LiteralDoc::Str(parent, p->Attr("parent")),
+                              LiteralDoc::Str(cur, p->Attr("cur"))});
+        return doc;
+      });
+}
 TVM_SCRIPT_REPR(tirx::ScopeIdDefNode, ReprPrintTIR);
 
 }  // namespace printer

--- a/src/tirx/script/printer/buffer.cc
+++ b/src/tirx/script/printer/buffer.cc
@@ -412,66 +412,73 @@ ffi::Array<Doc> BufferSlices(const ffi::Array<Range>& region, const AccessPath& 
   return indices;
 }
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<tirx::BufferRegion>(
-        "", [](tirx::BufferRegion buffer_region, AccessPath p, IRDocsifier d) -> Doc {
-          ExprDoc prefix = d->AsDoc<ExprDoc>(buffer_region->buffer, p->Attr("buffer"));
-          return prefix[BufferSlices(buffer_region->region, p->Attr("region"), d)];
-        });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<tirx::BufferRegion>(
+      "", [](tirx::BufferRegion buffer_region, AccessPath p, IRDocsifier d) -> Doc {
+        ExprDoc prefix = d->AsDoc<ExprDoc>(buffer_region->buffer, p->Attr("buffer"));
+        return prefix[BufferSlices(buffer_region->region, p->Attr("region"), d)];
+      });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<tirx::BufferStore>(  //
-        "", [](tirx::BufferStore store, AccessPath p, IRDocsifier d) -> Doc {
-          ExprDoc buffer = d->AsDoc<ExprDoc>(store->buffer, p->Attr("buffer"));
-          ExprDoc value = d->AsDoc<ExprDoc>(store->value, p->Attr("value"));
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<tirx::BufferStore>(  //
+      "", [](tirx::BufferStore store, AccessPath p, IRDocsifier d) -> Doc {
+        ExprDoc buffer = d->AsDoc<ExprDoc>(store->buffer, p->Attr("buffer"));
+        ExprDoc value = d->AsDoc<ExprDoc>(store->value, p->Attr("value"));
 
-          // special case for scalar buffers
-          if (store->buffer.IsScalar(true) || store->buffer.IsScalar(false)) {
-            // TVM_FFI_ICHECK(store->indices.size() == 1 && tirx::is_zero(store->indices[0]))
-            //     << "1-dim buffer with shape (1,) store with indices other than [0] is not "
-            //        "supported";
-            ffi::Optional<ExprDoc> doc = d->GetVarDoc(store->buffer);
-            TVM_FFI_ICHECK(doc.has_value())
-                << "buffer is not defined in the environment: " << store->buffer;
-            return AssignDoc(doc.value(), value, std::nullopt);
-          }
+        // special case for scalar buffers
+        if (store->buffer.IsScalar(true) || store->buffer.IsScalar(false)) {
+          // TVM_FFI_ICHECK(store->indices.size() == 1 && tirx::is_zero(store->indices[0]))
+          //     << "1-dim buffer with shape (1,) store with indices other than [0] is not "
+          //        "supported";
+          ffi::Optional<ExprDoc> doc = d->GetVarDoc(store->buffer);
+          TVM_FFI_ICHECK(doc.has_value())
+              << "buffer is not defined in the environment: " << store->buffer;
+          return AssignDoc(doc.value(), value, std::nullopt);
+        }
 
-          return AssignDoc(
-              /*lhs=*/buffer[BufferIndices(store->indices, p->Attr("indices"), d)],
-              /*rhs=*/value, std::nullopt);
-        });
+        return AssignDoc(
+            /*lhs=*/buffer[BufferIndices(store->indices, p->Attr("indices"), d)],
+            /*rhs=*/value, std::nullopt);
+      });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<TensorLoad>(  //
-        "", [](TensorLoad load, AccessPath p, IRDocsifier d) -> Doc {
-          tvm::tirx::BufferVar source = load->source.as_or_throw<tvm::tirx::BufferVar>();
-          ExprDoc buffer = d->AsDoc<ExprDoc>(source, p->Attr("source"));
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<TensorLoad>(  //
+      "", [](TensorLoad load, AccessPath p, IRDocsifier d) -> Doc {
+        tvm::tirx::BufferVar source = load->source.as_or_throw<tvm::tirx::BufferVar>();
+        ExprDoc buffer = d->AsDoc<ExprDoc>(source, p->Attr("source"));
 
-          // special case for scalar
-          if (source.IsScalar(true) || source.IsScalar(false)) {
-            // TVM_FFI_ICHECK(load->indices.size() == 1 && tirx::is_zero(load->indices[0]))
-            //     << "Scalar buffer load with indices other than [0] is not supported";
-            ffi::Optional<ExprDoc> doc = d->GetVarDoc(source);
-            TVM_FFI_ICHECK(doc.has_value())
-                << "Scalar buffer is not defined in the environment: " << source;
-            return doc.value();
-          }
+        // special case for scalar
+        if (source.IsScalar(true) || source.IsScalar(false)) {
+          // TVM_FFI_ICHECK(load->indices.size() == 1 && tirx::is_zero(load->indices[0]))
+          //     << "Scalar buffer load with indices other than [0] is not supported";
+          ffi::Optional<ExprDoc> doc = d->GetVarDoc(source);
+          TVM_FFI_ICHECK(doc.has_value())
+              << "Scalar buffer is not defined in the environment: " << source;
+          return doc.value();
+        }
 
-          return buffer[BufferLoadIndices(load->indices, p->Attr("indices"), d)];
-        });
+        return buffer[BufferLoadIndices(load->indices, p->Attr("indices"), d)];
+      });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<tirx::Axis>("", [](tirx::Axis axis, AccessPath p, IRDocsifier d) -> Doc {
-      return LiteralDoc::Str(axis->name, p->Attr("name"));
-    });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<tirx::Axis>(
+      "", [](tirx::Axis axis, AccessPath p, IRDocsifier d) -> Doc {
+        return LiteralDoc::Str(axis->name, p->Attr("name"));
+      });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<tirx::Iter>("", [](tirx::Iter iter, AccessPath p, IRDocsifier d) -> Doc {
-      return TIR(d, "Iter")->Call({d->AsDoc<ExprDoc>(iter->extent, p->Attr("extent")),
-                                   d->AsDoc<ExprDoc>(iter->stride, p->Attr("stride")),
-                                   d->AsDoc<ExprDoc>(iter->axis->name, p->Attr("axis"))},
-                                  {}, {});
-    });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<tirx::Iter>(
+      "", [](tirx::Iter iter, AccessPath p, IRDocsifier d) -> Doc {
+        return TIR(d, "Iter")->Call({d->AsDoc<ExprDoc>(iter->extent, p->Attr("extent")),
+                                     d->AsDoc<ExprDoc>(iter->stride, p->Attr("stride")),
+                                     d->AsDoc<ExprDoc>(iter->axis->name, p->Attr("axis"))},
+                                    {}, {});
+      });
+}
 
 Doc PrintTileLayout(tirx::TileLayout layout, IRDocsifier d, AccessPath p) {
   using OpKind = OperationDocNode::Kind;
@@ -559,39 +566,45 @@ Doc PrintTileLayout(tirx::TileLayout layout, IRDocsifier d, AccessPath p) {
   return TIRx(d, "TileLayout")->Call({spec.value()}, {}, {});
 }
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)  //
-    .set_dispatch<tirx::TileLayout>("",
-                                    [](tirx::TileLayout layout, AccessPath p, IRDocsifier d)
-                                        -> Doc { return PrintTileLayout(layout, d, p); });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable()  //
+      .set_dispatch<tirx::TileLayout>(
+          "", [](tirx::TileLayout layout, AccessPath p, IRDocsifier d) -> Doc {
+            return PrintTileLayout(layout, d, p);
+          });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)  //
-    .set_dispatch<tirx::ComposeLayout>(
-        "", [](tirx::ComposeLayout layout, AccessPath p, IRDocsifier d) -> Doc {
-          auto per_element = LiteralDoc::Int(layout->per_element, p->Attr("per_element"));
-          auto swizzle_len = LiteralDoc::Int(layout->swizzle_len, p->Attr("swizzle_len"));
-          auto atom_len = LiteralDoc::Int(layout->atom_len, p->Attr("atom_len"));
-          auto tile_doc = d->AsDoc<ExprDoc>(layout->tile_layout, p->Attr("tile_layout"));
-          ffi::Array<ffi::String> kwargs_keys;
-          ffi::Array<ExprDoc> kwargs_values;
-          if (!layout->swizzle_inner) {
-            kwargs_keys.push_back("swizzle_inner");
-            kwargs_values.push_back(
-                LiteralDoc::Boolean(layout->swizzle_inner, p->Attr("swizzle_inner")));
-          }
-          return TIRx(d, "ComposeLayout")
-              ->Call({per_element, swizzle_len, atom_len, tile_doc}, kwargs_keys, kwargs_values);
-        });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable()  //
+      .set_dispatch<tirx::ComposeLayout>(
+          "", [](tirx::ComposeLayout layout, AccessPath p, IRDocsifier d) -> Doc {
+            auto per_element = LiteralDoc::Int(layout->per_element, p->Attr("per_element"));
+            auto swizzle_len = LiteralDoc::Int(layout->swizzle_len, p->Attr("swizzle_len"));
+            auto atom_len = LiteralDoc::Int(layout->atom_len, p->Attr("atom_len"));
+            auto tile_doc = d->AsDoc<ExprDoc>(layout->tile_layout, p->Attr("tile_layout"));
+            ffi::Array<ffi::String> kwargs_keys;
+            ffi::Array<ExprDoc> kwargs_values;
+            if (!layout->swizzle_inner) {
+              kwargs_keys.push_back("swizzle_inner");
+              kwargs_values.push_back(
+                  LiteralDoc::Boolean(layout->swizzle_inner, p->Attr("swizzle_inner")));
+            }
+            return TIRx(d, "ComposeLayout")
+                ->Call({per_element, swizzle_len, atom_len, tile_doc}, kwargs_keys, kwargs_values);
+          });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<tirx::MatchBufferRegion>(
-        "", [](tirx::MatchBufferRegion stmt, AccessPath p, IRDocsifier d) -> Doc {
-          Frame frame = d->frames.back();
-          ExprDoc lhs = DefineBuffer(stmt->buffer, frame, d);
-          ExprDoc src_buffer = d->AsDoc<ExprDoc>(stmt->source, p->Attr("source"));
-          ExprDoc rhs = BufferDecl(stmt->buffer, "match_buffer", {src_buffer}, p->Attr("buffer"),
-                                   d->frames.back(), d, BufferVarDefinition::MatchBuffer);
-          return AssignDoc(lhs, rhs, std::nullopt);
-        });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<tirx::MatchBufferRegion>(
+      "", [](tirx::MatchBufferRegion stmt, AccessPath p, IRDocsifier d) -> Doc {
+        Frame frame = d->frames.back();
+        ExprDoc lhs = DefineBuffer(stmt->buffer, frame, d);
+        ExprDoc src_buffer = d->AsDoc<ExprDoc>(stmt->source, p->Attr("source"));
+        ExprDoc rhs = BufferDecl(stmt->buffer, "match_buffer", {src_buffer}, p->Attr("buffer"),
+                                 d->frames.back(), d, BufferVarDefinition::MatchBuffer);
+        return AssignDoc(lhs, rhs, std::nullopt);
+      });
+}
 
 TVM_SCRIPT_REPR(tirx::BufferRegionNode, ReprPrintTIR);
 TVM_SCRIPT_REPR(TensorLoadNode, ReprPrintTIR);

--- a/src/tirx/script/printer/expr.cc
+++ b/src/tirx/script/printer/expr.cc
@@ -26,17 +26,20 @@ namespace tvm {
 namespace script {
 namespace printer {
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<Tuple>("tirx", [](Tuple tuple, AccessPath tuple_p, IRDocsifier d) -> Doc {
-      return TupleDoc(d->AsDoc<ListDoc>(tuple->fields, tuple_p->Attr("fields"))->elements);
-    });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<Tuple>(
+      "tirx", [](Tuple tuple, AccessPath tuple_p, IRDocsifier d) -> Doc {
+        return TupleDoc(d->AsDoc<ListDoc>(tuple->fields, tuple_p->Attr("fields"))->elements);
+      });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<TupleGetItem>(
-        "tirx", [](TupleGetItem get_item, AccessPath get_item_p, IRDocsifier d) -> Doc {
-          ExprDoc index = LiteralDoc::Int(get_item->index, get_item_p->Attr("index"));
-          return d->AsDoc<ExprDoc>(get_item->tuple, get_item_p->Attr("tuple"))[{index}];
-        });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<TupleGetItem>(
+      "tirx", [](TupleGetItem get_item, AccessPath get_item_p, IRDocsifier d) -> Doc {
+        ExprDoc index = LiteralDoc::Int(get_item->index, get_item_p->Attr("index"));
+        return d->AsDoc<ExprDoc>(get_item->tuple, get_item_p->Attr("tuple"))[{index}];
+      });
+}
 
 ExprDoc PrintVarCreation(const tirx::Var& var, const AccessPath& var_p, const IRDocsifier& d) {
   Type type = var->ty;
@@ -99,145 +102,162 @@ Doc PrintVar(const tirx::Var& var, const AccessPath& var_p, const IRDocsifier& d
   TVM_FFI_UNREACHABLE();
 }
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)  //
-    .set_dispatch<tirx::Var>("", [](tirx::Var var, AccessPath p, IRDocsifier d) -> Doc {
-      if (var->ty.as<tirx::BufferTypeNode>()) {
-        tirx::BufferVar buffer(var);
-        if (!d->IsVarDefined(buffer)) {
-          if (ffi::Optional<Frame> opt_f = FindLowestVarDef(buffer, d)) {
-            ExprDoc lhs = DefineBuffer(buffer, opt_f.value(), d);
-            ExprDoc rhs = BufferDecl(buffer, "Buffer", {}, p, opt_f.value(), d,
-                                     BufferVarDefinition::DataPointer);
-            opt_f.value()->stmts.push_back(AssignDoc(lhs, rhs, std::nullopt));
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable()  //
+      .set_dispatch<tirx::Var>("", [](tirx::Var var, AccessPath p, IRDocsifier d) -> Doc {
+        if (var->ty.as<tirx::BufferTypeNode>()) {
+          tirx::BufferVar buffer(var);
+          if (!d->IsVarDefined(buffer)) {
+            if (ffi::Optional<Frame> opt_f = FindLowestVarDef(buffer, d)) {
+              ExprDoc lhs = DefineBuffer(buffer, opt_f.value(), d);
+              ExprDoc rhs = BufferDecl(buffer, "Buffer", {}, p, opt_f.value(), d,
+                                       BufferVarDefinition::DataPointer);
+              opt_f.value()->stmts.push_back(AssignDoc(lhs, rhs, std::nullopt));
+            }
           }
-        }
-        if (ffi::Optional<ExprDoc> doc = d->GetVarDoc(buffer)) {
-          // special case for scalar buffer
-          if (buffer.IsScalar()) {
-            return doc.value()->Attr("source");
+          if (ffi::Optional<ExprDoc> doc = d->GetVarDoc(buffer)) {
+            // special case for scalar buffer
+            if (buffer.IsScalar()) {
+              return doc.value()->Attr("source");
+            }
+            return doc.value();
           }
-          return doc.value();
+          TVM_FFI_THROW(IndexError) << "BufferVar is not defined in the environment: " << buffer;
         }
-        TVM_FFI_THROW(IndexError) << "BufferVar is not defined in the environment: " << buffer;
-      }
-      if (var->ty.as<PrimTypeNode>() || var->ty.as<PointerTypeNode>()) {
-        return PrintVar(var, p, d);
-      }
-      if (!d->IsVarDefined(var)) {
-        ExprDoc ann = d->AsDoc<ExprDoc>(var->ty, p->Attr("ty"));
-        Frame f = d->frames.back();
-        ExprDoc lhs = d->Define(var, f, var->name.empty() ? "v" : var->name);
-        f->stmts.push_back(AssignDoc(lhs, std::nullopt, ann));
-      }
-      return d->GetVarDoc(var).value();
-    });
-
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<tirx::IterVar>("", [](tirx::IterVar var, AccessPath var_p, IRDocsifier d) -> Doc {
-      return TIR(d, "iter_var")
-          ->Call({
-              d->AsDoc<ExprDoc>(var->var, var_p->Attr("var")),
-              d->AsDoc<ExprDoc>(var->dom, var_p->Attr("dom")),
-              LiteralDoc::Str(IterVarType2String(var->iter_type), var_p->Attr("iter_type")),
-              LiteralDoc::Str(var->thread_tag, var_p->Attr("thread_tag")),
-          });
-    });
-
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<prim::Not>("", [](prim::Not node, AccessPath p, IRDocsifier d) -> Doc {
-      ExprDoc a = d->AsDoc<ExprDoc>(node->a, p->Attr("a"));
-      if (a->IsInstance<LiteralDocNode>()) {
-        return TIR(d, "Not")->Call({a});
-      }
-      return OperationDoc(OperationDocNode::Kind::kNot, {a});
-    });
-
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<prim::StringImm>("", [](prim::StringImm s, AccessPath p, IRDocsifier d) -> Doc {
-      if (HasMultipleLines(s->value)) {
-        return d->AddMetadata(s);
-      } else {
-        return d->AsDoc<ExprDoc>(s->value, p->Attr("value"));
-      }
-    });
-
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<prim::Cast>("", [](prim::Cast cast, AccessPath p, IRDocsifier d) -> Doc {
-      ExprDoc dtype = LiteralDoc::DataType(cast.ty()->dtype, p->Attr("dtype"));
-      ExprDoc value = d->AsDoc<ExprDoc>(cast->value, p->Attr("value"));
-      return TIR(d, "Cast")->Call({dtype, value});
-    });
-
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<prim::Select>("", [](prim::Select select, AccessPath p, IRDocsifier d) -> Doc {
-      return TIR(d, "Select")
-          ->Call({
-              d->AsDoc<ExprDoc>(select->condition, p->Attr("condition")),
-              d->AsDoc<ExprDoc>(select->true_value, p->Attr("true_value")),
-              d->AsDoc<ExprDoc>(select->false_value, p->Attr("false_value")),
-          });
-    });
-
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<prim::Ramp>("", [](prim::Ramp ramp, AccessPath ramp_p, IRDocsifier d) -> Doc {
-      return TIR(d, "Ramp")->Call({
-          d->AsDoc<ExprDoc>(ramp->base, ramp_p->Attr("base")),
-          d->AsDoc<ExprDoc>(ramp->stride, ramp_p->Attr("stride")),
-          d->AsDoc<ExprDoc>(ramp->lanes, ramp_p->Attr("lanes")),
+        if (var->ty.as<PrimTypeNode>() || var->ty.as<PointerTypeNode>()) {
+          return PrintVar(var, p, d);
+        }
+        if (!d->IsVarDefined(var)) {
+          ExprDoc ann = d->AsDoc<ExprDoc>(var->ty, p->Attr("ty"));
+          Frame f = d->frames.back();
+          ExprDoc lhs = d->Define(var, f, var->name.empty() ? "v" : var->name);
+          f->stmts.push_back(AssignDoc(lhs, std::nullopt, ann));
+        }
+        return d->GetVarDoc(var).value();
       });
-    });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<prim::Broadcast>("",
-                                   [](prim::Broadcast bc, AccessPath bc_p, IRDocsifier d) -> Doc {
-                                     return TIR(d, "Broadcast")
-                                         ->Call({
-                                             d->AsDoc<ExprDoc>(bc->value, bc_p->Attr("value")),
-                                             d->AsDoc<ExprDoc>(bc->lanes, bc_p->Attr("lanes")),
-                                         });
-                                   });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<tirx::IterVar>(
+      "", [](tirx::IterVar var, AccessPath var_p, IRDocsifier d) -> Doc {
+        return TIR(d, "iter_var")
+            ->Call({
+                d->AsDoc<ExprDoc>(var->var, var_p->Attr("var")),
+                d->AsDoc<ExprDoc>(var->dom, var_p->Attr("dom")),
+                LiteralDoc::Str(IterVarType2String(var->iter_type), var_p->Attr("iter_type")),
+                LiteralDoc::Str(var->thread_tag, var_p->Attr("thread_tag")),
+            });
+      });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<prim::Shuffle>(  //
-        "", [](prim::Shuffle shuffle, AccessPath p, IRDocsifier d) -> Doc {
-          return TIR(d, "Shuffle")
-              ->Call({
-                  d->AsDoc<ExprDoc>(shuffle->vectors, p->Attr("vectors")),
-                  d->AsDoc<ExprDoc>(shuffle->indices, p->Attr("indices")),
-              });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<prim::Not>(
+      "", [](prim::Not node, AccessPath p, IRDocsifier d) -> Doc {
+        ExprDoc a = d->AsDoc<ExprDoc>(node->a, p->Attr("a"));
+        if (a->IsInstance<LiteralDocNode>()) {
+          return TIR(d, "Not")->Call({a});
+        }
+        return OperationDoc(OperationDocNode::Kind::kNot, {a});
+      });
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<prim::StringImm>(
+      "", [](prim::StringImm s, AccessPath p, IRDocsifier d) -> Doc {
+        if (HasMultipleLines(s->value)) {
+          return d->AddMetadata(s);
+        } else {
+          return d->AsDoc<ExprDoc>(s->value, p->Attr("value"));
+        }
+      });
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<prim::Cast>(
+      "", [](prim::Cast cast, AccessPath p, IRDocsifier d) -> Doc {
+        ExprDoc dtype = LiteralDoc::DataType(cast.ty()->dtype, p->Attr("dtype"));
+        ExprDoc value = d->AsDoc<ExprDoc>(cast->value, p->Attr("value"));
+        return TIR(d, "Cast")->Call({dtype, value});
+      });
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<prim::Select>(
+      "", [](prim::Select select, AccessPath p, IRDocsifier d) -> Doc {
+        return TIR(d, "Select")
+            ->Call({
+                d->AsDoc<ExprDoc>(select->condition, p->Attr("condition")),
+                d->AsDoc<ExprDoc>(select->true_value, p->Attr("true_value")),
+                d->AsDoc<ExprDoc>(select->false_value, p->Attr("false_value")),
+            });
+      });
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<prim::Ramp>(
+      "", [](prim::Ramp ramp, AccessPath ramp_p, IRDocsifier d) -> Doc {
+        return TIR(d, "Ramp")->Call({
+            d->AsDoc<ExprDoc>(ramp->base, ramp_p->Attr("base")),
+            d->AsDoc<ExprDoc>(ramp->stride, ramp_p->Attr("stride")),
+            d->AsDoc<ExprDoc>(ramp->lanes, ramp_p->Attr("lanes")),
         });
+      });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<te::CommReducer>(  //
-        "", [](te::CommReducer r, AccessPath p, IRDocsifier d) -> Doc {
-          TVM_FFI_ICHECK_EQ(r->lhs.size(), r->rhs.size());
-          ffi::Optional<LambdaDoc> lambda;
-          {
-            With<TIRFrame> f(d, r);
-            int n_vars = r->lhs.size();
-            ffi::Array<IdDoc> vars;
-            vars.reserve(n_vars + n_vars);
-            for (int i = 0; i < n_vars; ++i) {
-              vars.push_back(DefineVar(r->lhs[i], *f, d).as_or_throw<IdDoc>());
-            }
-            for (int i = 0; i < n_vars; ++i) {
-              vars.push_back(DefineVar(r->rhs[i], *f, d).as_or_throw<IdDoc>());
-            }
-            int n_results = r->result.size();
-            ffi::Array<ExprDoc> results;
-            results.reserve(n_results);
-            for (int i = 0; i < n_results; ++i) {
-              results.push_back(d->AsDoc<ExprDoc>(r->result[i], p->Attr("result")->ArrayItem(i)));
-            }
-            if (results.size() == 1) {
-              lambda = LambdaDoc(vars, results[0]);
-            } else {
-              lambda = LambdaDoc(vars, TupleDoc(results));
-            }
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<prim::Broadcast>(
+      "", [](prim::Broadcast bc, AccessPath bc_p, IRDocsifier d) -> Doc {
+        return TIR(d, "Broadcast")
+            ->Call({
+                d->AsDoc<ExprDoc>(bc->value, bc_p->Attr("value")),
+                d->AsDoc<ExprDoc>(bc->lanes, bc_p->Attr("lanes")),
+            });
+      });
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<prim::Shuffle>(  //
+      "", [](prim::Shuffle shuffle, AccessPath p, IRDocsifier d) -> Doc {
+        return TIR(d, "Shuffle")
+            ->Call({
+                d->AsDoc<ExprDoc>(shuffle->vectors, p->Attr("vectors")),
+                d->AsDoc<ExprDoc>(shuffle->indices, p->Attr("indices")),
+            });
+      });
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<te::CommReducer>(  //
+      "", [](te::CommReducer r, AccessPath p, IRDocsifier d) -> Doc {
+        TVM_FFI_ICHECK_EQ(r->lhs.size(), r->rhs.size());
+        ffi::Optional<LambdaDoc> lambda;
+        {
+          With<TIRFrame> f(d, r);
+          int n_vars = r->lhs.size();
+          ffi::Array<IdDoc> vars;
+          vars.reserve(n_vars + n_vars);
+          for (int i = 0; i < n_vars; ++i) {
+            vars.push_back(DefineVar(r->lhs[i], *f, d).as_or_throw<IdDoc>());
           }
-          ExprDoc id = d->AsDoc<ExprDoc>(r->identity_element, p->Attr("identity_element"));
-          return TIR(d, "comm_reducer")->Call({lambda.value(), id});
-        });
+          for (int i = 0; i < n_vars; ++i) {
+            vars.push_back(DefineVar(r->rhs[i], *f, d).as_or_throw<IdDoc>());
+          }
+          int n_results = r->result.size();
+          ffi::Array<ExprDoc> results;
+          results.reserve(n_results);
+          for (int i = 0; i < n_results; ++i) {
+            results.push_back(d->AsDoc<ExprDoc>(r->result[i], p->Attr("result")->ArrayItem(i)));
+          }
+          if (results.size() == 1) {
+            lambda = LambdaDoc(vars, results[0]);
+          } else {
+            lambda = LambdaDoc(vars, TupleDoc(results));
+          }
+        }
+        ExprDoc id = d->AsDoc<ExprDoc>(r->identity_element, p->Attr("identity_element"));
+        return TIR(d, "comm_reducer")->Call({lambda.value(), id});
+      });
+}
 
 LambdaDoc PrintIndexMap(const ffi::ObjectRef& map, const ffi::Array<tirx::PrimVar>& vs,
                         const AccessPath& vs_p, const ffi::Array<PrimExpr>& es,
@@ -254,22 +274,23 @@ LambdaDoc PrintIndexMap(const ffi::ObjectRef& map, const ffi::Array<tirx::PrimVa
   return LambdaDoc(vars, TupleDoc(exprs));
 }
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<tirx::IndexMap>(  //
-        "", [](tirx::IndexMap m, AccessPath m_p, IRDocsifier d) -> Doc {
-          LambdaDoc map = PrintIndexMap(m, m->initial_indices, m_p->Attr("initial_indices"),
-                                        m->final_indices, m_p->Attr("final_indices"), d);
-          if (m->inverse_index_map.has_value()) {
-            tirx::IndexMap inverse = m->inverse_index_map.value().as_or_throw<tirx::IndexMap>();
-            LambdaDoc inv = PrintIndexMap(inverse, inverse->initial_indices,
-                                          m_p->Attr("inverse_index_map")->Attr("initial_indices"),
-                                          inverse->final_indices,
-                                          m_p->Attr("inverse_index_map")->Attr("final_indices"), d);
-            return TIR(d, "index_map")->Call({map}, {"inverse_index_map"}, {inv});
-          } else {
-            return TIR(d, "index_map")->Call({map});
-          }
-        });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<tirx::IndexMap>(  //
+      "", [](tirx::IndexMap m, AccessPath m_p, IRDocsifier d) -> Doc {
+        LambdaDoc map = PrintIndexMap(m, m->initial_indices, m_p->Attr("initial_indices"),
+                                      m->final_indices, m_p->Attr("final_indices"), d);
+        if (m->inverse_index_map.has_value()) {
+          tirx::IndexMap inverse = m->inverse_index_map.value().as_or_throw<tirx::IndexMap>();
+          LambdaDoc inv = PrintIndexMap(inverse, inverse->initial_indices,
+                                        m_p->Attr("inverse_index_map")->Attr("initial_indices"),
+                                        inverse->final_indices,
+                                        m_p->Attr("inverse_index_map")->Attr("final_indices"), d);
+          return TIR(d, "index_map")->Call({map}, {"inverse_index_map"}, {inv});
+        } else {
+          return TIR(d, "index_map")->Call({map});
+        }
+      });
+}
 
 LambdaDoc PrintLambda(const ffi::ObjectRef& pred, const ffi::Array<tirx::Var>& vs,
                       const AccessPath& vs_p, const PrimExpr& p, const AccessPath& p_p,
@@ -283,20 +304,22 @@ LambdaDoc PrintLambda(const ffi::ObjectRef& pred, const ffi::Array<tirx::Var>& v
   return LambdaDoc(vars, pred_doc);
 }
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<tirx::LambdaExpr>("",
-                                    [](tirx::LambdaExpr pred, AccessPath p, IRDocsifier d) -> Doc {
-                                      return PrintLambda(pred, pred->vars, p->Attr("vars"),
-                                                         pred->pred, p->Attr("pred"), d);
-                                    });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<tirx::LambdaExpr>(
+      "", [](tirx::LambdaExpr pred, AccessPath p, IRDocsifier d) -> Doc {
+        return PrintLambda(pred, pred->vars, p->Attr("vars"), pred->pred, p->Attr("pred"), d);
+      });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<prim::Let>("", [](prim::Let let, AccessPath p, IRDocsifier d) -> Doc {
-      DictDoc where({d->AsDoc<ExprDoc>(let->var, p->Attr("var"))},
-                    {d->AsDoc<ExprDoc>(let->value, p->Attr("value"))});
-      return TIR(d, "Let")->Call({d->AsDoc<ExprDoc>(let->body, p->Attr("body"))},  //
-                                 {"where"}, {where});
-    });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<prim::Let>(
+      "", [](prim::Let let, AccessPath p, IRDocsifier d) -> Doc {
+        DictDoc where({d->AsDoc<ExprDoc>(let->var, p->Attr("var"))},
+                      {d->AsDoc<ExprDoc>(let->value, p->Attr("value"))});
+        return TIR(d, "Let")->Call({d->AsDoc<ExprDoc>(let->body, p->Attr("body"))},  //
+                                   {"where"}, {where});
+      });
+}
 
 Doc PrintTIRCall(Call call, AccessPath call_p, IRDocsifier d) {
   if (call->op.same_as(tirx::builtin::buffer_data())) {
@@ -429,80 +452,85 @@ Doc PrintTIRCall(Call call, AccessPath call_p, IRDocsifier d) {
   return prefix.value()->Call(args);
 }
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable).set_dispatch<Call>("tirx", PrintTIRCall);
+TVM_FFI_STATIC_INIT_BLOCK() { IRDocsifier::vtable().set_dispatch<Call>("tirx", PrintTIRCall); }
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<te::Reduce>("", [](te::Reduce r, AccessPath p, IRDocsifier d) -> Doc {
-      ExprDoc combiner = d->AsDoc<ExprDoc>(r->combiner, p->Attr("combiner"));
-      ExprDoc source = d->AsDoc<ExprDoc>(r->source, p->Attr("source"));
-      ExprDoc init = d->AsDoc<ExprDoc>(r->init, p->Attr("init"));
-      ExprDoc axis = d->AsDoc<ExprDoc>(r->axis, p->Attr("axis"));
-      ExprDoc condition = d->AsDoc<ExprDoc>(r->condition, p->Attr("condition"));
-      ExprDoc value_index = LiteralDoc::Int(r->value_index, p->Attr("value_index"));
-      return TIR(d, "reduce")
-          ->Call({combiner}, {"source", "init", "axis", "condition", "value_index"},
-                 {source, init, axis, condition, value_index});
-    });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<te::Reduce>(
+      "", [](te::Reduce r, AccessPath p, IRDocsifier d) -> Doc {
+        ExprDoc combiner = d->AsDoc<ExprDoc>(r->combiner, p->Attr("combiner"));
+        ExprDoc source = d->AsDoc<ExprDoc>(r->source, p->Attr("source"));
+        ExprDoc init = d->AsDoc<ExprDoc>(r->init, p->Attr("init"));
+        ExprDoc axis = d->AsDoc<ExprDoc>(r->axis, p->Attr("axis"));
+        ExprDoc condition = d->AsDoc<ExprDoc>(r->condition, p->Attr("condition"));
+        ExprDoc value_index = LiteralDoc::Int(r->value_index, p->Attr("value_index"));
+        return TIR(d, "reduce")
+            ->Call({combiner}, {"source", "init", "axis", "condition", "value_index"},
+                   {source, init, axis, condition, value_index});
+      });
+}
 
-#define TVM_SCRIPT_PRINTER_DEF_BINARY(NodeType, OpString)                                         \
-  TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)                                                      \
-      .set_dispatch<prim::NodeType>("",                                                           \
-                                    [](prim::NodeType node, AccessPath p, IRDocsifier d) -> Doc { \
-                                      ExprDoc a = d->AsDoc<ExprDoc>(node->a, p->Attr("a"));       \
-                                      ExprDoc b = d->AsDoc<ExprDoc>(node->b, p->Attr("b"));       \
-                                      return TIR(d, OpString)->Call({a, b});                      \
-                                    });
+#define TVM_SCRIPT_PRINTER_DEF_BINARY(NodeType, OpString)               \
+  IRDocsifier::vtable().set_dispatch<prim::NodeType>(                   \
+      "", [](prim::NodeType node, AccessPath p, IRDocsifier d) -> Doc { \
+        ExprDoc a = d->AsDoc<ExprDoc>(node->a, p->Attr("a"));           \
+        ExprDoc b = d->AsDoc<ExprDoc>(node->b, p->Attr("b"));           \
+        return TIR(d, OpString)->Call({a, b});                          \
+      });
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<prim::Div>("", [](prim::Div node, AccessPath p, IRDocsifier d) -> Doc {
-      ExprDoc a = d->AsDoc<ExprDoc>(node->a, p->Attr("a"));
-      ExprDoc b = d->AsDoc<ExprDoc>(node->b, p->Attr("b"));
-      PrimExpr ret = tvm::div(node->a, node->b);
-      if (!ret->IsInstance<prim::DivNode>()) {
-        return TIR(d, "Div")->Call({a, b});
-      }
-      PrimType a_ty = node->a.ty();
-      PrimType b_ty = node->b.ty();
-      if (a_ty.MatchesCode(DLDataTypeCode::kDLInt, DLDataTypeCode::kDLUInt) &&
-          b_ty.MatchesCode(DLDataTypeCode::kDLInt, DLDataTypeCode::kDLUInt)) {
-        return TIR(d, "Div")->Call({a, b});
-      }
-      return OperationDoc(OperationDocNode::Kind::kDiv, {a, b});
-    });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<prim::Div>(
+      "", [](prim::Div node, AccessPath p, IRDocsifier d) -> Doc {
+        ExprDoc a = d->AsDoc<ExprDoc>(node->a, p->Attr("a"));
+        ExprDoc b = d->AsDoc<ExprDoc>(node->b, p->Attr("b"));
+        PrimExpr ret = tvm::div(node->a, node->b);
+        if (!ret->IsInstance<prim::DivNode>()) {
+          return TIR(d, "Div")->Call({a, b});
+        }
+        PrimType a_ty = node->a.ty();
+        PrimType b_ty = node->b.ty();
+        if (a_ty.MatchesCode(DLDataTypeCode::kDLInt, DLDataTypeCode::kDLUInt) &&
+            b_ty.MatchesCode(DLDataTypeCode::kDLInt, DLDataTypeCode::kDLUInt)) {
+          return TIR(d, "Div")->Call({a, b});
+        }
+        return OperationDoc(OperationDocNode::Kind::kDiv, {a, b});
+      });
+}
 
 #define TVM_SCRIPT_PRINTER_DEF_BINARY_WITH_SUGAR(NodeType, NodeObj, NodeFunc, OpString, OpKind) \
-  TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)                                                    \
-      .set_dispatch<prim::NodeType>(                                                            \
-          "", [](prim::NodeType node, AccessPath p, IRDocsifier d) -> Doc {                     \
-            ExprDoc a = d->AsDoc<ExprDoc>(node->a, p->Attr("a"));                               \
-            ExprDoc b = d->AsDoc<ExprDoc>(node->b, p->Attr("b"));                               \
-            PrimExpr ret = tvm::NodeFunc(node->a, node->b);                                     \
-            if (const auto* ret_node = ret.as<tvm::NodeObj>()) {                                \
-              if (ret_node->a.same_as(node->a) && ret_node->b.same_as(node->b)) {               \
-                return OperationDoc(OperationDocNode::Kind::OpKind, {a, b});                    \
-              }                                                                                 \
-            }                                                                                   \
-            return TIR(d, OpString)->Call({a, b});                                              \
-          });
+  IRDocsifier::vtable().set_dispatch<prim::NodeType>(                                           \
+      "", [](prim::NodeType node, AccessPath p, IRDocsifier d) -> Doc {                         \
+        ExprDoc a = d->AsDoc<ExprDoc>(node->a, p->Attr("a"));                                   \
+        ExprDoc b = d->AsDoc<ExprDoc>(node->b, p->Attr("b"));                                   \
+        PrimExpr ret = tvm::NodeFunc(node->a, node->b);                                         \
+        if (const auto* ret_node = ret.as<tvm::NodeObj>()) {                                    \
+          if (ret_node->a.same_as(node->a) && ret_node->b.same_as(node->b)) {                   \
+            return OperationDoc(OperationDocNode::Kind::OpKind, {a, b});                        \
+          }                                                                                     \
+        }                                                                                       \
+        return TIR(d, OpString)->Call({a, b});                                                  \
+      });
 
-TVM_SCRIPT_PRINTER_DEF_BINARY_WITH_SUGAR(Add, prim::AddNode, add, "Add", kAdd);
-TVM_SCRIPT_PRINTER_DEF_BINARY_WITH_SUGAR(Sub, prim::SubNode, sub, "Sub", kSub);
-TVM_SCRIPT_PRINTER_DEF_BINARY_WITH_SUGAR(Mul, prim::MulNode, mul, "Mul", kMult);
-TVM_SCRIPT_PRINTER_DEF_BINARY_WITH_SUGAR(FloorDiv, prim::FloorDivNode, floordiv, "FloorDiv",
-                                         kFloorDiv);
-TVM_SCRIPT_PRINTER_DEF_BINARY_WITH_SUGAR(FloorMod, prim::FloorModNode, floormod, "FloorMod", kMod);
-TVM_SCRIPT_PRINTER_DEF_BINARY_WITH_SUGAR(LT, prim::LTNode, less, "LT", kLt);
-TVM_SCRIPT_PRINTER_DEF_BINARY_WITH_SUGAR(LE, prim::LENode, less_equal, "LE", kLtE);
-TVM_SCRIPT_PRINTER_DEF_BINARY_WITH_SUGAR(EQ, prim::EQNode, equal, "EQ", kEq);
-TVM_SCRIPT_PRINTER_DEF_BINARY_WITH_SUGAR(NE, prim::NENode, not_equal, "NE", kNotEq);
-TVM_SCRIPT_PRINTER_DEF_BINARY_WITH_SUGAR(GT, prim::GTNode, greater, "GT", kGt);
-TVM_SCRIPT_PRINTER_DEF_BINARY_WITH_SUGAR(GE, prim::GENode, greater_equal, "GE", kGtE);
-TVM_SCRIPT_PRINTER_DEF_BINARY_WITH_SUGAR(And, prim::AndNode, logical_and, "And", kAnd);
-TVM_SCRIPT_PRINTER_DEF_BINARY_WITH_SUGAR(Or, prim::OrNode, logical_or, "Or", kOr);
+TVM_FFI_STATIC_INIT_BLOCK() {
+  TVM_SCRIPT_PRINTER_DEF_BINARY_WITH_SUGAR(Add, prim::AddNode, add, "Add", kAdd);
+  TVM_SCRIPT_PRINTER_DEF_BINARY_WITH_SUGAR(Sub, prim::SubNode, sub, "Sub", kSub);
+  TVM_SCRIPT_PRINTER_DEF_BINARY_WITH_SUGAR(Mul, prim::MulNode, mul, "Mul", kMult);
+  TVM_SCRIPT_PRINTER_DEF_BINARY_WITH_SUGAR(FloorDiv, prim::FloorDivNode, floordiv, "FloorDiv",
+                                           kFloorDiv);
+  TVM_SCRIPT_PRINTER_DEF_BINARY_WITH_SUGAR(FloorMod, prim::FloorModNode, floormod, "FloorMod",
+                                           kMod);
+  TVM_SCRIPT_PRINTER_DEF_BINARY_WITH_SUGAR(LT, prim::LTNode, less, "LT", kLt);
+  TVM_SCRIPT_PRINTER_DEF_BINARY_WITH_SUGAR(LE, prim::LENode, less_equal, "LE", kLtE);
+  TVM_SCRIPT_PRINTER_DEF_BINARY_WITH_SUGAR(EQ, prim::EQNode, equal, "EQ", kEq);
+  TVM_SCRIPT_PRINTER_DEF_BINARY_WITH_SUGAR(NE, prim::NENode, not_equal, "NE", kNotEq);
+  TVM_SCRIPT_PRINTER_DEF_BINARY_WITH_SUGAR(GT, prim::GTNode, greater, "GT", kGt);
+  TVM_SCRIPT_PRINTER_DEF_BINARY_WITH_SUGAR(GE, prim::GENode, greater_equal, "GE", kGtE);
+  TVM_SCRIPT_PRINTER_DEF_BINARY_WITH_SUGAR(And, prim::AndNode, logical_and, "And", kAnd);
+  TVM_SCRIPT_PRINTER_DEF_BINARY_WITH_SUGAR(Or, prim::OrNode, logical_or, "Or", kOr);
 
-TVM_SCRIPT_PRINTER_DEF_BINARY(Mod, "truncmod");
-TVM_SCRIPT_PRINTER_DEF_BINARY(Min, "min");
-TVM_SCRIPT_PRINTER_DEF_BINARY(Max, "max");
+  TVM_SCRIPT_PRINTER_DEF_BINARY(Mod, "truncmod");
+  TVM_SCRIPT_PRINTER_DEF_BINARY(Min, "min");
+  TVM_SCRIPT_PRINTER_DEF_BINARY(Max, "max");
+}
 
 #undef TVM_SCRIPT_PRINTER_DEF_BINARY_WITH_SUGAR
 #undef TVM_SCRIPT_PRINTER_DEF_BINARY

--- a/src/tirx/script/printer/for_loop.cc
+++ b/src/tirx/script/printer/for_loop.cc
@@ -24,133 +24,135 @@ namespace tvm {
 namespace script {
 namespace printer {
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<tirx::For>("", [](tirx::For loop, AccessPath loop_p, IRDocsifier d) -> Doc {
-      // Step 1. Check syntactic sugar: `T.grid`
-      std::vector<const tirx::ForNode*> grid;
-      std::unordered_set<const tirx::VarNode*> grid_loop_vars;
-      auto f_var_dep = [&grid_loop_vars](const PrimExpr& e) -> bool {
-        auto walkfn = [&grid_loop_vars](const tirx::Var& var) -> ffi::Expected<ffi::WalkResult> {
-          return grid_loop_vars.count(var.get())
-                     ? ffi::WalkResult::Interrupt(ffi::VisitInterrupt(var))
-                     : ffi::WalkResult::Advance();
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<tirx::For>(
+      "", [](tirx::For loop, AccessPath loop_p, IRDocsifier d) -> Doc {
+        // Step 1. Check syntactic sugar: `T.grid`
+        std::vector<const tirx::ForNode*> grid;
+        std::unordered_set<const tirx::VarNode*> grid_loop_vars;
+        auto f_var_dep = [&grid_loop_vars](const PrimExpr& e) -> bool {
+          auto walkfn = [&grid_loop_vars](const tirx::Var& var) -> ffi::Expected<ffi::WalkResult> {
+            return grid_loop_vars.count(var.get())
+                       ? ffi::WalkResult::Interrupt(ffi::VisitInterrupt(var))
+                       : ffi::WalkResult::Advance();
+          };
+          return ffi::StructuralWalk<ffi::WalkOrder::kPreOrder>(e, walkfn).has_value();
         };
-        return ffi::StructuralWalk<ffi::WalkOrder::kPreOrder>(e, walkfn).has_value();
-      };
-      if (d->cfg->syntax_sugar) {
-        for (const tirx::ForNode* l = loop.get(); l != nullptr; l = l->body.as<tirx::ForNode>()) {
-          TVM_FFI_ICHECK(l->loop_var.ty() == l->min.ty());
-          TVM_FFI_ICHECK(l->loop_var.ty() == l->extent.ty());
-          if (l->kind != tirx::ForKind::kSerial ||  //
-              !tirx::is_zero(l->min) ||             //
-              !l->annotations.empty() ||            //
-              !l->HasTrivialStep() || f_var_dep(l->extent)) {
-            break;
+        if (d->cfg->syntax_sugar) {
+          for (const tirx::ForNode* l = loop.get(); l != nullptr; l = l->body.as<tirx::ForNode>()) {
+            TVM_FFI_ICHECK(l->loop_var.ty() == l->min.ty());
+            TVM_FFI_ICHECK(l->loop_var.ty() == l->extent.ty());
+            if (l->kind != tirx::ForKind::kSerial ||  //
+                !tirx::is_zero(l->min) ||             //
+                !l->annotations.empty() ||            //
+                !l->HasTrivialStep() || f_var_dep(l->extent)) {
+              break;
+            }
+            grid.push_back(l);
+            grid_loop_vars.insert(l->loop_var.get());
           }
-          grid.push_back(l);
-          grid_loop_vars.insert(l->loop_var.get());
         }
-      }
-      With<TIRFrame> f(d, loop);
-      // Step 2. Construct `T.grid`
-      if (grid.size() > 1) {
-        int n = grid.size();
-        ffi::Array<ExprDoc> lhs;
-        ffi::Array<ExprDoc> rhs;
-        lhs.reserve(n);
-        rhs.reserve(n);
-        for (int i = 0; i < n; ++i) {
-          const tirx::ForNode* loop = grid[i];
-          lhs.push_back(DefineVar(loop->loop_var, *f, d));
-          rhs.push_back(d->AsDoc<ExprDoc>(loop->extent, loop_p->Attr("extent")));
-          loop_p = loop_p->Attr("body");
+        With<TIRFrame> f(d, loop);
+        // Step 2. Construct `T.grid`
+        if (grid.size() > 1) {
+          int n = grid.size();
+          ffi::Array<ExprDoc> lhs;
+          ffi::Array<ExprDoc> rhs;
+          lhs.reserve(n);
+          rhs.reserve(n);
+          for (int i = 0; i < n; ++i) {
+            const tirx::ForNode* loop = grid[i];
+            lhs.push_back(DefineVar(loop->loop_var, *f, d));
+            rhs.push_back(d->AsDoc<ExprDoc>(loop->extent, loop_p->Attr("extent")));
+            loop_p = loop_p->Attr("body");
+          }
+          AsDocBody(grid.back()->body, loop_p, (*f).get(), d);
+          return ForDoc(TupleDoc(lhs), TIR(d, "grid")->Call(rhs), (*f)->stmts);
         }
-        AsDocBody(grid.back()->body, loop_p, (*f).get(), d);
-        return ForDoc(TupleDoc(lhs), TIR(d, "grid")->Call(rhs), (*f)->stmts);
-      }
-      // Step 3. If not `T.grid`, print loop kind accordingly
-      ExprDoc lhs = DefineVar(loop->loop_var, *f, d);
-      ffi::Optional<ExprDoc> min = std::nullopt;
-      ffi::Optional<ExprDoc> max = std::nullopt;
-      ffi::Optional<ExprDoc> annotations = std::nullopt;
-      ffi::Optional<ExprDoc> thread = std::nullopt;
-      if (tirx::is_zero(loop->min) && loop->HasTrivialStep()) {
-        max = d->AsDoc<ExprDoc>(loop->extent, loop_p->Attr("extent"));
-      } else {
-        min = d->AsDoc<ExprDoc>(loop->min, loop_p->Attr("min"));
-        max = d->AsDoc<ExprDoc>(loop->min + loop->extent, loop_p->Attr("extent"));
-      }
-      if (!loop->annotations.empty()) {
-        annotations = d->AsDoc<ExprDoc>(loop->annotations, loop_p->Attr("annotations"));
-      }
-      bool use_range_sugar = false;
-      ExprDoc prefix{ffi::UnsafeInit()};
-      if (loop->kind == tirx::ForKind::kSerial) {
-        if (loop->annotations.empty()) {
-          prefix = IdDoc("range");
-          use_range_sugar = true;
+        // Step 3. If not `T.grid`, print loop kind accordingly
+        ExprDoc lhs = DefineVar(loop->loop_var, *f, d);
+        ffi::Optional<ExprDoc> min = std::nullopt;
+        ffi::Optional<ExprDoc> max = std::nullopt;
+        ffi::Optional<ExprDoc> annotations = std::nullopt;
+        ffi::Optional<ExprDoc> thread = std::nullopt;
+        if (tirx::is_zero(loop->min) && loop->HasTrivialStep()) {
+          max = d->AsDoc<ExprDoc>(loop->extent, loop_p->Attr("extent"));
         } else {
-          prefix = TIR(d, "serial");
+          min = d->AsDoc<ExprDoc>(loop->min, loop_p->Attr("min"));
+          max = d->AsDoc<ExprDoc>(loop->min + loop->extent, loop_p->Attr("extent"));
         }
-      } else if (loop->kind == tirx::ForKind::kParallel) {
-        prefix = TIR(d, "parallel");
-      } else if (loop->kind == tirx::ForKind::kUnrolled) {
-        prefix = TIR(d, "unroll");
-      } else if (loop->kind == tirx::ForKind::kVectorized) {
-        prefix = TIR(d, "vectorized");
-      } else if (loop->kind == tirx::ForKind::kThreadBinding) {
-        prefix = TIR(d, "thread_binding");
-        thread = LiteralDoc::Str(loop->thread_binding.value()->thread_tag,
-                                 loop_p->Attr("thread_binding"));
-      } else {
-        TVM_FFI_THROW(ValueError) << "Unknown ForKind: " << tirx::ForKind2String(loop->kind);
-      }
-      ffi::Array<ExprDoc> args;
-      ffi::Array<ffi::String> kwargs_keys;
-      ffi::Array<ExprDoc> kwargs_values;
-      if (min.has_value()) {
-        args.push_back(min.value());
-      }
-      if (max.has_value()) {
-        args.push_back(max.value());
-      }
-      if (thread.has_value()) {
-        kwargs_keys.push_back("thread");
-        kwargs_values.push_back(thread.value());
-      }
-      if (annotations.has_value()) {
-        // Check for the special cases:
-        // - annotations == {"disable_unroll": True}: print as unroll=False
-        // - annotations == {"pragma_unroll": value}: print as unroll=value
-        bool printed_as_unroll = false;
-        if (loop->annotations.size() == 1 && loop->annotations.count("disable_unroll")) {
-          kwargs_keys.push_back("unroll");
-          kwargs_values.push_back(LiteralDoc::Boolean(false, loop_p->Attr("annotations")));
-          printed_as_unroll = true;
-        } else if (loop->annotations.size() == 1 && loop->annotations.count("pragma_unroll")) {
-          kwargs_keys.push_back("unroll");
-          kwargs_values.push_back(
-              d->AsDoc<ExprDoc>(loop->annotations["pragma_unroll"], loop_p->Attr("annotations")));
-          printed_as_unroll = true;
+        if (!loop->annotations.empty()) {
+          annotations = d->AsDoc<ExprDoc>(loop->annotations, loop_p->Attr("annotations"));
         }
-        if (!printed_as_unroll) {
-          kwargs_keys.push_back("annotations");
-          kwargs_values.push_back(annotations.value());
-        }
-      }
-      if (!loop->HasTrivialStep()) {
-        ExprDoc step = d->AsDoc<ExprDoc>(*loop->step, loop_p->Attr("step"));
-        if (use_range_sugar) {
-          args.push_back(step);
+        bool use_range_sugar = false;
+        ExprDoc prefix{ffi::UnsafeInit()};
+        if (loop->kind == tirx::ForKind::kSerial) {
+          if (loop->annotations.empty()) {
+            prefix = IdDoc("range");
+            use_range_sugar = true;
+          } else {
+            prefix = TIR(d, "serial");
+          }
+        } else if (loop->kind == tirx::ForKind::kParallel) {
+          prefix = TIR(d, "parallel");
+        } else if (loop->kind == tirx::ForKind::kUnrolled) {
+          prefix = TIR(d, "unroll");
+        } else if (loop->kind == tirx::ForKind::kVectorized) {
+          prefix = TIR(d, "vectorized");
+        } else if (loop->kind == tirx::ForKind::kThreadBinding) {
+          prefix = TIR(d, "thread_binding");
+          thread = LiteralDoc::Str(loop->thread_binding.value()->thread_tag,
+                                   loop_p->Attr("thread_binding"));
         } else {
-          kwargs_keys.push_back("step");
-          kwargs_values.push_back(step);
+          TVM_FFI_THROW(ValueError) << "Unknown ForKind: " << tirx::ForKind2String(loop->kind);
         }
-      }
-      ExprDoc rhs = prefix->Call(args, kwargs_keys, kwargs_values);
-      AsDocBody(loop->body, loop_p->Attr("body"), (*f).get(), d);
-      return ForDoc(lhs, rhs, (*f)->stmts);
-    });
+        ffi::Array<ExprDoc> args;
+        ffi::Array<ffi::String> kwargs_keys;
+        ffi::Array<ExprDoc> kwargs_values;
+        if (min.has_value()) {
+          args.push_back(min.value());
+        }
+        if (max.has_value()) {
+          args.push_back(max.value());
+        }
+        if (thread.has_value()) {
+          kwargs_keys.push_back("thread");
+          kwargs_values.push_back(thread.value());
+        }
+        if (annotations.has_value()) {
+          // Check for the special cases:
+          // - annotations == {"disable_unroll": True}: print as unroll=False
+          // - annotations == {"pragma_unroll": value}: print as unroll=value
+          bool printed_as_unroll = false;
+          if (loop->annotations.size() == 1 && loop->annotations.count("disable_unroll")) {
+            kwargs_keys.push_back("unroll");
+            kwargs_values.push_back(LiteralDoc::Boolean(false, loop_p->Attr("annotations")));
+            printed_as_unroll = true;
+          } else if (loop->annotations.size() == 1 && loop->annotations.count("pragma_unroll")) {
+            kwargs_keys.push_back("unroll");
+            kwargs_values.push_back(
+                d->AsDoc<ExprDoc>(loop->annotations["pragma_unroll"], loop_p->Attr("annotations")));
+            printed_as_unroll = true;
+          }
+          if (!printed_as_unroll) {
+            kwargs_keys.push_back("annotations");
+            kwargs_values.push_back(annotations.value());
+          }
+        }
+        if (!loop->HasTrivialStep()) {
+          ExprDoc step = d->AsDoc<ExprDoc>(*loop->step, loop_p->Attr("step"));
+          if (use_range_sugar) {
+            args.push_back(step);
+          } else {
+            kwargs_keys.push_back("step");
+            kwargs_values.push_back(step);
+          }
+        }
+        ExprDoc rhs = prefix->Call(args, kwargs_keys, kwargs_values);
+        AsDocBody(loop->body, loop_p->Attr("body"), (*f).get(), d);
+        return ForDoc(lhs, rhs, (*f)->stmts);
+      });
+}
 
 TVM_REGISTER_SCRIPT_AS_REPR(tirx::ForNode, ReprPrintTIR);
 

--- a/src/tirx/script/printer/function.cc
+++ b/src/tirx/script/printer/function.cc
@@ -26,230 +26,235 @@ namespace tvm {
 namespace script {
 namespace printer {
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<tirx::PrimFunc>("", [](tirx::PrimFunc func, AccessPath p, IRDocsifier d) -> Doc {
-      With<TIRFrame> f(d, func);
-      (*f)->AddDispatchToken(d, "tirx");
-      IdDoc func_name = IdDoc(FindFunctionName(d, func).value_or("main"));
-      d->SetCommonPrefix(func, [](const ffi::ObjectRef& obj) {
-        return obj->IsInstance<tirx::VarNode>() || obj->IsInstance<tirx::BufferTypeNode>();
-      });
-      std::unordered_set<const VarNode*> runtime_params;
-      for (const tirx::Var& param : func->params) {
-        runtime_params.insert(param.get());
-      }
-      std::unordered_set<const VarNode*> type_vars;
-      auto collect_type_vars = [&](const PrimExpr& expr) {
-        for (const tirx::Var& var : tirx::UndefinedVars(expr)) {
-          const auto* var_ty_node = var->ty.as<PrimTypeNode>();
-          if (var_ty_node == nullptr) {
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<tirx::PrimFunc>(
+      "", [](tirx::PrimFunc func, AccessPath p, IRDocsifier d) -> Doc {
+        With<TIRFrame> f(d, func);
+        (*f)->AddDispatchToken(d, "tirx");
+        IdDoc func_name = IdDoc(FindFunctionName(d, func).value_or("main"));
+        d->SetCommonPrefix(func, [](const ffi::ObjectRef& obj) {
+          return obj->IsInstance<tirx::VarNode>() || obj->IsInstance<tirx::BufferTypeNode>();
+        });
+        std::unordered_set<const VarNode*> runtime_params;
+        for (const tirx::Var& param : func->params) {
+          runtime_params.insert(param.get());
+        }
+        std::unordered_set<const VarNode*> type_vars;
+        auto collect_type_vars = [&](const PrimExpr& expr) {
+          for (const tirx::Var& var : tirx::UndefinedVars(expr)) {
+            const auto* var_ty_node = var->ty.as<PrimTypeNode>();
+            if (var_ty_node == nullptr) {
+              continue;
+            }
+            PrimType var_ty(var_ty_node->dtype);
+            if (!runtime_params.count(var.get()) && var_ty.IsScalar() &&
+                var_ty.MatchesElementType(DLDataTypeCode::kDLInt, 64)) {
+              type_vars.insert(var.get());
+            }
+          }
+        };
+        for (const tirx::Var& param : func->params) {
+          if (!param->ty.as<tirx::BufferTypeNode>()) {
             continue;
           }
-          PrimType var_ty(var_ty_node->dtype);
-          if (!runtime_params.count(var.get()) && var_ty.IsScalar() &&
-              var_ty.MatchesElementType(DLDataTypeCode::kDLInt, 64)) {
-            type_vars.insert(var.get());
+          tirx::BufferVar buffer(param);
+          for (const PrimExpr& extent : buffer->shape) {
+            collect_type_vars(extent);
+          }
+          for (const PrimExpr& stride : buffer->strides) {
+            collect_type_vars(stride);
+          }
+          collect_type_vars(buffer->elem_offset);
+          for (const PrimExpr& address : buffer->allocated_addr) {
+            collect_type_vars(address);
           }
         }
-      };
-      for (const tirx::Var& param : func->params) {
-        if (!param->ty.as<tirx::BufferTypeNode>()) {
-          continue;
+        auto type_var_docs = DefineTypeVarDocs(type_vars, ffi::GetRef<Frame>((*f).get()), d);
+        bool use_postponed_annotations = UsePEP695TypeVars(d) && !type_vars.empty();
+        int n_args = func->params.size();
+        // Step 1. Handle `func->params`
+        ffi::Array<AssignDoc> args;
+        args.reserve(n_args);
+        std::unordered_map<const tirx::VarNode*, ExprDoc> scalar_param_docs;
+        // Define scalar docs up front so a preceding Buffer parameter can render
+        // a reference to a later scalar parameter.  `bound_signature_vars`
+        // separately tracks source order: the first shape expression that sees
+        // an unbound Var must be quoted because Buffer shapes are match scopes.
+        std::unordered_set<tirx::Var> bound_signature_vars;
+        for (const tirx::Var& param : func->params) {
+          if (!param->ty.as<tirx::BufferTypeNode>()) {
+            scalar_param_docs.emplace(param.get(), DefineVar(param, *f, d));
+          }
         }
-        tirx::BufferVar buffer(param);
-        for (const PrimExpr& extent : buffer->shape) {
-          collect_type_vars(extent);
-        }
-        for (const PrimExpr& stride : buffer->strides) {
-          collect_type_vars(stride);
-        }
-        collect_type_vars(buffer->elem_offset);
-        for (const PrimExpr& address : buffer->allocated_addr) {
-          collect_type_vars(address);
-        }
-      }
-      auto type_var_docs = DefineTypeVarDocs(type_vars, ffi::GetRef<Frame>((*f).get()), d);
-      bool use_postponed_annotations = UsePEP695TypeVars(d) && !type_vars.empty();
-      int n_args = func->params.size();
-      // Step 1. Handle `func->params`
-      ffi::Array<AssignDoc> args;
-      args.reserve(n_args);
-      std::unordered_map<const tirx::VarNode*, ExprDoc> scalar_param_docs;
-      // Define scalar docs up front so a preceding Buffer parameter can render
-      // a reference to a later scalar parameter.  `bound_signature_vars`
-      // separately tracks source order: the first shape expression that sees
-      // an unbound Var must be quoted because Buffer shapes are match scopes.
-      std::unordered_set<tirx::Var> bound_signature_vars;
-      for (const tirx::Var& param : func->params) {
-        if (!param->ty.as<tirx::BufferTypeNode>()) {
-          scalar_param_docs.emplace(param.get(), DefineVar(param, *f, d));
-        }
-      }
-      for (int i = 0; i < n_args; ++i) {
-        tirx::Var var = func->params[i];
-        AccessPath var_p = p->Attr("params")->ArrayItem(i);
-        if (var->ty.as<tirx::BufferTypeNode>()) {
-          tirx::BufferVar buffer(var);
-          std::unordered_set<tirx::Var> stringify_shape_vars;
-          std::unordered_set<tirx::Var> stringify_compound_shape_vars;
-          std::unordered_set<tirx::Var> shape_vars;
-          auto walk_fn = [&](const tirx::Var& shape_var) -> ffi::Expected<ffi::WalkResult> {
-            shape_vars.insert(shape_var);
-            bool is_type_var = type_vars.count(shape_var.get());
-            if (!use_postponed_annotations && !bound_signature_vars.count(shape_var) &&
-                !is_type_var) {
-              stringify_shape_vars.insert(shape_var);
+        for (int i = 0; i < n_args; ++i) {
+          tirx::Var var = func->params[i];
+          AccessPath var_p = p->Attr("params")->ArrayItem(i);
+          if (var->ty.as<tirx::BufferTypeNode>()) {
+            tirx::BufferVar buffer(var);
+            std::unordered_set<tirx::Var> stringify_shape_vars;
+            std::unordered_set<tirx::Var> stringify_compound_shape_vars;
+            std::unordered_set<tirx::Var> shape_vars;
+            auto walk_fn = [&](const tirx::Var& shape_var) -> ffi::Expected<ffi::WalkResult> {
+              shape_vars.insert(shape_var);
+              bool is_type_var = type_vars.count(shape_var.get());
+              if (!use_postponed_annotations && !bound_signature_vars.count(shape_var) &&
+                  !is_type_var) {
+                stringify_shape_vars.insert(shape_var);
+              }
+              if (!use_postponed_annotations && is_type_var) {
+                stringify_compound_shape_vars.insert(shape_var);
+              }
+              return ffi::WalkResult::Advance();
+            };
+            for (const PrimExpr& shape : buffer->shape) {
+              ffi::StructuralWalk<ffi::WalkOrder::kPostOrder>(shape, walk_fn);
             }
-            if (!use_postponed_annotations && is_type_var) {
-              stringify_compound_shape_vars.insert(shape_var);
+            IdDoc lhs = DefineBuffer(buffer, *f, d);
+            ExprDoc annotation =
+                BufferAttn(buffer, var_p->Attr("ty"), *f, d, std::move(stringify_shape_vars),
+                           std::move(stringify_compound_shape_vars));
+            args.push_back(AssignDoc(lhs, std::nullopt, annotation));
+            for (const tirx::Var& shape_var : shape_vars) {
+              bound_signature_vars.insert(shape_var);
             }
-            return ffi::WalkResult::Advance();
-          };
-          for (const PrimExpr& shape : buffer->shape) {
-            ffi::StructuralWalk<ffi::WalkOrder::kPostOrder>(shape, walk_fn);
+            continue;
           }
-          IdDoc lhs = DefineBuffer(buffer, *f, d);
-          ExprDoc annotation =
-              BufferAttn(buffer, var_p->Attr("ty"), *f, d, std::move(stringify_shape_vars),
-                         std::move(stringify_compound_shape_vars));
-          args.push_back(AssignDoc(lhs, std::nullopt, annotation));
-          for (const tirx::Var& shape_var : shape_vars) {
-            bound_signature_vars.insert(shape_var);
+          ExprDoc a = d->AsDoc<ExprDoc>(var->ty, var_p->Attr("ty"));
+          args.push_back(AssignDoc(scalar_param_docs.at(var.get()), std::nullopt, a));
+          bound_signature_vars.insert(var);
+        }
+        ffi::Optional<ExprDoc> ret_type = std::nullopt;
+        if (!func->ret_type.IsMissing()) {
+          const auto* as_tuple = func->ret_type.as<TupleTypeNode>();
+          if (!as_tuple || as_tuple->fields.size()) {
+            ret_type = d->AsDoc<ExprDoc>(func->ret_type, p->Attr("ret_type"));
           }
-          continue;
         }
-        ExprDoc a = d->AsDoc<ExprDoc>(var->ty, var_p->Attr("ty"));
-        args.push_back(AssignDoc(scalar_param_docs.at(var.get()), std::nullopt, a));
-        bound_signature_vars.insert(var);
-      }
-      ffi::Optional<ExprDoc> ret_type = std::nullopt;
-      if (!func->ret_type.IsMissing()) {
-        const auto* as_tuple = func->ret_type.as<TupleTypeNode>();
-        if (!as_tuple || as_tuple->fields.size()) {
-          ret_type = d->AsDoc<ExprDoc>(func->ret_type, p->Attr("ret_type"));
+        // Step 2. Handle `func->attrs`
+        if (!func->attrs->dict.empty()) {
+          // for global symbol, don't display it if it matches the func name
+          std::unordered_set<ffi::String> keys_to_remove;
+          if (func->attrs->dict.count(tvm::attr::kGlobalSymbol) &&
+              func->attrs->dict.at(tvm::attr::kGlobalSymbol).as_or_throw<ffi::String>() ==
+                  func_name->name) {
+            keys_to_remove.insert(tvm::attr::kGlobalSymbol);
+          }
+          // s_tir is shown in decorator, not in attr dict.
+          if (func->attrs->dict.count(tvm::attr::kSTir)) {
+            keys_to_remove.insert(tvm::attr::kSTir);
+          }
+          // for persistent, don't display it (shown in decorator)
+          if (func->attrs->dict.count(tirx::attr::kPersistentKernel)) {
+            keys_to_remove.insert(tirx::attr::kPersistentKernel);
+          }
+          ffi::Map<ffi::String, Any> new_attrs;
+          for (auto kv : func->attrs->dict) {
+            if (!keys_to_remove.count(kv.first)) {
+              new_attrs.Set(kv.first, kv.second);
+            }
+          }
+          if (!new_attrs.empty()) {
+            (*f)->stmts.push_back(ExprStmtDoc(
+                TIR(d, "func_attr")  //
+                    ->Call({d->AsDoc<ExprDoc>(DictAttrs(new_attrs), p->Attr("attrs"))})));
+          }
         }
-      }
-      // Step 2. Handle `func->attrs`
-      if (!func->attrs->dict.empty()) {
-        // for global symbol, don't display it if it matches the func name
-        std::unordered_set<ffi::String> keys_to_remove;
-        if (func->attrs->dict.count(tvm::attr::kGlobalSymbol) &&
-            func->attrs->dict.at(tvm::attr::kGlobalSymbol).as_or_throw<ffi::String>() ==
-                func_name->name) {
-          keys_to_remove.insert(tvm::attr::kGlobalSymbol);
+        // Step 3. Handle `func->body`
+        ffi::Optional<tirx::SBlock> implicit_root_block = [&]() -> ffi::Optional<tirx::SBlock> {
+          const tirx::SBlockRealizeNode* root_block_realize =
+              func->body.as<tirx::SBlockRealizeNode>();
+          if (root_block_realize && !root_block_realize->iter_values.size() &&
+              tirx::is_one(root_block_realize->predicate)) {
+            tirx::SBlock root_block = root_block_realize->block;
+            if (!root_block->annotations.size() && !root_block->match_buffers.size() &&
+                !root_block->reads.size() && !root_block->writes.size() &&
+                !root_block->init.has_value()) {
+              const tirx::SBlockRealizeNode* block_realize =
+                  root_block->body.as<tirx::SBlockRealizeNode>();
+              if (root_block->alloc_buffers.size() ||
+                  (block_realize && block_realize->block->iter_vars.size()) ||
+                  (!block_realize &&
+                   tirx::ContainsNode<tirx::SBlockRealizeNode>(root_block->body))) {
+                return root_block;
+              }
+            }
+          }
+          return std::nullopt;
+        }();
+        if (d->cfg->syntax_sugar && implicit_root_block) {
+          tirx::SBlock root_block = implicit_root_block.value();
+          AccessPath root_block_p = p->Attr("body")->Attr("block");
+          (*f)->stmts.push_back(CommentDoc("with T.sblock(\"root\"):"));
+          // Handle root block `alloc_buffer`
+          for (int i = 0, n = root_block->alloc_buffers.size(); i < n; ++i) {
+            tirx::BufferVar buffer = root_block->alloc_buffers[i];
+            AccessPath buffer_p = root_block_p->Attr("alloc_buffers")->ArrayItem(i);
+            IdDoc lhs = DefineBuffer(buffer, *f, d);
+            ExprDoc rhs = BufferDecl(buffer, "sblock_alloc_buffer", {}, buffer_p, *f, d,
+                                     BufferVarDefinition::DataPointer);
+            (*f)->stmts.push_back(AssignDoc(lhs, rhs, std::nullopt));
+          }
+          AsDocBody(root_block->body, root_block_p->Attr("body"), f->get(), d);
+        } else {
+          AsDocBody(func->body, p->Attr("body"), f->get(), d);
         }
-        // s_tir is shown in decorator, not in attr dict.
+        // Step 5. Determine if we need to display the private annotation in the decorator
+        ExprDoc decorator = TIR(d, "prim_func");
+        ffi::Array<ffi::String, void> kwargs_keys;
+        ffi::Array<ExprDoc, void> kwargs_values;
+        // mark private if there is no global symbol
+        if (!func->attrs->dict.count(tvm::attr::kGlobalSymbol)) {
+          kwargs_keys.push_back("private");
+          kwargs_values.push_back(LiteralDoc::Boolean(true, ffi::Optional<AccessPath>()));
+        }
         if (func->attrs->dict.count(tvm::attr::kSTir)) {
-          keys_to_remove.insert(tvm::attr::kSTir);
+          kwargs_keys.push_back("s_tir");
+          kwargs_values.push_back(LiteralDoc::Boolean(true, ffi::Optional<AccessPath>()));
         }
-        // for persistent, don't display it (shown in decorator)
         if (func->attrs->dict.count(tirx::attr::kPersistentKernel)) {
-          keys_to_remove.insert(tirx::attr::kPersistentKernel);
+          kwargs_keys.push_back("persistent");
+          kwargs_values.push_back(LiteralDoc::Boolean(true, ffi::Optional<AccessPath>()));
         }
-        ffi::Map<ffi::String, Any> new_attrs;
-        for (auto kv : func->attrs->dict) {
-          if (!keys_to_remove.count(kv.first)) {
-            new_attrs.Set(kv.first, kv.second);
-          }
+        // Only emit ``@T.prim_func(...)`` when there is at least one keyword
+        // argument; otherwise print bare ``@T.prim_func`` to match apache.
+        if (!kwargs_keys.empty()) {
+          ffi::Array<ExprDoc> pos_args;
+          decorator = std::move(decorator->Call(pos_args, kwargs_keys, kwargs_values));
         }
-        if (!new_attrs.empty()) {
-          (*f)->stmts.push_back(
-              ExprStmtDoc(TIR(d, "func_attr")  //
-                              ->Call({d->AsDoc<ExprDoc>(DictAttrs(new_attrs), p->Attr("attrs"))})));
-        }
-      }
-      // Step 3. Handle `func->body`
-      ffi::Optional<tirx::SBlock> implicit_root_block = [&]() -> ffi::Optional<tirx::SBlock> {
-        const tirx::SBlockRealizeNode* root_block_realize =
-            func->body.as<tirx::SBlockRealizeNode>();
-        if (root_block_realize && !root_block_realize->iter_values.size() &&
-            tirx::is_one(root_block_realize->predicate)) {
-          tirx::SBlock root_block = root_block_realize->block;
-          if (!root_block->annotations.size() && !root_block->match_buffers.size() &&
-              !root_block->reads.size() && !root_block->writes.size() &&
-              !root_block->init.has_value()) {
-            const tirx::SBlockRealizeNode* block_realize =
-                root_block->body.as<tirx::SBlockRealizeNode>();
-            if (root_block->alloc_buffers.size() ||
-                (block_realize && block_realize->block->iter_vars.size()) ||
-                (!block_realize && tirx::ContainsNode<tirx::SBlockRealizeNode>(root_block->body))) {
-              return root_block;
-            }
-          }
-        }
-        return std::nullopt;
-      }();
-      if (d->cfg->syntax_sugar && implicit_root_block) {
-        tirx::SBlock root_block = implicit_root_block.value();
-        AccessPath root_block_p = p->Attr("body")->Attr("block");
-        (*f)->stmts.push_back(CommentDoc("with T.sblock(\"root\"):"));
-        // Handle root block `alloc_buffer`
-        for (int i = 0, n = root_block->alloc_buffers.size(); i < n; ++i) {
-          tirx::BufferVar buffer = root_block->alloc_buffers[i];
-          AccessPath buffer_p = root_block_p->Attr("alloc_buffers")->ArrayItem(i);
-          IdDoc lhs = DefineBuffer(buffer, *f, d);
-          ExprDoc rhs = BufferDecl(buffer, "sblock_alloc_buffer", {}, buffer_p, *f, d,
-                                   BufferVarDefinition::DataPointer);
-          (*f)->stmts.push_back(AssignDoc(lhs, rhs, std::nullopt));
-        }
-        AsDocBody(root_block->body, root_block_p->Attr("body"), f->get(), d);
-      } else {
-        AsDocBody(func->body, p->Attr("body"), f->get(), d);
-      }
-      // Step 5. Determine if we need to display the private annotation in the decorator
-      ExprDoc decorator = TIR(d, "prim_func");
-      ffi::Array<ffi::String, void> kwargs_keys;
-      ffi::Array<ExprDoc, void> kwargs_values;
-      // mark private if there is no global symbol
-      if (!func->attrs->dict.count(tvm::attr::kGlobalSymbol)) {
-        kwargs_keys.push_back("private");
-        kwargs_values.push_back(LiteralDoc::Boolean(true, ffi::Optional<AccessPath>()));
-      }
-      if (func->attrs->dict.count(tvm::attr::kSTir)) {
-        kwargs_keys.push_back("s_tir");
-        kwargs_values.push_back(LiteralDoc::Boolean(true, ffi::Optional<AccessPath>()));
-      }
-      if (func->attrs->dict.count(tirx::attr::kPersistentKernel)) {
-        kwargs_keys.push_back("persistent");
-        kwargs_values.push_back(LiteralDoc::Boolean(true, ffi::Optional<AccessPath>()));
-      }
-      // Only emit ``@T.prim_func(...)`` when there is at least one keyword
-      // argument; otherwise print bare ``@T.prim_func`` to match apache.
-      if (!kwargs_keys.empty()) {
-        ffi::Array<ExprDoc> pos_args;
-        decorator = std::move(decorator->Call(pos_args, kwargs_keys, kwargs_values));
-      }
-      return WrapFunctionDocWithTypeVars(d,
-                                         FunctionDoc(
-                                             /*name=*/func_name,
-                                             /*args=*/args,
-                                             /*decorators=*/{decorator},
-                                             /*return_type=*/ret_type,
-                                             /*body=*/(*f)->stmts),
-                                         type_var_docs);
-    });
+        return WrapFunctionDocWithTypeVars(d,
+                                           FunctionDoc(
+                                               /*name=*/func_name,
+                                               /*args=*/args,
+                                               /*decorators=*/{decorator},
+                                               /*return_type=*/ret_type,
+                                               /*body=*/(*f)->stmts),
+                                           type_var_docs);
+      });
+}
 
 TVM_REGISTER_SCRIPT_AS_REPR(tirx::PrimFuncNode, ReprPrintTIR);
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<tvm::GlobalVar>(                                            //
-        "tirx", [](tvm::GlobalVar n, AccessPath n_p, IRDocsifier d) -> Doc {  //
-          if (ffi::Optional<ExprDoc> doc = d->GetVarDoc(n)) {
-            return doc.value();
-          } else {
-            IdDoc ret(n->name_hint);
-            ret->source_paths.push_back(n_p);
-            return ret;
-          }
-        });
-
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<tvm::IRModule>(                                              //
-        "tirx", [](tvm::IRModule mod, AccessPath n_p, IRDocsifier d) -> Doc {  //
-          ffi::Optional<ExprDoc> doc = d->GetVarDoc(mod);
-          TVM_FFI_ICHECK(doc) << "Unable to print IRModule before definition in TIR.";
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<tvm::GlobalVar>(                       //
+      "tirx", [](tvm::GlobalVar n, AccessPath n_p, IRDocsifier d) -> Doc {  //
+        if (ffi::Optional<ExprDoc> doc = d->GetVarDoc(n)) {
           return doc.value();
-        });
+        } else {
+          IdDoc ret(n->name_hint);
+          ret->source_paths.push_back(n_p);
+          return ret;
+        }
+      });
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<tvm::IRModule>(                         //
+      "tirx", [](tvm::IRModule mod, AccessPath n_p, IRDocsifier d) -> Doc {  //
+        ffi::Optional<ExprDoc> doc = d->GetVarDoc(mod);
+        TVM_FFI_ICHECK(doc) << "Unable to print IRModule before definition in TIR.";
+        return doc.value();
+      });
+}
 
 }  // namespace printer
 }  // namespace script

--- a/src/tirx/script/printer/ir.cc
+++ b/src/tirx/script/printer/ir.cc
@@ -26,86 +26,101 @@ namespace printer {
 
 TVM_FFI_STATIC_INIT_BLOCK() { TIRFrameNode::RegisterReflection(); }
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<IntImm>("", [](IntImm imm, AccessPath imm_p, IRDocsifier d) -> Doc {
-      DLDataType dtype = imm->ty.as_or_throw<PrimType>()->dtype;
-      if (dtype == d->cfg->int_dtype) {
-        return LiteralDoc::Int(imm->value, imm_p->Attr("value"));
-      } else if (dtype == DLDataType{kDLBool, 8, 1}) {
-        return TIR(d, DType2Str(dtype))
-            ->Call({LiteralDoc::Boolean(imm->value, imm_p->Attr("value"))});
-      } else {
-        return TIR(d, DType2Str(dtype))->Call({LiteralDoc::Int(imm->value, imm_p->Attr("value"))});
-      }
-    });
-
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<FloatImm>("", [](FloatImm imm, AccessPath imm_p, IRDocsifier d) -> Doc {
-      DLDataType dtype = imm->ty.as_or_throw<PrimType>()->dtype;
-      if (dtype == d->cfg->float_dtype) {
-        return LiteralDoc::Float(imm->value, imm_p->Attr("value"));
-      } else {
-        return TIR(d, DType2Str(dtype))
-            ->Call({LiteralDoc::Float(imm->value, imm_p->Attr("value"))});
-      }
-    });
-
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<Range>("tirx", [](Range range, AccessPath p, IRDocsifier d) -> Doc {
-      return TIR(d, "Range")
-          ->Call({
-              d->AsDoc<ExprDoc>(range->min, p->Attr("min")),
-              d->AsDoc<ExprDoc>(range->extent + range->min, p->Attr("extent")),
-          });
-    });
-
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<PrimType>("", [](PrimType ty, AccessPath p, IRDocsifier d) -> Doc {
-      return TIR(d, DType2Str(ty->dtype));
-    });
-
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<PointerType>("", [](PointerType ty, AccessPath ty_p, IRDocsifier d) -> Doc {
-      ExprDoc element_type{ffi::UnsafeInit()};
-      TVM_FFI_ICHECK(!ty->element_type.IsMissing())
-          << "InternalError: PointerType.element_type is missing";
-      if (const auto* prim_type = ty->element_type.as<PrimTypeNode>()) {
-        if (ffi::GetRef<PrimType>(prim_type).IsVoid()) {
-          if (ty->storage_scope == "global") {
-            return TIR(d, "handle");
-          }
-          return TIR(d, "handle")
-              ->Call({}, {"storage_scope"},
-                     {LiteralDoc::Str(ty->storage_scope, ty_p->Attr("storage_scope"))});
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<IntImm>(
+      "", [](IntImm imm, AccessPath imm_p, IRDocsifier d) -> Doc {
+        DLDataType dtype = imm->ty.as_or_throw<PrimType>()->dtype;
+        if (dtype == d->cfg->int_dtype) {
+          return LiteralDoc::Int(imm->value, imm_p->Attr("value"));
+        } else if (dtype == DLDataType{kDLBool, 8, 1}) {
+          return TIR(d, DType2Str(dtype))
+              ->Call({LiteralDoc::Boolean(imm->value, imm_p->Attr("value"))});
+        } else {
+          return TIR(d, DType2Str(dtype))
+              ->Call({LiteralDoc::Int(imm->value, imm_p->Attr("value"))});
         }
-        element_type = LiteralDoc::DataType(prim_type->dtype,  //
-                                            ty_p->Attr("element_type")->Attr("dtype"));
-      } else if (ty->element_type.as<TensorMapTypeNode>()) {
-        return TIR(d, "TensorMap")->Call({});
-      } else {
-        element_type = d->AsDoc<ExprDoc>(ty->element_type, ty_p->Attr("element_type"));
-      }
-      if (ty->storage_scope == "") {
-        return TIR(d, "handle")->Call({element_type});
-      } else {
-        return TIR(d, "handle")
-            ->Call({element_type, LiteralDoc::Str(ty->storage_scope, ty_p->Attr("storage_scope"))});
-      }
-    });
+      });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<TupleType>("", [](TupleType ty, AccessPath p, IRDocsifier d) -> Doc {
-      if (ty->fields.empty()) {
-        return LiteralDoc::None(p);
-      }
-      return TIR(d, "Tuple")->Call(d->AsDoc<ListDoc>(ty->fields, p->Attr("fields"))->elements);
-    });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<FloatImm>(
+      "", [](FloatImm imm, AccessPath imm_p, IRDocsifier d) -> Doc {
+        DLDataType dtype = imm->ty.as_or_throw<PrimType>()->dtype;
+        if (dtype == d->cfg->float_dtype) {
+          return LiteralDoc::Float(imm->value, imm_p->Attr("value"));
+        } else {
+          return TIR(d, DType2Str(dtype))
+              ->Call({LiteralDoc::Float(imm->value, imm_p->Attr("value"))});
+        }
+      });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<Target>("", [](Target target, AccessPath p, IRDocsifier d) -> Doc {
-      ffi::Map<ffi::String, ffi::Any> config = target->ToConfig();
-      return TIR(d, "target")->Call({d->AsDoc<ExprDoc>(config, p)});
-    });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<Range>(
+      "tirx", [](Range range, AccessPath p, IRDocsifier d) -> Doc {
+        return TIR(d, "Range")
+            ->Call({
+                d->AsDoc<ExprDoc>(range->min, p->Attr("min")),
+                d->AsDoc<ExprDoc>(range->extent + range->min, p->Attr("extent")),
+            });
+      });
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<PrimType>(
+      "",
+      [](PrimType ty, AccessPath p, IRDocsifier d) -> Doc { return TIR(d, DType2Str(ty->dtype)); });
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<PointerType>(
+      "", [](PointerType ty, AccessPath ty_p, IRDocsifier d) -> Doc {
+        ExprDoc element_type{ffi::UnsafeInit()};
+        TVM_FFI_ICHECK(!ty->element_type.IsMissing())
+            << "InternalError: PointerType.element_type is missing";
+        if (const auto* prim_type = ty->element_type.as<PrimTypeNode>()) {
+          if (ffi::GetRef<PrimType>(prim_type).IsVoid()) {
+            if (ty->storage_scope == "global") {
+              return TIR(d, "handle");
+            }
+            return TIR(d, "handle")
+                ->Call({}, {"storage_scope"},
+                       {LiteralDoc::Str(ty->storage_scope, ty_p->Attr("storage_scope"))});
+          }
+          element_type = LiteralDoc::DataType(prim_type->dtype,  //
+                                              ty_p->Attr("element_type")->Attr("dtype"));
+        } else if (ty->element_type.as<TensorMapTypeNode>()) {
+          return TIR(d, "TensorMap")->Call({});
+        } else {
+          element_type = d->AsDoc<ExprDoc>(ty->element_type, ty_p->Attr("element_type"));
+        }
+        if (ty->storage_scope == "") {
+          return TIR(d, "handle")->Call({element_type});
+        } else {
+          return TIR(d, "handle")
+              ->Call(
+                  {element_type, LiteralDoc::Str(ty->storage_scope, ty_p->Attr("storage_scope"))});
+        }
+      });
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<TupleType>(
+      "", [](TupleType ty, AccessPath p, IRDocsifier d) -> Doc {
+        if (ty->fields.empty()) {
+          return LiteralDoc::None(p);
+        }
+        return TIR(d, "Tuple")->Call(d->AsDoc<ListDoc>(ty->fields, p->Attr("fields"))->elements);
+      });
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<Target>(
+      "", [](Target target, AccessPath p, IRDocsifier d) -> Doc {
+        ffi::Map<ffi::String, ffi::Any> config = target->ToConfig();
+        return TIR(d, "target")->Call({d->AsDoc<ExprDoc>(config, p)});
+      });
+}
 
 TVM_REGISTER_SCRIPT_AS_REPR(IntImmNode, ReprPrintTIR);
 TVM_REGISTER_SCRIPT_AS_REPR(FloatImmNode, ReprPrintTIR);

--- a/src/tirx/script/printer/stmt.cc
+++ b/src/tirx/script/printer/stmt.cc
@@ -68,188 +68,197 @@ bool IsAncestorOfAllVarUse(const tirx::Stmt& node, const ffi::ObjectRef& var,
   return false;
 }
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<tirx::TilePrimitiveCall>(
-        "", [](tirx::TilePrimitiveCall op_call, AccessPath p, IRDocsifier d) -> Doc {
-          static const OpAttrMap<tirx::TScriptPrinterName>& op_names =
-              Op::GetAttrMap<tirx::TScriptPrinterName>("TScriptPrinterName");
-          auto op = op_call->op;
-          if (op_names.count(op) == 0) {
-            LOG(WARNING) << "No TScriptPrinterName attribute for " << op->name;
-          }
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<tirx::TilePrimitiveCall>(
+      "", [](tirx::TilePrimitiveCall op_call, AccessPath p, IRDocsifier d) -> Doc {
+        static const OpAttrMap<tirx::TScriptPrinterName>& op_names =
+            Op::GetAttrMap<tirx::TScriptPrinterName>("TScriptPrinterName");
+        auto op = op_call->op;
+        if (op_names.count(op) == 0) {
+          LOG(WARNING) << "No TScriptPrinterName attribute for " << op->name;
+        }
 
-          static const auto& category_map = Op::GetAttrMap<tirx::TIRxOpCategory>("TIRxOpCategory");
-          bool is_tile_primitive = category_map.get(op, ffi::String("")) == "tile_primitive";
-          TVM_FFI_ICHECK(is_tile_primitive)
-              << "Only tile primitive ops can be used in tirx::TilePrimitiveCall";
-          ffi::String name = op_names.get(op, op->name);
-          // Per-call execution scope is printed as a namespace prefix on the op,
-          // e.g. ``T.warp.copy(...)``. ``warpgroup`` prints as ``wg``. The
-          // default ``thread`` scope prints through the explicit tile namespace,
-          // e.g. ``T.tile.copy(...)``, so canonical script only needs the full
-          // TIRx dialect import. ``Tx`` remains a handwritten shorthand for
-          // ``T.tile`` and ``T.<scope>`` tile calls.
-          auto scope_ns = [](tirx::ScopeKind k) -> ffi::Optional<ffi::String> {
-            switch (k) {
-              case tirx::ScopeKind::kWarp:
-                return ffi::String("warp");
-              case tirx::ScopeKind::kWarpgroup:
-                return ffi::String("wg");
-              case tirx::ScopeKind::kCta:
-                return ffi::String("cta");
-              case tirx::ScopeKind::kCluster:
-                return ffi::String("cluster");
-              default:  // kThread -> no prefix
-                return std::nullopt;
-            }
-          };
-          auto scoped_callee = [&](const ffi::String& op_name) -> ExprDoc {
-            ffi::Optional<ffi::String> ns = scope_ns(op_call->scope->kind);
-            if (ns.has_value()) {
-              return TIRx(d, ns.value())->Attr(op_name);
-            }
-            return TIRx(d, "tile")->Attr(op_name);
-          };
-          if (!op.same_as(tirx::compose_op())) {
-            // Trim trailing None args (e.g. optional bias=None, scale=None)
-            size_t n_args = op_call->args.size();
-            while (n_args > 0 &&
-                   op_call->args[n_args - 1].type_index() == ffi::TypeIndex::kTVMFFINone) {
-              --n_args;
-            }
-            // Detect in-place unary ops: after trimming Nones, if exactly 2 args
-            // and args[0]/args[1] refer to the same buffer region, collapse to 1 arg
-            bool inplace_unary = false;
-            if (n_args == 2) {
-              auto dst_opt = op_call->args[0].as<tirx::BufferRegion>();
-              auto src_opt = op_call->args[1].as<tirx::BufferRegion>();
-              if (dst_opt.has_value() && src_opt.has_value() &&
-                  dst_opt.value()->buffer.same_as(src_opt.value()->buffer) &&
-                  StructuralEqual()(dst_opt.value()->region, src_opt.value()->region)) {
-                inplace_unary = true;
-              }
-            }
-            ffi::Array<Doc> args;
-            for (size_t i = 0; i < n_args; ++i) {
-              if (inplace_unary && i == 1) continue;  // skip duplicate src
-              args.push_back(d->AsDoc<Doc>(op_call->args[i], p->Attr("args")->ArrayItem(i)));
-            }
-            ffi::Optional<ExprDoc> disp = std::nullopt;
-            if (op_call->dispatch.has_value()) {
-              disp = LiteralDoc::Str(op_call->dispatch.value(), p->Attr("dispatch"));
-            }
-            return OpCallDoc(scoped_callee(name), args,
-                             d->AsDoc<DictDoc>(op_call->workspace, p->Attr("workspace")),
-                             d->AsDoc<DictDoc>(op_call->config, p->Attr("config")), disp);
-          } else {
-            With<TIRFrame> f(d, op_call);
-            ffi::Array<tirx::Stmt> stmts;
-            for (size_t i = 0, n = op_call->args.size(); i < n; ++i) {
-              stmts.push_back(op_call->args[i].as_or_throw<tirx::Stmt>());
-            }
-            tirx::SeqStmt seq_stmt(stmts);
-            AsDocBody(seq_stmt, p->Attr("args"), f->get(), d);
-            // Build kwargs: workspace, dispatch, then flatten config
-            ffi::Array<ffi::String> kw_keys;
-            ffi::Array<ExprDoc> kw_values;
-            if (!op_call->workspace.empty()) {
-              kw_keys.push_back("workspace");
-              kw_values.push_back(d->AsDoc<DictDoc>(op_call->workspace, p->Attr("workspace")));
-            }
-            if (op_call->dispatch.has_value()) {
-              kw_keys.push_back("dispatch");
-              kw_values.push_back(LiteralDoc::Str(op_call->dispatch.value(), p->Attr("dispatch")));
-            }
-            using POO = std::pair<ffi::String, ffi::Any>;
-            std::vector<POO> items{op_call->config.begin(), op_call->config.end()};
-            std::sort(items.begin(), items.end(),
-                      [](const POO& a, const POO& b) { return a.first < b.first; });
-            for (const auto& kv : items) {
-              kw_keys.push_back(kv.first);
-              kw_values.push_back(
-                  d->AsDoc<ExprDoc>(kv.second, p->Attr("config")->MapItem(kv.first)));
-            }
-            return ScopeDoc(std::nullopt, scoped_callee("compose_op")->Call({}, kw_keys, kw_values),
-                            (*f)->stmts);
+        static const auto& category_map = Op::GetAttrMap<tirx::TIRxOpCategory>("TIRxOpCategory");
+        bool is_tile_primitive = category_map.get(op, ffi::String("")) == "tile_primitive";
+        TVM_FFI_ICHECK(is_tile_primitive)
+            << "Only tile primitive ops can be used in tirx::TilePrimitiveCall";
+        ffi::String name = op_names.get(op, op->name);
+        // Per-call execution scope is printed as a namespace prefix on the op,
+        // e.g. ``T.warp.copy(...)``. ``warpgroup`` prints as ``wg``. The
+        // default ``thread`` scope prints through the explicit tile namespace,
+        // e.g. ``T.tile.copy(...)``, so canonical script only needs the full
+        // TIRx dialect import. ``Tx`` remains a handwritten shorthand for
+        // ``T.tile`` and ``T.<scope>`` tile calls.
+        auto scope_ns = [](tirx::ScopeKind k) -> ffi::Optional<ffi::String> {
+          switch (k) {
+            case tirx::ScopeKind::kWarp:
+              return ffi::String("warp");
+            case tirx::ScopeKind::kWarpgroup:
+              return ffi::String("wg");
+            case tirx::ScopeKind::kCta:
+              return ffi::String("cta");
+            case tirx::ScopeKind::kCluster:
+              return ffi::String("cluster");
+            default:  // kThread -> no prefix
+              return std::nullopt;
           }
-        });
+        };
+        auto scoped_callee = [&](const ffi::String& op_name) -> ExprDoc {
+          ffi::Optional<ffi::String> ns = scope_ns(op_call->scope->kind);
+          if (ns.has_value()) {
+            return TIRx(d, ns.value())->Attr(op_name);
+          }
+          return TIRx(d, "tile")->Attr(op_name);
+        };
+        if (!op.same_as(tirx::compose_op())) {
+          // Trim trailing None args (e.g. optional bias=None, scale=None)
+          size_t n_args = op_call->args.size();
+          while (n_args > 0 &&
+                 op_call->args[n_args - 1].type_index() == ffi::TypeIndex::kTVMFFINone) {
+            --n_args;
+          }
+          // Detect in-place unary ops: after trimming Nones, if exactly 2 args
+          // and args[0]/args[1] refer to the same buffer region, collapse to 1 arg
+          bool inplace_unary = false;
+          if (n_args == 2) {
+            auto dst_opt = op_call->args[0].as<tirx::BufferRegion>();
+            auto src_opt = op_call->args[1].as<tirx::BufferRegion>();
+            if (dst_opt.has_value() && src_opt.has_value() &&
+                dst_opt.value()->buffer.same_as(src_opt.value()->buffer) &&
+                StructuralEqual()(dst_opt.value()->region, src_opt.value()->region)) {
+              inplace_unary = true;
+            }
+          }
+          ffi::Array<Doc> args;
+          for (size_t i = 0; i < n_args; ++i) {
+            if (inplace_unary && i == 1) continue;  // skip duplicate src
+            args.push_back(d->AsDoc<Doc>(op_call->args[i], p->Attr("args")->ArrayItem(i)));
+          }
+          ffi::Optional<ExprDoc> disp = std::nullopt;
+          if (op_call->dispatch.has_value()) {
+            disp = LiteralDoc::Str(op_call->dispatch.value(), p->Attr("dispatch"));
+          }
+          return OpCallDoc(scoped_callee(name), args,
+                           d->AsDoc<DictDoc>(op_call->workspace, p->Attr("workspace")),
+                           d->AsDoc<DictDoc>(op_call->config, p->Attr("config")), disp);
+        } else {
+          With<TIRFrame> f(d, op_call);
+          ffi::Array<tirx::Stmt> stmts;
+          for (size_t i = 0, n = op_call->args.size(); i < n; ++i) {
+            stmts.push_back(op_call->args[i].as_or_throw<tirx::Stmt>());
+          }
+          tirx::SeqStmt seq_stmt(stmts);
+          AsDocBody(seq_stmt, p->Attr("args"), f->get(), d);
+          // Build kwargs: workspace, dispatch, then flatten config
+          ffi::Array<ffi::String> kw_keys;
+          ffi::Array<ExprDoc> kw_values;
+          if (!op_call->workspace.empty()) {
+            kw_keys.push_back("workspace");
+            kw_values.push_back(d->AsDoc<DictDoc>(op_call->workspace, p->Attr("workspace")));
+          }
+          if (op_call->dispatch.has_value()) {
+            kw_keys.push_back("dispatch");
+            kw_values.push_back(LiteralDoc::Str(op_call->dispatch.value(), p->Attr("dispatch")));
+          }
+          using POO = std::pair<ffi::String, ffi::Any>;
+          std::vector<POO> items{op_call->config.begin(), op_call->config.end()};
+          std::sort(items.begin(), items.end(),
+                    [](const POO& a, const POO& b) { return a.first < b.first; });
+          for (const auto& kv : items) {
+            kw_keys.push_back(kv.first);
+            kw_values.push_back(d->AsDoc<ExprDoc>(kv.second, p->Attr("config")->MapItem(kv.first)));
+          }
+          return ScopeDoc(std::nullopt, scoped_callee("compose_op")->Call({}, kw_keys, kw_values),
+                          (*f)->stmts);
+        }
+      });
+}
 TVM_SCRIPT_REPR(tirx::TilePrimitiveCallNode, ReprPrintTIR);
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<tirx::Evaluate>("", [](tirx::Evaluate eval, AccessPath p, IRDocsifier d) -> Doc {
-      ExprDoc value = d->AsDoc<ExprDoc>(eval->value, p->Attr("value"));
-      const auto* call = eval->value.as<CallNode>();
-      if (call && !call->op.same_as(tirx::builtin::buffer_data())) {
-        return ExprStmtDoc(value);
-      }
-      return ExprStmtDoc(TIR(d, "evaluate")->Call({value}));
-    });
-
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<tirx::Return>("", [](tirx::Return stmt, AccessPath p, IRDocsifier d) -> Doc {
-      ExprDoc value = d->AsDoc<ExprDoc>(stmt->value, p->Attr("value"));
-      return ReturnDoc(value);
-    });
-
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<tirx::Bind>("", [](tirx::Bind stmt, AccessPath p, IRDocsifier d) -> Doc {
-      // Step 1. Type annotation
-      TVM_FFI_ICHECK(!stmt->var->ty.IsMissing())
-          << "Type annotation is required for variable: " << stmt->var->name;
-      ffi::Optional<ExprDoc> type_doc = d->AsDoc<ExprDoc>(stmt->var->ty,  //
-                                                          p->Attr("var")->Attr("ty"));
-      if (const auto* tuple_type = stmt->var->ty.as<TupleTypeNode>()) {
-        if (tuple_type->fields.empty()) {
-          type_doc = std::nullopt;
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<tirx::Evaluate>(
+      "", [](tirx::Evaluate eval, AccessPath p, IRDocsifier d) -> Doc {
+        ExprDoc value = d->AsDoc<ExprDoc>(eval->value, p->Attr("value"));
+        const auto* call = eval->value.as<CallNode>();
+        if (call && !call->op.same_as(tirx::builtin::buffer_data())) {
+          return ExprStmtDoc(value);
         }
-      }
-      // Step 2. RHS
-      ExprDoc rhs = d->AsDoc<ExprDoc>(stmt->value, p->Attr("value"));
-      // Step 3. LHS - Bind is flat, define var if new, otherwise just assign
-      if (!d->IsVarDefined(stmt->var)) {
-        TVM_FFI_ICHECK(!d->frames.empty());
-        ExprDoc lhs = DefineVar(stmt->var, d->frames.back(), d);
-        ExprDoc let_ann = type_doc.has_value()
-                              ? ExprDoc(IndexDoc(TIR(d, "let"), {type_doc.value()}))
-                              : TIR(d, "let");
-        return AssignDoc(lhs, rhs, let_ann);
-      } else {
-        ExprDoc lhs = d->AsDoc<ExprDoc>(stmt->var, p->Attr("var"));
-        return AssignDoc(lhs, rhs, std::nullopt);
-      }
-    });
+        return ExprStmtDoc(TIR(d, "evaluate")->Call({value}));
+      });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<tirx::AssertStmt>(
-        "", [](tirx::AssertStmt stmt, AccessPath p, IRDocsifier d) -> Doc {
-          ExprDoc cond = d->AsDoc<ExprDoc>(stmt->condition, p->Attr("condition"));
-          // Always emit the canonical tuple form: assert cond, ("Kind", ["part0", "part1", ...])
-          ffi::Array<ExprDoc> parts;
-          auto parts_path = p->Attr("message_parts");
-          for (size_t i = 0; i < stmt->message_parts.size(); ++i) {
-            parts.push_back(d->AsDoc<ExprDoc>(stmt->message_parts[i], parts_path->ArrayItem(i)));
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<tirx::Return>(
+      "", [](tirx::Return stmt, AccessPath p, IRDocsifier d) -> Doc {
+        ExprDoc value = d->AsDoc<ExprDoc>(stmt->value, p->Attr("value"));
+        return ReturnDoc(value);
+      });
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<tirx::Bind>(
+      "", [](tirx::Bind stmt, AccessPath p, IRDocsifier d) -> Doc {
+        // Step 1. Type annotation
+        TVM_FFI_ICHECK(!stmt->var->ty.IsMissing())
+            << "Type annotation is required for variable: " << stmt->var->name;
+        ffi::Optional<ExprDoc> type_doc = d->AsDoc<ExprDoc>(stmt->var->ty,  //
+                                                            p->Attr("var")->Attr("ty"));
+        if (const auto* tuple_type = stmt->var->ty.as<TupleTypeNode>()) {
+          if (tuple_type->fields.empty()) {
+            type_doc = std::nullopt;
           }
-          ExprDoc kind_doc = d->AsDoc<ExprDoc>(stmt->error_kind, p->Attr("error_kind"));
-          return AssertDoc(cond, TupleDoc({kind_doc, ListDoc(parts)}));
-        });
+        }
+        // Step 2. RHS
+        ExprDoc rhs = d->AsDoc<ExprDoc>(stmt->value, p->Attr("value"));
+        // Step 3. LHS - Bind is flat, define var if new, otherwise just assign
+        if (!d->IsVarDefined(stmt->var)) {
+          TVM_FFI_ICHECK(!d->frames.empty());
+          ExprDoc lhs = DefineVar(stmt->var, d->frames.back(), d);
+          ExprDoc let_ann = type_doc.has_value()
+                                ? ExprDoc(IndexDoc(TIR(d, "let"), {type_doc.value()}))
+                                : TIR(d, "let");
+          return AssignDoc(lhs, rhs, let_ann);
+        } else {
+          ExprDoc lhs = d->AsDoc<ExprDoc>(stmt->var, p->Attr("var"));
+          return AssignDoc(lhs, rhs, std::nullopt);
+        }
+      });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<tirx::While>("", [](tirx::While stmt, AccessPath p, IRDocsifier d) -> Doc {
-      ExprDoc cond = d->AsDoc<ExprDoc>(stmt->condition, p->Attr("condition"));
-      With<TIRFrame> f(d, stmt);
-      AsDocBody(stmt->body, p->Attr("body"), f->get(), d);
-      return WhileDoc(cond, (*f)->stmts);
-    });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<tirx::AssertStmt>(
+      "", [](tirx::AssertStmt stmt, AccessPath p, IRDocsifier d) -> Doc {
+        ExprDoc cond = d->AsDoc<ExprDoc>(stmt->condition, p->Attr("condition"));
+        // Always emit the canonical tuple form: assert cond, ("Kind", ["part0", "part1", ...])
+        ffi::Array<ExprDoc> parts;
+        auto parts_path = p->Attr("message_parts");
+        for (size_t i = 0; i < stmt->message_parts.size(); ++i) {
+          parts.push_back(d->AsDoc<ExprDoc>(stmt->message_parts[i], parts_path->ArrayItem(i)));
+        }
+        ExprDoc kind_doc = d->AsDoc<ExprDoc>(stmt->error_kind, p->Attr("error_kind"));
+        return AssertDoc(cond, TupleDoc({kind_doc, ListDoc(parts)}));
+      });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<tirx::Break>("", [](tirx::Break stmt, AccessPath p, IRDocsifier d) -> Doc {
-      return BreakDoc();
-    });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<tirx::While>(
+      "", [](tirx::While stmt, AccessPath p, IRDocsifier d) -> Doc {
+        ExprDoc cond = d->AsDoc<ExprDoc>(stmt->condition, p->Attr("condition"));
+        With<TIRFrame> f(d, stmt);
+        AsDocBody(stmt->body, p->Attr("body"), f->get(), d);
+        return WhileDoc(cond, (*f)->stmts);
+      });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<tirx::Continue>("", [](tirx::Continue stmt, AccessPath p, IRDocsifier d) -> Doc {
-      return ContinueDoc();
-    });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<tirx::Break>(
+      "", [](tirx::Break stmt, AccessPath p, IRDocsifier d) -> Doc { return BreakDoc(); });
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<tirx::Continue>(
+      "", [](tirx::Continue stmt, AccessPath p, IRDocsifier d) -> Doc { return ContinueDoc(); });
+}
 
 namespace {
 
@@ -673,11 +682,12 @@ Doc DeclBufferDoc(tirx::DeclBuffer stmt, AccessPath p, IRDocsifier d,
 }
 }  // namespace
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<tirx::DeclBuffer>(  //
-        "", [](tirx::DeclBuffer stmt, AccessPath p, IRDocsifier d) -> Doc {
-          return DeclBufferDoc(stmt, p, d, BufferVarDefinition::None);
-        });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<tirx::DeclBuffer>(  //
+      "", [](tirx::DeclBuffer stmt, AccessPath p, IRDocsifier d) -> Doc {
+        return DeclBufferDoc(stmt, p, d, BufferVarDefinition::None);
+      });
+}
 
 namespace {
 Doc AllocBufferDoc(tirx::AllocBuffer stmt, AccessPath p, IRDocsifier d) {
@@ -706,37 +716,41 @@ Doc AllocBufferDoc(tirx::AllocBuffer stmt, AccessPath p, IRDocsifier d) {
 
 }  // namespace
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<tirx::AllocBuffer>(  //
-        "", [](tirx::AllocBuffer stmt, AccessPath p, IRDocsifier d) -> Doc {
-          return AllocBufferDoc(stmt, p, d);
-        });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<tirx::AllocBuffer>(  //
+      "", [](tirx::AllocBuffer stmt, AccessPath p, IRDocsifier d) -> Doc {
+        return AllocBufferDoc(stmt, p, d);
+      });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<tirx::IfThenElse>(  //
-        "", [](tirx::IfThenElse stmt, AccessPath p, IRDocsifier d) -> Doc {
-          ExprDoc cond = d->AsDoc<ExprDoc>(stmt->condition, p->Attr("condition"));
-          ffi::Array<StmtDoc> then_branch;
-          ffi::Array<StmtDoc> else_branch;
-          if (stmt->then_case.defined()) {
-            With<TIRFrame> f(d, stmt->then_case);
-            AsDocBody(stmt->then_case, p->Attr("then_case"), f->get(), d);
-            then_branch = (*f)->stmts;
-          }
-          if (stmt->else_case.has_value()) {
-            With<TIRFrame> f(d, stmt->else_case.value());
-            AsDocBody(stmt->else_case.value(), p->Attr("else_case"), f->get(), d);
-            else_branch = (*f)->stmts;
-          }
-          return IfDoc(cond, then_branch, else_branch);
-        });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<tirx::IfThenElse>(  //
+      "", [](tirx::IfThenElse stmt, AccessPath p, IRDocsifier d) -> Doc {
+        ExprDoc cond = d->AsDoc<ExprDoc>(stmt->condition, p->Attr("condition"));
+        ffi::Array<StmtDoc> then_branch;
+        ffi::Array<StmtDoc> else_branch;
+        if (stmt->then_case.defined()) {
+          With<TIRFrame> f(d, stmt->then_case);
+          AsDocBody(stmt->then_case, p->Attr("then_case"), f->get(), d);
+          then_branch = (*f)->stmts;
+        }
+        if (stmt->else_case.has_value()) {
+          With<TIRFrame> f(d, stmt->else_case.value());
+          AsDocBody(stmt->else_case.value(), p->Attr("else_case"), f->get(), d);
+          else_branch = (*f)->stmts;
+        }
+        return IfDoc(cond, then_branch, else_branch);
+      });
+}
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<tirx::SeqStmt>("", [](tirx::SeqStmt stmt, AccessPath p, IRDocsifier d) -> Doc {
-      With<TIRFrame> f(d, stmt);
-      AsDocBody(stmt, p, f->get(), d);
-      return StmtBlockDoc((*f)->stmts);
-    });
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<tirx::SeqStmt>(
+      "", [](tirx::SeqStmt stmt, AccessPath p, IRDocsifier d) -> Doc {
+        With<TIRFrame> f(d, stmt);
+        AsDocBody(stmt, p, f->get(), d);
+        return StmtBlockDoc((*f)->stmts);
+      });
+}
 
 void InsertEnvThread(const tirx::IterVar& iter_var, const AccessPath& iter_var_p,
                      const IRDocsifier& d) {
@@ -779,74 +793,75 @@ static bool IsDictAttrPattern(const tirx::AttrStmt& stmt) {
   return false;
 }
 
-TVM_STATIC_IR_FUNCTOR(IRDocsifier, vtable)
-    .set_dispatch<tirx::AttrStmt>(  //
-        "", [](tirx::AttrStmt stmt, AccessPath stmt_p, IRDocsifier d) -> Doc {
-          bool concise = AllowConciseScoping(d, stmt);
-          ffi::Optional<ExprDoc> lhs = std::nullopt;
-          ffi::Optional<ExprDoc> rhs = std::nullopt;
-          ffi::Optional<tirx::Var> define_var = std::nullopt;
-          tirx::Stmt body = stmt->body;
-          AccessPath body_p = stmt_p->Attr("body");
-          if (stmt->attr_key == "thread_extent" || stmt->attr_key == "virtual_thread") {
-            if (stmt->node.as<tirx::IterVarNode>()) {
-              rhs = DocsifyLaunchThread(stmt, stmt_p, &define_var, d);
-            }
+TVM_FFI_STATIC_INIT_BLOCK() {
+  IRDocsifier::vtable().set_dispatch<tirx::AttrStmt>(  //
+      "", [](tirx::AttrStmt stmt, AccessPath stmt_p, IRDocsifier d) -> Doc {
+        bool concise = AllowConciseScoping(d, stmt);
+        ffi::Optional<ExprDoc> lhs = std::nullopt;
+        ffi::Optional<ExprDoc> rhs = std::nullopt;
+        ffi::Optional<tirx::Var> define_var = std::nullopt;
+        tirx::Stmt body = stmt->body;
+        AccessPath body_p = stmt_p->Attr("body");
+        if (stmt->attr_key == "thread_extent" || stmt->attr_key == "virtual_thread") {
+          if (stmt->node.as<tirx::IterVarNode>()) {
+            rhs = DocsifyLaunchThread(stmt, stmt_p, &define_var, d);
           }
-          if (stmt->attr_key == "tirx_hint") {
-            if (auto map_node = stmt->node.as<ffi::Map<ffi::String, ffi::Any>>()) {
-              ffi::Array<ExprDoc> args;
-              ffi::Array<ffi::String> kwargs_keys;
-              ffi::Array<ExprDoc> kwargs_values;
-              for (const auto& [k, v] : map_node.value()) {
-                if (k == "message") {
-                  auto s = v.as<ffi::String>().value();
-                  args.push_back(LiteralDoc::Str(s, stmt_p->Attr("node")));
-                } else {
-                  kwargs_keys.push_back(k);
-                  kwargs_values.push_back(d->AsDoc<ExprDoc>(v, stmt_p->Attr("node")));
+        }
+        if (stmt->attr_key == "tirx_hint") {
+          if (auto map_node = stmt->node.as<ffi::Map<ffi::String, ffi::Any>>()) {
+            ffi::Array<ExprDoc> args;
+            ffi::Array<ffi::String> kwargs_keys;
+            ffi::Array<ExprDoc> kwargs_values;
+            for (const auto& [k, v] : map_node.value()) {
+              if (k == "message") {
+                auto s = v.as<ffi::String>().value();
+                args.push_back(LiteralDoc::Str(s, stmt_p->Attr("node")));
+              } else {
+                kwargs_keys.push_back(k);
+                kwargs_values.push_back(d->AsDoc<ExprDoc>(v, stmt_p->Attr("node")));
+              }
+            }
+            rhs = TIR(d, "hint")->Call(args, kwargs_keys, kwargs_values);
+          }
+        }
+        if (!rhs.has_value()) {
+          // Try to collapse consecutive dict-attr-pattern AttrStmts into T.attr({...})
+          if (IsDictAttrPattern(stmt)) {
+            ffi::Array<ExprDoc> keys;
+            ffi::Array<ExprDoc> values;
+            tirx::AttrStmt cur = stmt;
+            AccessPath cur_p = stmt_p;
+            while (true) {
+              keys.push_back(LiteralDoc::Str(cur->attr_key, cur_p->Attr("attr_key")));
+              values.push_back(d->AsDoc<ExprDoc>(cur->value, cur_p->Attr("value")));
+              if (auto next = cur->body.as<tirx::AttrStmt>()) {
+                if (IsDictAttrPattern(next.value())) {
+                  cur = next.value();
+                  cur_p = cur_p->Attr("body");
+                  continue;
                 }
               }
-              rhs = TIR(d, "hint")->Call(args, kwargs_keys, kwargs_values);
+              body = cur->body;
+              body_p = cur_p->Attr("body");
+              break;
             }
+            rhs = TIR(d, "attr")->Call({DictDoc(keys, values)});
+          } else {
+            rhs = TIR(d, "attr")->Call({
+                d->AsDoc<ExprDoc>(stmt->node, stmt_p->Attr("node")),
+                LiteralDoc::Str(stmt->attr_key, stmt_p->Attr("attr_key")),
+                d->AsDoc<ExprDoc>(stmt->value, stmt_p->Attr("value")),
+            });
           }
-          if (!rhs.has_value()) {
-            // Try to collapse consecutive dict-attr-pattern AttrStmts into T.attr({...})
-            if (IsDictAttrPattern(stmt)) {
-              ffi::Array<ExprDoc> keys;
-              ffi::Array<ExprDoc> values;
-              tirx::AttrStmt cur = stmt;
-              AccessPath cur_p = stmt_p;
-              while (true) {
-                keys.push_back(LiteralDoc::Str(cur->attr_key, cur_p->Attr("attr_key")));
-                values.push_back(d->AsDoc<ExprDoc>(cur->value, cur_p->Attr("value")));
-                if (auto next = cur->body.as<tirx::AttrStmt>()) {
-                  if (IsDictAttrPattern(next.value())) {
-                    cur = next.value();
-                    cur_p = cur_p->Attr("body");
-                    continue;
-                  }
-                }
-                body = cur->body;
-                body_p = cur_p->Attr("body");
-                break;
-              }
-              rhs = TIR(d, "attr")->Call({DictDoc(keys, values)});
-            } else {
-              rhs = TIR(d, "attr")->Call({
-                  d->AsDoc<ExprDoc>(stmt->node, stmt_p->Attr("node")),
-                  LiteralDoc::Str(stmt->attr_key, stmt_p->Attr("attr_key")),
-                  d->AsDoc<ExprDoc>(stmt->value, stmt_p->Attr("value")),
-              });
-            }
-          }
-          With<TIRFrame> f(d, stmt);
-          if (define_var.has_value()) {
-            lhs = DefineVar(define_var.value(), *f, d);
-          }
-          AsDocBody(body, body_p, f->get(), d);
-          return DoConciseScoping(lhs, rhs.value(), &(*f)->stmts, concise);
-        });
+        }
+        With<TIRFrame> f(d, stmt);
+        if (define_var.has_value()) {
+          lhs = DefineVar(define_var.value(), *f, d);
+        }
+        AsDocBody(body, body_p, f->get(), d);
+        return DoConciseScoping(lhs, rhs.value(), &(*f)->stmts, concise);
+      });
+}
 
 TVM_SCRIPT_REPR(tirx::BindNode, ReprPrintTIR);
 TVM_SCRIPT_REPR(tirx::AttrStmtNode, ReprPrintTIR);

--- a/tests/cpp/ir_functor_test.cc
+++ b/tests/cpp/ir_functor_test.cc
@@ -22,7 +22,7 @@
 #include <tvm/ffi/extra/structural_mutate.h>
 #include <tvm/ffi/extra/structural_visit.h>
 #include <tvm/ir/module.h>
-#include <tvm/ir/node_functor.h>
+#include <tvm/ir/object_functor.h>
 #include <tvm/ir/prim/builtin.h>
 #include <tvm/ir/prim/expr.h>
 #include <tvm/runtime/logging.h>
@@ -42,11 +42,58 @@ TEST(IRF, Basic) {
   PrimVar x("x");
   auto z = x + 1;
 
-  NodeFunctor<int(const ffi::ObjectRef& n, int b)> f;
-  f.set_dispatch<VarNode>([](const ffi::ObjectRef& n, int b) { return b; });
-  f.set_dispatch<prim::AddNode>([](const ffi::ObjectRef& n, int b) { return b + 2; });
+  ObjectFunctor<int(const ffi::ObjectRef& n, int b)> f;
+  f.SetDispatch<VarNode>([](const ffi::ObjectRef& n, int b) { return b; });
+  f.SetDispatch<prim::AddNode>([](const ffi::ObjectRef& n, int b) { return b + 2; });
   TVM_FFI_ICHECK_EQ(f(x, 2), 2);
   TVM_FFI_ICHECK_EQ(f(z, 2), 4);
+}
+
+TEST(IRF, ObjectFunctorDispatch) {
+  using namespace tvm;
+  tirx::PrimVar x("x");
+  ObjectFunctor<int(const ffi::ObjectRef&)> f;
+
+  EXPECT_FALSE(f.CanDispatch(x));
+  EXPECT_THROW(f(x), ffi::Error);
+  f.SetDispatch<ffi::Object>([](const ffi::ObjectRef&) {
+     return 1;
+   }).SetDispatch<ExprNode>([](const ffi::ObjectRef&) { return 2; });
+  // Invocation uses the nearest registered ancestor; CanDispatch checks only the exact type.
+  EXPECT_FALSE(f.CanDispatch(x));
+  EXPECT_EQ(f(x), 2);
+  f.SetDispatch<VarNode>([](const ffi::ObjectRef&) { return 3; });
+  EXPECT_TRUE(f.CanDispatch(x));
+  EXPECT_EQ(f(x), 3);
+  EXPECT_THROW(f.SetDispatch<VarNode>([](const ffi::ObjectRef&) { return 4; }), ffi::Error);
+
+  f.ClearDispatch<VarNode>();
+  EXPECT_FALSE(f.CanDispatch(x));
+  EXPECT_EQ(f(x), 2);
+  f.ClearDispatch<ExprNode>();
+  EXPECT_EQ(f(x), 1);
+  f.SetDispatch<VarNode>([](const ffi::ObjectRef&) { return 4; });
+  EXPECT_TRUE(f.CanDispatch(x));
+  EXPECT_EQ(f(x), 4);
+}
+
+TEST(IRF, ObjectFunctorFinalize) {
+  using namespace tvm;
+  tirx::PrimVar x("x");
+  PrimExpr z = x + 1;
+  ObjectFunctor<int(const ffi::ObjectRef&, int)> f;
+  f.SetDispatch<ExprNode>([](const ffi::ObjectRef&, int b) {
+     return b;
+   }).SetDispatch<prim::AddNode>([](const ffi::ObjectRef&, int b) { return b + 2; });
+
+  f.Finalize();
+  EXPECT_FALSE(f.CanDispatch(x));
+  EXPECT_TRUE(f.CanDispatch(z));
+  EXPECT_EQ(f(x, 2), 2);
+  EXPECT_EQ(f(z, 2), 4);
+  EXPECT_THROW(f.Finalize(), ffi::Error);
+  EXPECT_THROW(f.SetDispatch<VarNode>([](const ffi::ObjectRef&, int b) { return b; }), ffi::Error);
+  EXPECT_THROW(f.ClearDispatch<ExprNode>(), ffi::Error);
 }
 
 TEST(IRF, CountVar) {


### PR DESCRIPTION
Rename the uniform runtime-object dispatch table from `NodeFunctor` to `ObjectFunctor` in `tvm/ir/object_functor.h`, with `SetDispatch`, `ClearDispatch`, and `CanDispatch` as its public registration API. Place the public API before private storage and update all in-tree consumers.

Replace the old functor registration macro with direct accessor calls inside existing FFI static initialization blocks, including printer and representation registrations. Dispatch signatures, exact and ancestor lookup, registration errors, and finalization behavior are preserved.

Validation: full LLVM/CUDA compiler and runtime build; all 135 C++ tests, including dispatch and finalization coverage; affected TVMScript and Relax suites (876 passed, 1 skipped, 1 xfailed); repr/Script smoke checks; applicable C++ lint hooks.
