### PR TITLE
[Test] Restore shadowed duplicate test functions in relax/runtime tests

### DIFF
--- a/tests/python/relax/test_analysis.py
+++ b/tests/python/relax/test_analysis.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# ruff: noqa: F811, F841
+# ruff: noqa: F841
 
 
 import pytest
@@ -819,19 +819,6 @@ def test_reshape_pattern_reject_seqstmt():
 
     assert not has_reshape_pattern(identity_bias)
     assert not has_reshape_pattern(identity_identity)
-
-
-def test_reshape_pattern_reject_reduction():
-    @T.prim_func(s_tir=True)
-    def reduction(A: T.Buffer((4, 4), "float32"), B: T.Buffer((4,), "float32")):
-        for i0, i1 in T.grid(4, 4):
-            with T.sblock("identity"):
-                vi0, vi1 = T.axis.remap("SR", [i0, i1])
-                with T.init():
-                    B[vi0] = T.float32(0)
-                B[vi0] = B[vi0] + A[vi0, vi1]
-
-    assert not has_reshape_pattern(reduction)
 
 
 def test_reshape_pattern_reject_reduction():

--- a/tests/python/relax/test_analysis_well_formed.py
+++ b/tests/python/relax/test_analysis_well_formed.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# ruff: noqa: F811, RUF005
+# ruff: noqa: RUF005
 
 import pytest
 
@@ -1453,27 +1453,6 @@ def test_ty_may_be_incomplete():
             return C
 
     rx.analysis.well_formed(Module)
-
-
-def test_incomplete_ty_must_be_consistent():
-    """Type annotations must be accurate
-
-    Even though Type annotation may be less specific, the
-    information that they do contain must be correct.
-
-    """
-
-    @I.ir_module(check_well_formed=False, s_tir=True)
-    class Module:
-        @R.function
-        def main(
-            A: R.Tensor(shape=[128, 32], dtype="float32"),
-            B: R.Tensor(shape=[128, 32], dtype="float32"),
-        ):
-            C: R.Tensor(ndim=3) = R.add(A, B)
-            return C
-
-    assert not rx.analysis.check_well_formed(Module)
 
 
 if __name__ == "__main__":

--- a/tests/python/relax/test_ast_printer.py
+++ b/tests/python/relax/test_ast_printer.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# ruff: noqa: F811, F841
+# ruff: noqa: F841
 import re
 from functools import partial
 
@@ -194,15 +194,15 @@ def test_seq_expr() -> None:
     assert "body=" in seqe_str
 
 
-def test_shape_expr() -> None:
-    m = tirx.Var("m", ty="int32")
-    n = tirx.Var("n", ty="int32")
+def test_shape_expr_symbolic() -> None:
+    m = tirx.Var("m", ty="int64")
+    n = tirx.Var("n", ty="int64")
     s = rx.ShapeExpr([m, n])
     s_str = dump_ast(s)
     assert s_str.startswith("ShapeExpr(")
     assert "values=" in s_str
-    assert "Expr(value=`m: int32`)" in s_str
-    assert "Expr(value=`n: int32`)" in s_str
+    assert "Expr(value=`m`)" in s_str
+    assert "Expr(value=`n`)" in s_str
 
 
 def test_func():

--- a/tests/python/relax/test_expr.py
+++ b/tests/python/relax/test_expr.py
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# ruff: noqa: F811
 import numpy as np
 import pytest
 import tvm_ffi
@@ -160,8 +159,8 @@ def test_match_cast() -> None:
     var = rx.Var("v0", R.Shape())
     b0 = rx.MatchCast(var, shape, R.Tensor([m, n], "int32"))
     assert b0.value == shape
-    assert b0.pattern[0] == m
-    assert b0.pattern[1] == n
+    assert b0.ty.shape[0].same_as(m)
+    assert b0.ty.shape[1].same_as(n)
     assert b0.var is not None
 
     # var1: R.Tensor((m, n), "float32") =
@@ -171,12 +170,12 @@ def test_match_cast() -> None:
     var = rx.Var("v1", R.Tensor([m, n], "float32"))
     b1 = rx.MatchCast(var, value, R.Tensor([m, n], "float32"))
     assert b1.value == value
-    assert b1.pattern[0] == m
-    assert b1.pattern[1] == n
+    assert b1.ty.shape[0].same_as(m)
+    assert b1.ty.shape[1].same_as(n)
     assert b1.var is not None
 
 
-def test_match_cast() -> None:
+def test_match_cast_json_roundtrip() -> None:
     m = tirx.Var("m", ty="int64")
     n = tirx.Var("n", ty="int64")
     ivalue = rx.Var("input_value")

--- a/tests/python/relax/test_transform_gradient_checkpoint.py
+++ b/tests/python/relax/test_transform_gradient_checkpoint.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# ruff: noqa: E501, F811
+# ruff: noqa: E501
 """Unit tests for gradient with checkpointing."""
 
 import tvm
@@ -691,28 +691,6 @@ def test_checkpoint_sequential_checkpoint_last():
     # fmt: on
 
     assert_structural_equal(bb.get(), Expected)
-
-
-def test_checkpoint_dag():
-    """Comp. graph is a DAG with only one output. Here we only test the simple case: comp. graph
-    is a sequence of sub-graphs, and the checkpoints are the intersections of connected
-    subgraphs."""
-
-    def func(x):
-        return x * relax.const(2, "float32") * relax.const(2, "float32")
-
-    bb = BlockBuilder()
-    x = relax.Var("x", relax.TensorType((3, 3), "float32"))
-    with bb.function("main", [x]):
-        with bb.dataflow():
-            lv1 = bb.emit(nn.checkpoint(func, x))
-            lv2 = bb.emit(x * lv1)
-            lv3 = bb.emit(nn.checkpoint(func, lv2))
-            lv4 = bb.emit(lv2 * lv3)
-            lv5 = bb.emit(nn.checkpoint(func, lv4))
-            lv6 = bb.emit(lv4 * lv5)
-            gv = bb.emit_output(relax.op.sum(lv6))
-        bb.emit_func_output(gv)
 
 
 def test_checkpoint_with_intermediate_require_grads():

--- a/tests/python/runtime/test_runtime_nd_array.py
+++ b/tests/python/runtime/test_runtime_nd_array.py
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# ruff: noqa: F811
 
 import numpy as np
 import pytest
@@ -45,7 +44,7 @@ def test_1d_view_of_first_half_of_1d_arr():
     np.testing.assert_equal(tvm_output.numpy(), np_expected)
 
 
-def test_1d_view_of_first_half_of_1d_arr():
+def test_1d_view_of_second_half_of_1d_arr():
     """Subset returned by Tensor::CreateView may have a byte offset"""
     np_input = np.arange(1024, dtype="int32")
     tvm_input = tvm.runtime.tensor(np_input)


### PR DESCRIPTION
Several relax/runtime test modules define the same test function name twice. The second `def` rebinds the module-level name, so pytest only collects the later one and the earlier test silently never runs. File-level `# ruff: noqa: F811` headers were hiding the lint signal (`ruff check --select F811 --ignore-noqa` shows them).

| File | Duplicate | Fix |
|---|---|---|
| `relax/test_expr.py` | `test_match_cast` (two different tests) | Rename the second to `test_match_cast_json_roundtrip`. The restored first test still used the removed `MatchCast.pattern` field → switched to `b.ty.shape[i].same_as(m)`. |
| `relax/test_ast_printer.py` | `test_shape_expr` (symbolic vars vs. constants) | Rename the first to `test_shape_expr_symbolic`. `ShapeExpr` now requires int64 values, so the vars are int64 and the expected printout is ``Expr(value=`m`)``. |
| `runtime/test_runtime_nd_array.py` | `test_1d_view_of_first_half_of_1d_arr` | The second one uses `relative_byte_offset=512 * 4` → rename to `test_1d_view_of_second_half_of_1d_arr` (mirrors the existing 2d pair). |
| `relax/test_transform_gradient_checkpoint.py` | `test_checkpoint_dag` | The **second** copy — the one pytest was collecting — is truncated: it builds the function but has no `Expected` module and no `assert_structural_equal`. Removed it so the full test runs. |
| `relax/test_analysis.py` | `test_reshape_pattern_reject_reduction` | Byte-identical second copy removed. |
| `relax/test_analysis_well_formed.py` | `test_incomplete_ty_must_be_consistent` | Byte-identical second copy removed. |

F811 is dropped from the file-level noqa headers that no longer need it (otherwise `RUF100` fires).

Left alone: `test_op_gradient_numeric.py::test_reshape` has the same issue, but it is LLVM-gated and I could not run it locally, so it is not included here.

### Testing

CPU build of current `main` (ccd98e9, `USE_LLVM OFF`), `pytest` per file:

| File | before | after |
|---|---|---|
| `relax/test_expr.py` | 31 passed | **32 passed** |
| `relax/test_ast_printer.py` | 24 passed | **25 passed** |
| `runtime/test_runtime_nd_array.py` | 14 passed | **15 passed** |
| `relax/test_transform_gradient_checkpoint.py` | 11 passed | 11 passed (`test_checkpoint_dag` now includes the structural-equality check) |
| `relax/test_analysis.py` | 37 passed | 37 passed |
| `relax/test_analysis_well_formed.py` | 57 passed, 2 xfailed | 57 passed, 2 xfailed |

Without the two small updates, the restored `test_match_cast` fails with `AttributeError: 'MatchCast' object has no attribute 'pattern'` and `test_shape_expr_symbolic` fails with `the value in ShapeType can only have dtype of int64`, i.e. both had drifted while hidden.

`ruff check` / `ruff format --check` (v0.12.3, repo config) pass on all six files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
